### PR TITLE
docs(opencode): add vision review rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@
 - Prefer automation: execute requested actions without confirmation unless blocked by missing info or safety/irreversibility.
 - When validation or tooling needs credentials, inspect the repo root `.env` before treating them as missing or escalating.
 - Hard-cut policy: prefer one canonical current-state path. Do not add compatibility bridges, legacy aliases, fallbacks, dual behavior, or migration glue unless the user explicitly requests them. If a temporary exception is unavoidable, state why, why the main path is insufficient, and the deletion trigger in the same diff.
+- Visual QA: for UI, image, screenshot, and logo work, use [$vision-review](/Users/nick/.codex/skills/vision-review/SKILL.md), inspect original-resolution cropped evidence, and keep iterating until no visible defect remains or you can name the exact blocker.
+- OpenAI image detail: when using the OpenAI API for visual review, set `detail: "high"`; official docs currently expose only `high`, `low`, and `auto`.
 
 ## Fork Context
 


### PR DESCRIPTION
## Issue
- visual review work needs a clear, high-fidelity evidence rule

## Type of Change
- [ ] Enhancement
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## What Changed
- added a concise AGENTS rule for UI/image/logo work to require original-resolution crops and iterative cleanup
- added the accurate OpenAI image-detail note (`high`, `low`, `auto`)

## Why
- recent logo work showed that visual review quality needs an explicit standard instead of ad-hoc judgment

## Verification
- `bun x prettier --check AGENTS.md`
- verified the official OpenAI docs expose `high`, `low`, and `auto` for image detail

## Checklist
- [x] scoped to AGENTS guidance only
- [x] kept the change short
- [x] preserved existing remove > update > add guidance