### PR TITLE
fix: add TUI auth logout flow

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -620,11 +620,12 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
     },
     {
-      title: "Authenticate provider",
+      title: "Manage provider auth",
       value: "provider.auth",
       suggested: !connected(),
       slash: {
         name: "auth",
+        aliases: ["logout"],
       },
       onSelect: () => {
         dialog.replace(() => <DialogAuth />)

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -164,8 +164,72 @@ export function DialogProvider(props: DialogProviderProps = {}) {
   return <DialogSelect title={props.title ?? "Connect a provider"} options={options()} />
 }
 
+function DialogRemoveCredential() {
+  const sync = useSync()
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const toast = useToast()
+  const options = createMemo(() =>
+    pipe(
+      sync.data.provider_next.all,
+      (items) =>
+        items.filter((provider) => {
+          if (provider.id === AgencySwarmAdapter.PROVIDER_ID) return false
+          if (!sync.data.provider_next.connected.includes(provider.id)) return false
+          if (isConsoleManagedProvider(sync.data.console_state.consoleManagedProviders, provider.id)) return false
+          return true
+        }),
+      sortBy((provider) => PROVIDER_PRIORITY[provider.id] ?? 99),
+      map((provider) => ({
+        title: provider.name,
+        value: provider.id,
+        onSelect: async () => {
+          await sdk.client.auth.remove({
+            providerID: provider.id,
+          })
+          await sdk.client.instance.dispose()
+          await sync.bootstrap()
+          toast.show({
+            variant: "success",
+            message: `${provider.name} credential removed`,
+            duration: 3000,
+          })
+          dialog.replace(() => <DialogAuth />)
+        },
+      })),
+    ),
+  )
+  return <DialogSelect title="Remove credential" options={options()} />
+}
+
 export function DialogAuth() {
-  return <DialogProvider title="Authenticate provider" />
+  const dialog = useDialog()
+  const sync = useSync()
+  const providerOptions = createDialogProviderOptions()
+  const options = createMemo<DialogSelectOption<string>[]>(() => {
+    const removable = sync.data.provider_next.all.filter((provider) => {
+      if (provider.id === AgencySwarmAdapter.PROVIDER_ID) return false
+      if (!sync.data.provider_next.connected.includes(provider.id)) return false
+      if (isConsoleManagedProvider(sync.data.console_state.consoleManagedProviders, provider.id)) return false
+      return true
+    })
+    if (removable.length === 0) return providerOptions()
+
+    return [
+      {
+        title: "Remove credential",
+        value: "__remove__",
+        description: "Delete a stored provider credential",
+        category: "Manage",
+        onSelect: () => {
+          dialog.replace(() => <DialogRemoveCredential />)
+        },
+      },
+      ...providerOptions(),
+    ]
+  })
+
+  return <DialogSelect title="Manage provider auth" options={options()} />
 }
 
 type Option =


### PR DESCRIPTION
### Issue for this PR

Closes #32

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds the missing TUI path for deleting stored provider credentials without adding any new auth backend logic.

The `/auth` dialog now has a `Remove credential` action when at least one removable provider credential exists. That action calls the existing `auth.remove` API, refreshes sync state, and returns to the auth dialog.

I also renamed the command-palette item from `Authenticate provider` to `Manage provider auth` and added `logout` as a slash alias so the command is easier to find.

### How did you verify your code works?

- ran `bun run --cwd packages/opencode typecheck`
- drove the real TUI in a clean temp home
- confirmed `Remove credential` appears in `/auth`
- removed an `OpenAI` credential through the TUI
- confirmed `auth.json` became `{}` and `auth list` returned `0 credentials`

### Screenshots / recordings

- none

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
