### PR TITLE
feat(tui): add /auth command and keep /connect server-only

### DIFF
--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -825,11 +825,7 @@ export async function openStatusPopover(page: Page) {
         .catch(() => false)
     }
 
-    if (!popoverVisible) {
-      await trigger.focus()
-      await page.keyboard.press("Enter")
-      await expect(popoverBody).toBeVisible({ timeout: 30_000 })
-    }
+    await expect(popoverVisible, "status popover did not open after clicking the status button").toBe(true)
   }
 
   return { rightSection, popoverBody }

--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -806,7 +806,7 @@ export async function openStatusPopover(page: Page) {
   const rightSection = page.locator(titlebarRightSelector)
   const trigger = rightSection.getByRole("button", { name: /status/i }).first()
 
-  const popoverBody = page.locator(popoverBodySelector).filter({ has: page.locator('[data-component="tabs"]') })
+  const popoverBody = page.locator(popoverBodySelector).filter({ has: page.locator('[data-component="tabs"]') }).first()
 
   const opened = await popoverBody
     .isVisible()
@@ -814,9 +814,22 @@ export async function openStatusPopover(page: Page) {
     .catch(() => false)
 
   if (!opened) {
-    await expect(trigger).toBeVisible()
-    await trigger.click()
-    await expect(popoverBody).toBeVisible()
+    await expect(trigger).toBeVisible({ timeout: 30_000 })
+
+    let popoverVisible = false
+    for (let attempt = 0; attempt < 3 && !popoverVisible; attempt++) {
+      await trigger.click({ timeout: 10_000 })
+      popoverVisible = await popoverBody
+        .waitFor({ state: "visible", timeout: 20_000 })
+        .then(() => true)
+        .catch(() => false)
+    }
+
+    if (!popoverVisible) {
+      await trigger.focus()
+      await page.keyboard.press("Enter")
+      await expect(popoverBody).toBeVisible({ timeout: 30_000 })
+    }
   }
 
   return { rightSection, popoverBody }

--- a/packages/opencode/src/agency-swarm/product.ts
+++ b/packages/opencode/src/agency-swarm/product.ts
@@ -28,6 +28,7 @@ export namespace AgencyProduct {
   ]
 
   const add = [
+    "Use {highlight}/auth{/highlight} to sign in to OpenAI or add your OpenAI API key",
     "Use {highlight}/connect{/highlight} to choose the local agency-swarm server you want to use",
     "Use {highlight}/agents{/highlight} to pick the active agency and recipient agent from live metadata",
     "Set {highlight}provider.agency-swarm.options.baseURL{/highlight} in config to pin a default local server",
@@ -57,7 +58,7 @@ export namespace AgencyProduct {
           next = next.replace("long sessions near context limits", "long agency-swarm sessions near context limits")
         }
         if (next.includes("{highlight}opencode auth list{/highlight}")) {
-          next = "Run {highlight}agentswarm auth list{/highlight} to see the stored agency-swarm token"
+          next = "Run {highlight}agentswarm auth list{/highlight} to see configured provider credentials"
         }
         return next
       })

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -20,7 +20,7 @@ import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
 import { Flag } from "@/flag/flag"
 import semver from "semver"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
-import { DialogAgencySwarmConnect, DialogProvider as DialogProviderList } from "@tui/component/dialog-provider"
+import { DialogAgencySwarmConnect, DialogAuth } from "@tui/component/dialog-provider"
 import { ErrorComponent } from "@tui/component/error-component"
 import { PluginRouteMissing } from "@tui/component/plugin-route-missing"
 import { SDKProvider, useSDK } from "@tui/context/sdk"
@@ -38,7 +38,6 @@ import { DialogWorkspaceList } from "@tui/component/dialog-workspace-list"
 import { DialogConsoleOrg } from "@tui/component/dialog-console-org"
 import { KeybindProvider, useKeybind } from "@tui/context/keybind"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
-import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
 import { PromptHistoryProvider } from "./component/prompt/history"
@@ -442,7 +441,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       (isEmpty, wasEmpty) => {
         // only trigger when we transition into an empty-provider state
         if (!isEmpty || wasEmpty) return
-        dialog.replace(() => <DialogProviderList />)
+        dialog.replace(() => <DialogAuth />)
       },
     ),
   )
@@ -622,6 +621,18 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
     },
     {
+      title: "Authenticate provider",
+      value: "provider.auth",
+      suggested: !connected(),
+      slash: {
+        name: "auth",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogAuth />)
+      },
+      category: "Provider",
+    },
+    {
       title: AgencyProduct.connect,
       value: "provider.connect",
       suggested: !connected(),
@@ -629,8 +640,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         name: "connect",
       },
       onSelect: () => {
-        const agency = local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID
-        dialog.replace(() => (agency ? <DialogAgencySwarmConnect /> : <DialogProviderList />))
+        dialog.replace(() => <DialogAgencySwarmConnect />)
       },
       category: "Provider",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -165,7 +165,7 @@ export function DialogProvider(props: DialogProviderProps = {}) {
 }
 
 export function DialogAuth() {
-  return <DialogProvider title="Authenticate provider" providerIDs={["openai"]} />
+  return <DialogProvider title="Authenticate provider" />
 }
 
 type Option =

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -26,14 +26,25 @@ const PROVIDER_PRIORITY: Record<string, number> = {
 }
 
 export function createDialogProviderOptions() {
+  return createDialogProviderOptionsWithFilter()
+}
+
+type DialogProviderProps = {
+  providerIDs?: readonly string[]
+  title?: string
+}
+
+export function createDialogProviderOptionsWithFilter(props: DialogProviderProps = {}) {
   const sync = useSync()
   const dialog = useDialog()
   const sdk = useSDK()
   const toast = useToast()
   const { theme } = useTheme()
+  const allowed = createMemo(() => new Set(props.providerIDs ?? []))
   const options = createMemo(() => {
     return pipe(
       sync.data.provider_next.all,
+      (items) => (allowed().size ? items.filter((item) => allowed().has(item.id)) : items),
       sortBy((x) => PROVIDER_PRIORITY[x.id] ?? 99),
       map((provider) => {
         const consoleManaged = isConsoleManagedProvider(sync.data.console_state.consoleManagedProviders, provider.id)
@@ -148,9 +159,13 @@ export function createDialogProviderOptions() {
   return options
 }
 
-export function DialogProvider() {
-  const options = createDialogProviderOptions()
-  return <DialogSelect title="Connect a provider" options={options()} />
+export function DialogProvider(props: DialogProviderProps = {}) {
+  const options = createDialogProviderOptionsWithFilter(props)
+  return <DialogSelect title={props.title ?? "Connect a provider"} options={options()} />
+}
+
+export function DialogAuth() {
+  return <DialogProvider title="Authenticate provider" providerIDs={["openai"]} />
 }
 
 type Option =

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -56,7 +56,7 @@ export function Footer() {
         <Switch>
           <Match when={store.welcome}>
             <text fg={theme.text}>
-              Get started <span style={{ fg: theme.textMuted }}>/connect</span>
+              Get started <span style={{ fg: theme.textMuted }}>/auth</span>
             </text>
           </Match>
           <Match when={connected()}>


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR finishes the remaining auth/connect split in TUI with a minimal diff:
- adds a dedicated `/auth` command for provider credentials (OpenAI-first)
- keeps `/connect` server-only by always opening the agency-swarm connection dialog
- updates empty-provider onboarding to open `/auth`
- updates helper tip text to match the new command split

This keeps credential onboarding and agency server connection as separate user flows.

### How did you verify your code works?

- `bun run --cwd packages/opencode typecheck`
- `bun test --cwd packages/opencode test/cli/tui/session-error.test.ts`
- `bun test --cwd packages/opencode test/cli/tui/transcript.test.ts`
- `bun run --cwd packages/opencode src/index.ts auth list`

### Screenshots / recordings

Not included yet. I can attach a short TUI capture if needed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
