### PR TITLE
Fix local Agency Swarm auth and run-mode session resume

### DIFF
--- a/packages/opencode/src/agency-swarm/adapter.ts
+++ b/packages/opencode/src/agency-swarm/adapter.ts
@@ -495,11 +495,13 @@ export namespace AgencySwarmAdapter {
     const baseURL = asString(value["base_url"]) ?? asString(value["baseURL"])
     const apiKey = asString(value["api_key"]) ?? asString(value["apiKey"])
     const litellmKeys = asRecord(value["litellm_keys"]) ?? asRecord(value["litellmKeys"])
+    const headers = readStringRecord(value["default_headers"]) ?? readStringRecord(value["defaultHeaders"])
 
     const payload: Record<string, unknown> = {}
     if (baseURL) payload["base_url"] = baseURL
     if (apiKey) payload["api_key"] = apiKey
     if (litellmKeys && Object.keys(litellmKeys).length > 0) payload["litellm_keys"] = litellmKeys
+    if (headers) payload["default_headers"] = headers
 
     return Object.keys(payload).length > 0 ? payload : undefined
   }
@@ -610,6 +612,15 @@ export namespace AgencySwarmAdapter {
     if (typeof value !== "string") return undefined
     const trimmed = value.trim()
     return trimmed ? trimmed : undefined
+  }
+
+  function readStringRecord(value: unknown): Record<string, string> | undefined {
+    const record = asRecord(value)
+    if (!record) return undefined
+    const result = Object.fromEntries(
+      Object.entries(record).flatMap(([key, item]) => (typeof item === "string" ? [[key, item]] : [])),
+    )
+    return Object.keys(result).length > 0 ? result : undefined
   }
 
   function asArray(value: unknown): unknown[] {

--- a/packages/opencode/src/agency-swarm/client-config.ts
+++ b/packages/opencode/src/agency-swarm/client-config.ts
@@ -12,7 +12,10 @@ export function readStringRecord(value: unknown): Record<string, string> | undef
   const record = asRecord(value)
   if (!record) return undefined
   const result = Object.fromEntries(
-    Object.entries(record).flatMap(([key, item]) => (typeof item === "string" ? [[key, item]] : [])),
+    Object.entries(record).flatMap(([key, item]) => {
+      const text = asString(item)
+      return text ? [[key, text]] : []
+    }),
   )
   return Object.keys(result).length > 0 ? result : undefined
 }

