### PR TITLE
fix(opencode): decouple agentswarm launcher from opencode

### DIFF
--- a/packages/opencode/bin/agency
+++ b/packages/opencode/bin/agency
@@ -18,7 +18,7 @@ function run(target) {
   process.exit(code)
 }
 
-const envPath = process.env.AGENCY_BIN_PATH || process.env.OPENCODE_BIN_PATH
+const envPath = process.env.AGENCY_BIN_PATH
 if (envPath) {
   run(envPath)
 }
@@ -27,7 +27,7 @@ const scriptPath = fs.realpathSync(fileURLToPath(import.meta.url))
 const scriptDir = path.dirname(scriptPath)
 
 //
-const cached = path.join(scriptDir, ".opencode")
+const cached = path.join(scriptDir, ".agentswarm")
 if (fs.existsSync(cached)) {
   run(cached)
 }

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -109,7 +109,7 @@ async function main() {
     // On non-Windows platforms, just verify the binary package exists
     // Don't replace the wrapper script - it handles binary execution
     const { binaryPath } = findBinary()
-    const target = path.join(__dirname, "bin", ".opencode")
+    const target = path.join(__dirname, "bin", ".agentswarm")
     if (fs.existsSync(target)) fs.unlinkSync(target)
     try {
       fs.linkSync(binaryPath, target)

--- a/packages/opencode/test/cli/bin.test.ts
+++ b/packages/opencode/test/cli/bin.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
+import fs from "node:fs"
 import { fileURLToPath } from "node:url"
 
 describe("cli bin launcher", () => {
-  test("runs under node when AGENCY_BIN_PATH is set", () => {
-    const binPath = fileURLToPath(new URL("../../bin/agency", import.meta.url))
+  const binPath = fileURLToPath(new URL("../../bin/agency", import.meta.url))
+  const postinstallPath = fileURLToPath(new URL("../../script/postinstall.mjs", import.meta.url))
 
+  test("runs under node when AGENCY_BIN_PATH is set", () => {
     const result = spawnSync(process.execPath, [binPath, "--version"], {
       env: {
         ...process.env,
@@ -15,5 +17,15 @@ describe("cli bin launcher", () => {
 
     expect(result.status).toBe(0)
     expect(result.error).toBeUndefined()
+  })
+
+  test("does not retain opencode launcher coupling", () => {
+    const bin = fs.readFileSync(binPath, "utf8")
+    const postinstall = fs.readFileSync(postinstallPath, "utf8")
+
+    expect(bin.includes("OPENCODE_BIN_PATH")).toBe(false)
+    expect(bin.includes('".agentswarm"')).toBe(true)
+    expect(postinstall.includes('".agentswarm"')).toBe(true)
+    expect(postinstall.includes('".opencode"')).toBe(false)
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #19

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the remaining launcher coupling between `agentswarm-cli` and `opencode`. The launcher no longer reads `OPENCODE_BIN_PATH`, the cached launcher path changes from `.opencode` to `.agentswarm`, and the CLI bin tests now assert that the fork does not retain opencode-specific state.

### How did you verify your code works?

- `cd packages/opencode && bun x prettier --check bin/agency script/postinstall.mjs test/cli/bin.test.ts`
- `cd packages/opencode && bun test test/cli/bin.test.ts`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR