### PR TITLE
fix: detect existing agency projects in launcher

### DIFF
--- a/packages/opencode/bin/agentswarm
+++ b/packages/opencode/bin/agentswarm
@@ -9,6 +9,10 @@ import { fileURLToPath } from "node:url"
 function run(target) {
   const result = childProcess.spawnSync(target, process.argv.slice(2), {
     stdio: "inherit",
+    env: {
+      ...process.env,
+      AGENTSWARM_NPX: process.env.AGENTSWARM_NPX || "1",
+    },
   })
   if (result.error) {
     console.error(result.error.message)

--- a/packages/opencode/bin/agentswarm
+++ b/packages/opencode/bin/agentswarm
@@ -11,7 +11,7 @@ function run(target) {
     stdio: "inherit",
     env: {
       ...process.env,
-      AGENTSWARM_NPX: process.env.AGENTSWARM_NPX || "1",
+      AGENTSWARM_LAUNCHER: process.env.AGENTSWARM_LAUNCHER || "1",
     },
   })
   if (result.error) {

--- a/packages/opencode/bin/agentswarm-npx
+++ b/packages/opencode/bin/agentswarm-npx
@@ -28,7 +28,7 @@ const result = childProcess.spawnSync(process.execPath, [binary, ...process.argv
   stdio: "inherit",
   env: {
     ...process.env,
-    AGENTSWARM_NPX: "1",
+    AGENTSWARM_LAUNCHER: "1",
   },
 })
 

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -32,6 +32,12 @@ interface CommandResult {
   stderr: string
 }
 
+interface PythonInfo {
+  cmd: string[]
+  executable: string
+  version: string
+}
+
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
   model?: string
@@ -89,7 +95,7 @@ export async function detectAgencyProject(directory: string) {
 }
 
 export function formatProjectLabel(project: AgencyProject) {
-  return `Use this Agency Swarm project (${project.directory})`
+  return `Use detected Agency Swarm project (${project.directory})`
 }
 
 export function validateStarterName(base: string, value?: string) {
@@ -131,6 +137,10 @@ export async function prepareNpxLaunch(directory: string): Promise<PreparedNpxLa
   }
 
   const launch = await prepareProjectLaunch(targetProject)
+  if (!launch) {
+    prompts.outro("Cancelled")
+    return
+  }
   prompts.outro(`Opening Agent Swarm in ${targetProject.directory}`)
   return launch
 }
@@ -138,7 +148,7 @@ export async function prepareNpxLaunch(directory: string): Promise<PreparedNpxLa
 async function chooseLaunchChoice(project: AgencyProject | undefined) {
   prompts.log.info("1. Choose how to start the terminal UI.")
   prompts.log.info(
-    "   The NPX launcher can reuse the current project, create a starter project, or connect to an existing server.",
+    "   The launcher can use a detected project, create a starter project, or connect to an existing server.",
   )
 
   const result = await prompts.select<LaunchChoice>({
@@ -349,13 +359,16 @@ async function createStarterProject(input: { baseDirectory: string }): Promise<A
   }
 }
 
-export async function prepareProjectLaunch(project: AgencyProject): Promise<PreparedNpxLaunch> {
+export async function prepareProjectLaunch(project: AgencyProject): Promise<PreparedNpxLaunch | undefined> {
   prompts.log.info("3. Start the Agency Swarm project.")
   prompts.log.info(
     "   The launcher will reuse a project `.venv`, start a local FastAPI server, and connect the terminal UI to it.",
   )
 
-  const server = await startProjectServer(project.directory, await ensureProjectPython(project.directory))
+  const python = await ensureProjectPython(project.directory)
+  if (!python) return
+
+  const server = await startProjectServer(project.directory, python)
   return {
     directory: project.directory,
     configContent: buildAgencyConfig({
@@ -369,33 +382,38 @@ export async function prepareProjectLaunch(project: AgencyProject): Promise<Prep
 async function ensureProjectPython(directory: string) {
   const venvPython = getVenvPythonPath(directory)
   const hasVenv = await Filesystem.exists(venvPython)
-  if (hasVenv) return [venvPython]
+  if (hasVenv) {
+    const info = await inspectPython([venvPython])
+    prompts.log.info(`Using project Python: ${formatPython(info, [venvPython])}`)
+    return [venvPython]
+  }
 
   const detected = await findPythonExecutable()
   if (!detected) {
     throw new Error("Python 3.12 or newer was not found. Install Python, then rerun `npx @vrsen/agentswarm`.")
   }
+  prompts.log.info(`Detected Python: ${formatPython(detected, detected.cmd)}`)
 
   const createVenv = await prompts.confirm({
     message: "Create a local `.venv` in this project?",
     initialValue: true,
   })
   if (prompts.isCancel(createVenv)) {
-    throw new Error("Cancelled before creating the project virtual environment.")
+    return
   }
   if (!createVenv) {
-    const check = await runCommand([...detected, "-c", "import agency_swarm"])
+    const check = await runCommand([...detected.cmd, "-c", "import agency_swarm"])
     if (check.code !== 0) {
       throw new Error(
         "This project does not have a `.venv` yet, and the selected Python environment cannot import `agency_swarm`.",
       )
     }
-    return detected
+    return detected.cmd
   }
 
   const spinner = prompts.spinner()
   spinner.start("Creating `.venv`")
-  const created = await runCommand([...detected, "-m", "venv", ".venv"], {
+  const created = await runCommand([...detected.cmd, "-m", "venv", ".venv"], {
     cwd: directory,
   })
   if (created.code !== 0) {
@@ -533,17 +551,31 @@ async function findPythonExecutable() {
       : [["python3.13"], ["python3.12"], ["python3"], ["python"]]
 
   for (const candidate of candidates) {
-    const result = await runCommand([...candidate, "--version"])
-    if (result.code !== 0) continue
-    const versionText = `${result.stdout}${result.stderr}`
-    const match = versionText.match(/Python (\d+)\.(\d+)/)
+    const info = await inspectPython(candidate)
+    if (!info) continue
+    const match = info.version.match(/^(\d+)\.(\d+)/)
     if (!match) continue
     const major = Number(match[1])
     const minor = Number(match[2])
-    if (major > 3 || (major === 3 && minor >= 12)) {
-      return candidate
-    }
+    if (major > 3 || (major === 3 && minor >= 12)) return info
   }
+}
+
+async function inspectPython(cmd: string[]): Promise<PythonInfo | undefined> {
+  const result = await runCommand([...cmd, "-c", "import sys; print(sys.executable); print(sys.version.split()[0])"])
+  if (result.code !== 0) return
+  const [executable, version] = result.stdout.trim().split(/\r?\n/)
+  if (!executable || !version) return
+  return {
+    cmd,
+    executable,
+    version,
+  }
+}
+
+function formatPython(info: PythonInfo | undefined, cmd: string[]) {
+  if (!info) return cmd.join(" ")
+  return `${info.executable} (Python ${info.version})`
 }
 
 function getVenvPythonPath(directory: string) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -5,9 +5,10 @@ import path from "node:path"
 import { existsSync } from "node:fs"
 import { mkdtemp, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
+import { SERVER_LAUNCHER_SCRIPT } from "./server-launcher"
 import { Filesystem } from "@/util/filesystem"
 
-export const NPX_ENTRY_ENV = "AGENTSWARM_NPX"
+export const LAUNCHER_ENTRY_ENV = "AGENTSWARM_LAUNCHER"
 export const STARTER_TEMPLATE_REPO = "agency-ai-solutions/agency-starter-template"
 export const STARTER_TEMPLATE_URL = `https://github.com/${STARTER_TEMPLATE_REPO}.git`
 export const LOCAL_AGENCY_ID = "local-agency"
@@ -47,7 +48,7 @@ export function shouldRunNpxOnboarding(input: {
   prompt?: string
   agent?: string
 }) {
-  if (input.env[NPX_ENTRY_ENV] !== "1" && !isAgentswarmCommand(input.argv ?? process.argv)) return false
+  if (input.env[LAUNCHER_ENTRY_ENV] !== "1" && !isAgentswarmCommand(input.argv ?? process.argv)) return false
   if (input.model) return false
   if (input.continue) return false
   if (input.session) return false
@@ -472,26 +473,7 @@ async function startProjectServer(directory: string, python: string[]) {
     }).catch(() => undefined)
 
   try {
-    await Filesystem.write(
-      scriptPath,
-      [
-        "from agency import create_agency",
-        "from agency_swarm.integrations.fastapi import run_fastapi",
-        "import sys",
-        "",
-        "port = int(sys.argv[1])",
-        "agency_id = sys.argv[2]",
-        "",
-        "run_fastapi(",
-        "    agencies={agency_id: create_agency},",
-        '    host="127.0.0.1",',
-        "    port=port,",
-        '    server_url=f"http://127.0.0.1:{port}",',
-        '    app_token_env="",',
-        ")",
-        "",
-      ].join("\n"),
-    )
+    await Filesystem.write(scriptPath, SERVER_LAUNCHER_SCRIPT)
   } catch (error) {
     await remove()
     throw error

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -2,6 +2,7 @@ import * as prompts from "@clack/prompts"
 import net from "node:net"
 import os from "node:os"
 import path from "node:path"
+import { existsSync } from "node:fs"
 import { mkdtemp, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
 import { Filesystem } from "@/util/filesystem"
@@ -89,6 +90,13 @@ export async function detectAgencyProject(directory: string) {
 
 export function formatProjectLabel(project: AgencyProject) {
   return `Use this Agency Swarm project (${project.directory})`
+}
+
+export function validateStarterName(base: string, value?: string) {
+  const name = value?.trim()
+  if (!name) return "A name is required"
+  if (/[\\/:*?\"<>|]/.test(name)) return "Use a simple folder or repository name"
+  if (existsSync(path.join(base, name))) return "A folder with this name already exists"
 }
 
 export async function prepareNpxLaunch(directory: string): Promise<PreparedNpxLaunch | undefined> {
@@ -253,8 +261,7 @@ async function createStarterProject(input: { baseDirectory: string }): Promise<A
     message: "Project or repository name",
     placeholder: "my-agency",
     validate(value) {
-      if (!value?.trim()) return "A name is required"
-      if (/[\\/:*?\"<>|]/.test(value)) return "Use a simple folder or repository name"
+      return validateStarterName(input.baseDirectory, value)
     },
   })
   if (prompts.isCancel(repoName)) return
@@ -459,22 +466,29 @@ async function startProjectServer(directory: string, python: string[]) {
   })
   const stderrPromise = child.stderr ? new Response(child.stderr).text().catch(() => "") : Promise.resolve("")
 
-  await waitForServer({
-    baseURL: `http://127.0.0.1:${port}`,
-    child,
-    stderrPromise,
-  })
+  const cleanup = async () => {
+    child.kill()
+    await Promise.race([child.exited, sleep(5000)])
+    await rm(tempDirectory, {
+      recursive: true,
+      force: true,
+    }).catch(() => undefined)
+  }
+
+  try {
+    await waitForServer({
+      baseURL: `http://127.0.0.1:${port}`,
+      child,
+      stderrPromise,
+    })
+  } catch (error) {
+    await cleanup()
+    throw error
+  }
 
   return {
     baseURL: `http://127.0.0.1:${port}`,
-    cleanup: async () => {
-      child.kill()
-      await Promise.race([child.exited, sleep(5000)])
-      await rm(tempDirectory, {
-        recursive: true,
-        force: true,
-      }).catch(() => undefined)
-    },
+    cleanup,
   }
 }
 

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -2,7 +2,7 @@ import * as prompts from "@clack/prompts"
 import net from "node:net"
 import os from "node:os"
 import path from "node:path"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, readdir, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
 import { Filesystem } from "@/util/filesystem"
 
@@ -75,6 +75,31 @@ export function buildPythonEnv(directory: string, env: NodeJS.ProcessEnv = proce
 }
 
 export async function detectAgencyProject(directory: string) {
+  const project = await findProject(directory)
+  if (project) return project
+
+  const children = await readdir(directory, { withFileTypes: true }).catch(() => [])
+  const projects = (
+    await Promise.all(
+      children
+        .filter((child) => child.isDirectory() && !child.name.startsWith("."))
+        .map((child) => readProject(path.join(directory, child.name))),
+    )
+  ).filter((project): project is AgencyProject => Boolean(project))
+  if (projects.length === 1) return projects[0]
+}
+
+async function findProject(directory: string): Promise<AgencyProject | undefined> {
+  const dir = path.resolve(directory)
+  const project = await readProject(dir)
+  if (project) return project
+
+  const parent = path.dirname(dir)
+  if (parent === dir) return
+  return findProject(parent)
+}
+
+async function readProject(directory: string): Promise<AgencyProject | undefined> {
   const agencyFile = path.join(directory, "agency.py")
   if (!(await Filesystem.exists(agencyFile))) return
   const source = await Filesystem.readText(agencyFile).catch(() => "")
@@ -136,7 +161,7 @@ async function chooseLaunchChoice(project: AgencyProject | undefined) {
         ? [
             {
               value: "project" as const,
-              label: "Use the current Agency Swarm project",
+              label: "Use existing Agency Swarm project",
               hint: path.basename(project.directory),
             },
           ]

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -454,43 +454,57 @@ async function startProjectServer(directory: string, python: string[]) {
   const port = await getFreePort()
   const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "agentswarm-npx-"))
   const scriptPath = path.join(tempDirectory, "launch_agency.py")
-  await Filesystem.write(
-    scriptPath,
-    [
-      "from agency import create_agency",
-      "from agency_swarm.integrations.fastapi import run_fastapi",
-      "import sys",
-      "",
-      "port = int(sys.argv[1])",
-      "agency_id = sys.argv[2]",
-      "",
-      "run_fastapi(",
-      "    agencies={agency_id: create_agency},",
-      '    host="127.0.0.1",',
-      "    port=port,",
-      '    server_url=f"http://127.0.0.1:{port}",',
-      '    app_token_env="",',
-      ")",
-      "",
-    ].join("\n"),
-  )
+  const remove = () =>
+    rm(tempDirectory, {
+      recursive: true,
+      force: true,
+    }).catch(() => undefined)
 
-  const child = Bun.spawn({
-    cmd: [...python, scriptPath, String(port), LOCAL_AGENCY_ID],
-    cwd: directory,
-    stdout: "ignore",
-    stderr: "pipe",
-    env: buildPythonEnv(directory),
-  })
+  try {
+    await Filesystem.write(
+      scriptPath,
+      [
+        "from agency import create_agency",
+        "from agency_swarm.integrations.fastapi import run_fastapi",
+        "import sys",
+        "",
+        "port = int(sys.argv[1])",
+        "agency_id = sys.argv[2]",
+        "",
+        "run_fastapi(",
+        "    agencies={agency_id: create_agency},",
+        '    host="127.0.0.1",',
+        "    port=port,",
+        '    server_url=f"http://127.0.0.1:{port}",',
+        '    app_token_env="",',
+        ")",
+        "",
+      ].join("\n"),
+    )
+  } catch (error) {
+    await remove()
+    throw error
+  }
+
+  let child
+  try {
+    child = Bun.spawn({
+      cmd: [...python, scriptPath, String(port), LOCAL_AGENCY_ID],
+      cwd: directory,
+      stdout: "ignore",
+      stderr: "pipe",
+      env: buildPythonEnv(directory),
+    })
+  } catch (error) {
+    await remove()
+    throw error
+  }
   const stderrPromise = child.stderr ? new Response(child.stderr).text().catch(() => "") : Promise.resolve("")
 
   const cleanup = async () => {
     child.kill()
     await Promise.race([child.exited, sleep(5000)])
-    await rm(tempDirectory, {
-      recursive: true,
-      force: true,
-    }).catch(() => undefined)
+    await remove()
   }
 
   try {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -40,19 +40,30 @@ interface PythonInfo {
 
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
+  argv?: string[]
   model?: string
   continue?: boolean
   session?: string
   prompt?: string
   agent?: string
 }) {
-  if (input.env[NPX_ENTRY_ENV] !== "1") return false
+  if (input.env[NPX_ENTRY_ENV] !== "1" && !isAgentswarmCommand(input.argv ?? process.argv)) return false
   if (input.model) return false
   if (input.continue) return false
   if (input.session) return false
   if (input.prompt) return false
   if (input.agent) return false
   return true
+}
+
+function isAgentswarmCommand(argv: string[]) {
+  return argv.slice(0, 2).some(
+    (item) =>
+      item
+        .split(/[\\/]/)
+        .at(-1)
+        ?.replace(/\.exe$/i, "") === "agentswarm",
+  )
 }
 
 export function buildAgencyConfig(input: { baseURL: string; agency: string; token?: string }) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -89,6 +89,11 @@ export async function detectAgencyProject(directory: string) {
   if (projects.length === 1) return projects[0]
 }
 
+export function getStarterBaseDirectory(directory: string, project?: AgencyProject) {
+  if (project) return path.dirname(project.directory)
+  return directory
+}
+
 async function findProject(directory: string): Promise<AgencyProject | undefined> {
   const dir = path.resolve(directory)
   const project = await readProject(dir)
@@ -135,8 +140,7 @@ export async function prepareNpxLaunch(directory: string): Promise<PreparedNpxLa
     choice === "project"
       ? project
       : await createStarterProject({
-          currentDirectory: directory,
-          createInsideCurrentDirectory: !project,
+          baseDirectory: getStarterBaseDirectory(directory, project),
         })
   if (!targetProject) {
     prompts.outro("Cancelled")
@@ -267,10 +271,7 @@ async function prepareRemoteLaunch(directory: string): Promise<PreparedNpxLaunch
   }
 }
 
-async function createStarterProject(input: {
-  currentDirectory: string
-  createInsideCurrentDirectory: boolean
-}): Promise<AgencyProject | undefined> {
+async function createStarterProject(input: { baseDirectory: string }): Promise<AgencyProject | undefined> {
   prompts.log.info("2. Create the starter project.")
   prompts.log.info("   This gives the terminal UI a ready-to-run Agency Swarm project to launch.")
 
@@ -307,10 +308,7 @@ async function createStarterProject(input: {
   }
 
   const name = repoName.trim()
-  const baseDirectory = input.createInsideCurrentDirectory
-    ? input.currentDirectory
-    : path.dirname(input.currentDirectory)
-  const targetDirectory = path.join(baseDirectory, name)
+  const targetDirectory = path.join(input.baseDirectory, name)
   if (await Filesystem.exists(targetDirectory)) {
     throw new Error(`Target directory already exists: ${targetDirectory}`)
   }
@@ -341,7 +339,7 @@ async function createStarterProject(input: {
       const result = await runCommand(
         ["gh", "repo", "create", name, "--template", STARTER_TEMPLATE_REPO, "--clone", `--${visibility}`],
         {
-          cwd: baseDirectory,
+          cwd: input.baseDirectory,
         },
       )
       if (result.code !== 0) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -2,7 +2,7 @@ import * as prompts from "@clack/prompts"
 import net from "node:net"
 import os from "node:os"
 import path from "node:path"
-import { mkdtemp, readdir, rm } from "node:fs/promises"
+import { mkdtemp, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
 import { Filesystem } from "@/util/filesystem"
 
@@ -75,45 +75,20 @@ export function buildPythonEnv(directory: string, env: NodeJS.ProcessEnv = proce
 }
 
 export async function detectAgencyProject(directory: string) {
-  const project = await findProject(directory)
-  if (project) return project
-
-  const children = await readdir(directory, { withFileTypes: true }).catch(() => [])
-  const projects = (
-    await Promise.all(
-      children
-        .filter((child) => child.isDirectory() && !child.name.startsWith("."))
-        .map((child) => readProject(path.join(directory, child.name))),
-    )
-  ).filter((project): project is AgencyProject => Boolean(project))
-  if (projects.length === 1) return projects[0]
-}
-
-export function getStarterBaseDirectory(directory: string, project?: AgencyProject) {
-  if (project) return path.dirname(project.directory)
-  return directory
-}
-
-async function findProject(directory: string): Promise<AgencyProject | undefined> {
   const dir = path.resolve(directory)
-  const project = await readProject(dir)
-  if (project) return project
-
-  const parent = path.dirname(dir)
-  if (parent === dir) return
-  return findProject(parent)
-}
-
-async function readProject(directory: string): Promise<AgencyProject | undefined> {
-  const agencyFile = path.join(directory, "agency.py")
+  const agencyFile = path.join(dir, "agency.py")
   if (!(await Filesystem.exists(agencyFile))) return
   const source = await Filesystem.readText(agencyFile).catch(() => "")
   if (!source.includes("def create_agency")) return
   if (!source.includes("agency_swarm")) return
   return {
-    directory,
+    directory: dir,
     agencyFile,
   } satisfies AgencyProject
+}
+
+export function formatProjectLabel(project: AgencyProject) {
+  return `Use this Agency Swarm project (${project.directory})`
 }
 
 export async function prepareNpxLaunch(directory: string): Promise<PreparedNpxLaunch | undefined> {
@@ -140,7 +115,7 @@ export async function prepareNpxLaunch(directory: string): Promise<PreparedNpxLa
     choice === "project"
       ? project
       : await createStarterProject({
-          baseDirectory: getStarterBaseDirectory(directory, project),
+          baseDirectory: directory,
         })
   if (!targetProject) {
     prompts.outro("Cancelled")
@@ -165,8 +140,7 @@ async function chooseLaunchChoice(project: AgencyProject | undefined) {
         ? [
             {
               value: "project" as const,
-              label: "Use existing Agency Swarm project",
-              hint: path.basename(project.directory),
+              label: formatProjectLabel(project),
             },
           ]
         : []),
@@ -369,14 +343,19 @@ async function createStarterProject(input: { baseDirectory: string }): Promise<A
 }
 
 export async function prepareProjectLaunch(project: AgencyProject): Promise<PreparedNpxLaunch> {
-  prompts.log.info("3. Prepare Python for Agent Builder.")
+  prompts.log.info("3. Start the Agency Swarm project.")
   prompts.log.info(
-    "   The launcher will reuse a project `.venv` when it exists, otherwise it will create one before opening the local builder.",
+    "   The launcher will reuse a project `.venv`, start a local FastAPI server, and connect the terminal UI to it.",
   )
 
-  await ensureProjectPython(project.directory)
+  const server = await startProjectServer(project.directory, await ensureProjectPython(project.directory))
   return {
     directory: project.directory,
+    configContent: buildAgencyConfig({
+      baseURL: server.baseURL,
+      agency: LOCAL_AGENCY_ID,
+    }),
+    cleanup: server.cleanup,
   }
 }
 

--- a/packages/opencode/src/agency-swarm/server-launcher.ts
+++ b/packages/opencode/src/agency-swarm/server-launcher.ts
@@ -1,0 +1,15 @@
+export const SERVER_LAUNCHER_SCRIPT = `from agency import create_agency
+from agency_swarm.integrations.fastapi import run_fastapi
+import sys
+
+port = int(sys.argv[1])
+agency_id = sys.argv[2]
+
+run_fastapi(
+    agencies={agency_id: create_agency},
+    host="127.0.0.1",
+    port=port,
+    server_url=f"http://127.0.0.1:{port}",
+    app_token_env="",
+)
+`

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -252,12 +252,15 @@ export const TuiThreadCommand = cmd({
         })
       } finally {
         await stop()
+      }
+    } finally {
+      try {
         if (cleanup) {
           await cleanup()
         }
+      } finally {
+        unguard?.()
       }
-    } finally {
-      unguard?.()
     }
     process.exit(0)
   },

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -5,9 +5,8 @@ import {
   buildAgencyConfig,
   buildPythonEnv,
   detectAgencyProject,
-  getStarterBaseDirectory,
+  formatProjectLabel,
   NPX_ENTRY_ENV,
-  prepareProjectLaunch,
   shouldRunNpxOnboarding,
 } from "../../src/agency-swarm/npx"
 import { tmpdir } from "../fixture/fixture"
@@ -73,36 +72,11 @@ describe("agency-swarm npx onboarding", () => {
     expect(project?.agencyFile).toBe(path.join(dir.path, "agency.py"))
   })
 
-  test("detectAgencyProject finds the project root from nested folders", async () => {
-    await using dir = await tmpdir()
-    const nested = path.join(dir.path, "example_agent", "tools")
-    await mkdir(nested, { recursive: true })
-    await writeAgency(dir.path)
-
-    const project = await detectAgencyProject(nested)
-
-    expect(project?.directory).toBe(dir.path)
-    expect(project?.agencyFile).toBe(path.join(dir.path, "agency.py"))
-  })
-
-  test("detectAgencyProject finds one starter project inside the current folder", async () => {
+  test("detectAgencyProject only checks the selected directory", async () => {
     await using dir = await tmpdir()
     const child = path.join(dir.path, "my-agency")
     await mkdir(child)
     await writeAgency(child)
-
-    const project = await detectAgencyProject(dir.path)
-
-    expect(project?.directory).toBe(child)
-    expect(project?.agencyFile).toBe(path.join(child, "agency.py"))
-  })
-
-  test("detectAgencyProject ignores ambiguous starter project folders", async () => {
-    await using dir = await tmpdir()
-    await mkdir(path.join(dir.path, "first"))
-    await mkdir(path.join(dir.path, "second"))
-    await writeAgency(path.join(dir.path, "first"))
-    await writeAgency(path.join(dir.path, "second"))
 
     const project = await detectAgencyProject(dir.path)
 
@@ -118,46 +92,15 @@ describe("agency-swarm npx onboarding", () => {
     expect(project).toBeUndefined()
   })
 
-  test("getStarterBaseDirectory keeps new starter projects beside detected projects", () => {
+  test("formatProjectLabel includes the full project path", () => {
     const root = path.join("/tmp", "workspace", "agency")
-    const nested = path.join(root, "example_agent", "tools")
-    const parent = path.dirname(root)
 
     expect(
-      getStarterBaseDirectory(nested, {
+      formatProjectLabel({
         directory: root,
         agencyFile: path.join(root, "agency.py"),
       }),
-    ).toBe(parent)
-
-    expect(
-      getStarterBaseDirectory(parent, {
-        directory: root,
-        agencyFile: path.join(root, "agency.py"),
-      }),
-    ).toBe(parent)
-    expect(getStarterBaseDirectory(parent)).toBe(parent)
-  })
-
-  test("prepareProjectLaunch keeps project launches in local Agent Builder mode", async () => {
-    await using dir = await tmpdir()
-    const venvPython = path.join(
-      dir.path,
-      ".venv",
-      process.platform === "win32" ? "Scripts" : "bin",
-      process.platform === "win32" ? "python.exe" : "python",
-    )
-    await mkdir(path.dirname(venvPython), { recursive: true })
-    await Bun.write(venvPython, "")
-
-    const launch = await prepareProjectLaunch({
-      directory: dir.path,
-      agencyFile: path.join(dir.path, "agency.py"),
-    })
-
-    expect(launch).toEqual({
-      directory: dir.path,
-    })
+    ).toBe(`Use this Agency Swarm project (${root})`)
   })
 })
 

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -112,7 +112,7 @@ describe("agency-swarm npx onboarding", () => {
         directory: root,
         agencyFile: path.join(root, "agency.py"),
       }),
-    ).toBe(`Use this Agency Swarm project (${root})`)
+    ).toBe(`Use detected Agency Swarm project (${root})`)
   })
 
   test("validateStarterName rejects existing target folders", async () => {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -8,6 +8,7 @@ import {
   formatProjectLabel,
   NPX_ENTRY_ENV,
   shouldRunNpxOnboarding,
+  validateStarterName,
 } from "../../src/agency-swarm/npx"
 import { tmpdir } from "../fixture/fixture"
 
@@ -83,6 +84,17 @@ describe("agency-swarm npx onboarding", () => {
     expect(project).toBeUndefined()
   })
 
+  test("detectAgencyProject ignores parent agency projects", async () => {
+    await using dir = await tmpdir()
+    const nested = path.join(dir.path, "example_agent")
+    await mkdir(nested)
+    await writeAgency(dir.path)
+
+    const project = await detectAgencyProject(nested)
+
+    expect(project).toBeUndefined()
+  })
+
   test("detectAgencyProject ignores unrelated python files", async () => {
     await using dir = await tmpdir()
     await Bun.write(path.join(dir.path, "agency.py"), "print('hello')")
@@ -101,6 +113,14 @@ describe("agency-swarm npx onboarding", () => {
         agencyFile: path.join(root, "agency.py"),
       }),
     ).toBe(`Use this Agency Swarm project (${root})`)
+  })
+
+  test("validateStarterName rejects existing target folders", async () => {
+    await using dir = await tmpdir()
+    await mkdir(path.join(dir.path, "my-agency"))
+
+    expect(validateStarterName(dir.path, "my-agency")).toBe("A folder with this name already exists")
+    expect(validateStarterName(dir.path, "new-agency")).toBeUndefined()
   })
 })
 

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -37,6 +37,31 @@ describe("agency-swarm npx onboarding", () => {
     ).toBe(false)
   })
 
+  test("installed agentswarm binary enables onboarding for the default launch", () => {
+    delete process.env[NPX_ENTRY_ENV]
+
+    expect(
+      shouldRunNpxOnboarding({
+        env: process.env,
+        argv: ["/usr/local/bin/agentswarm"],
+      }),
+    ).toBe(true)
+
+    expect(
+      shouldRunNpxOnboarding({
+        env: process.env,
+        argv: ["C:\\Users\\runner\\bin\\agentswarm.exe"],
+      }),
+    ).toBe(true)
+
+    expect(
+      shouldRunNpxOnboarding({
+        env: process.env,
+        argv: ["/usr/local/bin/opencode"],
+      }),
+    ).toBe(false)
+  })
+
   test("buildAgencyConfig keeps launch config session-scoped", () => {
     const config = JSON.parse(
       buildAgencyConfig({

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -5,6 +5,7 @@ import {
   buildAgencyConfig,
   buildPythonEnv,
   detectAgencyProject,
+  getStarterBaseDirectory,
   NPX_ENTRY_ENV,
   prepareProjectLaunch,
   shouldRunNpxOnboarding,
@@ -115,6 +116,27 @@ describe("agency-swarm npx onboarding", () => {
     const project = await detectAgencyProject(dir.path)
 
     expect(project).toBeUndefined()
+  })
+
+  test("getStarterBaseDirectory keeps new starter projects beside detected projects", () => {
+    const root = path.join("/tmp", "workspace", "agency")
+    const nested = path.join(root, "example_agent", "tools")
+    const parent = path.dirname(root)
+
+    expect(
+      getStarterBaseDirectory(nested, {
+        directory: root,
+        agencyFile: path.join(root, "agency.py"),
+      }),
+    ).toBe(parent)
+
+    expect(
+      getStarterBaseDirectory(parent, {
+        directory: root,
+        agencyFile: path.join(root, "agency.py"),
+      }),
+    ).toBe(parent)
+    expect(getStarterBaseDirectory(parent)).toBe(parent)
   })
 
   test("prepareProjectLaunch keeps project launches in local Agent Builder mode", async () => {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -6,22 +6,22 @@ import {
   buildPythonEnv,
   detectAgencyProject,
   formatProjectLabel,
-  NPX_ENTRY_ENV,
+  LAUNCHER_ENTRY_ENV,
   shouldRunNpxOnboarding,
   validateStarterName,
 } from "../../src/agency-swarm/npx"
 import { tmpdir } from "../fixture/fixture"
 
 describe("agency-swarm npx onboarding", () => {
-  const originalEnv = process.env[NPX_ENTRY_ENV]
+  const originalEnv = process.env[LAUNCHER_ENTRY_ENV]
 
   afterEach(() => {
-    if (originalEnv === undefined) delete process.env[NPX_ENTRY_ENV]
-    else process.env[NPX_ENTRY_ENV] = originalEnv
+    if (originalEnv === undefined) delete process.env[LAUNCHER_ENTRY_ENV]
+    else process.env[LAUNCHER_ENTRY_ENV] = originalEnv
   })
 
   test("wrapper env enables onboarding for the default launch only", () => {
-    process.env[NPX_ENTRY_ENV] = "1"
+    process.env[LAUNCHER_ENTRY_ENV] = "1"
 
     expect(
       shouldRunNpxOnboarding({
@@ -38,7 +38,7 @@ describe("agency-swarm npx onboarding", () => {
   })
 
   test("installed agentswarm binary enables onboarding for the default launch", () => {
-    delete process.env[NPX_ENTRY_ENV]
+    delete process.env[LAUNCHER_ENTRY_ENV]
 
     expect(
       shouldRunNpxOnboarding({

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -64,20 +64,48 @@ describe("agency-swarm npx onboarding", () => {
 
   test("detectAgencyProject requires agency.py with create_agency", async () => {
     await using dir = await tmpdir()
-    await Bun.write(
-      path.join(dir.path, "agency.py"),
-      [
-        "from agency_swarm import Agency",
-        "",
-        "def create_agency(load_threads_callback=None):",
-        "    return Agency()",
-      ].join("\n"),
-    )
+    await writeAgency(dir.path)
 
     const project = await detectAgencyProject(dir.path)
 
     expect(project?.directory).toBe(dir.path)
     expect(project?.agencyFile).toBe(path.join(dir.path, "agency.py"))
+  })
+
+  test("detectAgencyProject finds the project root from nested folders", async () => {
+    await using dir = await tmpdir()
+    const nested = path.join(dir.path, "example_agent", "tools")
+    await mkdir(nested, { recursive: true })
+    await writeAgency(dir.path)
+
+    const project = await detectAgencyProject(nested)
+
+    expect(project?.directory).toBe(dir.path)
+    expect(project?.agencyFile).toBe(path.join(dir.path, "agency.py"))
+  })
+
+  test("detectAgencyProject finds one starter project inside the current folder", async () => {
+    await using dir = await tmpdir()
+    const child = path.join(dir.path, "my-agency")
+    await mkdir(child)
+    await writeAgency(child)
+
+    const project = await detectAgencyProject(dir.path)
+
+    expect(project?.directory).toBe(child)
+    expect(project?.agencyFile).toBe(path.join(child, "agency.py"))
+  })
+
+  test("detectAgencyProject ignores ambiguous starter project folders", async () => {
+    await using dir = await tmpdir()
+    await mkdir(path.join(dir.path, "first"))
+    await mkdir(path.join(dir.path, "second"))
+    await writeAgency(path.join(dir.path, "first"))
+    await writeAgency(path.join(dir.path, "second"))
+
+    const project = await detectAgencyProject(dir.path)
+
+    expect(project).toBeUndefined()
   })
 
   test("detectAgencyProject ignores unrelated python files", async () => {
@@ -110,3 +138,15 @@ describe("agency-swarm npx onboarding", () => {
     })
   })
 })
+
+async function writeAgency(dir: string) {
+  await Bun.write(
+    path.join(dir, "agency.py"),
+    [
+      "from agency_swarm import Agency",
+      "",
+      "def create_agency(load_threads_callback=None):",
+      "    return Agency()",
+    ].join("\n"),
+  )
+}


### PR DESCRIPTION
## What changed
- Detect an Agency Swarm project only when the current directory itself has a valid `agency.py`.
- Show the first option as `Use detected Agency Swarm project (<full path>)` when detection succeeds.
- Selecting that option starts a local FastAPI server for the project and connects the terminal UI with session-scoped config.
- If detection fails, the launcher offers starter creation and connecting to an existing agency.
- Show the Python executable/version before project startup, and prefer the project `.venv` when present.
- Reject existing starter target folders in the prompt instead of crashing with `Target directory already exists`.
- Make installed `agentswarm` default no-argument launch enter the same onboarding path as `npx @vrsen/agentswarm`; subcommands and flags still bypass onboarding.
- Rename the wrapper marker from `AGENTSWARM_NPX` to `AGENTSWARM_LAUNCHER` because it applies to both npm and installed launcher paths.
- Move the Python FastAPI bootstrap script into a dedicated launcher module so the TypeScript flow stays focused on orchestration.
- Checked with `bun test test/agency-swarm/npx.test.ts` (10 passing), `bun typecheck`, Prettier check, `git diff --check`, and the pre-push typecheck hook.
- Manual PTY smokes covered detected-project startup, nested-folder non-detection, existing starter folder validation, Python-version display, and installed `agentswarm` launcher behavior.
