### PR TITLE
fix: sync SDK summarize types

### DIFF
--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3173,8 +3173,8 @@ export type SessionDiffResponse = SessionDiffResponses[keyof SessionDiffResponse
 
 export type SessionSummarizeData = {
   body?: {
-    providerID: string
-    modelID: string
+    providerID?: string
+    modelID?: string
     auto?: boolean
   }
   path: {


### PR DESCRIPTION
## Summary\n- regenerate the JS SDK after the summarize API changed to allow model resolution from session state\n- update SessionSummarizeData so provider/model ids are optional in the generated v2 types\n\n## Verification\n- ./packages/sdk/js/script/build.ts