### PR TITLE
fix: align agency search events with figma

### DIFF
--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-duplicates:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/packages/opencode/src/agency-swarm/tui.ts
+++ b/packages/opencode/src/agency-swarm/tui.ts
@@ -1,0 +1,91 @@
+function read(input: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = input[key]
+    if (typeof value !== "string") continue
+    const text = value.trim()
+    if (text) return text
+  }
+}
+
+function parse(raw: string) {
+  try {
+    return JSON.parse(raw) as unknown
+  } catch {
+    return
+  }
+}
+
+function text(input: Record<string, unknown>) {
+  const value =
+    read(input, ["snippet", "excerpt", "text", "content", "summary", "match", "preview"]) ??
+    (typeof input["content"] === "object" && input["content"] !== null
+      ? read(input["content"] as Record<string, unknown>, ["text", "value", "content"])
+      : undefined)
+  if (!value) return
+  return value.replace(/\s+/g, " ").trim().slice(0, 140)
+}
+
+function row(value: unknown) {
+  if (!value || typeof value !== "object") return []
+  const item = value as Record<string, unknown>
+  return [
+    {
+      title:
+        read(item, [
+          "filename",
+          "file_name",
+          "file",
+          "path",
+          "file_path",
+          "filepath",
+          "relative_path",
+          "name",
+          "title",
+          "id",
+          "file_id",
+        ]) ?? "Result",
+      text: text(item),
+    },
+  ]
+}
+
+export function queries(input: Record<string, unknown>) {
+  const values = new Set<string>()
+  const add = (value: unknown) => {
+    if (typeof value !== "string") return
+    const text = value.trim()
+    if (!text) return
+    const lower = text.toLowerCase()
+    if (lower === "none" || lower === "null" || lower === "undefined") return
+    values.add(text)
+  }
+  const addMany = (value: unknown) => {
+    if (!Array.isArray(value)) return
+    value.forEach(add)
+  }
+  addMany(input["queries"])
+  add(input["query"])
+  add(input["search_query"])
+  add(input["search_prompt"])
+  const action = input["action"]
+  if (typeof action === "object" && action !== null) {
+    const item = action as Record<string, unknown>
+    addMany(item["queries"])
+    add(item["query"])
+    add(item["search_query"])
+    add(item["search_prompt"])
+  }
+  if (typeof action === "string") add(action)
+  return [...values]
+}
+
+export function rows(raw?: string) {
+  if (!raw) return []
+  const data = parse(raw)
+  if (Array.isArray(data)) return data.flatMap(row)
+  if (data && typeof data === "object") {
+    const item = data as Record<string, unknown>
+    if (Array.isArray(item["results"])) return item["results"].flatMap(row)
+  }
+  return []
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -58,6 +58,7 @@ import { TodoItem } from "../../component/todo-item"
 import { DialogMessage } from "./dialog-message"
 import type { PromptInfo } from "../../component/prompt/history"
 import { DialogConfirm } from "@tui/ui/dialog-confirm"
+import { queries, rows } from "@/agency-swarm/tui"
 import { DialogTimeline } from "./dialog-timeline"
 import { DialogForkFromTimeline } from "./dialog-fork-from-timeline"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
@@ -1978,6 +1979,7 @@ function WebSearch(props: ToolProps<any>) {
 }
 
 function FileSearch(props: ToolProps<any>) {
+  const { theme } = useTheme()
   const query = createMemo(() => {
     const input = props.input as Record<string, unknown>
     const firstQuery = input["queries"]
@@ -1989,23 +1991,57 @@ function FileSearch(props: ToolProps<any>) {
     if (typeof query === "string" && query.trim()) return query.trim()
     return undefined
   })
+  const list = createMemo(() => rows(props.output))
+  const title = createMemo(() => {
+    if (!query()) return "File Search"
+    return `File Search "${query()}"`
+  })
 
   return (
-    <InlineTool
-      icon="⌕"
-      pending="Searching files..."
-      complete={props.part.state.status !== "pending"}
-      part={props.part}
-    >
-      File Search
-      <Show when={query()}>{(value) => <> "{value()}"</>}</Show>
-    </InlineTool>
+    <Switch>
+      <Match when={props.part.state.status === "completed"}>
+        <BlockTool title={title()} part={props.part}>
+          <box gap={1}>
+            <Show
+              when={list().length}
+              fallback={
+                <text fg={theme.textMuted}>
+                  No results found
+                  <Show when={query()}>{(value) => <> for "{value()}"</>}</Show>
+                </text>
+              }
+            >
+              <For each={list().slice(0, 3)}>
+                {(row) => (
+                  <box flexDirection="column">
+                    <text fg={theme.text}>• {row.title}</text>
+                    <Show when={row.text}>
+                      <text fg={theme.textMuted}>{row.text}</text>
+                    </Show>
+                  </box>
+                )}
+              </For>
+            </Show>
+          </box>
+        </BlockTool>
+      </Match>
+      <Match when={true}>
+        <InlineTool
+          icon="⌕"
+          pending="Searching files..."
+          complete={props.part.state.status !== "pending"}
+          part={props.part}
+        >
+          {title()}
+        </InlineTool>
+      </Match>
+    </Switch>
   )
 }
 
 function WebSearchSpecial(props: ToolProps<any>) {
   const query = createMemo(() => {
-    const values = readSearchQueries(props.input as Record<string, unknown>)
+    const values = queries(props.input as Record<string, unknown>)
     if (values.length === 0) return
     return values.map((value) => `"${value}"`).join(", ")
   })
@@ -2013,7 +2049,7 @@ function WebSearchSpecial(props: ToolProps<any>) {
   return (
     <InlineTool icon="◈" pending="Searching web..." complete={props.part.state.status !== "pending"} part={props.part}>
       Web Search
-      <Show when={query()}>{(value) => <> "{value()}"</>}</Show>
+      <Show when={query()}>{(value) => <> {value()}</>}</Show>
     </InlineTool>
   )
 }
@@ -2134,38 +2170,6 @@ function readFirstString(input: Record<string, unknown>, keys: string[]) {
     const value = input[key]
     if (typeof value === "string" && value.trim()) return value.trim()
   }
-}
-
-function readSearchQueries(input: Record<string, unknown>) {
-  const values = new Set<string>()
-  const add = (value: unknown) => {
-    if (typeof value !== "string") return
-    const text = value.trim()
-    if (!text) return
-    const lower = text.toLowerCase()
-    if (lower === "none" || lower === "null" || lower === "undefined") return
-    values.add(text)
-  }
-  const addMany = (value: unknown) => {
-    if (!Array.isArray(value)) return
-    value.forEach(add)
-  }
-  addMany(input["queries"])
-  add(input["query"])
-  add(input["search_query"])
-  add(input["search_prompt"])
-  const action = input["action"]
-  if (typeof action === "object" && action !== null) {
-    const actionInput = action as Record<string, unknown>
-    addMany(actionInput["queries"])
-    add(actionInput["query"])
-    add(actionInput["search_query"])
-    add(actionInput["search_prompt"])
-  }
-  if (typeof action === "string") {
-    add(action)
-  }
-  return [...values]
 }
 
 function resolveSpecialTool(tool: string): SpecialTool | undefined {

--- a/packages/opencode/test/agency-swarm/tui.test.ts
+++ b/packages/opencode/test/agency-swarm/tui.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+import { queries, rows } from "../../src/agency-swarm/tui"
+
+describe("agency-swarm tui helpers", () => {
+  test("queries drops placeholder values and keeps action query", () => {
+    expect(
+      queries({
+        query: "None",
+        queries: ["agency swarm events", "None"],
+        action: {
+          type: "search",
+          query: "show latest agency swarm release",
+        },
+      }),
+    ).toEqual(["agency swarm events", "show latest agency swarm release"])
+  })
+
+  test("rows parses top-level search results", () => {
+    expect(
+      rows(
+        JSON.stringify([
+          {
+            file_id: "daily_revenue_report.pdf",
+            text: "Daily report with revenue summary and top metrics",
+          },
+        ]),
+      ),
+    ).toEqual([
+      {
+        title: "daily_revenue_report.pdf",
+        text: "Daily report with revenue summary and top metrics",
+      },
+    ])
+  })
+
+  test("rows parses nested results arrays and trims snippets", () => {
+    expect(
+      rows(
+        JSON.stringify({
+          results: [
+            {
+              path: "reports/daily_revenue_report.pdf",
+              content: {
+                text: "  first line\nsecond line\nthird line  ",
+              },
+            },
+          ],
+        }),
+      ),
+    ).toEqual([
+      {
+        title: "reports/daily_revenue_report.pdf",
+        text: "first line second line third line",
+      },
+    ])
+  })
+
+  test("rows returns empty rows for invalid payloads", () => {
+    expect(rows("not json")).toEqual([])
+    expect(rows(JSON.stringify({ results: [] }))).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- render completed Agency file-search events as dedicated result or no-result cards instead of a single generic line
- fix web-search query label formatting so multiple prompts render correctly
- move Agency TUI parsing into a fork-owned helper with targeted tests

## Validation
- `bun test test/agency-swarm/tui.test.ts`
- `bun x prettier --check src/agency-swarm/tui.ts src/cli/cmd/tui/routes/session/index.tsx test/agency-swarm/tui.test.ts`
- `bun typecheck` still fails on existing workspace baseline issues outside this diff

## Figma audit
- verified the linked Figma node `10982:451301` (File Search - Component) against the current CLI screenshots in the Notion task attachments
- this diff closes the concrete gap where file search lacked the dedicated result/no-result event card and web search still formatted prompts incorrectly