### PR TITLE
feat(opencode): align plan and Agent Builder prompts

### DIFF
--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -99,7 +99,7 @@ export function buildOutgoingMessage(message: MessageV2.WithParts): string {
   const textParts = message.parts
     .filter((part): part is MessageV2.TextPart => part.type === "text")
     .filter((part) => !part.ignored)
-    .map((part) => part.text.trim())
+    .map((part) => visibleOutgoingText(part))
     .filter(Boolean)
 
   if (textParts.length === 0) {
@@ -107,6 +107,18 @@ export function buildOutgoingMessage(message: MessageV2.WithParts): string {
   }
 
   return textParts.join("\n\n")
+}
+
+function visibleOutgoingText(part: MessageV2.TextPart): string {
+  if (!part.synthetic) return part.text.trim()
+
+  const text = part.text.trimStart()
+  if (!text.startsWith("<system-reminder>")) return text.trim()
+
+  const end = text.indexOf("</system-reminder>")
+  if (end === -1) return ""
+
+  return text.slice(end + "</system-reminder>".length).trim()
 }
 
 export function findRecipientAgent(message: MessageV2.WithParts): string | undefined {

--- a/packages/opencode/src/session/agent-planner.ts
+++ b/packages/opencode/src/session/agent-planner.ts
@@ -1,0 +1,9 @@
+import PROMPT_AGENT_PLANNER from "./prompt/agent-planner.txt"
+import { SessionAgencySwarm } from "./agency-swarm"
+
+export function agentPlannerInstructions(agent: string, providerID: string, enabled = true) {
+  if (!enabled) return []
+  if (agent !== "plan") return []
+  if (providerID === SessionAgencySwarm.PROVIDER_ID) return []
+  return [PROMPT_AGENT_PLANNER]
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -52,6 +52,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { SessionAgencySwarm } from "./agency-swarm"
 import { agentBuilderInstructions } from "./agent-builder"
+import { agentPlannerInstructions } from "./agent-planner"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1550,6 +1551,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   ...env,
                   ...(skills ? [skills] : []),
                   ...instructions,
+                  ...agentPlannerInstructions(lastUser.agent, model.providerID, Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE),
                   ...agentBuilderInstructions(lastUser.agent, model.providerID),
                 ]
                 const format = lastUser.format ?? { type: "text" as const }

--- a/packages/opencode/src/session/prompt/agent-builder.txt
+++ b/packages/opencode/src/session/prompt/agent-builder.txt
@@ -2,25 +2,26 @@ Apply these additional instructions when working as the local Agent Builder for 
 Use the Agency Swarm starter template as the reference for project structure and the agent-creation workflow:
 https://github.com/agency-ai-solutions/agency-starter-template
 
-# Agent Swarm Agent Creator Instructions
+# Agent Swarm Agent Builder Instructions
 
 Agency Swarm is built on the OpenAI Agents SDK. Your job in Agent Builder mode is to create or improve an Agency Swarm project in the actual file system, not to describe hypothetical steps.
 
 ## Workflow
 
 0. Create a todo list for the work before you start coding.
-1. Activate a virtual environment if one exists. If it does not exist, create one and install the project requirements.
-2. Explore the project before changing it.
-3. Create or update agent folders and templates in the expected structure.
-4. Build robust tools in the correct agent tool folders.
-5. Create or update agent classes and their instructions.
-6. Create or update the main agency wiring and shared instructions.
-7. Test the tools and the agency, then iterate until the result works.
+1. If the latest system reminder or handoff mentions an approved session plan file, read it before you change code and treat it as the source of truth.
+2. Activate a virtual environment if one exists. If it does not exist, create one and install the project requirements.
+3. Explore the project before changing it.
+4. Create or update agent folders and templates in the expected structure.
+5. Build robust tools in the correct agent tool folders.
+6. Create or update agent classes and their instructions.
+7. Create or update the main agency wiring and shared instructions.
+8. Test the tools and the agency, then iterate until the result works.
 
 ## Project Exploration
 
 - Check the project root structure first.
-- Look for `prd.txt` and read it fully if it exists.
+- When an approved session plan file is provided, read it first.
 - Review `agency.py`, `shared_instructions.md`, agent `instructions.md` files, and agent tool folders.
 - Remove example agents if they are still present and clean the example wiring out of `agency.py`.
 - If the task needs external systems such as Slack or Notion, verify the needed API keys exist in `.env` before proceeding.

--- a/packages/opencode/src/session/prompt/agent-planner.txt
+++ b/packages/opencode/src/session/prompt/agent-planner.txt
@@ -1,0 +1,38 @@
+Apply these additional instructions when working as the local Plan agent for an Agency Swarm project.
+Use the Agency Swarm starter template as the reference for project structure and the agent-creation workflow:
+https://github.com/agency-ai-solutions/agency-starter-template
+
+# Agent Swarm Planner Instructions
+
+The native session plan file for this conversation is the implementation brief for the next Agent Builder turn. Write and refine that file so Agent Builder can execute directly from it after approval.
+
+## Workflow
+
+0. Create a todo list for the planning work.
+1. Explore the project before you commit to a design.
+2. Prefer the smallest viable agent roster.
+3. Prefer MCP servers over custom tools when they fit the task.
+4. Ask focused questions when requirements, integrations, or constraints are still unclear.
+5. Keep updating the session plan file until it is concrete enough to implement without guesswork.
+
+## Plan File Requirements
+
+Write the session plan file as a concise implementation brief with these sections:
+
+- Goal and scope
+- Agency name and entry agent
+- Agent roster and responsibilities
+- Communication flows
+- Tool and MCP mapping
+- Dependencies and required env keys
+- File-by-file implementation order
+- Verification plan
+- Agent Builder handoff notes
+
+## Planning Rules
+
+- Treat the session plan file as the source of truth for the next Agent Builder turn.
+- Stay on the native session plan file. Do not create separate planning artifacts unless the user explicitly asks.
+- Reuse existing project files and starter-template patterns when they help.
+- Make the plan concrete enough that Agent Builder can edit files immediately after approval.
+- If the repo still contains example agents or placeholder wiring, call out the cleanup explicitly in the plan.

--- a/packages/opencode/test/session/agency-swarm-utils.test.ts
+++ b/packages/opencode/test/session/agency-swarm-utils.test.ts
@@ -152,10 +152,17 @@ describe("session.agency-swarm-utils", () => {
         msg([
           text("part-1", { type: "text", text: " first " }),
           text("part-2", { type: "text", text: "ignored", ignored: true }),
-          text("part-3", { type: "text", text: " second " }),
+          text("part-3", { type: "text", text: "<system-reminder>local only</system-reminder>", synthetic: true }),
+          text("part-4", {
+            type: "text",
+            text: "<system-reminder>local only</system-reminder>\n\nhandoff",
+            synthetic: true,
+          }),
+          text("part-5", { type: "text", text: " context ", synthetic: true }),
+          text("part-6", { type: "text", text: " second " }),
         ]),
       ),
-    ).toBe("first\n\nsecond")
+    ).toBe("first\n\nhandoff\n\ncontext\n\nsecond")
     expect(
       findRecipientAgent(
         msg([

--- a/packages/opencode/test/session/agent-builder.test.ts
+++ b/packages/opencode/test/session/agent-builder.test.ts
@@ -4,8 +4,12 @@ import { agentBuilderInstructions } from "../../src/session/agent-builder"
 test("agentBuilderInstructions applies only to local build turns", () => {
   const local = agentBuilderInstructions("build", "openai")
   expect(local).toHaveLength(1)
-  expect(local[0]).toContain("Agent Swarm Agent Creator Instructions")
+  expect(local[0]).toContain("Agent Swarm Agent Builder Instructions")
   expect(local[0]).toContain("https://github.com/agency-ai-solutions/agency-starter-template")
+  expect(local[0]).toContain(
+    "If the latest system reminder or handoff mentions an approved session plan file, read it before you change code",
+  )
+  expect(local[0]).not.toContain("prd.txt")
 
   expect(agentBuilderInstructions("plan", "openai")).toEqual([])
   expect(agentBuilderInstructions("build", "agency-swarm")).toEqual([])

--- a/packages/opencode/test/session/agent-planner.test.ts
+++ b/packages/opencode/test/session/agent-planner.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { agentPlannerInstructions } from "../../src/session/agent-planner"
+
+test("agentPlannerInstructions applies only to local plan turns with native plan artifacts", () => {
+  const local = agentPlannerInstructions("plan", "openai")
+  expect(local).toHaveLength(1)
+  expect(local[0]).toContain("Agent Swarm Planner Instructions")
+  expect(local[0]).toContain("Stay on the native session plan file.")
+  expect(local[0]).not.toContain("prd.txt")
+
+  expect(agentPlannerInstructions("build", "openai")).toEqual([])
+  expect(agentPlannerInstructions("plan", "agency-swarm")).toEqual([])
+  expect(agentPlannerInstructions("plan", "openai", false)).toEqual([])
+})


### PR DESCRIPTION
## Summary
- add local Agent Swarm planner instructions for native OpenCode session plan artifacts
- make Agent Builder consume approved session plans only when a handoff provides them
- strip local system-reminder blocks from Agency Swarm outgoing messages while preserving useful handoff/context text

## Validation
- bun test --timeout 30000 test/session/agency-swarm-utils.test.ts test/session/agent-builder.test.ts test/session/agent-planner.test.ts
- bun typecheck
- git diff --check
- local Codex review: /tmp/codex_review_plan_builder_final3.txt -> No findings

## Stack
- Stacked on #33 / codex/framework-default-v2 so #33 stays stable and green.