--- a/packages/opencode/src/agency-swarm/client-config.ts
+++ b/packages/opencode/src/agency-swarm/client-config.ts
@@ -1,0 +1,38 @@
+function asString(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function asRecord(value: unknown) {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined
+}
+
+const AUTH_HEADER_PATTERN = /(^authorization$|(^|[-_])(api[-_]?key|token|auth[-_]?token)$)/i
+
+export function readStringRecord(value: unknown): Record<string, string> | undefined {
+  const record = asRecord(value)
+  if (!record) return undefined
+  const result = Object.fromEntries(
+    Object.entries(record).flatMap(([key, item]) => (typeof item === "string" ? [[key, item]] : [])),
+  )
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+export function readCredentialHeaders(config: Record<string, unknown>) {
+  const headers = readStringRecord(config["default_headers"]) ?? readStringRecord(config["defaultHeaders"])
+  if (!headers) return undefined
+  const result = Object.fromEntries(Object.entries(headers).filter(([key]) => AUTH_HEADER_PATTERN.test(key)))
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+export function hasClientConfigCredential(config: Record<string, unknown>) {
+  if (asString(config["api_key"]) ?? asString(config["apiKey"])) return true
+  const litellmKeys = asRecord(config["litellm_keys"]) ?? asRecord(config["litellmKeys"])
+  if (litellmKeys && Object.values(litellmKeys).some((item) => typeof item === "string" && item.length > 0)) {
+    return true
+  }
+  return !!readCredentialHeaders(config)
+}
+
+export function hasExplicitOpenAIClientConfig(config: Record<string, unknown> | undefined) {
+  return !!(config && (asString(config["api_key"]) ?? asString(config["apiKey"]) ?? readCredentialHeaders(config)))
+}

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -5,8 +5,11 @@ import path from "node:path"
 import { existsSync } from "node:fs"
 import { mkdtemp, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
+import { AgencySwarmRunSession } from "./run-session"
 import { SERVER_LAUNCHER_SCRIPT } from "./server-launcher"
 import { Filesystem } from "@/util/filesystem"
+import type { Session } from "@/session"
+import { SessionID } from "@/session/schema"
 
 export const LAUNCHER_ENTRY_ENV = "AGENTSWARM_LAUNCHER"
 export const STARTER_TEMPLATE_REPO = "agency-ai-solutions/agency-starter-template"
@@ -19,6 +22,7 @@ type StarterMode = "github" | "local"
 export interface PreparedNpxLaunch {
   directory: string
   configContent?: string
+  runProjectDirectory?: string
   cleanup?: () => Promise<void>
 }
 
@@ -48,13 +52,82 @@ export function shouldRunNpxOnboarding(input: {
   prompt?: string
   agent?: string
 }) {
-  if (input.env[LAUNCHER_ENTRY_ENV] !== "1" && !isAgentswarmCommand(input.argv ?? process.argv)) return false
+  if (!isLauncher(input)) return false
   if (input.model) return false
   if (input.continue) return false
   if (input.session) return false
   if (input.prompt) return false
   if (input.agent) return false
   return true
+}
+
+export async function resolveNpxAutoProject(input: {
+  directory: string
+  env: NodeJS.ProcessEnv
+  argv?: string[]
+  model?: string
+  continue?: boolean
+  fork?: boolean
+  session?: string
+  prompt?: string
+  agent?: string
+  sessions?: Iterable<Pick<Session.Info, "id" | "directory" | "parentID" | "time">>
+  runSessions?: Iterable<{ sessionID: string; directory: string }>
+}) {
+  if (!isLauncher(input)) return
+  if (input.model && input.model.split("/")[0] !== AgencySwarmAdapter.PROVIDER_ID) return
+
+  if (input.session) {
+    const session = await getResumeSession(input.session, input.sessions)
+    return session ? resolveRunProject(session, input.runSessions) : undefined
+  }
+
+  if (input.continue) {
+    const sessions = input.sessions ? Array.from(input.sessions) : await listResumeSessions(input.directory)
+    const session = sessions
+      .filter((item) => item.directory === input.directory && !item.parentID)
+      .toSorted((a, b) => b.time.updated - a.time.updated)[0]
+    if (session) return resolveRunProject(session, input.runSessions)
+    if (input.fork) return
+    return detectAgencyProject(input.directory)
+  }
+
+  if (input.prompt || input.agent || input.model) {
+    return detectAgencyProject(input.directory)
+  }
+}
+
+async function getResumeSession(
+  sessionID: string,
+  sessions?: Iterable<Pick<Session.Info, "id" | "directory" | "parentID" | "time">>,
+) {
+  if (sessions) {
+    return Array.from(sessions).find((item) => item.id === sessionID)
+  }
+  const { Session } = await import("@/session")
+  return Session.get(SessionID.make(sessionID)).catch(() => undefined)
+}
+
+async function listResumeSessions(directory: string) {
+  const { Session } = await import("@/session")
+  const start = Date.now() - 30 * 24 * 60 * 60 * 1000
+  return Array.from(Session.listGlobal({ directory, roots: true, start, limit: 1 }))
+}
+
+function isLauncher(input: { env: NodeJS.ProcessEnv; argv?: string[] }) {
+  return input.env[LAUNCHER_ENTRY_ENV] === "1" || isAgentswarmCommand(input.argv ?? process.argv)
+}
+
+async function resolveRunProject(
+  session: Pick<Session.Info, "id" | "directory">,
+  runSessions?: Iterable<{ sessionID: string; directory: string }>,
+) {
+  const run = runSessions
+    ? Array.from(runSessions).find((item) => item.sessionID === session.id)
+    : await AgencySwarmRunSession.get(session.id)
+  if (!run) return
+  if (path.resolve(run.directory) !== path.resolve(session.directory)) return
+  return detectAgencyProject(run.directory)
 }
 
 function isAgentswarmCommand(argv: string[]) {
@@ -383,6 +456,7 @@ export async function prepareProjectLaunch(project: AgencyProject): Promise<Prep
   const server = await startProjectServer(project.directory, python)
   return {
     directory: project.directory,
+    runProjectDirectory: project.directory,
     configContent: buildAgencyConfig({
       baseURL: server.baseURL,
       agency: LOCAL_AGENCY_ID,

--- a/packages/opencode/src/agency-swarm/run-session.ts
+++ b/packages/opencode/src/agency-swarm/run-session.ts
@@ -4,6 +4,7 @@ import { Filesystem } from "@/util/filesystem"
 
 export namespace AgencySwarmRunSession {
   export const LOCAL_PROJECT_ENV = "AGENTSWARM_RUN_PROJECT"
+  const PROVIDER_ID = "agency-swarm"
 
   type Info = {
     mode: "local-project"
@@ -18,7 +19,22 @@ export namespace AgencySwarmRunSession {
       mode: "local-project",
       directory: path.resolve(input.directory),
     }
-    await Filesystem.writeJson(file, data)
+    await write(data)
+  }
+
+  export async function clear(sessionID: string) {
+    const data = await read()
+    if (!(sessionID in data)) return
+    delete data[sessionID]
+    await write(data)
+  }
+
+  export async function sync(input: { sessionID: string; providerID: string; directory?: string }) {
+    if (input.providerID !== PROVIDER_ID || !input.directory) {
+      await clear(input.sessionID)
+      return
+    }
+    await mark({ sessionID: input.sessionID, directory: input.directory })
   }
 
   export async function get(sessionID: string): Promise<Info | undefined> {
@@ -28,5 +44,9 @@ export namespace AgencySwarmRunSession {
   async function read(): Promise<Record<string, Info>> {
     const data = await Filesystem.readJson<Record<string, Info>>(file).catch((): Record<string, Info> => ({}))
     return data && typeof data === "object" && !Array.isArray(data) ? data : {}
+  }
+
+  async function write(data: Record<string, Info>) {
+    await Filesystem.writeJson(file, data)
   }
 }

--- a/packages/opencode/src/agency-swarm/run-session.ts
+++ b/packages/opencode/src/agency-swarm/run-session.ts
@@ -1,0 +1,32 @@
+import path from "node:path"
+import { Global } from "@/global"
+import { Filesystem } from "@/util/filesystem"
+
+export namespace AgencySwarmRunSession {
+  export const LOCAL_PROJECT_ENV = "AGENTSWARM_RUN_PROJECT"
+
+  type Info = {
+    mode: "local-project"
+    directory: string
+  }
+
+  const file = path.join(Global.Path.state, "agency-swarm-run-sessions.json")
+
+  export async function mark(input: { sessionID: string; directory: string }) {
+    const data = await read()
+    data[input.sessionID] = {
+      mode: "local-project",
+      directory: path.resolve(input.directory),
+    }
+    await Filesystem.writeJson(file, data)
+  }
+
+  export async function get(sessionID: string): Promise<Info | undefined> {
+    return (await read())[sessionID]
+  }
+
+  async function read(): Promise<Record<string, Info>> {
+    const data = await Filesystem.readJson<Record<string, Info>>(file).catch((): Record<string, Info> => ({}))
+    return data && typeof data === "object" && !Array.isArray(data) ? data : {}
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -455,6 +455,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   )
 
   const connected = useConnected()
+  const frameworkMode = createMemo(() => local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID)
   command.register(() => [
     {
       title: "Switch session",
@@ -516,6 +517,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       keybind: "model_list",
       suggested: true,
       category: "Agent",
+      hidden: frameworkMode(),
       slash: {
         name: "models",
       },
@@ -601,6 +603,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       value: "variant.cycle",
       keybind: "variant_cycle",
       category: "Agent",
+      hidden: frameworkMode(),
       onSelect: () => {
         local.model.variant.cycle()
       },
@@ -610,7 +613,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       value: "variant.list",
       keybind: "variant_list",
       category: "Agent",
-      hidden: local.model.variant.list().length === 0,
+      hidden: frameworkMode() || local.model.variant.list().length === 0,
       slash: {
         name: "variants",
       },

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -439,12 +439,11 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   createEffect(
     on(
       () => {
-        const selected = args.model ? Provider.parseModel(args.model).providerID : undefined
         return (
           sync.status === "complete" &&
           shouldOpenStartupAuthDialog({
             providers: sync.data.provider,
-            frameworkMode: selected === AgencySwarmAdapter.PROVIDER_ID,
+            frameworkMode: local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID,
           })
         )
       },

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -517,6 +517,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       keybind: "model_list",
       suggested: true,
       category: "Agent",
+      enabled: !frameworkMode(),
       hidden: frameworkMode(),
       slash: {
         name: "models",
@@ -603,6 +604,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       value: "variant.cycle",
       keybind: "variant_cycle",
       category: "Agent",
+      enabled: !frameworkMode(),
       hidden: frameworkMode(),
       onSelect: () => {
         local.model.variant.cycle()
@@ -613,6 +615,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       value: "variant.list",
       keybind: "variant_list",
       category: "Agent",
+      enabled: !frameworkMode(),
       hidden: frameworkMode() || local.model.variant.list().length === 0,
       slash: {
         name: "variants",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -39,6 +39,7 @@ import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
 import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "@tui/util/provider-origin"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
 
 export type PromptProps = {
   sessionID?: string
@@ -304,6 +305,13 @@ export function Prompt(props: PromptProps) {
         },
         onSelect: async (dialog) => {
           dialog.clear()
+          if (!Editor.isConfigured()) {
+            toast.show({
+              message: "Set VISUAL or EDITOR to use the external editor",
+              variant: "warning",
+            })
+            return
+          }
 
           // replace summarized text parts with the actual text
           const text = store.prompt.parts
@@ -655,6 +663,11 @@ export function Prompt(props: PromptProps) {
     // Capture mode before it gets reset
     const currentMode = store.mode
     const variant = local.model.variant.current()
+    void AgencySwarmRunSession.sync({
+      sessionID,
+      providerID: selectedModel.providerID,
+      directory: process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV],
+    })
 
     if (store.mode === "shell") {
       sdk.client.session.shell({

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -877,6 +877,14 @@ export function Session() {
           )
 
           if (options.openWithoutSaving) {
+            if (!Editor.isConfigured()) {
+              toast.show({
+                message: "Set VISUAL or EDITOR to open the transcript in your editor",
+                variant: "warning",
+              })
+              dialog.clear()
+              return
+            }
             // Just open in editor without saving
             await Editor.open({ value: transcript, renderer })
           } else {
@@ -887,7 +895,7 @@ export function Session() {
             await Filesystem.write(filepath, transcript)
 
             // Open with EDITOR if available
-            const result = await Editor.open({ value: transcript, renderer })
+            const result = Editor.isConfigured() ? await Editor.open({ value: transcript, renderer }) : undefined
             if (result !== undefined) {
               await Filesystem.write(filepath, result)
             }

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,17 +1,34 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import type { Provider } from "@opencode-ai/sdk/v2"
 
-export function hasUsableProvider(providers: Provider[]) {
+export function hasUsableProvider(providers: Provider[], credentialed = false) {
   return providers.some((provider) => {
-    if (provider.id !== "opencode") return true
+    if (provider.id !== "opencode") return credentialed ? hasCredential(provider) : true
     return Object.values(provider.models).some((model) => model.cost?.input !== 0)
   })
+}
+
+function hasCredential(provider: Provider) {
+  if (provider.key) return true
+  if (provider.source === "api" || provider.source === "env") return true
+  const options = provider.options ?? {}
+  return [options["apiKey"], options["api_key"], options["key"], options["token"]].some(
+    (item) => typeof item === "string" && item.length > 0,
+  )
 }
 
 function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
   const raw = provider?.options?.["clientConfig"] ?? provider?.options?.["client_config"]
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return false
-  return Object.keys(raw).length > 0
+  return hasClientConfigCredential(raw as Record<string, unknown>)
+}
+
+function hasClientConfigCredential(config: Record<string, unknown>) {
+  if (typeof config["api_key"] === "string" && config["api_key"]) return true
+  if (typeof config["apiKey"] === "string" && config["apiKey"]) return true
+  const litellmKeys = config["litellm_keys"] ?? config["litellmKeys"]
+  if (!litellmKeys || typeof litellmKeys !== "object" || Array.isArray(litellmKeys)) return false
+  return Object.values(litellmKeys).some((item) => typeof item === "string" && item.length > 0)
 }
 
 export function shouldOpenStartupAuthDialog(input: { providers: Provider[]; frameworkMode: boolean }) {
@@ -20,7 +37,10 @@ export function shouldOpenStartupAuthDialog(input: { providers: Provider[]; fram
   const agencyProvider = input.providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
   if (hasExplicitAgencyClientConfig(agencyProvider)) return false
 
-  return !hasUsableProvider(input.providers.filter((provider) => provider.id !== AgencySwarmAdapter.PROVIDER_ID))
+  return !hasUsableProvider(
+    input.providers.filter((provider) => provider.id !== AgencySwarmAdapter.PROVIDER_ID),
+    true,
+  )
 }
 
 export function shouldOpenAgencyConnectDialog(input: { providerID?: string; message: string }) {

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,4 +1,5 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { hasClientConfigCredential } from "@/agency-swarm/client-config"
 import type { Provider } from "@opencode-ai/sdk/v2"
 
 export function hasUsableProvider(providers: Provider[], credentialed = false) {
@@ -21,14 +22,6 @@ function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
   const raw = provider?.options?.["clientConfig"] ?? provider?.options?.["client_config"]
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return false
   return hasClientConfigCredential(raw as Record<string, unknown>)
-}
-
-function hasClientConfigCredential(config: Record<string, unknown>) {
-  if (typeof config["api_key"] === "string" && config["api_key"]) return true
-  if (typeof config["apiKey"] === "string" && config["apiKey"]) return true
-  const litellmKeys = config["litellm_keys"] ?? config["litellmKeys"]
-  if (!litellmKeys || typeof litellmKeys !== "object" || Array.isArray(litellmKeys)) return false
-  return Object.values(litellmKeys).some((item) => typeof item === "string" && item.length > 0)
 }
 
 export function shouldOpenStartupAuthDialog(input: { providers: Provider[]; frameworkMode: boolean }) {

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -17,7 +17,13 @@ import { TuiConfig } from "@/config/tui"
 import { Instance } from "@/project/instance"
 import { writeHeapSnapshot } from "v8"
 import { AgencyProduct } from "@/agency-swarm/product"
-import { prepareNpxLaunch, shouldRunNpxOnboarding } from "@/agency-swarm/npx"
+import {
+  prepareNpxLaunch,
+  prepareProjectLaunch,
+  resolveNpxAutoProject,
+  shouldRunNpxOnboarding,
+} from "@/agency-swarm/npx"
+import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -141,13 +147,32 @@ export const TuiThreadCommand = cmd({
         prompt: args.prompt,
         agent: args.agent,
       })
-      const prepared = shouldBootstrap ? await prepareNpxLaunch(selectedProject) : undefined
-      if (shouldBootstrap && !prepared) {
+      const project = shouldBootstrap
+        ? undefined
+        : await resolveNpxAutoProject({
+            directory: selectedProject,
+            env: process.env,
+            model: args.model,
+            continue: args.continue,
+            fork: args.fork,
+            session: args.session,
+            prompt: args.prompt,
+            agent: args.agent,
+          })
+      const prepared = shouldBootstrap
+        ? await prepareNpxLaunch(selectedProject)
+        : project
+          ? await prepareProjectLaunch(project)
+          : undefined
+      if ((shouldBootstrap || project) && !prepared) {
         return
       }
       cleanup = prepared?.cleanup
       if (prepared?.configContent) {
         process.env.OPENCODE_CONFIG_CONTENT = prepared.configContent
+      }
+      if (prepared?.runProjectDirectory) {
+        process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV] = Filesystem.resolve(prepared.runProjectDirectory)
       }
       const next = prepared?.directory ? Filesystem.resolve(prepared.directory) : selectedProject
       const file = await target()

--- a/packages/opencode/src/cli/cmd/tui/util/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/editor.ts
@@ -7,6 +7,10 @@ import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
 
 export namespace Editor {
+  export function isConfigured() {
+    return Boolean(process.env["VISUAL"] || process.env["EDITOR"])
+  }
+
   export async function open(opts: { value: string; renderer: CliRenderer }): Promise<string | undefined> {
     const editor = process.env["VISUAL"] || process.env["EDITOR"]
     if (!editor) return

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -12,7 +12,8 @@ const log = Log.create({ service: "plugin.codex" })
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const ISSUER = "https://auth.openai.com"
-const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
+export const CODEX_API_BASE_URL = "https://chatgpt.com/backend-api/codex"
+const CODEX_API_ENDPOINT = `${CODEX_API_BASE_URL}/responses`
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
 
@@ -129,7 +130,7 @@ async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: Pk
   return response.json()
 }
 
-async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
+export async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
   const response = await fetch(`${ISSUER}/oauth/token`, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -136,7 +136,7 @@ export namespace SessionAgencySwarm {
 
     const explicitBaseURL = asString(explicit["base_url"]) ?? asString(explicit["baseURL"])
     const generatedBaseURL = asString(generated["base_url"])
-    if (explicitBaseURL && (explicitAPIKey || generatedBaseURL !== CODEX_API_BASE_URL)) {
+    if (explicitBaseURL) {
       merged["base_url"] = explicitBaseURL
     } else if (generatedBaseURL) {
       merged["base_url"] = generatedBaseURL

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -3,6 +3,7 @@ import { AgencySwarmHistory } from "@/agency-swarm/history"
 import { mapProviderIDToLiteLLMProvider } from "@/agency-swarm/litellm-provider"
 import { Auth } from "@/auth"
 import { Env } from "@/env"
+import { CODEX_API_BASE_URL, extractAccountId, refreshAccessToken } from "@/plugin/codex"
 import { Provider } from "@/provider/provider"
 import { Session } from "@/session"
 import { MessageV2 } from "@/session/message-v2"
@@ -109,7 +110,12 @@ export namespace SessionAgencySwarm {
     config: Record<string, unknown> | undefined,
   ): Promise<Record<string, unknown> | undefined> {
     const generated = isLoopbackBaseURL(baseURL)
-      ? buildAuthClientConfig(await Auth.all(), await listProvidersForEnvCheck(), getEnvForClientConfig())
+      ? await buildAuthClientConfig(
+          await Auth.all(),
+          await listProvidersForEnvCheck(),
+          getEnvForClientConfig(),
+          hasExplicitOpenAIConfig(config),
+        )
       : undefined
     if (!config) return generated
     if (!generated) return config
@@ -122,17 +128,20 @@ export namespace SessionAgencySwarm {
       ...explicit,
     }
 
-    const explicitBaseURL = asString(explicit["base_url"]) ?? asString(explicit["baseURL"])
-    if (explicitBaseURL) {
-      merged["base_url"] = explicitBaseURL
-    }
-    delete merged["baseURL"]
-
     const explicitAPIKey = asString(explicit["api_key"]) ?? asString(explicit["apiKey"])
     if (explicitAPIKey) {
       merged["api_key"] = explicitAPIKey
     }
     delete merged["apiKey"]
+
+    const explicitBaseURL = asString(explicit["base_url"]) ?? asString(explicit["baseURL"])
+    const generatedBaseURL = asString(generated["base_url"])
+    if (explicitBaseURL && (explicitAPIKey || generatedBaseURL !== CODEX_API_BASE_URL)) {
+      merged["base_url"] = explicitBaseURL
+    } else if (generatedBaseURL) {
+      merged["base_url"] = generatedBaseURL
+    }
+    delete merged["baseURL"]
 
     const generatedLiteLLMKeys = asRecord(generated["litellm_keys"])
     const explicitLiteLLMKeys = asRecord(explicit["litellm_keys"]) ?? asRecord(explicit["litellmKeys"])
@@ -144,24 +153,58 @@ export namespace SessionAgencySwarm {
     }
     delete merged["litellmKeys"]
 
+    const generatedHeaders = readStringRecord(generated["default_headers"])
+    const explicitHeaders =
+      readStringRecord(explicit["default_headers"]) ?? readStringRecord(explicit["defaultHeaders"])
+    if (generatedHeaders || explicitHeaders) {
+      merged["default_headers"] = {
+        ...(generatedHeaders ?? {}),
+        ...(explicitHeaders ?? {}),
+      }
+    }
+    delete merged["defaultHeaders"]
+
     return merged
   }
 
-  function buildAuthClientConfig(
+  async function buildAuthClientConfig(
     auths: Record<string, Auth.Info>,
     providers: Record<string, Provider.Info> | undefined,
     env: Record<string, string | undefined>,
-  ): Record<string, unknown> | undefined {
+    skipOpenAI: boolean,
+  ): Promise<Record<string, unknown> | undefined> {
     const litellmKeys: Record<string, string> = {}
     const payload: Record<string, unknown> = {}
 
-    for (const [providerID, auth] of Object.entries(auths)) {
+    for (const [providerID, provider] of Object.entries(providers ?? {})) {
       if (providerID === AgencySwarmAdapter.PROVIDER_ID) continue
-      if (auth.type !== "api") continue
-      if (hasEnvCredential(providerID, providers, env)) continue
+      const key = getEnvCredential(provider, env)
+      if (!key) continue
 
       if (providerID === "openai") {
-        payload["api_key"] = auth.key
+        if (!skipOpenAI) payload["api_key"] = key
+        continue
+      }
+
+      const litellmProvider = mapProviderIDToLiteLLMProvider(providerID)
+      if (!litellmProvider) continue
+      litellmKeys[litellmProvider] = key
+    }
+
+    for (const [providerID, auth] of Object.entries(auths)) {
+      if (providerID === AgencySwarmAdapter.PROVIDER_ID) continue
+      if (hasEnvCredential(providerID, providers, env)) continue
+
+      if (providerID === "openai" && auth.type === "oauth") {
+        if (skipOpenAI) continue
+        Object.assign(payload, await buildOpenAIOAuthClientConfig(auth))
+        continue
+      }
+
+      if (auth.type !== "api") continue
+
+      if (providerID === "openai") {
+        if (!skipOpenAI) payload["api_key"] = auth.key
         continue
       }
 
@@ -177,6 +220,44 @@ export namespace SessionAgencySwarm {
     return Object.keys(payload).length > 0 ? payload : undefined
   }
 
+  async function buildOpenAIOAuthClientConfig(auth: Auth.Oauth): Promise<Record<string, unknown>> {
+    const current =
+      auth.expires < Date.now()
+        ? await refreshAccessToken(auth.refresh).then(async (tokens) => {
+            const accountID = extractAccountId(tokens) ?? auth.accountId
+            const next = {
+              type: "oauth" as const,
+              refresh: tokens.refresh_token,
+              access: tokens.access_token,
+              expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+              ...(accountID ? { accountId: accountID } : {}),
+            }
+            await Auth.set("openai", next)
+            return next
+          })
+        : auth
+    const headers: Record<string, string> = {}
+    if (current.accountId) headers["ChatGPT-Account-Id"] = current.accountId
+    return {
+      api_key: current.access,
+      base_url: CODEX_API_BASE_URL,
+      ...(Object.keys(headers).length > 0 ? { default_headers: headers } : {}),
+    }
+  }
+
+  function readStringRecord(value: unknown): Record<string, string> | undefined {
+    const record = asRecord(value)
+    if (!record) return undefined
+    const result = Object.fromEntries(
+      Object.entries(record).flatMap(([key, item]) => (typeof item === "string" ? [[key, item]] : [])),
+    )
+    return Object.keys(result).length > 0 ? result : undefined
+  }
+
+  function hasExplicitOpenAIConfig(config: Record<string, unknown> | undefined) {
+    return !!(asString(config?.["api_key"]) ?? asString(config?.["apiKey"]))
+  }
+
   function hasEnvCredential(
     providerID: string,
     providers: Record<string, Provider.Info> | undefined,
@@ -185,7 +266,17 @@ export namespace SessionAgencySwarm {
     if (!providers) return false
     const provider = providers[providerID]
     if (!provider) return false
-    return provider.env.some((key) => Boolean(env[key]))
+    return !!getEnvCredential(provider, env)
+  }
+
+  function getEnvCredential(provider: Provider.Info, env: Record<string, string | undefined>) {
+    if (provider.env.length === 0) return undefined
+    if (!provider.env.every(isAPIKeyEnvName)) return undefined
+    return provider.env.map((key) => env[key]).find(Boolean)
+  }
+
+  function isAPIKeyEnvName(name: string) {
+    return /(^|_)(API_KEY|API_TOKEN|PAT|TOKEN)$/.test(name)
   }
 
   async function listProvidersForEnvCheck(): Promise<Record<string, Provider.Info> | undefined> {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1,4 +1,8 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import {
+  hasExplicitOpenAIClientConfig,
+  readStringRecord,
+} from "@/agency-swarm/client-config"
 import { AgencySwarmHistory } from "@/agency-swarm/history"
 import { mapProviderIDToLiteLLMProvider } from "@/agency-swarm/litellm-provider"
 import { Auth } from "@/auth"
@@ -114,7 +118,7 @@ export namespace SessionAgencySwarm {
           await Auth.all(),
           await listProvidersForEnvCheck(),
           getEnvForClientConfig(),
-          hasExplicitOpenAIConfig(config),
+          hasExplicitOpenAIClientConfig(config),
         )
       : undefined
     if (!config) return generated
@@ -243,19 +247,6 @@ export namespace SessionAgencySwarm {
       base_url: CODEX_API_BASE_URL,
       ...(Object.keys(headers).length > 0 ? { default_headers: headers } : {}),
     }
-  }
-
-  function readStringRecord(value: unknown): Record<string, string> | undefined {
-    const record = asRecord(value)
-    if (!record) return undefined
-    const result = Object.fromEntries(
-      Object.entries(record).flatMap(([key, item]) => (typeof item === "string" ? [[key, item]] : [])),
-    )
-    return Object.keys(result).length > 0 ? result : undefined
-  }
-
-  function hasExplicitOpenAIConfig(config: Record<string, unknown> | undefined) {
-    return !!(asString(config?.["api_key"]) ?? asString(config?.["apiKey"]))
   }
 
   function hasEnvCredential(

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -33,6 +33,7 @@ import { ModelID, ProviderID } from "@/provider/schema"
 import { Permission } from "@/permission"
 import { Global } from "@/global"
 import { AgencyBrand } from "@/agency-swarm/brand"
+import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
 import type { LanguageModelV2Usage } from "@ai-sdk/provider"
 import { Effect, Layer, Scope, ServiceMap } from "effect"
 import { makeRuntime } from "@/effect/run-service"
@@ -403,6 +404,10 @@ export namespace Session {
         log.info("created", result)
 
         yield* Effect.sync(() => SyncEvent.run(Event.Created, { sessionID: result.id, info: result }))
+        const runProject = process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
+        if (runProject && path.resolve(runProject) === path.resolve(result.directory)) {
+          yield* Effect.promise(() => AgencySwarmRunSession.mark({ sessionID: result.id, directory: result.directory }))
+        }
 
         const cfg = yield* config.get()
         if (!result.parentID && (Flag.OPENCODE_AUTO_SHARE || cfg.share === "auto")) {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -33,7 +33,6 @@ import { ModelID, ProviderID } from "@/provider/schema"
 import { Permission } from "@/permission"
 import { Global } from "@/global"
 import { AgencyBrand } from "@/agency-swarm/brand"
-import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
 import type { LanguageModelV2Usage } from "@ai-sdk/provider"
 import { Effect, Layer, Scope, ServiceMap } from "effect"
 import { makeRuntime } from "@/effect/run-service"
@@ -404,10 +403,6 @@ export namespace Session {
         log.info("created", result)
 
         yield* Effect.sync(() => SyncEvent.run(Event.Created, { sessionID: result.id, info: result }))
-        const runProject = process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
-        if (runProject && path.resolve(runProject) === path.resolve(result.directory)) {
-          yield* Effect.promise(() => AgencySwarmRunSession.mark({ sessionID: result.id, directory: result.directory }))
-        }
 
         const cfg = yield* config.get()
         if (!result.parentID && (Flag.OPENCODE_AUTO_SHARE || cfg.share === "auto")) {

--- a/packages/opencode/test/agency-swarm/adapter.test.ts
+++ b/packages/opencode/test/agency-swarm/adapter.test.ts
@@ -184,6 +184,9 @@ describe("agency-swarm.adapter", () => {
       clientConfig: {
         baseURL: "https://proxy.example.com/v1",
         apiKey: "secret",
+        defaultHeaders: {
+          "ChatGPT-Account-Id": "acct_123",
+        },
         litellmKeys: {
           anthropic: "ant-secret",
         },
@@ -208,6 +211,9 @@ describe("agency-swarm.adapter", () => {
       client_config: {
         base_url: "https://proxy.example.com/v1",
         api_key: "secret",
+        default_headers: {
+          "ChatGPT-Account-Id": "acct_123",
+        },
         litellm_keys: {
           anthropic: "ant-secret",
         },

--- a/packages/opencode/test/agency-swarm/client-config.test.ts
+++ b/packages/opencode/test/agency-swarm/client-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import { hasClientConfigCredential, hasExplicitOpenAIClientConfig } from "../../src/agency-swarm/client-config"
+
+describe("agency-swarm client config credentials", () => {
+  test("treats api_key and LiteLLM keys as credentials", () => {
+    expect(hasClientConfigCredential({ api_key: "sk-openai" })).toBe(true)
+    expect(
+      hasClientConfigCredential({
+        litellm_keys: {
+          anthropic: "sk-ant",
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test("treats Authorization headers as credentials", () => {
+    expect(
+      hasClientConfigCredential({
+        default_headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      }),
+    ).toBe(true)
+    expect(
+      hasExplicitOpenAIClientConfig({
+        default_headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test("ignores non-auth headers", () => {
+    expect(
+      hasClientConfigCredential({
+        default_headers: {
+          "x-proxy": "1",
+        },
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/opencode/test/agency-swarm/client-config.test.ts
+++ b/packages/opencode/test/agency-swarm/client-config.test.ts
@@ -39,4 +39,21 @@ describe("agency-swarm client config credentials", () => {
       }),
     ).toBe(false)
   })
+
+  test("ignores empty auth-like headers", () => {
+    expect(
+      hasClientConfigCredential({
+        default_headers: {
+          Authorization: "",
+        },
+      }),
+    ).toBe(false)
+    expect(
+      hasExplicitOpenAIClientConfig({
+        default_headers: {
+          Authorization: "",
+        },
+      }),
+    ).toBe(false)
+  })
 })

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -7,9 +7,13 @@ import {
   detectAgencyProject,
   formatProjectLabel,
   LAUNCHER_ENTRY_ENV,
+  resolveNpxAutoProject,
   shouldRunNpxOnboarding,
   validateStarterName,
 } from "../../src/agency-swarm/npx"
+import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
 import { tmpdir } from "../fixture/fixture"
 
 describe("agency-swarm npx onboarding", () => {
@@ -146,6 +150,274 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(validateStarterName(dir.path, "my-agency")).toBe("A folder with this name already exists")
     expect(validateStarterName(dir.path, "new-agency")).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject uses session directory for explicit session resumes", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: "/tmp/elsewhere",
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [{ sessionID: "ses_123", directory: dir.path }],
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject does not auto-start explicit sessions without run metadata", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject does not fallback when explicit session is stale", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_missing",
+      sessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject does not fallback when explicit session is not an agency project", async () => {
+    await using dir = await tmpdir()
+    await using other = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: other.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [{ sessionID: "ses_123", directory: other.path }],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject uses latest local root session for continue", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      sessions: [
+        {
+          id: "ses_old" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+        {
+          id: "ses_new" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 2,
+            updated: 2,
+          },
+        },
+      ],
+      runSessions: [{ sessionID: "ses_new", directory: dir.path }],
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject does not auto-start continue sessions without run metadata", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      sessions: [
+        {
+          id: "ses_remote" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject falls back to current project when continue has no local session", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      sessions: [],
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject does not fallback when forking continue without a local session", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      fork: true,
+      sessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject starts current project for prompt launch", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      prompt: "hello",
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject starts current project for agent launch", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      agent: "build",
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject starts current project for agency-swarm model launch", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      model: "agency-swarm/default",
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject skips non agency-swarm model overrides", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      model: "openai/gpt-5",
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("created run-mode sessions can be resumed by explicit session id", async () => {
+    await using dir = await tmpdir({ git: true })
+    await writeAgency(dir.path)
+    const runProject = process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
+
+    try {
+      process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV] = dir.path
+      let session: Session.Info | undefined
+      await Instance.provide({
+        directory: dir.path,
+        fn: async () => {
+          session = await Session.create({})
+        },
+      })
+
+      if (!session) throw new Error("Expected session")
+      const current = session
+      expect((await AgencySwarmRunSession.get(current.id))?.directory).toBe(dir.path)
+
+      const project = await resolveNpxAutoProject({
+        directory: "/tmp/elsewhere",
+        env: { [LAUNCHER_ENTRY_ENV]: "1" },
+        session: current.id,
+      })
+
+      expect(project?.directory).toBe(dir.path)
+      await Instance.provide({
+        directory: dir.path,
+        fn: async () => {
+          await Session.remove(current.id)
+        },
+      })
+    } finally {
+      if (runProject === undefined) delete process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
+      else process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV] = runProject
+    }
   })
 })
 

--- a/packages/opencode/test/agency-swarm/run-session.test.ts
+++ b/packages/opencode/test/agency-swarm/run-session.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
+import { Filesystem } from "../../src/util/filesystem"
+
+describe("agency-swarm run session state", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test("sync stores local-project metadata only for agency-swarm sessions", async () => {
+    const readJson = spyOn(Filesystem, "readJson").mockRejectedValue(new Error("missing"))
+    const writeJson = spyOn(Filesystem, "writeJson").mockResolvedValue(undefined as never)
+
+    await AgencySwarmRunSession.sync({
+      sessionID: "ses_123",
+      providerID: "agency-swarm",
+      directory: "/tmp/project",
+    })
+
+    expect(readJson).toHaveBeenCalledTimes(1)
+    expect(writeJson).toHaveBeenCalledTimes(1)
+    expect(writeJson.mock.calls[0]?.[1]).toEqual({
+      ses_123: {
+        mode: "local-project",
+        directory: "/tmp/project",
+      },
+    })
+  })
+
+  test("sync clears stale local-project metadata for non-agency sessions", async () => {
+    spyOn(Filesystem, "readJson").mockResolvedValue({
+      ses_123: {
+        mode: "local-project",
+        directory: "/tmp/project",
+      },
+    } as never)
+    const writeJson = spyOn(Filesystem, "writeJson").mockResolvedValue(undefined as never)
+
+    await AgencySwarmRunSession.sync({
+      sessionID: "ses_123",
+      providerID: "openai",
+      directory: "/tmp/project",
+    })
+
+    expect(writeJson).toHaveBeenCalledTimes(1)
+    expect(writeJson.mock.calls[0]?.[1]).toEqual({})
+  })
+})

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -149,6 +149,55 @@ describe("agency session errors", () => {
     ).toBe(false)
   })
 
+  test("framework mode skips auth when explicit client_config has LiteLLM keys", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              clientConfig: {
+                litellm_keys: {
+                  anthropic: "manual-ant",
+                },
+              },
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode opens auth when explicit client_config has no credentials", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              clientConfig: {
+                base_url: "https://proxy.example.com/v1",
+                default_headers: {
+                  "x-proxy": "1",
+                },
+              },
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
   test("framework mode skips auth when another provider is available", () => {
     expect(
       shouldOpenStartupAuthDialog({
@@ -166,6 +215,113 @@ describe("agency session errors", () => {
             id: "openai",
             name: "OpenAI",
             source: "env",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode skips auth when a configured provider carries an env key", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            key: "env-openai",
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode opens auth when another provider has no credential", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  test("framework mode skips auth when stored oauth credentials are available", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "custom",
+            env: [],
+            options: {
+              apiKey: "oauth-dummy",
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode skips auth when stored api credentials are available", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "api",
             env: ["OPENAI_API_KEY"],
             options: {},
             models: {},

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -223,6 +223,31 @@ describe("agency session errors", () => {
     ).toBe(false)
   })
 
+  test("framework mode opens auth when auth-like headers are empty", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              clientConfig: {
+                base_url: "https://proxy.example.com/v1",
+                default_headers: {
+                  Authorization: "",
+                },
+              },
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
   test("framework mode skips auth when another provider is available", () => {
     expect(
       shouldOpenStartupAuthDialog({

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -198,6 +198,31 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
+  test("framework mode skips auth when explicit client_config authenticates through headers", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              clientConfig: {
+                base_url: "https://proxy.example.com/v1",
+                default_headers: {
+                  Authorization: "Bearer proxy-token",
+                },
+              },
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
   test("framework mode skips auth when another provider is available", () => {
     expect(
       shouldOpenStartupAuthDialog({

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -10,11 +10,14 @@ import * as Network from "../../../src/cli/network"
 import * as Win32 from "../../../src/cli/cmd/tui/win32"
 import { TuiConfig } from "../../../src/config/tui"
 import { Instance } from "../../../src/project/instance"
+import { AgencySwarmRunSession } from "../../../src/agency-swarm/run-session"
 
 const stop = new Error("stop")
 const seen = {
   tui: [] as string[],
   inst: [] as string[],
+  config: [] as Array<string | undefined>,
+  runEnv: [] as Array<string | undefined>,
 }
 
 function setup() {
@@ -45,6 +48,8 @@ function setup() {
   spyOn(TuiConfig, "get").mockResolvedValue({})
   spyOn(Instance, "provide").mockImplementation(async (input) => {
     seen.inst.push(input.directory)
+    seen.config.push(process.env.OPENCODE_CONFIG_CONTENT)
+    seen.runEnv.push(process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV])
     return input.fn()
   })
 }
@@ -54,7 +59,7 @@ describe("tui thread", () => {
     mock.restore()
   })
 
-  async function call(project?: string) {
+  async function call(project?: string, overrides: Record<string, unknown> = {}) {
     const { TuiThreadCommand } = await import("../../../src/cli/cmd/tui/thread")
     const args: Parameters<NonNullable<typeof TuiThreadCommand.handler>>[0] = {
       _: [],
@@ -72,6 +77,7 @@ describe("tui thread", () => {
       "mdns-domain": "opencode.local",
       mdnsDomain: "opencode.local",
       cors: [],
+      ...overrides,
     }
     return TuiThreadCommand.handler(args)
   }
@@ -87,6 +93,8 @@ describe("tui thread", () => {
     const type = process.platform === "win32" ? "junction" : "dir"
     seen.tui.length = 0
     seen.inst.length = 0
+    seen.config.length = 0
+    seen.runEnv.length = 0
     await fs.symlink(tmp.path, link, type)
 
     Object.defineProperty(process.stdin, "isTTY", {
@@ -125,4 +133,76 @@ describe("tui thread", () => {
   test("uses the real cwd after resolving a relative project from PWD", async () => {
     await check(".")
   })
+
+  test("prepares detected project before prompt launch", async () => {
+    setup()
+    const Npx = await import("../../../src/agency-swarm/npx")
+    await using tmp = await tmpdir({ git: true })
+    await writeAgency(tmp.path)
+    const cwd = process.cwd()
+    const pwd = process.env.PWD
+    const launcher = process.env[Npx.LAUNCHER_ENTRY_ENV]
+    const config = process.env.OPENCODE_CONFIG_CONTENT
+    const worker = globalThis.Worker
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+    const cleanup = mock(async () => {})
+    seen.tui.length = 0
+    seen.inst.length = 0
+    seen.config.length = 0
+    seen.runEnv.length = 0
+
+    spyOn(Npx, "prepareProjectLaunch").mockResolvedValue({
+      directory: tmp.path,
+      runProjectDirectory: tmp.path,
+      configContent: "project-config",
+      cleanup,
+    })
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+    globalThis.Worker = class extends EventTarget {
+      onerror = null
+      onmessage = null
+      onmessageerror = null
+      postMessage() {}
+      terminate() {}
+    } as unknown as typeof Worker
+
+    try {
+      process.chdir(tmp.path)
+      process.env.PWD = tmp.path
+      process.env[Npx.LAUNCHER_ENTRY_ENV] = "1"
+      await expect(call()).rejects.toBe(stop)
+      expect(Npx.prepareProjectLaunch).toHaveBeenCalledTimes(1)
+      expect(seen.config[0]).toBe("project-config")
+      expect(seen.runEnv[0]).toBe(tmp.path)
+      expect(seen.inst[0]).toBe(tmp.path)
+      expect(seen.tui[0]).toBe(tmp.path)
+      expect(cleanup).toHaveBeenCalledTimes(1)
+    } finally {
+      process.chdir(cwd)
+      if (pwd === undefined) delete process.env.PWD
+      else process.env.PWD = pwd
+      if (launcher === undefined) delete process.env[Npx.LAUNCHER_ENTRY_ENV]
+      else process.env[Npx.LAUNCHER_ENTRY_ENV] = launcher
+      if (config === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+      else process.env.OPENCODE_CONFIG_CONTENT = config
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+      globalThis.Worker = worker
+    }
+  })
 })
+
+async function writeAgency(dir: string) {
+  await fs.writeFile(
+    path.join(dir, "agency.py"),
+    [
+      "from agency_swarm import Agency",
+      "",
+      "def create_agency(load_threads_callback=None):",
+      "    return Agency()",
+    ].join("\n"),
+  )
+}

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -388,6 +388,82 @@ describe("session.agency-swarm", () => {
     }
   })
 
+  test("stream sends explicit header-based client_config to a real local agency server", async () => {
+    mockHistory()
+    await Auth.set("openai", {
+      type: "oauth",
+      access: "oauth-access",
+      refresh: "oauth-refresh",
+      expires: Date.now() + 60_000,
+      accountId: "acct_123",
+    } as any)
+
+    let body: Record<string, unknown> | undefined
+    const server = createServer(async (request, response) => {
+      if (request.url !== "/builder/get_response_stream") {
+        response.writeHead(404)
+        response.end("not found")
+        return
+      }
+
+      const chunks: Buffer[] = []
+      for await (const chunk of request) {
+        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+        else chunks.push(Buffer.from(chunk))
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+      })
+      response.end(
+        [
+          'data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"ok"}}}\n\n',
+          "event: end\ndata: [DONE]\n\n",
+        ].join(""),
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      server.close()
+      throw new Error("Expected local test server address")
+    }
+
+    try {
+      const { input } = helper()
+      input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      input.options.clientConfig = {
+        base_url: "https://proxy.example.com/v1",
+        default_headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      }
+      const stream = await SessionAgencySwarm.stream(input)
+      const text: string[] = []
+      for await (const event of stream.fullStream) {
+        if (event.type === "text-delta") text.push(event.text)
+      }
+
+      expect(text).toEqual(["ok"])
+      expect(body?.["client_config"]).toEqual({
+        base_url: "https://proxy.example.com/v1",
+        default_headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+      await Auth.remove("openai")
+    }
+  })
+
   test("stream prefers env auth over stored auth for providers already covered by env", async () => {
     mockHistory()
     Auth.all = (async () => ({
@@ -528,6 +604,44 @@ describe("session.agency-swarm", () => {
     expect(captured).toEqual({
       api_key: "oauth-access",
       base_url: "https://proxy.example.com/v1",
+    })
+  })
+
+  test("stream preserves explicit header-based OpenAI auth without merging stored OAuth", async () => {
+    mockHistory()
+    Auth.all = (async () => ({
+      openai: {
+        type: "oauth",
+        access: "oauth-access",
+        refresh: "oauth-refresh",
+        expires: Date.now() + 60_000,
+      } as any,
+    })) as typeof Auth.all
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.clientConfig = {
+      base_url: "https://proxy.example.com/v1",
+      default_headers: {
+        Authorization: "Bearer proxy-token",
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      base_url: "https://proxy.example.com/v1",
+      default_headers: {
+        Authorization: "Bearer proxy-token",
+      },
     })
   })
 

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -498,7 +498,7 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream keeps generated OpenAI OAuth bound to Codex base URL", async () => {
+  test("stream keeps explicit base_url when stored OpenAI OAuth exists", async () => {
     mockHistory()
     Auth.all = (async () => ({
       openai: {
@@ -527,7 +527,7 @@ describe("session.agency-swarm", () => {
 
     expect(captured).toEqual({
       api_key: "oauth-access",
-      base_url: "https://chatgpt.com/backend-api/codex",
+      base_url: "https://proxy.example.com/v1",
     })
   })
 

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { createServer } from "node:http"
+import type { AddressInfo } from "node:net"
 import { Auth } from "../../src/auth"
 import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
 import { AgencySwarmHistory } from "../../src/agency-swarm/history"
@@ -315,14 +317,89 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream does not forward stored auth for providers already covered by env", async () => {
+  test("stream sends stored OpenAI OAuth auth to a real local agency server", async () => {
+    mockHistory()
+    await Auth.set("openai", {
+      type: "oauth",
+      access: "oauth-access",
+      refresh: "oauth-refresh",
+      expires: Date.now() + 60_000,
+      accountId: "acct_123",
+    } as any)
+
+    let body: Record<string, unknown> | undefined
+    const server = createServer(async (request, response) => {
+      if (request.url !== "/builder/get_response_stream") {
+        response.writeHead(404)
+        response.end("not found")
+        return
+      }
+
+      const chunks: Buffer[] = []
+      for await (const chunk of request) {
+        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+        else chunks.push(Buffer.from(chunk))
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+      })
+      response.end(
+        [
+          'data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"ok"}}}\n\n',
+          "event: end\ndata: [DONE]\n\n",
+        ].join(""),
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      server.close()
+      throw new Error("Expected local test server address")
+    }
+
+    try {
+      const { input } = helper()
+      input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      const stream = await SessionAgencySwarm.stream(input)
+      const text: string[] = []
+      for await (const event of stream.fullStream) {
+        if (event.type === "text-delta") text.push(event.text)
+      }
+
+      expect(text).toEqual(["ok"])
+      expect(body?.["client_config"]).toEqual({
+        api_key: "oauth-access",
+        base_url: "https://chatgpt.com/backend-api/codex",
+        default_headers: {
+          "ChatGPT-Account-Id": "acct_123",
+        },
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+      await Auth.remove("openai")
+    }
+  })
+
+  test("stream prefers env auth over stored auth for providers already covered by env", async () => {
     mockHistory()
     Auth.all = (async () => ({
       openai: { type: "api", key: "stored-openai" } as any,
       anthropic: { type: "api", key: "stored-anthropic" } as any,
+      azure: { type: "api", key: "stored-azure" } as any,
     })) as typeof Auth.all
     Env.all = (() => ({
       OPENAI_API_KEY: "env-openai",
+      AZURE_RESOURCE_NAME: "azure-resource",
+      AZURE_API_KEY: "env-azure",
+      GOOGLE_GENERATIVE_AI_API_KEY: "env-google",
     })) as typeof Env.all
     Provider.list = (async () => ({
       openai: {
@@ -338,6 +415,22 @@ describe("session.agency-swarm", () => {
         name: "Anthropic",
         source: "api",
         env: ["ANTHROPIC_API_KEY"],
+        options: {},
+        models: {},
+      },
+      azure: {
+        id: "azure",
+        name: "Azure",
+        source: "api",
+        env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+        options: {},
+        models: {},
+      },
+      google: {
+        id: "google",
+        name: "Google",
+        source: "api",
+        env: ["GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"],
         options: {},
         models: {},
       },
@@ -364,9 +457,77 @@ describe("session.agency-swarm", () => {
     }
 
     expect(captured).toEqual({
+      api_key: "env-openai",
       litellm_keys: {
         anthropic: "stored-anthropic",
+        azure: "stored-azure",
+        gemini: "env-google",
       },
+    })
+  })
+
+  test("stream does not refresh stored OpenAI OAuth when explicit OpenAI client_config exists", async () => {
+    mockHistory()
+    Auth.all = (async () => ({
+      openai: {
+        type: "oauth",
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: 1,
+      } as any,
+    })) as typeof Auth.all
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.clientConfig = {
+      api_key: "manual-openai",
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "manual-openai",
+    })
+  })
+
+  test("stream keeps generated OpenAI OAuth bound to Codex base URL", async () => {
+    mockHistory()
+    Auth.all = (async () => ({
+      openai: {
+        type: "oauth",
+        access: "oauth-access",
+        refresh: "oauth-refresh",
+        expires: Date.now() + 60_000,
+      } as any,
+    })) as typeof Auth.all
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.clientConfig = {
+      base_url: "https://proxy.example.com/v1",
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "oauth-access",
+      base_url: "https://chatgpt.com/backend-api/codex",
     })
   })
 


### PR DESCRIPTION
Summary
- send usable local provider credentials to detected Agency Swarm projects, including stored OpenAI Codex OAuth and API-key flows
- open the startup auth dialog only when framework mode truly has no usable non-agency credentials
- persist local run-mode session metadata so agentswarm -s session-id and related launcher bypass paths restart or reconnect the local Agency Swarm project

Why
Detected local Agency Swarm projects had two broken happy paths:
1. local requests could start but fail silently because no request-scoped client_config reached the FastAPI server
2. sessions created from detected-project run mode could not be resumed with -s because the launcher path did not restore the local project context

Scope
- keep the fork diff contained to Agency Swarm startup/auth/session integration paths
- avoid changing upstream provider loading beyond a small credential-gating fix in TUI startup auth logic

Evidence
- focused tests plus bun typecheck passed in packages/opencode
- local build smoke passed
- real wrapper QA passed in a real Agency Swarm starter project: detected project launch answered a prompt successfully, then agentswarm -s on the saved session restarted the local project and answered a second prompt successfully