### PR TITLE
feat: add dedicated /auth TUI flow and keep /connect server-only

### DIFF
--- a/packages/opencode/src/agency-swarm/product.ts
+++ b/packages/opencode/src/agency-swarm/product.ts
@@ -7,6 +7,7 @@ export namespace AgencyProduct {
   export const start = [
     "Connect to a local agency-swarm server before sending prompts.",
     "Use /connect to choose the server, store a token, and refresh status.",
+    "Use /auth to add provider credentials (OpenAI first).",
   ]
 
   const skip = [
@@ -29,6 +30,7 @@ export namespace AgencyProduct {
 
   const add = [
     "Use {highlight}/connect{/highlight} to choose the local agency-swarm server you want to use",
+    "Use {highlight}/auth{/highlight} to manage provider credentials",
     "Use {highlight}/agents{/highlight} to pick the active agency and recipient agent from live metadata",
     "Set {highlight}provider.agency-swarm.options.baseURL{/highlight} in config to pin a default local server",
     "Use {highlight}/connect{/highlight} to configure local server ports and your Agency token",
@@ -57,7 +59,7 @@ export namespace AgencyProduct {
           next = next.replace("long sessions near context limits", "long agency-swarm sessions near context limits")
         }
         if (next.includes("{highlight}opencode auth list{/highlight}")) {
-          next = "Run {highlight}agentswarm auth list{/highlight} to see the stored agency-swarm token"
+          next = `Run {highlight}${cmd} auth list{/highlight} to see stored credentials`
         }
         return next
       })

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -20,7 +20,11 @@ import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
 import { Flag } from "@/flag/flag"
 import semver from "semver"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
-import { DialogAgencySwarmConnect, DialogProvider as DialogProviderList } from "@tui/component/dialog-provider"
+import {
+  DialogAgencySwarmConnect,
+  DialogProvider as DialogProviderList,
+  DialogProviderAuth,
+} from "@tui/component/dialog-provider"
 import { ErrorComponent } from "@tui/component/error-component"
 import { PluginRouteMissing } from "@tui/component/plugin-route-missing"
 import { SDKProvider, useSDK } from "@tui/context/sdk"
@@ -442,7 +446,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       (isEmpty, wasEmpty) => {
         // only trigger when we transition into an empty-provider state
         if (!isEmpty || wasEmpty) return
-        dialog.replace(() => <DialogProviderList />)
+        dialog.replace(() => <DialogProviderAuth />)
       },
     ),
   )
@@ -629,8 +633,18 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         name: "connect",
       },
       onSelect: () => {
-        const agency = local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID
-        dialog.replace(() => (agency ? <DialogAgencySwarmConnect /> : <DialogProviderList />))
+        dialog.replace(() => <DialogAgencySwarmConnect />)
+      },
+      category: "Provider",
+    },
+    {
+      title: "Authenticate provider",
+      value: "provider.auth",
+      slash: {
+        name: "auth",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogProviderAuth />)
       },
       category: "Provider",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -153,6 +153,12 @@ export function DialogProvider() {
   return <DialogSelect title="Connect a provider" options={options()} />
 }
 
+export function DialogProviderAuth() {
+  const options = createDialogProviderOptions()
+  const filtered = createMemo(() => options().filter((item) => item.value === "openai"))
+  return <DialogSelect title="Authenticate provider" options={filtered()} />
+}
+
 type Option =
   | {
       kind: "server"


### PR DESCRIPTION
## Summary
- add a dedicated `/auth` command in the TUI command palette
- keep `/connect` focused on Agency Swarm server connectivity only
- wire `/auth` to a provider-auth dialog scoped to OpenAI for fast onboarding
- update product tips to clearly separate `/connect` (server) vs `/auth` (credentials)

## Why
This keeps auth UX aligned with the agreed split:
- `/connect` = Agency Swarm server/token flow
- `/auth` = provider credentials flow

## Validation
- `bun run --cwd packages/opencode format`
- `bun run --cwd packages/opencode typecheck`
- `bun --cwd packages/opencode test test/cli/tui/transcript.test.ts`
- `bun --cwd packages/opencode test test/cli/plugin-auth-picker.test.ts`
