### PR TITLE
chore(opencode): publish npm from GitHub releases

### DIFF
--- a/.github/workflows/publish-npm-on-release.yml
+++ b/.github/workflows/publish-npm-on-release.yml
@@ -1,0 +1,55 @@
+name: publish-npm-on-release
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.repository == 'VRSEN/agentswarm-cli'
+    runs-on: ubuntu-latest
+    env:
+      OPENCODE_VERSION: ${{ github.event.release.tag_name }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_CONFIG_PROVENANCE: false
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Normalize version
+        run: echo "OPENCODE_VERSION=${OPENCODE_VERSION#v}" >> "$GITHUB_ENV"
+
+      - name: Select npm channel
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            echo "OPENCODE_CHANNEL=next" >> "$GITHUB_ENV"
+          else
+            echo "OPENCODE_CHANNEL=latest" >> "$GITHUB_ENV"
+          fi
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build CLI packages
+        run: ./packages/opencode/script/build.ts
+
+      - name: Publish npm packages
+        run: ./packages/opencode/script/publish.ts


### PR DESCRIPTION
### Issue for this PR

Closes #10

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a release-driven npm publish workflow for the forked CLI. When a GitHub release is published in `VRSEN/agentswarm-cli`, the workflow checks out the exact release tag, normalizes the version, chooses `next` for prereleases and `latest` for stable releases, builds the CLI packages, and publishes them to npm with the existing build/publish scripts.

This keeps the release trigger aligned with GitHub Releases instead of relying on a manual local publish step.

### How did you verify your code works?

- `bun x prettier --check .github/workflows/publish-npm-on-release.yml`
- Reviewed the workflow against `packages/opencode/script/build.ts`, `packages/opencode/script/publish.ts`, and the current npm package layout so the env vars and dist-tag mapping match the existing release path.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
