### PR TITLE
fix(opencode): align Agent Swarm TUI with local builder mode

### DIFF
--- a/.github/workflows/nix-eval.yml
+++ b/.github/workflows/nix-eval.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   nix-eval:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-duplicates:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   typecheck:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/packages/app/e2e/session/session-model-persistence.spec.ts
+++ b/packages/app/e2e/session/session-model-persistence.spec.ts
@@ -324,7 +324,11 @@ test("session model restore across workspaces", async ({ page, project }) => {
   const twoDir = await newWorkspaceSession(page, two.slug)
   project.trackDirectory(twoDir)
 
-  const thirdState = await chooseOtherModel(page, [firstKey, secondKey])
+  const thirdKey = await currentModel(page)
+  const thirdState =
+    thirdKey !== firstKey && thirdKey !== secondKey
+      ? await read(page)
+      : await chooseOtherModel(page, [firstKey, secondKey])
   const third = await submit(project, `workspace two ${Date.now()}`)
 
   await goto(page, root, first)

--- a/packages/opencode/src/agency-swarm/history.ts
+++ b/packages/opencode/src/agency-swarm/history.ts
@@ -1,4 +1,6 @@
 import { Storage } from "@/storage/storage"
+import { Global } from "@/global"
+import path from "path"
 import { AgencySwarmAdapter } from "./adapter"
 
 export namespace AgencySwarmHistory {
@@ -18,22 +20,19 @@ export namespace AgencySwarmHistory {
   export async function load(scope: Scope): Promise<Entry> {
     const key = storageKey(scope)
     const expectedScope = scopeKey(scope)
+    const current = normalize(
+      await Storage.read<Entry>(key).catch((error) => {
+        if (Storage.NotFoundError.isInstance(error)) return undefined
+        throw error
+      }),
+      expectedScope,
+    )
+    if (current) return current
 
-    const existing = await Storage.read<Entry>(key).catch((error) => {
-      if (Storage.NotFoundError.isInstance(error)) return undefined
-      throw error
-    })
-
-    if (!existing || existing.scope !== expectedScope) {
-      return empty(expectedScope)
-    }
-
-    return {
-      scope: existing.scope,
-      chat_history: asHistory(existing.chat_history),
-      last_run_id: typeof existing.last_run_id === "string" && existing.last_run_id ? existing.last_run_id : undefined,
-      updated_at: typeof existing.updated_at === "number" ? existing.updated_at : Date.now(),
-    }
+    const legacy = normalize(await loadLegacy(scope), expectedScope)
+    if (!legacy) return empty(expectedScope)
+    await save(scope, legacy)
+    return legacy
   }
 
   export async function appendMessages(scope: Scope, newMessages: unknown): Promise<Entry> {
@@ -84,5 +83,27 @@ export namespace AgencySwarmHistory {
   function asHistory(input: unknown): Array<Record<string, unknown>> {
     if (!Array.isArray(input)) return []
     return input.filter((item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item))
+  }
+
+  async function loadLegacy(scope: Scope): Promise<Entry | undefined> {
+    const file = legacyFile(scope)
+    const existing = await Bun.file(file)
+      .json()
+      .catch(() => undefined)
+    return existing as Entry | undefined
+  }
+
+  function legacyFile(scope: Scope) {
+    return path.join(path.dirname(Global.Path.data), "opencode", "storage", ...storageKey(scope)) + ".json"
+  }
+
+  function normalize(existing: Entry | undefined, expectedScope: string): Entry | undefined {
+    if (!existing || existing.scope !== expectedScope) return
+    return {
+      scope: existing.scope,
+      chat_history: asHistory(existing.chat_history),
+      last_run_id: typeof existing.last_run_id === "string" && existing.last_run_id ? existing.last_run_id : undefined,
+      updated_at: typeof existing.updated_at === "number" ? existing.updated_at : Date.now(),
+    }
   }
 }

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -20,7 +20,7 @@ export interface PreparedNpxLaunch {
   cleanup?: () => Promise<void>
 }
 
-interface AgencyProject {
+export interface AgencyProject {
   directory: string
   agencyFile: string
 }
@@ -345,19 +345,15 @@ async function createStarterProject(input: {
   }
 }
 
-async function prepareProjectLaunch(project: AgencyProject): Promise<PreparedNpxLaunch> {
-  prompts.log.info("3. Prepare Python and the local server.")
-  prompts.log.info("   The launcher will reuse a project `.venv` when it exists, otherwise it will create one.")
+export async function prepareProjectLaunch(project: AgencyProject): Promise<PreparedNpxLaunch> {
+  prompts.log.info("3. Prepare Python for Agent Builder.")
+  prompts.log.info(
+    "   The launcher will reuse a project `.venv` when it exists, otherwise it will create one before opening the local builder.",
+  )
 
-  const python = await ensureProjectPython(project.directory)
-  const server = await startProjectServer(project.directory, python)
+  await ensureProjectPython(project.directory)
   return {
     directory: project.directory,
-    configContent: buildAgencyConfig({
-      baseURL: server.baseURL,
-      agency: LOCAL_AGENCY_ID,
-    }),
-    cleanup: server.cleanup,
   }
 }
 

--- a/packages/opencode/src/agent/display.ts
+++ b/packages/opencode/src/agent/display.ts
@@ -1,0 +1,6 @@
+import { Locale } from "@/util/locale"
+
+export function displayAgentName(name: string) {
+  if (name === "build") return "Agent Builder"
+  return Locale.titlecase(name)
+}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -1,4 +1,5 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { displayAgentName } from "@/agent/display"
 import { useLocal } from "@tui/context/local"
 import { useSDK } from "@tui/context/sdk"
 import { useSync } from "@tui/context/sync"
@@ -102,7 +103,7 @@ export function DialogAgent() {
             kind: "local",
             agent: item.name,
           } as AgentOptionValue,
-          title: item.name,
+          title: displayAgentName(item.name),
           description: item.native ? "native" : item.description,
         }
       })

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -7,6 +7,7 @@ import { useSDK } from "../context/sdk"
 import { DialogPrompt } from "../ui/dialog-prompt"
 import { Link } from "../ui/link"
 import { useTheme } from "../context/theme"
+import { useLocal } from "@tui/context/local"
 import { TextAttributes } from "@opentui/core"
 import type { ProviderAuthAuthorization, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
 import { DialogModel } from "./dialog-model"
@@ -594,6 +595,7 @@ function AutoMethod(props: AutoMethodProps) {
   const sdk = useSDK()
   const dialog = useDialog()
   const sync = useSync()
+  const local = useLocal()
   const toast = useToast()
 
   useKeyboard((evt) => {
@@ -616,6 +618,10 @@ function AutoMethod(props: AutoMethodProps) {
     }
     await sdk.client.instance.dispose()
     await sync.bootstrap()
+    if (local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID) {
+      dialog.clear()
+      return
+    }
     dialog.replace(() => <DialogModel providerID={props.providerID} />)
   })
 
@@ -652,6 +658,7 @@ function CodeMethod(props: CodeMethodProps) {
   const sdk = useSDK()
   const sync = useSync()
   const dialog = useDialog()
+  const local = useLocal()
   const [error, setError] = createSignal(false)
 
   return (
@@ -667,6 +674,10 @@ function CodeMethod(props: CodeMethodProps) {
         if (!error) {
           await sdk.client.instance.dispose()
           await sync.bootstrap()
+          if (local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID) {
+            dialog.clear()
+            return
+          }
           dialog.replace(() => <DialogModel providerID={props.providerID} />)
           return
         }
@@ -694,6 +705,7 @@ function ApiMethod(props: ApiMethodProps) {
   const dialog = useDialog()
   const sdk = useSDK()
   const sync = useSync()
+  const local = useLocal()
   const { theme } = useTheme()
 
   return (
@@ -738,6 +750,10 @@ function ApiMethod(props: ApiMethodProps) {
         })
         await sdk.client.instance.dispose()
         await sync.bootstrap()
+        if (local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID) {
+          dialog.clear()
+          return
+        }
         dialog.replace(() => <DialogModel providerID={props.providerID} />)
       }}
     />

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
@@ -115,11 +115,7 @@ function DialogWorkspaceCreate(props: { onSelect: (workspaceID: string) => Promi
     if (creating()) return
     setCreating(type)
 
-    const result = await sdk.client.experimental.workspace.create({ type, branch: null }).catch((err) => {
-      console.log(err)
-      return undefined
-    })
-    console.log(JSON.stringify(result, null, 2))
+    const result = await sdk.client.experimental.workspace.create({ type, branch: null }).catch(() => undefined)
     const workspace = result?.data
     if (!workspace) {
       setCreating(undefined)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -11,6 +11,7 @@ import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { MessageID, PartID } from "@/session/schema"
+import { displayAgentName } from "@/agent/display"
 import { createStore, produce } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
 import { usePromptHistory, type PromptInfo } from "./history"
@@ -618,10 +619,8 @@ export function Prompt(props: PromptProps) {
       })
 
       if (res.error) {
-        console.log("Creating a session failed:", res.error)
-
         toast.show({
-          message: "Creating a session failed. Open console for more details.",
+          message: "Creating a session failed.",
           variant: "error",
         })
 
@@ -1102,7 +1101,7 @@ export function Prompt(props: PromptProps) {
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1} justifyContent="space-between">
               <box flexDirection="row" gap={1}>
                 <text fg={highlight()}>
-                  {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
+                  {store.mode === "shell" ? "Shell" : displayAgentName(local.agent.current().name)}{" "}
                 </text>
                 <Show when={store.mode === "normal"}>
                   <box flexDirection="row" gap={1}>

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -359,7 +359,6 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const args = useArgs()
 
     async function bootstrap() {
-      console.log("bootstrapping")
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
         .list({ start: start })

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -49,7 +49,7 @@ export function Tips() {
 const TIPS = AgencyProduct.tips([
   "Type {highlight}@{/highlight} followed by a filename to fuzzy search and attach files",
   "Start a message with {highlight}!{/highlight} to run shell commands directly (e.g., {highlight}!ls -la{/highlight})",
-  "Press {highlight}Tab{/highlight} to cycle between Build and Plan agents",
+  "Press {highlight}Tab{/highlight} to cycle between Agent Builder and Plan agents",
   "Use {highlight}/undo{/highlight} to revert the last message and file changes",
   "Use {highlight}/redo{/highlight} to restore previously undone messages and file changes",
   "Run {highlight}/share{/highlight} to create a public link to your conversation at opencode.ai",

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -105,7 +105,6 @@ export namespace Clipboard {
     const os = platform()
 
     if (os === "darwin" && which("osascript")) {
-      console.log("clipboard: using osascript")
       return async (text: string) => {
         const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
         await Process.run(["osascript", "-e", `set the clipboard to "${escaped}"`], { nothrow: true })
@@ -114,7 +113,6 @@ export namespace Clipboard {
 
     if (os === "linux") {
       if (process.env["WAYLAND_DISPLAY"] && which("wl-copy")) {
-        console.log("clipboard: using wl-copy")
         return async (text: string) => {
           const proc = Process.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
           if (!proc.stdin) return
@@ -124,7 +122,6 @@ export namespace Clipboard {
         }
       }
       if (which("xclip")) {
-        console.log("clipboard: using xclip")
         return async (text: string) => {
           const proc = Process.spawn(["xclip", "-selection", "clipboard"], {
             stdin: "pipe",
@@ -138,7 +135,6 @@ export namespace Clipboard {
         }
       }
       if (which("xsel")) {
-        console.log("clipboard: using xsel")
         return async (text: string) => {
           const proc = Process.spawn(["xsel", "--clipboard", "--input"], {
             stdin: "pipe",
@@ -154,7 +150,6 @@ export namespace Clipboard {
     }
 
     if (os === "win32") {
-      console.log("clipboard: using powershell")
       return async (text: string) => {
         // Pipe via stdin to avoid PowerShell string interpolation ($env:FOO, $(), etc.)
         const proc = Process.spawn(
@@ -179,7 +174,6 @@ export namespace Clipboard {
       }
     }
 
-    console.log("clipboard: no native support")
     return async (text: string) => {
       await clipboardy.write(text).catch(() => {})
     }

--- a/packages/opencode/src/cli/cmd/tui/util/transcript.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/transcript.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage, Part, Provider, UserMessage } from "@opencode-ai/sdk/v2"
+import { displayAgentName } from "@/agent/display"
 import { Locale } from "@/util/locale"
 import * as Model from "./model"
 
@@ -78,7 +79,7 @@ export function formatAssistantHeader(
 
   const modelName = Model.name(providers, msg.providerID, msg.modelID)
 
-  return `## Assistant (${Locale.titlecase(msg.agent)} · ${modelName}${duration ? ` · ${duration}` : ""})\n\n`
+  return `## Assistant (${displayAgentName(msg.agent)} · ${modelName}${duration ? ` · ${duration}` : ""})\n\n`
 }
 
 export function formatPart(part: Part, options: TranscriptOptions): string {

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -99,7 +99,7 @@ export function buildOutgoingMessage(message: MessageV2.WithParts): string {
   const textParts = message.parts
     .filter((part): part is MessageV2.TextPart => part.type === "text")
     .filter((part) => !part.ignored)
-    .map((part) => part.text.trim())
+    .map((part) => visibleOutgoingText(part))
     .filter(Boolean)
 
   if (textParts.length === 0) {
@@ -107,6 +107,18 @@ export function buildOutgoingMessage(message: MessageV2.WithParts): string {
   }
 
   return textParts.join("\n\n")
+}
+
+function visibleOutgoingText(part: MessageV2.TextPart): string {
+  if (!part.synthetic) return part.text.trim()
+
+  const text = part.text.trimStart()
+  if (!text.startsWith("<system-reminder>")) return text.trim()
+
+  const end = text.indexOf("</system-reminder>")
+  if (end === -1) return ""
+
+  return text.slice(end + "</system-reminder>".length).trim()
 }
 
 export function findRecipientAgent(message: MessageV2.WithParts): string | undefined {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1033,12 +1033,16 @@ export namespace SessionAgencySwarm {
         if (!callID) return []
         const toolName = normalizeToolName(itemType, rawItem)
         const itemID = asString(rawItem["id"])
+        const rawInput = toolRawInput(itemType, rawItem)
+        const knownRaw = tools.get(callID)?.raw ?? ""
         if (itemID) callByItem.set(itemID, callID)
         return [
-          ...ensureToolInput(callID, toolName, toolRawInput(itemType, rawItem), eventMeta, {
-            item_id: itemID,
-            source: "run_item_stream_event",
-          }),
+          ...(rawInput && rawInput !== knownRaw
+            ? ensureToolInput(callID, toolName, rawInput, eventMeta, {
+                item_id: itemID,
+                source: "run_item_stream_event",
+              })
+            : []),
           ...runTool(callID, toolName, eventMeta, {
             item_id: itemID,
             source: "run_item_stream_event",

--- a/packages/opencode/src/session/agent-builder.ts
+++ b/packages/opencode/src/session/agent-builder.ts
@@ -1,0 +1,8 @@
+import PROMPT_AGENT_BUILDER from "./prompt/agent-builder.txt"
+import { SessionAgencySwarm } from "./agency-swarm"
+
+export function agentBuilderInstructions(agent: string, providerID: string) {
+  if (agent !== "build") return []
+  if (providerID === SessionAgencySwarm.PROVIDER_ID) return []
+  return [PROMPT_AGENT_BUILDER]
+}

--- a/packages/opencode/src/session/agent-planner.ts
+++ b/packages/opencode/src/session/agent-planner.ts
@@ -1,0 +1,9 @@
+import PROMPT_AGENT_PLANNER from "./prompt/agent-planner.txt"
+import { SessionAgencySwarm } from "./agency-swarm"
+
+export function agentPlannerInstructions(agent: string, providerID: string, enabled = true) {
+  if (!enabled) return []
+  if (agent !== "plan") return []
+  if (providerID === SessionAgencySwarm.PROVIDER_ID) return []
+  return [PROMPT_AGENT_PLANNER]
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -51,6 +51,7 @@ import { Cause, Effect, Exit, Layer, Option, Scope, ServiceMap } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { SessionAgencySwarm } from "./agency-swarm"
+import { agentBuilderInstructions } from "./agent-builder"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1545,7 +1546,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   instruction.system().pipe(Effect.orDie),
                   Effect.promise(() => MessageV2.toModelMessages(msgs, model)),
                 ])
-                const system = [...env, ...(skills ? [skills] : []), ...instructions]
+                const system = [
+                  ...env,
+                  ...(skills ? [skills] : []),
+                  ...instructions,
+                  ...agentBuilderInstructions(lastUser.agent, model.providerID),
+                ]
                 const format = lastUser.format ?? { type: "text" as const }
                 if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
                 const result = yield* handle.process({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -52,6 +52,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { SessionAgencySwarm } from "./agency-swarm"
 import { agentBuilderInstructions } from "./agent-builder"
+import { agentPlannerInstructions } from "./agent-planner"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1550,6 +1551,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   ...env,
                   ...(skills ? [skills] : []),
                   ...instructions,
+                  ...agentPlannerInstructions(lastUser.agent, model.providerID, Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE),
                   ...agentBuilderInstructions(lastUser.agent, model.providerID),
                 ]
                 const format = lastUser.format ?? { type: "text" as const }

--- a/packages/opencode/src/session/prompt/agent-builder.txt
+++ b/packages/opencode/src/session/prompt/agent-builder.txt
@@ -1,5 +1,6 @@
 Apply these additional instructions when working as the local Agent Builder for an Agency Swarm project.
-They are copied and condensed from the Agency Swarm starter-template workflow so the default local editing path follows the same structure.
+Use the Agency Swarm starter template as the reference for project structure and the agent-creation workflow:
+https://github.com/agency-ai-solutions/agency-starter-template
 
 # Agent Swarm Agent Creator Instructions
 

--- a/packages/opencode/src/session/prompt/agent-builder.txt
+++ b/packages/opencode/src/session/prompt/agent-builder.txt
@@ -2,25 +2,26 @@ Apply these additional instructions when working as the local Agent Builder for 
 Use the Agency Swarm starter template as the reference for project structure and the agent-creation workflow:
 https://github.com/agency-ai-solutions/agency-starter-template
 
-# Agent Swarm Agent Creator Instructions
+# Agent Swarm Agent Builder Instructions
 
 Agency Swarm is built on the OpenAI Agents SDK. Your job in Agent Builder mode is to create or improve an Agency Swarm project in the actual file system, not to describe hypothetical steps.
 
 ## Workflow
 
 0. Create a todo list for the work before you start coding.
-1. Activate a virtual environment if one exists. If it does not exist, create one and install the project requirements.
-2. Explore the project before changing it.
-3. Create or update agent folders and templates in the expected structure.
-4. Build robust tools in the correct agent tool folders.
-5. Create or update agent classes and their instructions.
-6. Create or update the main agency wiring and shared instructions.
-7. Test the tools and the agency, then iterate until the result works.
+1. If the latest system reminder or handoff mentions an approved session plan file, read it before you change code and treat it as the source of truth.
+2. Activate a virtual environment if one exists. If it does not exist, create one and install the project requirements.
+3. Explore the project before changing it.
+4. Create or update agent folders and templates in the expected structure.
+5. Build robust tools in the correct agent tool folders.
+6. Create or update agent classes and their instructions.
+7. Create or update the main agency wiring and shared instructions.
+8. Test the tools and the agency, then iterate until the result works.
 
 ## Project Exploration
 
 - Check the project root structure first.
-- Look for `prd.txt` and read it fully if it exists.
+- When an approved session plan file is provided, read it first.
 - Review `agency.py`, `shared_instructions.md`, agent `instructions.md` files, and agent tool folders.
 - Remove example agents if they are still present and clean the example wiring out of `agency.py`.
 - If the task needs external systems such as Slack or Notion, verify the needed API keys exist in `.env` before proceeding.

--- a/packages/opencode/src/session/prompt/agent-builder.txt
+++ b/packages/opencode/src/session/prompt/agent-builder.txt
@@ -1,0 +1,71 @@
+Apply these additional instructions when working as the local Agent Builder for an Agency Swarm project.
+They are copied and condensed from the Agency Swarm starter-template workflow so the default local editing path follows the same structure.
+
+# Agent Swarm Agent Creator Instructions
+
+Agency Swarm is built on the OpenAI Agents SDK. Your job in Agent Builder mode is to create or improve an Agency Swarm project in the actual file system, not to describe hypothetical steps.
+
+## Workflow
+
+0. Create a todo list for the work before you start coding.
+1. Activate a virtual environment if one exists. If it does not exist, create one and install the project requirements.
+2. Explore the project before changing it.
+3. Create or update agent folders and templates in the expected structure.
+4. Build robust tools in the correct agent tool folders.
+5. Create or update agent classes and their instructions.
+6. Create or update the main agency wiring and shared instructions.
+7. Test the tools and the agency, then iterate until the result works.
+
+## Project Exploration
+
+- Check the project root structure first.
+- Look for `prd.txt` and read it fully if it exists.
+- Review `agency.py`, `shared_instructions.md`, agent `instructions.md` files, and agent tool folders.
+- Remove example agents if they are still present and clean the example wiring out of `agency.py`.
+- If the task needs external systems such as Slack or Notion, verify the needed API keys exist in `.env` before proceeding.
+- If requirements are missing or unclear, ask focused clarifying questions before coding.
+
+## Folder Structure
+
+- Use lowercase snake_case names for agency and agent folders.
+- Each agent folder should contain:
+  - `__init__.py`
+  - the main agent file
+  - `instructions.md`
+  - `files/`
+  - `tools/`
+- Put each tool in its own file under that agent's `tools/` folder.
+- Add all new dependencies to `requirements.txt`.
+- `agency.py` is the main wiring file where agents and communication flows are defined.
+- Ensure `.env` contains placeholders for `OPENAI_API_KEY` and any other required credentials.
+
+## Agent Creation
+
+- Prefer realistic job-style agent roles such as `Data Analyst` or `Campaign Manager`, not narrow task labels like `Email Sender`.
+- Start with the fewest agents possible. Use one agent unless more are clearly needed.
+- Prefer the CLI template flow when creating new agents:
+  `agency-swarm create-agent-template --description "Description of the agent" --model "gpt-5.2" --reasoning "medium" "agent_name"`
+- Use `gpt-5.2` with medium reasoning by default unless the user asks for something else.
+
+## Tool Creation
+
+- Tools must be production-ready. Do not leave mocks, placeholders, or sample snippets in real project files.
+- Tools should be standalone, configurable, and composable.
+- MCP servers, built-in tools, and custom tools are all valid when they fit the task.
+- Load environment variables where needed and make the final code runnable by the user immediately.
+- Use Agency context for shared state when it helps tools and agents share data cleanly.
+
+## Instructions and Agency Wiring
+
+- Write agent instructions with a clear role, goals, process, output format, and important notes.
+- Import the agents into `agency.py`.
+- Define the communication flows explicitly in `agency.py`.
+- Keep `shared_instructions.md` aligned with how the agents should collaborate.
+
+## Testing and Delivery
+
+- Install dependencies before testing.
+- Run the tool files you create or modify.
+- Test the agency end to end.
+- Do not hand off until the agency behaves consistently and the files are actually updated.
+- Never respond with file snippets instead of making the real file changes.

--- a/packages/opencode/src/session/prompt/agent-builder.txt
+++ b/packages/opencode/src/session/prompt/agent-builder.txt
@@ -44,8 +44,8 @@ Agency Swarm is built on the OpenAI Agents SDK. Your job in Agent Builder mode i
 - Prefer realistic job-style agent roles such as `Data Analyst` or `Campaign Manager`, not narrow task labels like `Email Sender`.
 - Start with the fewest agents possible. Use one agent unless more are clearly needed.
 - Prefer the CLI template flow when creating new agents:
-  `agency-swarm create-agent-template --description "Description of the agent" --model "gpt-5.2" --reasoning "medium" "agent_name"`
-- Use `gpt-5.2` with medium reasoning by default unless the user asks for something else.
+  `agency-swarm create-agent-template --description "Description of the agent" --model "gpt-5.4-mini" --reasoning "medium" "agent_name"`
+- Use `gpt-5.4-mini` with medium reasoning by default unless the user asks for something else.
 
 ## Tool Creation
 

--- a/packages/opencode/src/session/prompt/agent-planner.txt
+++ b/packages/opencode/src/session/prompt/agent-planner.txt
@@ -1,0 +1,38 @@
+Apply these additional instructions when working as the local Plan agent for an Agency Swarm project.
+Use the Agency Swarm starter template as the reference for project structure and the agent-creation workflow:
+https://github.com/agency-ai-solutions/agency-starter-template
+
+# Agent Swarm Planner Instructions
+
+The native session plan file for this conversation is the implementation brief for the next Agent Builder turn. Write and refine that file so Agent Builder can execute directly from it after approval.
+
+## Workflow
+
+0. Create a todo list for the planning work.
+1. Explore the project before you commit to a design.
+2. Prefer the smallest viable agent roster.
+3. Prefer MCP servers over custom tools when they fit the task.
+4. Ask focused questions when requirements, integrations, or constraints are still unclear.
+5. Keep updating the session plan file until it is concrete enough to implement without guesswork.
+
+## Plan File Requirements
+
+Write the session plan file as a concise implementation brief with these sections:
+
+- Goal and scope
+- Agency name and entry agent
+- Agent roster and responsibilities
+- Communication flows
+- Tool and MCP mapping
+- Dependencies and required env keys
+- File-by-file implementation order
+- Verification plan
+- Agent Builder handoff notes
+
+## Planning Rules
+
+- Treat the session plan file as the source of truth for the next Agent Builder turn.
+- Stay on the native session plan file. Do not create separate planning artifacts unless the user explicitly asks.
+- Reuse existing project files and starter-template patterns when they help.
+- Make the plan concrete enough that Agent Builder can edit files immediately after approval.
+- If the repo still contains example agents or placeholder wiring, call out the cleanup explicitly in the plan.

--- a/packages/opencode/src/tool/plan-exit.txt
+++ b/packages/opencode/src/tool/plan-exit.txt
@@ -1,6 +1,6 @@
 Use this tool when you have completed the planning phase and are ready to exit plan agent.
 
-This tool will ask the user if they want to switch to build agent to start implementing the plan.
+This tool will ask the user if they want to switch to Agent Builder to start implementing the plan.
 
 Call this tool:
 - After you have written a complete plan to the plan file

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -6,6 +6,7 @@ import { Session } from "../session"
 import { MessageV2 } from "../session/message-v2"
 import { Provider } from "../provider/provider"
 import { Instance } from "../project/instance"
+import { displayAgentName } from "@/agent/display"
 import { type SessionID, MessageID, PartID } from "../session/schema"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 
@@ -27,10 +28,10 @@ export const PlanExitTool = Tool.define("plan_exit", {
       questions: [
         {
           question: `Plan at ${plan} is complete. Would you like to switch to the build agent and start implementing?`,
-          header: "Build Agent",
+          header: displayAgentName("build"),
           custom: false,
           options: [
-            { label: "Yes", description: "Switch to build agent and start implementing the plan" },
+            { label: "Yes", description: `Switch to ${displayAgentName("build")} and start implementing the plan` },
             { label: "No", description: "Stay with plan agent to continue refining the plan" },
           ],
         },
@@ -64,8 +65,8 @@ export const PlanExitTool = Tool.define("plan_exit", {
     } satisfies MessageV2.TextPart)
 
     return {
-      title: "Switching to build agent",
-      output: "User approved switching to build agent. Wait for further instructions.",
+      title: `Switching to ${displayAgentName("build")}`,
+      output: `User approved switching to ${displayAgentName("build")}. Wait for further instructions.`,
       metadata: {},
     }
   },

--- a/packages/opencode/test/agency-swarm/history.test.ts
+++ b/packages/opencode/test/agency-swarm/history.test.ts
@@ -1,76 +1,57 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, expect, test } from "bun:test"
 import { AgencySwarmHistory } from "../../src/agency-swarm/history"
-import { Instance } from "../../src/project/instance"
-import { tmpdir } from "../fixture/fixture"
+import { Storage } from "../../src/storage/storage"
 
-describe("agency-swarm.history", () => {
-  test("stores and resumes chat history for the same baseURL/agency/session key", async () => {
-    await using tmp = await tmpdir({ config: {} })
+const originalRead = Storage.read
+const originalWrite = Storage.write
+const originalFile = Bun.file
 
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const scope = {
-          baseURL: "http://127.0.0.1:8000",
-          agency: "builder",
-          sessionID: "sess_1",
-        }
+afterEach(() => {
+  Storage.read = originalRead
+  Storage.write = originalWrite
+  Bun.file = originalFile
+})
 
-        await AgencySwarmHistory.appendMessages(scope, [{ type: "message", id: "msg_1" }])
-        const loaded = await AgencySwarmHistory.load(scope)
+test("load falls back to legacy opencode storage and migrates entry", async () => {
+  const scope = {
+    baseURL: "http://127.0.0.1:8000",
+    agency: "builder",
+    sessionID: "session_1",
+  }
+  const scopedKey = AgencySwarmHistory.scopeKey(scope)
+  const hash = Bun.hash.xxHash32(scopedKey).toString(16).padStart(8, "0")
+  const writes: Array<{ key: string[]; content: unknown }> = []
 
-        expect(loaded.chat_history).toEqual([{ type: "message", id: "msg_1" }])
-      },
-    })
+  Storage.read = (async () => {
+    throw new Storage.NotFoundError({ message: "missing" })
+  }) as typeof Storage.read
+  Storage.write = (async (key, content) => {
+    writes.push({ key, content })
+  }) as typeof Storage.write
+  Bun.file = ((file: string) => ({
+    json: async () => {
+      expect(file.endsWith(`/opencode/storage/agency_swarm_history/${hash}.json`)).toBeTrue()
+      return {
+        scope: scopedKey,
+        chat_history: [{ type: "message", role: "assistant" }],
+        last_run_id: "run_1",
+        updated_at: 123,
+      }
+    },
+  })) as typeof Bun.file
+
+  const entry = await AgencySwarmHistory.load(scope)
+
+  expect(entry).toEqual({
+    scope: scopedKey,
+    chat_history: [{ type: "message", role: "assistant" }],
+    last_run_id: "run_1",
+    updated_at: 123,
   })
-
-  test("does not leak history across baseURL or agency changes", async () => {
-    await using tmp = await tmpdir({ config: {} })
-
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const primary = {
-          baseURL: "http://127.0.0.1:8000",
-          agency: "builder",
-          sessionID: "sess_2",
-        }
-
-        await AgencySwarmHistory.appendMessages(primary, [{ type: "message", id: "msg_primary" }])
-
-        const differentAgency = await AgencySwarmHistory.load({
-          ...primary,
-          agency: "research",
-        })
-
-        const differentBaseURL = await AgencySwarmHistory.load({
-          ...primary,
-          baseURL: "http://127.0.0.1:9000",
-        })
-
-        expect(differentAgency.chat_history).toEqual([])
-        expect(differentBaseURL.chat_history).toEqual([])
-      },
-    })
-  })
-
-  test("stores last_run_id alongside chat_history", async () => {
-    await using tmp = await tmpdir({ config: {} })
-
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const scope = {
-          baseURL: "http://127.0.0.1:8000",
-          agency: "builder",
-          sessionID: "sess_3",
-        }
-
-        await AgencySwarmHistory.setLastRunID(scope, "run_123")
-        const loaded = await AgencySwarmHistory.load(scope)
-
-        expect(loaded.last_run_id).toBe("run_123")
-      },
-    })
-  })
+  expect(writes).toEqual([
+    {
+      key: ["agency_swarm_history", hash],
+      content: entry,
+    },
+  ])
 })

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import {
   buildAgencyConfig,
   buildPythonEnv,
   detectAgencyProject,
   NPX_ENTRY_ENV,
+  prepareProjectLaunch,
   shouldRunNpxOnboarding,
 } from "../../src/agency-swarm/npx"
 import { tmpdir } from "../fixture/fixture"
@@ -85,5 +87,26 @@ describe("agency-swarm npx onboarding", () => {
     const project = await detectAgencyProject(dir.path)
 
     expect(project).toBeUndefined()
+  })
+
+  test("prepareProjectLaunch keeps project launches in local Agent Builder mode", async () => {
+    await using dir = await tmpdir()
+    const venvPython = path.join(
+      dir.path,
+      ".venv",
+      process.platform === "win32" ? "Scripts" : "bin",
+      process.platform === "win32" ? "python.exe" : "python",
+    )
+    await mkdir(path.dirname(venvPython), { recursive: true })
+    await Bun.write(venvPython, "")
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    expect(launch).toEqual({
+      directory: dir.path,
+    })
   })
 })

--- a/packages/opencode/test/agent/display.test.ts
+++ b/packages/opencode/test/agent/display.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test"
+import { displayAgentName } from "../../src/agent/display"
+
+test("displayAgentName brands build as Agent Builder", () => {
+  expect(displayAgentName("build")).toBe("Agent Builder")
+})
+
+test("displayAgentName titlecases other agent names", () => {
+  expect(displayAgentName("plan")).toBe("Plan")
+  expect(displayAgentName("general")).toBe("General")
+})

--- a/packages/opencode/test/cli/tui/transcript.test.ts
+++ b/packages/opencode/test/cli/tui/transcript.test.ts
@@ -85,12 +85,12 @@ describe("transcript", () => {
 
     test("includes metadata when enabled", () => {
       const result = formatAssistantHeader(baseMsg, true)
-      expect(result).toBe("## Assistant (Build · claude-sonnet-4-20250514 · 5.4s)\n\n")
+      expect(result).toBe("## Assistant (Agent Builder · claude-sonnet-4-20250514 · 5.4s)\n\n")
     })
 
     test("uses model display name when available", () => {
       const result = formatAssistantHeader(baseMsg, true, providers)
-      expect(result).toBe("## Assistant (Build · Claude Sonnet 4 · 5.4s)\n\n")
+      expect(result).toBe("## Assistant (Agent Builder · Claude Sonnet 4 · 5.4s)\n\n")
     })
 
     test("excludes metadata when disabled", () => {
@@ -101,7 +101,7 @@ describe("transcript", () => {
     test("handles missing completed time", () => {
       const msg = { ...baseMsg, time: { created: 1000000 } }
       const result = formatAssistantHeader(msg as AssistantMessage, true)
-      expect(result).toBe("## Assistant (Build · claude-sonnet-4-20250514)\n\n")
+      expect(result).toBe("## Assistant (Agent Builder · claude-sonnet-4-20250514)\n\n")
     })
 
     test("titlecases agent name", () => {
@@ -294,7 +294,7 @@ describe("transcript", () => {
       }
       const parts: Part[] = [{ id: "p1", sessionID: "ses_123", messageID: "msg_123", type: "text", text: "Hi there" }]
       const result = formatMessage(msg, parts, options)
-      expect(result).toContain("## Assistant (Build · Claude Sonnet 4 · 5.4s)")
+      expect(result).toContain("## Assistant (Agent Builder · Claude Sonnet 4 · 5.4s)")
       expect(result).toContain("Hi there")
     })
   })
@@ -349,7 +349,7 @@ describe("transcript", () => {
       expect(result).toContain("**Session ID:** ses_abc123")
       expect(result).toContain("## User")
       expect(result).toContain("Hello")
-      expect(result).toContain("## Assistant (Build · Claude Sonnet 4 · 0.5s)")
+      expect(result).toContain("## Assistant (Agent Builder · Claude Sonnet 4 · 0.5s)")
       expect(result).toContain("Hi!")
       expect(result).toContain("---")
     })
@@ -386,7 +386,7 @@ describe("transcript", () => {
         assistantMetadata: true,
       })
 
-      expect(result).toContain("## Assistant (Build · claude-sonnet-4-20250514 · 0.5s)")
+      expect(result).toContain("## Assistant (Agent Builder · claude-sonnet-4-20250514 · 0.5s)")
     })
 
     test("formats transcript without assistant metadata", () => {
@@ -419,7 +419,7 @@ describe("transcript", () => {
       const result = formatTranscript(session, messages, options)
 
       expect(result).toContain("## Assistant\n\n")
-      expect(result).not.toContain("Build")
+      expect(result).not.toContain("Agent Builder")
       expect(result).not.toContain("claude-sonnet-4-20250514")
     })
   })

--- a/packages/opencode/test/session/agency-swarm-utils.test.ts
+++ b/packages/opencode/test/session/agency-swarm-utils.test.ts
@@ -152,10 +152,17 @@ describe("session.agency-swarm-utils", () => {
         msg([
           text("part-1", { type: "text", text: " first " }),
           text("part-2", { type: "text", text: "ignored", ignored: true }),
-          text("part-3", { type: "text", text: " second " }),
+          text("part-3", { type: "text", text: "<system-reminder>local only</system-reminder>", synthetic: true }),
+          text("part-4", {
+            type: "text",
+            text: "<system-reminder>local only</system-reminder>\n\nhandoff",
+            synthetic: true,
+          }),
+          text("part-5", { type: "text", text: " context ", synthetic: true }),
+          text("part-6", { type: "text", text: " second " }),
         ]),
       ),
-    ).toBe("first\n\nsecond")
+    ).toBe("first\n\nhandoff\n\ncontext\n\nsecond")
     expect(
       findRecipientAgent(
         msg([

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1497,6 +1497,81 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["Find the right file first."])
   })
 
+  test("stream does not duplicate tool input when tool_called follows output_item.added", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: {
+              type: "function_call",
+              id: "call_item_1",
+              call_id: "call_1",
+              name: "search",
+              arguments: '{"query":"hello"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "tool_called",
+          item: {
+            raw_item: {
+              type: "function_call",
+              id: "call_item_1",
+              call_id: "call_1",
+              name: "search",
+              arguments: '{"query":"hello"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: {
+              type: "function_call",
+              id: "call_item_1",
+              call_id: "call_1",
+              name: "search",
+              arguments: '{"query":"hello"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "messages",
+        payload: {
+          new_messages: [{ type: "function_call_output", call_id: "call_1", output: "ok" }],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    const calls: any[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "tool-input-delta") deltas.push(event.delta)
+      if (event.type === "tool-call") calls.push(event)
+    }
+
+    expect(deltas).toEqual(['{"query":"hello"}'])
+    expect(calls).toHaveLength(1)
+  })
+
   test("stream closes prior text part before switching content_index", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agent-builder.test.ts
+++ b/packages/opencode/test/session/agent-builder.test.ts
@@ -4,8 +4,12 @@ import { agentBuilderInstructions } from "../../src/session/agent-builder"
 test("agentBuilderInstructions applies only to local build turns", () => {
   const local = agentBuilderInstructions("build", "openai")
   expect(local).toHaveLength(1)
-  expect(local[0]).toContain("Agent Swarm Agent Creator Instructions")
+  expect(local[0]).toContain("Agent Swarm Agent Builder Instructions")
   expect(local[0]).toContain("https://github.com/agency-ai-solutions/agency-starter-template")
+  expect(local[0]).toContain(
+    "If the latest system reminder or handoff mentions an approved session plan file, read it before you change code",
+  )
+  expect(local[0]).not.toContain("prd.txt")
 
   expect(agentBuilderInstructions("plan", "openai")).toEqual([])
   expect(agentBuilderInstructions("build", "agency-swarm")).toEqual([])

--- a/packages/opencode/test/session/agent-builder.test.ts
+++ b/packages/opencode/test/session/agent-builder.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test"
+import { agentBuilderInstructions } from "../../src/session/agent-builder"
+
+test("agentBuilderInstructions applies only to local build turns", () => {
+  const local = agentBuilderInstructions("build", "openai")
+  expect(local).toHaveLength(1)
+  expect(local[0]).toContain("Agent Swarm Agent Creator Instructions")
+
+  expect(agentBuilderInstructions("plan", "openai")).toEqual([])
+  expect(agentBuilderInstructions("build", "agency-swarm")).toEqual([])
+})

--- a/packages/opencode/test/session/agent-builder.test.ts
+++ b/packages/opencode/test/session/agent-builder.test.ts
@@ -5,6 +5,7 @@ test("agentBuilderInstructions applies only to local build turns", () => {
   const local = agentBuilderInstructions("build", "openai")
   expect(local).toHaveLength(1)
   expect(local[0]).toContain("Agent Swarm Agent Creator Instructions")
+  expect(local[0]).toContain("https://github.com/agency-ai-solutions/agency-starter-template")
 
   expect(agentBuilderInstructions("plan", "openai")).toEqual([])
   expect(agentBuilderInstructions("build", "agency-swarm")).toEqual([])

--- a/packages/opencode/test/session/agent-planner.test.ts
+++ b/packages/opencode/test/session/agent-planner.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { agentPlannerInstructions } from "../../src/session/agent-planner"
+
+test("agentPlannerInstructions applies only to local plan turns with native plan artifacts", () => {
+  const local = agentPlannerInstructions("plan", "openai")
+  expect(local).toHaveLength(1)
+  expect(local[0]).toContain("Agent Swarm Planner Instructions")
+  expect(local[0]).toContain("Stay on the native session plan file.")
+  expect(local[0]).not.toContain("prd.txt")
+
+  expect(agentPlannerInstructions("build", "openai")).toEqual([])
+  expect(agentPlannerInstructions("plan", "agency-swarm")).toEqual([])
+  expect(agentPlannerInstructions("plan", "openai", false)).toEqual([])
+})


### PR DESCRIPTION
### Issue for this PR

Closes #26

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This keeps the Agent Swarm terminal flow in local `Agent Builder` mode for `npx` project and starter launches, while restoring the validated framework TUI fixes that regressed during the onboarding work. It keeps the fork closer to the intended product split: local builder work stays local, and bridge-backed Agency Swarm runtime stays on the explicit connect path.

The branch also restores the recent fixes for the auth-to-agents flow, duplicate tool input, legacy session history migration, packaged Builder instructions, and the `Agent Builder` display naming. Raw debug `console.log` calls were removed from interactive TUI paths.

### How did you verify your code works?

- `bun run test -- test/agency-swarm/npx.test.ts test/agent/display.test.ts test/session/agent-builder.test.ts test/cli/tui/transcript.test.ts test/agency-swarm/history.test.ts test/session/agency-swarm.test.ts test/cli/tui/session-error.test.ts`
- `bun run typecheck`
- Real PTY smoke of the local project onboarding path and the connect path

### Screenshots / recordings

UI change only in the terminal/TUI flow. No browser screenshot was captured for this PR.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
