### PR TITLE
fix(opencode): harden agent swarm auth onboarding

### DIFF
--- a/packages/opencode/src/agency-swarm/adapter.ts
+++ b/packages/opencode/src/agency-swarm/adapter.ts
@@ -495,11 +495,13 @@ export namespace AgencySwarmAdapter {
     const baseURL = asString(value["base_url"]) ?? asString(value["baseURL"])
     const apiKey = asString(value["api_key"]) ?? asString(value["apiKey"])
     const litellmKeys = asRecord(value["litellm_keys"]) ?? asRecord(value["litellmKeys"])
+    const headers = readStringRecord(value["default_headers"]) ?? readStringRecord(value["defaultHeaders"])
 
     const payload: Record<string, unknown> = {}
     if (baseURL) payload["base_url"] = baseURL
     if (apiKey) payload["api_key"] = apiKey
     if (litellmKeys && Object.keys(litellmKeys).length > 0) payload["litellm_keys"] = litellmKeys
+    if (headers) payload["default_headers"] = headers
 
     return Object.keys(payload).length > 0 ? payload : undefined
   }
@@ -610,6 +612,15 @@ export namespace AgencySwarmAdapter {
     if (typeof value !== "string") return undefined
     const trimmed = value.trim()
     return trimmed ? trimmed : undefined
+  }
+
+  function readStringRecord(value: unknown): Record<string, string> | undefined {
+    const record = asRecord(value)
+    if (!record) return undefined
+    const result = Object.fromEntries(
+      Object.entries(record).flatMap(([key, item]) => (typeof item === "string" ? [[key, item]] : [])),
+    )
+    return Object.keys(result).length > 0 ? result : undefined
   }
 
   function asArray(value: unknown): unknown[] {

--- a/packages/opencode/src/agency-swarm/client-config.ts
+++ b/packages/opencode/src/agency-swarm/client-config.ts
@@ -12,7 +12,10 @@ export function readStringRecord(value: unknown): Record<string, string> | undef
   const record = asRecord(value)
   if (!record) return undefined
   const result = Object.fromEntries(
-    Object.entries(record).flatMap(([key, item]) => (typeof item === "string" ? [[key, item]] : [])),
+    Object.entries(record).flatMap(([key, item]) => {
+      const text = asString(item)
+      return text ? [[key, text]] : []
+    }),
   )
   return Object.keys(result).length > 0 ? result : undefined
 }

--- a/packages/opencode/src/agency-swarm/client-config.ts
+++ b/packages/opencode/src/agency-swarm/client-config.ts
@@ -1,0 +1,38 @@
+function asString(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function asRecord(value: unknown) {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined
+}
+
+const AUTH_HEADER_PATTERN = /(^authorization$|(^|[-_])(api[-_]?key|token|auth[-_]?token)$)/i
+
+export function readStringRecord(value: unknown): Record<string, string> | undefined {
+  const record = asRecord(value)
+  if (!record) return undefined
+  const result = Object.fromEntries(
+    Object.entries(record).flatMap(([key, item]) => (typeof item === "string" ? [[key, item]] : [])),
+  )
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+export function readCredentialHeaders(config: Record<string, unknown>) {
+  const headers = readStringRecord(config["default_headers"]) ?? readStringRecord(config["defaultHeaders"])
+  if (!headers) return undefined
+  const result = Object.fromEntries(Object.entries(headers).filter(([key]) => AUTH_HEADER_PATTERN.test(key)))
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+export function hasClientConfigCredential(config: Record<string, unknown>) {
+  if (asString(config["api_key"]) ?? asString(config["apiKey"])) return true
+  const litellmKeys = asRecord(config["litellm_keys"]) ?? asRecord(config["litellmKeys"])
+  if (litellmKeys && Object.values(litellmKeys).some((item) => typeof item === "string" && item.length > 0)) {
+    return true
+  }
+  return !!readCredentialHeaders(config)
+}
+
+export function hasExplicitOpenAIClientConfig(config: Record<string, unknown> | undefined) {
+  return !!(config && (asString(config["api_key"]) ?? asString(config["apiKey"]) ?? readCredentialHeaders(config)))
+}

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -7,6 +7,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
 import { AgencySwarmRunSession } from "./run-session"
 import { SERVER_LAUNCHER_SCRIPT } from "./server-launcher"
+import { Storage } from "@/storage/storage"
 import { Filesystem } from "@/util/filesystem"
 import type { Session } from "@/session"
 import { SessionID } from "@/session/schema"
@@ -125,9 +126,15 @@ async function resolveRunProject(
   const run = runSessions
     ? Array.from(runSessions).find((item) => item.sessionID === session.id)
     : await AgencySwarmRunSession.get(session.id)
-  if (!run) return
-  if (path.resolve(run.directory) !== path.resolve(session.directory)) return
-  return detectAgencyProject(run.directory)
+  if (run) {
+    if (path.resolve(run.directory) !== path.resolve(session.directory)) return
+    return detectAgencyProject(run.directory)
+  }
+
+  const project = await detectAgencyProject(session.directory)
+  if (!project) return
+  if (!(await hasLegacyLocalAgencyHistory(session.id))) return
+  return project
 }
 
 function isAgentswarmCommand(argv: string[]) {
@@ -138,6 +145,20 @@ function isAgentswarmCommand(argv: string[]) {
         .at(-1)
         ?.replace(/\.exe$/i, "") === "agentswarm",
   )
+}
+
+async function hasLegacyLocalAgencyHistory(sessionID: string) {
+  const keys = await Storage.list(["agency_swarm_history"]).catch(() => [] as string[][])
+  for (const key of keys) {
+    const entry = await Storage.read<{ scope?: unknown }>(key).catch(() => undefined)
+    const scope = typeof entry?.scope === "string" ? entry.scope : undefined
+    if (!scope) continue
+    const parts = scope.split("|")
+    if (parts.at(-1) !== sessionID) continue
+    if (parts.at(-2) !== LOCAL_AGENCY_ID) continue
+    return true
+  }
+  return false
 }
 
 export function buildAgencyConfig(input: { baseURL: string; agency: string; token?: string }) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -5,8 +5,11 @@ import path from "node:path"
 import { existsSync } from "node:fs"
 import { mkdtemp, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
+import { AgencySwarmRunSession } from "./run-session"
 import { SERVER_LAUNCHER_SCRIPT } from "./server-launcher"
 import { Filesystem } from "@/util/filesystem"
+import type { Session } from "@/session"
+import { SessionID } from "@/session/schema"
 
 export const LAUNCHER_ENTRY_ENV = "AGENTSWARM_LAUNCHER"
 export const STARTER_TEMPLATE_REPO = "agency-ai-solutions/agency-starter-template"
@@ -19,6 +22,7 @@ type StarterMode = "github" | "local"
 export interface PreparedNpxLaunch {
   directory: string
   configContent?: string
+  runProjectDirectory?: string
   cleanup?: () => Promise<void>
 }
 
@@ -48,13 +52,82 @@ export function shouldRunNpxOnboarding(input: {
   prompt?: string
   agent?: string
 }) {
-  if (input.env[LAUNCHER_ENTRY_ENV] !== "1" && !isAgentswarmCommand(input.argv ?? process.argv)) return false
+  if (!isLauncher(input)) return false
   if (input.model) return false
   if (input.continue) return false
   if (input.session) return false
   if (input.prompt) return false
   if (input.agent) return false
   return true
+}
+
+export async function resolveNpxAutoProject(input: {
+  directory: string
+  env: NodeJS.ProcessEnv
+  argv?: string[]
+  model?: string
+  continue?: boolean
+  fork?: boolean
+  session?: string
+  prompt?: string
+  agent?: string
+  sessions?: Iterable<Pick<Session.Info, "id" | "directory" | "parentID" | "time">>
+  runSessions?: Iterable<{ sessionID: string; directory: string }>
+}) {
+  if (!isLauncher(input)) return
+  if (input.model && input.model.split("/")[0] !== AgencySwarmAdapter.PROVIDER_ID) return
+
+  if (input.session) {
+    const session = await getResumeSession(input.session, input.sessions)
+    return session ? resolveRunProject(session, input.runSessions) : undefined
+  }
+
+  if (input.continue) {
+    const sessions = input.sessions ? Array.from(input.sessions) : await listResumeSessions(input.directory)
+    const session = sessions
+      .filter((item) => item.directory === input.directory && !item.parentID)
+      .toSorted((a, b) => b.time.updated - a.time.updated)[0]
+    if (session) return resolveRunProject(session, input.runSessions)
+    if (input.fork) return
+    return detectAgencyProject(input.directory)
+  }
+
+  if (input.prompt || input.agent || input.model) {
+    return detectAgencyProject(input.directory)
+  }
+}
+
+async function getResumeSession(
+  sessionID: string,
+  sessions?: Iterable<Pick<Session.Info, "id" | "directory" | "parentID" | "time">>,
+) {
+  if (sessions) {
+    return Array.from(sessions).find((item) => item.id === sessionID)
+  }
+  const { Session } = await import("@/session")
+  return Session.get(SessionID.make(sessionID)).catch(() => undefined)
+}
+
+async function listResumeSessions(directory: string) {
+  const { Session } = await import("@/session")
+  const start = Date.now() - 30 * 24 * 60 * 60 * 1000
+  return Array.from(Session.listGlobal({ directory, roots: true, start, limit: 1 }))
+}
+
+function isLauncher(input: { env: NodeJS.ProcessEnv; argv?: string[] }) {
+  return input.env[LAUNCHER_ENTRY_ENV] === "1" || isAgentswarmCommand(input.argv ?? process.argv)
+}
+
+async function resolveRunProject(
+  session: Pick<Session.Info, "id" | "directory">,
+  runSessions?: Iterable<{ sessionID: string; directory: string }>,
+) {
+  const run = runSessions
+    ? Array.from(runSessions).find((item) => item.sessionID === session.id)
+    : await AgencySwarmRunSession.get(session.id)
+  if (!run) return
+  if (path.resolve(run.directory) !== path.resolve(session.directory)) return
+  return detectAgencyProject(run.directory)
 }
 
 function isAgentswarmCommand(argv: string[]) {
@@ -383,6 +456,7 @@ export async function prepareProjectLaunch(project: AgencyProject): Promise<Prep
   const server = await startProjectServer(project.directory, python)
   return {
     directory: project.directory,
+    runProjectDirectory: project.directory,
     configContent: buildAgencyConfig({
       baseURL: server.baseURL,
       agency: LOCAL_AGENCY_ID,

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -149,16 +149,54 @@ function isAgentswarmCommand(argv: string[]) {
 
 async function hasLegacyLocalAgencyHistory(sessionID: string) {
   const keys = await Storage.list(["agency_swarm_history"]).catch(() => [] as string[][])
+  let newest:
+    | {
+        agency: string
+        baseURL: string
+        updatedAt: number
+      }
+    | undefined
   for (const key of keys) {
-    const entry = await Storage.read<{ scope?: unknown }>(key).catch(() => undefined)
-    const scope = typeof entry?.scope === "string" ? entry.scope : undefined
-    if (!scope) continue
-    const parts = scope.split("|")
-    if (parts.at(-1) !== sessionID) continue
-    if (parts.at(-2) !== LOCAL_AGENCY_ID) continue
-    return true
+    const entry = await Storage.read<{ scope?: unknown; updated_at?: unknown }>(key).catch(() => undefined)
+    const parsed = parseLegacyHistoryScope(entry?.scope)
+    if (!parsed || parsed.sessionID !== sessionID) continue
+    const updatedAt = typeof entry?.updated_at === "number" ? entry.updated_at : 0
+    if (!newest || updatedAt > newest.updatedAt) {
+      newest = {
+        agency: parsed.agency,
+        baseURL: parsed.baseURL,
+        updatedAt,
+      }
+    }
   }
-  return false
+  return !!newest && newest.agency === LOCAL_AGENCY_ID && isLoopbackBaseURL(newest.baseURL)
+}
+
+function parseLegacyHistoryScope(scope: unknown) {
+  if (typeof scope !== "string") return
+  const parts = scope.split("|")
+  const sessionID = parts.at(-1)
+  const agency = parts.at(-2)
+  if (!sessionID || !agency || parts.length < 3) return
+  return {
+    baseURL: parts.slice(0, -2).join("|"),
+    agency,
+    sessionID,
+  }
+}
+
+function isLoopbackBaseURL(baseURL: string) {
+  try {
+    const parsed = new URL(baseURL)
+    return (
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "0.0.0.0" ||
+      parsed.hostname === "localhost" ||
+      parsed.hostname === "::1"
+    )
+  } catch {
+    return false
+  }
 }
 
 export function buildAgencyConfig(input: { baseURL: string; agency: string; token?: string }) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -133,8 +133,22 @@ async function resolveRunProject(
 
   const project = await detectAgencyProject(session.directory)
   if (!project) return
+  if (!(await isLegacyAgencySwarmRunSession(session.id))) return
   if (!(await hasLegacyLocalAgencyHistory(session.id))) return
   return project
+}
+
+async function isLegacyAgencySwarmRunSession(sessionID: Session.Info["id"]) {
+  const providerID = await getLatestSessionProviderID(sessionID)
+  if (providerID && providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
+  return true
+}
+
+async function getLatestSessionProviderID(sessionID: Session.Info["id"]) {
+  const { Session } = await import("@/session")
+  const [latest] = await Session.messages({ sessionID, limit: 1 }).catch(() => [])
+  if (!latest) return
+  return latest.info.role === "user" ? latest.info.model.providerID : latest.info.providerID
 }
 
 function isAgentswarmCommand(argv: string[]) {

--- a/packages/opencode/src/agency-swarm/run-session.ts
+++ b/packages/opencode/src/agency-swarm/run-session.ts
@@ -4,6 +4,7 @@ import { Filesystem } from "@/util/filesystem"
 
 export namespace AgencySwarmRunSession {
   export const LOCAL_PROJECT_ENV = "AGENTSWARM_RUN_PROJECT"
+  const PROVIDER_ID = "agency-swarm"
 
   type Info = {
     mode: "local-project"
@@ -18,7 +19,22 @@ export namespace AgencySwarmRunSession {
       mode: "local-project",
       directory: path.resolve(input.directory),
     }
-    await Filesystem.writeJson(file, data)
+    await write(data)
+  }
+
+  export async function clear(sessionID: string) {
+    const data = await read()
+    if (!(sessionID in data)) return
+    delete data[sessionID]
+    await write(data)
+  }
+
+  export async function sync(input: { sessionID: string; providerID: string; directory?: string }) {
+    if (input.providerID !== PROVIDER_ID || !input.directory) {
+      await clear(input.sessionID)
+      return
+    }
+    await mark({ sessionID: input.sessionID, directory: input.directory })
   }
 
   export async function get(sessionID: string): Promise<Info | undefined> {
@@ -28,5 +44,9 @@ export namespace AgencySwarmRunSession {
   async function read(): Promise<Record<string, Info>> {
     const data = await Filesystem.readJson<Record<string, Info>>(file).catch((): Record<string, Info> => ({}))
     return data && typeof data === "object" && !Array.isArray(data) ? data : {}
+  }
+
+  async function write(data: Record<string, Info>) {
+    await Filesystem.writeJson(file, data)
   }
 }

--- a/packages/opencode/src/agency-swarm/run-session.ts
+++ b/packages/opencode/src/agency-swarm/run-session.ts
@@ -1,0 +1,32 @@
+import path from "node:path"
+import { Global } from "@/global"
+import { Filesystem } from "@/util/filesystem"
+
+export namespace AgencySwarmRunSession {
+  export const LOCAL_PROJECT_ENV = "AGENTSWARM_RUN_PROJECT"
+
+  type Info = {
+    mode: "local-project"
+    directory: string
+  }
+
+  const file = path.join(Global.Path.state, "agency-swarm-run-sessions.json")
+
+  export async function mark(input: { sessionID: string; directory: string }) {
+    const data = await read()
+    data[input.sessionID] = {
+      mode: "local-project",
+      directory: path.resolve(input.directory),
+    }
+    await Filesystem.writeJson(file, data)
+  }
+
+  export async function get(sessionID: string): Promise<Info | undefined> {
+    return (await read())[sessionID]
+  }
+
+  async function read(): Promise<Record<string, Info>> {
+    const data = await Filesystem.readJson<Record<string, Info>>(file).catch((): Record<string, Info> => ({}))
+    return data && typeof data === "object" && !Array.isArray(data) ? data : {}
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -61,7 +61,7 @@ import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { AgencyProduct } from "@/agency-swarm/product"
-import { shouldOpenAgencyConnectDialog, shouldOpenStartupAuthDialog } from "./session-error"
+import { isAgencySwarmFrameworkMode, shouldOpenAgencyConnectDialog, shouldOpenStartupAuthDialog } from "./session-error"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -443,7 +443,10 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           sync.status === "complete" &&
           shouldOpenStartupAuthDialog({
             providers: sync.data.provider,
-            frameworkMode: local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID,
+            frameworkMode: isAgencySwarmFrameworkMode({
+              currentProviderID: local.model.current()?.providerID,
+              configuredModel: sync.data.config.model,
+            }),
           })
         )
       },
@@ -455,7 +458,12 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   )
 
   const connected = useConnected()
-  const frameworkMode = createMemo(() => local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID)
+  const frameworkMode = createMemo(() =>
+    isAgencySwarmFrameworkMode({
+      currentProviderID: local.model.current()?.providerID,
+      configuredModel: sync.data.config.model,
+    }),
+  )
   command.register(() => [
     {
       title: "Switch session",
@@ -837,7 +845,12 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     const error = evt.properties.error
     if (error && typeof error === "object" && error.name === "MessageAbortedError") return
     const message = errorMessage(error)
-    if (shouldOpenAgencyConnectDialog({ providerID: local.model.current()?.providerID, message })) {
+    if (
+      shouldOpenAgencyConnectDialog({
+        providerID: frameworkMode() ? AgencySwarmAdapter.PROVIDER_ID : local.model.current()?.providerID,
+        message,
+      })
+    ) {
       dialog.replace(() => <DialogAgencySwarmConnect />)
       return
     }

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -61,7 +61,13 @@ import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { AgencyProduct } from "@/agency-swarm/product"
-import { isAgencySwarmFrameworkMode, shouldOpenAgencyConnectDialog, shouldOpenStartupAuthDialog } from "./session-error"
+import {
+  describeAgencyAuthFailure,
+  isAgencySwarmFrameworkMode,
+  shouldOpenAgencyAuthDialog,
+  shouldOpenAgencyConnectDialog,
+  shouldOpenStartupAuthDialog,
+} from "./session-error"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -443,6 +449,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           sync.status === "complete" &&
           shouldOpenStartupAuthDialog({
             providers: sync.data.provider,
+            providerAuth: sync.data.provider_auth,
             frameworkMode: isAgencySwarmFrameworkMode({
               currentProviderID: local.model.current()?.providerID,
               configuredModel: sync.data.config.model,
@@ -852,6 +859,20 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       })
     ) {
       dialog.replace(() => <DialogAgencySwarmConnect />)
+      return
+    }
+    if (
+      shouldOpenAgencyAuthDialog({
+        providerID: frameworkMode() ? AgencySwarmAdapter.PROVIDER_ID : local.model.current()?.providerID,
+        message,
+      })
+    ) {
+      toast.show({
+        variant: "error",
+        message: describeAgencyAuthFailure(message),
+        duration: 5000,
+      })
+      dialog.replace(() => <DialogAuth />)
       return
     }
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -455,6 +455,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   )
 
   const connected = useConnected()
+  const frameworkMode = createMemo(() => local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID)
   command.register(() => [
     {
       title: "Switch session",
@@ -516,6 +517,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       keybind: "model_list",
       suggested: true,
       category: "Agent",
+      hidden: frameworkMode(),
       slash: {
         name: "models",
       },
@@ -601,6 +603,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       value: "variant.cycle",
       keybind: "variant_cycle",
       category: "Agent",
+      hidden: frameworkMode(),
       onSelect: () => {
         local.model.variant.cycle()
       },
@@ -610,7 +613,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       value: "variant.list",
       keybind: "variant_list",
       category: "Agent",
-      hidden: local.model.variant.list().length === 0,
+      hidden: frameworkMode() || local.model.variant.list().length === 0,
       slash: {
         name: "variants",
       },

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -439,12 +439,11 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   createEffect(
     on(
       () => {
-        const selected = args.model ? Provider.parseModel(args.model).providerID : undefined
         return (
           sync.status === "complete" &&
           shouldOpenStartupAuthDialog({
             providers: sync.data.provider,
-            frameworkMode: selected === AgencySwarmAdapter.PROVIDER_ID,
+            frameworkMode: local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID,
           })
         )
       },

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -517,6 +517,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       keybind: "model_list",
       suggested: true,
       category: "Agent",
+      enabled: !frameworkMode(),
       hidden: frameworkMode(),
       slash: {
         name: "models",
@@ -603,6 +604,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       value: "variant.cycle",
       keybind: "variant_cycle",
       category: "Agent",
+      enabled: !frameworkMode(),
       hidden: frameworkMode(),
       onSelect: () => {
         local.model.variant.cycle()
@@ -613,6 +615,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       value: "variant.list",
       keybind: "variant_list",
       category: "Agent",
+      enabled: !frameworkMode(),
       hidden: frameworkMode() || local.model.variant.list().length === 0,
       slash: {
         name: "variants",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -8,6 +8,7 @@ import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
 import { useToast } from "@tui/ui/toast"
 import { createMemo, createResource } from "solid-js"
 import { DialogAgencySwarmConnect } from "./dialog-provider"
+import { isAgencySwarmFrameworkMode } from "../session-error"
 
 type AgentOptionValue =
   | {
@@ -35,7 +36,12 @@ export function DialogAgent() {
   const toast = useToast()
 
   const currentModel = createMemo(() => local.model.current())
-  const agencySwarmEnabled = createMemo(() => currentModel()?.providerID === AgencySwarmAdapter.PROVIDER_ID)
+  const agencySwarmEnabled = createMemo(() =>
+    isAgencySwarmFrameworkMode({
+      currentProviderID: currentModel()?.providerID,
+      configuredModel: sync.data.config.model,
+    }),
+  )
 
   const providerOptions = createMemo(() => {
     const provider = sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID]

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -15,9 +15,11 @@ import { useKeyboard } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
 import { useToast } from "../ui/toast"
 import { CONSOLE_MANAGED_ICON, isConsoleManagedProvider } from "@tui/util/provider-origin"
-import { hasStoredProviderCredential } from "@tui/util/provider-auth"
+import { getVisibleProviderAuthMethods, hasStoredProviderCredential } from "@tui/util/provider-auth"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
-import { isAgencySwarmFrameworkMode } from "../session-error"
+import { AGENCY_SWARM_AUTH_PROVIDER_IDS, isAgencySwarmFrameworkMode } from "../session-error"
+import { errorMessage as toErrorMessage } from "@/util/error"
+import open from "open"
 
 const PROVIDER_PRIORITY: Record<string, number> = {
   openai: 0,
@@ -42,8 +44,15 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
   const dialog = useDialog()
   const sdk = useSDK()
   const toast = useToast()
+  const local = useLocal()
   const { theme } = useTheme()
   const allowed = createMemo(() => new Set(props.providerIDs ?? []))
+  const frameworkMode = createMemo(() =>
+    isAgencySwarmFrameworkMode({
+      currentProviderID: local.model.current()?.providerID,
+      configuredModel: sync.data.config.model,
+    }),
+  )
   const options = createMemo(() => {
     return pipe(
       sync.data.provider_next.all,
@@ -59,7 +68,7 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
           description: {
             opencode: "(Recommended)",
             anthropic: "(API key)",
-            openai: "(ChatGPT Plus/Pro or API key)",
+            openai: "(Browser sign-in or API key)",
             "opencode-go": "Low cost subscription for everyone",
           }[provider.id],
           footer: consoleManaged ? sync.data.console_state.activeOrgName : undefined,
@@ -72,19 +81,25 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
           async onSelect() {
             if (consoleManaged) return
 
-            const methods = sync.data.provider_auth[provider.id] ?? [
+            const methods = getVisibleProviderAuthMethods(
+              provider.id,
+              sync.data.provider_auth[provider.id] ?? [
+                {
+                  type: "api",
+                  label: "API key",
+                },
+              ],
               {
-                type: "api",
-                label: "API key",
+                frameworkMode: frameworkMode(),
               },
-            ]
+            )
             let index: number | null = 0
             if (methods.length > 1) {
               index = await new Promise<number | null>((resolve) => {
                 dialog.replace(
                   () => (
                     <DialogSelect
-                      title="Select auth method"
+                      title={`Select ${provider.name} auth method`}
                       options={methods.map((x, index) => ({
                         title: x.label,
                         value: index,
@@ -117,9 +132,9 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
               if (result.error) {
                 toast.show({
                   variant: "error",
-                  message: JSON.stringify(result.error),
+                  message: toErrorMessage(result.error),
+                  duration: 5000,
                 })
-                dialog.clear()
                 return
               }
               if (result.data?.method === "code") {
@@ -167,17 +182,19 @@ export function DialogProvider(props: DialogProviderProps = {}) {
   return <DialogSelect title={props.title ?? "Connect a provider"} options={options()} />
 }
 
-function DialogRemoveCredential() {
+function DialogRemoveCredential(props: DialogProviderProps = {}) {
   const sync = useSync()
   const dialog = useDialog()
   const sdk = useSDK()
   const toast = useToast()
+  const allowed = new Set<string>(props.providerIDs ?? [])
   const options = createMemo(() =>
     pipe(
       sync.data.provider_next.all,
       (items) =>
         items.filter((provider) => {
           if (provider.id === AgencySwarmAdapter.PROVIDER_ID) return false
+          if (allowed.size > 0 && !allowed.has(provider.id)) return false
           if (
             !hasStoredProviderCredential(sync.data.provider, sync.data.provider_auth, provider.id)
           )
@@ -211,10 +228,20 @@ function DialogRemoveCredential() {
 export function DialogAuth() {
   const dialog = useDialog()
   const sync = useSync()
-  const providerOptions = createDialogProviderOptions()
+  const local = useLocal()
+  const frameworkMode = createMemo(() =>
+    isAgencySwarmFrameworkMode({
+      currentProviderID: local.model.current()?.providerID,
+      configuredModel: sync.data.config.model,
+    }),
+  )
+  const providerIDs = frameworkMode() ? [...AGENCY_SWARM_AUTH_PROVIDER_IDS] : undefined
+  const allowed = new Set<string>(providerIDs ?? [])
+  const providerOptions = createDialogProviderOptionsWithFilter({ providerIDs })
   const options = createMemo<DialogSelectOption<string>[]>(() => {
     const removable = sync.data.provider_next.all.filter((provider) => {
       if (provider.id === AgencySwarmAdapter.PROVIDER_ID) return false
+      if (allowed.size > 0 && !allowed.has(provider.id)) return false
       if (!hasStoredProviderCredential(sync.data.provider, sync.data.provider_auth, provider.id)) return false
       if (isConsoleManagedProvider(sync.data.console_state.consoleManagedProviders, provider.id)) return false
       return true
@@ -228,14 +255,14 @@ export function DialogAuth() {
         description: "Delete a stored provider credential",
         category: "Manage",
         onSelect: () => {
-          dialog.replace(() => <DialogRemoveCredential />)
+          dialog.replace(() => <DialogRemoveCredential providerIDs={providerIDs} />)
         },
       },
       ...providerOptions(),
     ]
   })
 
-  return <DialogSelect title="Manage provider auth" options={options()} />
+  return <DialogSelect title={frameworkMode() ? "Manage Agent Swarm auth" : "Manage provider auth"} options={options()} />
 }
 
 type Option =
@@ -598,6 +625,7 @@ function AutoMethod(props: AutoMethodProps) {
   const sync = useSync()
   const local = useLocal()
   const toast = useToast()
+  const [error, setError] = createSignal<string>()
   const frameworkMode = createMemo(() =>
     isAgencySwarmFrameworkMode({
       currentProviderID: local.model.current()?.providerID,
@@ -615,21 +643,40 @@ function AutoMethod(props: AutoMethodProps) {
   })
 
   onMount(async () => {
+    if (frameworkMode()) {
+      void open(props.authorization.url).catch(() => undefined)
+    }
     const result = await sdk.client.provider.oauth.callback({
       providerID: props.providerID,
       method: props.index,
     })
     if (result.error) {
-      dialog.clear()
+      const message = toErrorMessage(result.error)
+      setError(message)
+      toast.show({
+        variant: "error",
+        message,
+        duration: 5000,
+      })
       return
     }
-    await sdk.client.instance.dispose()
-    await sync.bootstrap()
-    if (frameworkMode()) {
-      dialog.clear()
-      return
+    try {
+      await sdk.client.instance.dispose()
+      await sync.bootstrap()
+      if (frameworkMode()) {
+        dialog.clear()
+        return
+      }
+      dialog.replace(() => <DialogModel providerID={props.providerID} />)
+    } catch (error) {
+      const message = toErrorMessage(error)
+      setError(message)
+      toast.show({
+        variant: "error",
+        message,
+        duration: 5000,
+      })
     }
-    dialog.replace(() => <DialogModel providerID={props.providerID} />)
   })
 
   return (
@@ -646,7 +693,14 @@ function AutoMethod(props: AutoMethodProps) {
         <Link href={props.authorization.url} fg={theme.primary} />
         <text fg={theme.textMuted}>{props.authorization.instructions}</text>
       </box>
-      <text fg={theme.textMuted}>Waiting for authorization...</text>
+      <text fg={theme.textMuted}>
+        {frameworkMode()
+          ? "Your default browser should open. If it does not, use the link above."
+          : "Finish sign-in in your browser, then wait here."}
+      </text>
+      <Show when={error()}>
+        {(message) => <text fg={theme.error}>{message()}</text>}
+      </Show>
       <text fg={theme.text}>
         c <span style={{ fg: theme.textMuted }}>copy</span>
       </text>
@@ -666,7 +720,8 @@ function CodeMethod(props: CodeMethodProps) {
   const sync = useSync()
   const dialog = useDialog()
   const local = useLocal()
-  const [error, setError] = createSignal(false)
+  const toast = useToast()
+  const [error, setError] = createSignal<string>()
   const frameworkMode = createMemo(() =>
     isAgencySwarmFrameworkMode({
       currentProviderID: local.model.current()?.providerID,
@@ -685,23 +740,39 @@ function CodeMethod(props: CodeMethodProps) {
           code: value,
         })
         if (!error) {
-          await sdk.client.instance.dispose()
-          await sync.bootstrap()
-          if (frameworkMode()) {
-            dialog.clear()
-            return
+          try {
+            await sdk.client.instance.dispose()
+            await sync.bootstrap()
+            if (frameworkMode()) {
+              dialog.clear()
+              return
+            }
+            dialog.replace(() => <DialogModel providerID={props.providerID} />)
+          } catch (error) {
+            const message = toErrorMessage(error)
+            setError(message)
+            toast.show({
+              variant: "error",
+              message,
+              duration: 5000,
+            })
           }
-          dialog.replace(() => <DialogModel providerID={props.providerID} />)
           return
         }
-        setError(true)
+        const message = toErrorMessage(error)
+        setError(message)
+        toast.show({
+          variant: "error",
+          message,
+          duration: 5000,
+        })
       }}
       description={() => (
         <box gap={1}>
           <text fg={theme.textMuted}>{props.authorization.instructions}</text>
           <Link href={props.authorization.url} fg={theme.primary} />
           <Show when={error()}>
-            <text fg={theme.error}>Invalid code</text>
+            {(message) => <text fg={theme.error}>{message()}</text>}
           </Show>
         </box>
       )}
@@ -719,47 +790,60 @@ function ApiMethod(props: ApiMethodProps) {
   const sdk = useSDK()
   const sync = useSync()
   const local = useLocal()
+  const toast = useToast()
   const { theme } = useTheme()
+  const [error, setError] = createSignal<string>()
   const frameworkMode = createMemo(() =>
     isAgencySwarmFrameworkMode({
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
     }),
   )
+  const description = () => {
+    const builtin =
+      {
+        opencode: (
+          <box gap={1}>
+            <text fg={theme.textMuted}>
+              OpenCode Zen gives you access to all the best coding models at the cheapest prices with a single API
+              key.
+            </text>
+            <text fg={theme.text}>
+              Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> to get a key
+            </text>
+          </box>
+        ),
+        "opencode-go": (
+          <box gap={1}>
+            <text fg={theme.textMuted}>
+              OpenCode Go is a $10 per month subscription that provides reliable access to popular open coding models
+              with generous usage limits.
+            </text>
+            <text fg={theme.text}>
+              Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> and enable OpenCode Go
+            </text>
+          </box>
+        ),
+      }[props.providerID] ?? undefined
+
+    return (
+      <box gap={1}>
+        {builtin}
+        <Show when={error()}>
+          {(message) => <text fg={theme.error}>{message()}</text>}
+        </Show>
+      </box>
+    )
+  }
 
   return (
     <DialogPrompt
       title={props.title}
       placeholder="API key"
-      description={
-        {
-          opencode: (
-            <box gap={1}>
-              <text fg={theme.textMuted}>
-                OpenCode Zen gives you access to all the best coding models at the cheapest prices with a single API
-                key.
-              </text>
-              <text fg={theme.text}>
-                Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> to get a key
-              </text>
-            </box>
-          ),
-          "opencode-go": (
-            <box gap={1}>
-              <text fg={theme.textMuted}>
-                OpenCode Go is a $10 per month subscription that provides reliable access to popular open coding models
-                with generous usage limits.
-              </text>
-              <text fg={theme.text}>
-                Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> and enable OpenCode Go
-              </text>
-            </box>
-          ),
-        }[props.providerID] ?? undefined
-      }
+      description={description}
       onConfirm={async (value) => {
         if (!value) return
-        await sdk.client.auth.set({
+        const result = await sdk.client.auth.set({
           providerID: props.providerID,
           auth: {
             type: "api",
@@ -767,13 +851,33 @@ function ApiMethod(props: ApiMethodProps) {
             ...(props.metadata ? { metadata: props.metadata } : {}),
           },
         })
-        await sdk.client.instance.dispose()
-        await sync.bootstrap()
-        if (frameworkMode()) {
-          dialog.clear()
+        if (result.error) {
+          const message = toErrorMessage(result.error)
+          setError(message)
+          toast.show({
+            variant: "error",
+            message,
+            duration: 5000,
+          })
           return
         }
-        dialog.replace(() => <DialogModel providerID={props.providerID} />)
+        try {
+          await sdk.client.instance.dispose()
+          await sync.bootstrap()
+          if (frameworkMode()) {
+            dialog.clear()
+            return
+          }
+          dialog.replace(() => <DialogModel providerID={props.providerID} />)
+        } catch (error) {
+          const message = toErrorMessage(error)
+          setError(message)
+          toast.show({
+            variant: "error",
+            message,
+            duration: 5000,
+          })
+        }
       }}
     />
   )

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -20,6 +20,7 @@ import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { isAgencySwarmFrameworkMode, isSupportedAgencyAuthProvider } from "../session-error"
 import { errorMessage as toErrorMessage } from "@/util/error"
 import open from "open"
+import type { Provider } from "@opencode-ai/sdk/v2"
 
 const PROVIDER_PRIORITY: Record<string, number> = {
   openai: 0,
@@ -37,6 +38,20 @@ export function createDialogProviderOptions() {
 type DialogProviderProps = {
   providerIDs?: readonly string[]
   title?: string
+}
+
+export function listRemovableAuthProviders(input: {
+  all: { id: string; name: string }[]
+  providers: Provider[]
+  providerAuth: Record<string, ProviderAuthMethod[]>
+  consoleManagedProviders: string[]
+}) {
+  return input.all.filter((provider) => {
+    if (provider.id === AgencySwarmAdapter.PROVIDER_ID) return false
+    if (!hasStoredProviderCredential(input.providers, input.providerAuth, provider.id)) return false
+    if (isConsoleManagedProvider(input.consoleManagedProviders, provider.id)) return false
+    return true
+  })
 }
 
 export function createDialogProviderOptionsWithFilter(props: DialogProviderProps = {}) {
@@ -190,26 +205,19 @@ export function DialogProvider(props: DialogProviderProps = {}) {
   return <DialogSelect title={props.title ?? "Connect a provider"} options={options()} />
 }
 
-function DialogRemoveCredential(props: DialogProviderProps = {}) {
+function DialogRemoveCredential() {
   const sync = useSync()
   const dialog = useDialog()
   const sdk = useSDK()
   const toast = useToast()
-  const allowed = new Set<string>(props.providerIDs ?? [])
   const options = createMemo(() =>
     pipe(
-      sync.data.provider_next.all,
-      (items) =>
-        items.filter((provider) => {
-          if (provider.id === AgencySwarmAdapter.PROVIDER_ID) return false
-          if (allowed.size > 0 && !allowed.has(provider.id)) return false
-          if (
-            !hasStoredProviderCredential(sync.data.provider, sync.data.provider_auth, provider.id)
-          )
-            return false
-          if (isConsoleManagedProvider(sync.data.console_state.consoleManagedProviders, provider.id)) return false
-          return true
-        }),
+      listRemovableAuthProviders({
+        all: sync.data.provider_next.all,
+        providers: sync.data.provider,
+        providerAuth: sync.data.provider_auth,
+        consoleManagedProviders: sync.data.console_state.consoleManagedProviders,
+      }),
       sortBy((provider) => PROVIDER_PRIORITY[provider.id] ?? 99),
       map((provider) => ({
         title: provider.name,
@@ -248,15 +256,13 @@ export function DialogAuth() {
         .filter((provider) => isSupportedAgencyAuthProvider(provider.id, provider, sync.data.provider_auth[provider.id] ?? []))
         .map((provider) => provider.id)
     : undefined
-  const allowed = new Set<string>(providerIDs ?? [])
   const providerOptions = createDialogProviderOptionsWithFilter({ providerIDs })
   const options = createMemo<DialogSelectOption<string>[]>(() => {
-    const removable = sync.data.provider_next.all.filter((provider) => {
-      if (provider.id === AgencySwarmAdapter.PROVIDER_ID) return false
-      if (allowed.size > 0 && !allowed.has(provider.id)) return false
-      if (!hasStoredProviderCredential(sync.data.provider, sync.data.provider_auth, provider.id)) return false
-      if (isConsoleManagedProvider(sync.data.console_state.consoleManagedProviders, provider.id)) return false
-      return true
+    const removable = listRemovableAuthProviders({
+      all: sync.data.provider_next.all,
+      providers: sync.data.provider,
+      providerAuth: sync.data.provider_auth,
+      consoleManagedProviders: sync.data.console_state.consoleManagedProviders,
     })
     if (removable.length === 0) return providerOptions()
 
@@ -267,7 +273,7 @@ export function DialogAuth() {
         description: "Delete a stored provider credential",
         category: "Manage",
         onSelect: () => {
-          dialog.replace(() => <DialogRemoveCredential providerIDs={providerIDs} />)
+          dialog.replace(() => <DialogRemoveCredential />)
         },
       },
       ...providerOptions(),

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -244,7 +244,9 @@ export function DialogAuth() {
     }),
   )
   const providerIDs = frameworkMode()
-    ? sync.data.provider_next.all.filter((provider) => isSupportedAgencyAuthProvider(provider.id)).map((provider) => provider.id)
+    ? sync.data.provider_next.all
+        .filter((provider) => isSupportedAgencyAuthProvider(provider.id, provider, sync.data.provider_auth[provider.id] ?? []))
+        .map((provider) => provider.id)
     : undefined
   const allowed = new Set<string>(providerIDs ?? [])
   const providerOptions = createDialogProviderOptionsWithFilter({ providerIDs })

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -17,7 +17,7 @@ import { useToast } from "../ui/toast"
 import { CONSOLE_MANAGED_ICON, isConsoleManagedProvider } from "@tui/util/provider-origin"
 import { getVisibleProviderAuthMethods, hasStoredProviderCredential } from "@tui/util/provider-auth"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
-import { AGENCY_SWARM_AUTH_PROVIDER_IDS, isAgencySwarmFrameworkMode } from "../session-error"
+import { isAgencySwarmFrameworkMode, isSupportedAgencyAuthProvider } from "../session-error"
 import { errorMessage as toErrorMessage } from "@/util/error"
 import open from "open"
 
@@ -93,14 +93,22 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
                 frameworkMode: frameworkMode(),
               },
             )
+            const visibleMethods = methods.length
+              ? methods
+              : [
+                  {
+                    type: "api" as const,
+                    label: "API key",
+                  },
+                ]
             let index: number | null = 0
-            if (methods.length > 1) {
+            if (visibleMethods.length > 1) {
               index = await new Promise<number | null>((resolve) => {
                 dialog.replace(
                   () => (
                     <DialogSelect
                       title={`Select ${provider.name} auth method`}
-                      options={methods.map((x, index) => ({
+                      options={visibleMethods.map((x, index) => ({
                         title: x.label,
                         value: index,
                       }))}
@@ -112,7 +120,7 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
               })
             }
             if (index == null) return
-            const method = methods[index]
+            const method = visibleMethods[index]
             if (method.type === "oauth") {
               let inputs: Record<string, string> | undefined
               if (method.prompts?.length) {
@@ -235,7 +243,9 @@ export function DialogAuth() {
       configuredModel: sync.data.config.model,
     }),
   )
-  const providerIDs = frameworkMode() ? [...AGENCY_SWARM_AUTH_PROVIDER_IDS] : undefined
+  const providerIDs = frameworkMode()
+    ? sync.data.provider_next.all.filter((provider) => isSupportedAgencyAuthProvider(provider.id)).map((provider) => provider.id)
+    : undefined
   const allowed = new Set<string>(providerIDs ?? [])
   const providerOptions = createDialogProviderOptionsWithFilter({ providerIDs })
   const options = createMemo<DialogSelectOption<string>[]>(() => {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -17,6 +17,7 @@ import { useToast } from "../ui/toast"
 import { CONSOLE_MANAGED_ICON, isConsoleManagedProvider } from "@tui/util/provider-origin"
 import { hasStoredProviderCredential } from "@tui/util/provider-auth"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { isAgencySwarmFrameworkMode } from "../session-error"
 
 const PROVIDER_PRIORITY: Record<string, number> = {
   openai: 0,
@@ -597,6 +598,12 @@ function AutoMethod(props: AutoMethodProps) {
   const sync = useSync()
   const local = useLocal()
   const toast = useToast()
+  const frameworkMode = createMemo(() =>
+    isAgencySwarmFrameworkMode({
+      currentProviderID: local.model.current()?.providerID,
+      configuredModel: sync.data.config.model,
+    }),
+  )
 
   useKeyboard((evt) => {
     if (evt.name === "c" && !evt.ctrl && !evt.meta) {
@@ -618,7 +625,7 @@ function AutoMethod(props: AutoMethodProps) {
     }
     await sdk.client.instance.dispose()
     await sync.bootstrap()
-    if (local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID) {
+    if (frameworkMode()) {
       dialog.clear()
       return
     }
@@ -660,6 +667,12 @@ function CodeMethod(props: CodeMethodProps) {
   const dialog = useDialog()
   const local = useLocal()
   const [error, setError] = createSignal(false)
+  const frameworkMode = createMemo(() =>
+    isAgencySwarmFrameworkMode({
+      currentProviderID: local.model.current()?.providerID,
+      configuredModel: sync.data.config.model,
+    }),
+  )
 
   return (
     <DialogPrompt
@@ -674,7 +687,7 @@ function CodeMethod(props: CodeMethodProps) {
         if (!error) {
           await sdk.client.instance.dispose()
           await sync.bootstrap()
-          if (local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID) {
+          if (frameworkMode()) {
             dialog.clear()
             return
           }
@@ -707,6 +720,12 @@ function ApiMethod(props: ApiMethodProps) {
   const sync = useSync()
   const local = useLocal()
   const { theme } = useTheme()
+  const frameworkMode = createMemo(() =>
+    isAgencySwarmFrameworkMode({
+      currentProviderID: local.model.current()?.providerID,
+      configuredModel: sync.data.config.model,
+    }),
+  )
 
   return (
     <DialogPrompt
@@ -750,7 +769,7 @@ function ApiMethod(props: ApiMethodProps) {
         })
         await sdk.client.instance.dispose()
         await sync.bootstrap()
-        if (local.model.current()?.providerID === AgencySwarmAdapter.PROVIDER_ID) {
+        if (frameworkMode()) {
           dialog.clear()
           return
         }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -39,6 +39,7 @@ import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
 import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "@tui/util/provider-origin"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
 
 export type PromptProps = {
   sessionID?: string
@@ -304,6 +305,13 @@ export function Prompt(props: PromptProps) {
         },
         onSelect: async (dialog) => {
           dialog.clear()
+          if (!Editor.isConfigured()) {
+            toast.show({
+              message: "Set VISUAL or EDITOR to use the external editor",
+              variant: "warning",
+            })
+            return
+          }
 
           // replace summarized text parts with the actual text
           const text = store.prompt.parts
@@ -655,6 +663,11 @@ export function Prompt(props: PromptProps) {
     // Capture mode before it gets reset
     const currentMode = store.mode
     const variant = local.model.variant.current()
+    void AgencySwarmRunSession.sync({
+      sessionID,
+      providerID: selectedModel.providerID,
+      directory: process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV],
+    })
 
     if (store.mode === "shell") {
       sdk.client.session.shell({

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -31,7 +31,7 @@ import { Locale } from "@/util/locale"
 import { formatDuration } from "@/util/format"
 import { createColors, createFrames } from "../../ui/spinner.ts"
 import { useDialog } from "@tui/ui/dialog"
-import { DialogAgencySwarmConnect, DialogProvider as DialogProviderConnect } from "../dialog-provider"
+import { DialogAgencySwarmConnect, DialogAuth, DialogProvider as DialogProviderConnect } from "../dialog-provider"
 import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
@@ -40,6 +40,8 @@ import { DialogSkill } from "../dialog-skill"
 import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "@tui/util/provider-origin"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
+import { describeAgencyAuthFailure, shouldBlockAgencyPromptSubmit, shouldOpenAgencyAuthDialog } from "../../session-error"
+import { errorMessage as toErrorMessage } from "@/util/error"
 
 export type PromptProps = {
   sessionID?: string
@@ -607,31 +609,6 @@ export function Prompt(props: PromptProps) {
       exit()
       return
     }
-    const selectedModel = local.model.current()
-    if (!selectedModel) {
-      promptModelWarning()
-      return
-    }
-
-    let sessionID = props.sessionID
-    if (sessionID == null) {
-      const res = await sdk.client.session.create({
-        workspaceID: props.workspaceID,
-      })
-
-      if (res.error) {
-        toast.show({
-          message: "Creating a session failed.",
-          variant: "error",
-        })
-
-        return
-      }
-
-      sessionID = res.data.id
-    }
-
-    const messageID = MessageID.ascending()
     let inputText = store.prompt.input
 
     // Expand pasted text inline before submitting
@@ -652,10 +629,92 @@ export function Prompt(props: PromptProps) {
 
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
+    const firstLineEnd = inputText.indexOf("\n")
+    const firstLine = firstLineEnd === -1 ? inputText : inputText.slice(0, firstLineEnd)
+    const firstWord = firstLine.split(" ")[0]
+    const localSlash = firstWord.startsWith("/")
+      ? command
+          .slashes()
+          .find((item) => [item.display, ...(item.aliases ?? [])].includes(firstWord))
+      : undefined
+
+    const clearSubmittedPrompt = (submittedMode: typeof store.mode) => {
+      history.append({
+        ...store.prompt,
+        mode: submittedMode,
+      })
+      input.extmarks.clear()
+      setStore("prompt", {
+        input: "",
+        parts: [],
+      })
+      setStore("extmarkToPartIndex", new Map())
+      props.onSubmit?.()
+      input.clear()
+    }
+
+    if (localSlash) {
+      localSlash.onSelect()
+      clearSubmittedPrompt(store.mode)
+      return
+    }
+
+    const selectedModel = local.model.current()
+    if (!selectedModel) {
+      promptModelWarning()
+      return
+    }
 
     // Capture mode before it gets reset
     const currentMode = store.mode
     const variant = local.model.variant.current()
+    const isServerSlashCommand =
+      inputText.startsWith("/") &&
+      iife(() => {
+        const commandName = firstWord.slice(1)
+        return sync.data.command.some((x) => x.name === commandName)
+      })
+
+    if (
+      shouldBlockAgencyPromptSubmit({
+        currentProviderID: selectedModel.providerID,
+        configuredModel: sync.data.config.model,
+        providers: sync.data.provider,
+        providerAuth: sync.data.provider_auth,
+        mode: currentMode,
+        isSlashCommand: isServerSlashCommand,
+      })
+    ) {
+      toast.show({
+        variant: "warning",
+        message: "Add an OpenAI or Anthropic credential before sending a message",
+        duration: 4000,
+      })
+      dialog.replace(() => <DialogAuth />)
+      return
+    }
+
+    let sessionID = props.sessionID
+    let createdSessionID: string | undefined
+    if (sessionID == null) {
+      const res = await sdk.client.session.create({
+        workspaceID: props.workspaceID,
+      })
+
+      if (res.error) {
+        toast.show({
+          message: "Creating a session failed.",
+          variant: "error",
+        })
+
+        return
+      }
+
+      sessionID = res.data.id
+      createdSessionID = sessionID
+    }
+
+    const messageID = MessageID.ascending()
     void AgencySwarmRunSession.sync({
       sessionID,
       providerID: selectedModel.providerID,
@@ -673,17 +732,8 @@ export function Prompt(props: PromptProps) {
         command: inputText,
       })
       setStore("mode", "normal")
-    } else if (
-      inputText.startsWith("/") &&
-      iife(() => {
-        const firstLine = inputText.split("\n")[0]
-        const command = firstLine.split(" ")[0].slice(1)
-        return sync.data.command.some((x) => x.name === command)
-      })
-    ) {
+    } else if (isServerSlashCommand) {
       // Parse command from first line, preserve multi-line content in arguments
-      const firstLineEnd = inputText.indexOf("\n")
-      const firstLine = firstLineEnd === -1 ? inputText : inputText.slice(0, firstLineEnd)
       const [command, ...firstLineArgs] = firstLine.split(" ")
       const restOfInput = firstLineEnd === -1 ? "" : inputText.slice(firstLineEnd + 1)
       const args = firstLineArgs.join(" ") + (restOfInput ? "\n" + restOfInput : "")
@@ -704,8 +754,8 @@ export function Prompt(props: PromptProps) {
           })),
       })
     } else {
-      sdk.client.session
-        .prompt({
+      try {
+        await sdk.client.session.prompt({
           sessionID,
           ...selectedModel,
           messageID,
@@ -721,19 +771,36 @@ export function Prompt(props: PromptProps) {
             ...nonTextParts.map(assign),
           ],
         })
-        .catch(() => {})
+      } catch (error) {
+        const message = toErrorMessage(error)
+        if (createdSessionID) {
+          void sdk.client.session.delete({
+            sessionID: createdSessionID,
+          })
+        }
+        if (
+          shouldOpenAgencyAuthDialog({
+            providerID: selectedModel.providerID,
+            message,
+          })
+        ) {
+          toast.show({
+            variant: "error",
+            message: describeAgencyAuthFailure(message),
+            duration: 5000,
+          })
+          dialog.replace(() => <DialogAuth />)
+          return
+        }
+        toast.show({
+          variant: "error",
+          message,
+          duration: 5000,
+        })
+        return
+      }
     }
-    history.append({
-      ...store.prompt,
-      mode: currentMode,
-    })
-    input.extmarks.clear()
-    setStore("prompt", {
-      input: "",
-      parts: [],
-    })
-    setStore("extmarkToPartIndex", new Map())
-    props.onSubmit?.()
+    clearSubmittedPrompt(currentMode)
 
     // temporary hack to make sure the message is sent
     if (!props.sessionID)
@@ -743,7 +810,6 @@ export function Prompt(props: PromptProps) {
           sessionID,
         })
       }, 50)
-    input.clear()
   }
   const exit = useExit()
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -687,7 +687,7 @@ export function Prompt(props: PromptProps) {
     ) {
       toast.show({
         variant: "warning",
-        message: "Add an OpenAI or Anthropic credential before sending a message",
+        message: "Add a supported provider credential before sending a message",
         duration: 4000,
       })
       dialog.replace(() => <DialogAuth />)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -305,13 +305,6 @@ export function Prompt(props: PromptProps) {
         },
         onSelect: async (dialog) => {
           dialog.clear()
-          if (!Editor.isConfigured()) {
-            toast.show({
-              message: "Set VISUAL or EDITOR to use the external editor",
-              variant: "warning",
-            })
-            return
-          }
 
           // replace summarized text parts with the actual text
           const text = store.prompt.parts

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -773,17 +773,18 @@ export function Prompt(props: PromptProps) {
         })
       } catch (error) {
         const message = toErrorMessage(error)
+        const shouldReopenAuth = shouldOpenAgencyAuthDialog({
+          providerID: selectedModel.providerID,
+          message,
+        })
         if (createdSessionID) {
-          void sdk.client.session.delete({
-            sessionID: createdSessionID,
-          })
+          if (shouldReopenAuth) {
+            void sdk.client.session.delete({
+              sessionID: createdSessionID,
+            })
+          }
         }
-        if (
-          shouldOpenAgencyAuthDialog({
-            providerID: selectedModel.providerID,
-            message,
-          })
-        ) {
+        if (shouldReopenAuth) {
           toast.show({
             variant: "error",
             message: describeAgencyAuthFailure(message),

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -4,6 +4,7 @@ import { useSync } from "@tui/context/sync"
 import { useTheme } from "@tui/context/theme"
 import { uniqueBy } from "remeda"
 import path from "path"
+import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { Global } from "@/global"
 import { iife } from "@/util/iife"
 import { createSimpleContext } from "./helper"
@@ -14,16 +15,49 @@ import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
 import { Filesystem } from "@/util/filesystem"
 
+export function isUsableModel(input: {
+  model: {
+    providerID: string
+    modelID: string
+  }
+  providers: {
+    id: string
+    models: Record<string, unknown>
+  }[]
+  argModel?: string
+  configModel?: string
+  configuredProviders?: Record<string, unknown>
+}) {
+  const provider = input.providers.find((x) => x.id === input.model.providerID)
+  if (provider?.models[input.model.modelID]) return true
+  if (input.model.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
+  if (input.model.modelID !== AgencySwarmAdapter.DEFAULT_MODEL_ID) return false
+  const selectedAgencySwarmModel = [input.argModel, input.configModel].some(
+    (value) => value === `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`,
+  )
+  if (!selectedAgencySwarmModel) return false
+  return !!input.configuredProviders?.[AgencySwarmAdapter.PROVIDER_ID]
+}
+
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
   init: () => {
     const sync = useSync()
     const sdk = useSDK()
     const toast = useToast()
+    const args = useArgs()
 
     function isModelValid(model: { providerID: string; modelID: string }) {
-      const provider = sync.data.provider.find((x) => x.id === model.providerID)
-      return !!provider?.models[model.modelID]
+      return isUsableModel({
+        model,
+        providers: sync.data.provider.map((item) => ({
+          id: item.id,
+          models: item.models,
+        })),
+        argModel: args.model,
+        configModel: sync.data.config.model,
+        configuredProviders: sync.data.config.provider,
+      })
     }
 
     function getFirstValidModel(...modelFns: (() => { providerID: string; modelID: string } | undefined)[]) {
@@ -150,7 +184,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (state.pending) save()
         })
 
-      const args = useArgs()
       const fallbackModel = createMemo(() => {
         if (args.model) {
           const { providerID, modelID } = Provider.parseModel(args.model)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -877,6 +877,14 @@ export function Session() {
           )
 
           if (options.openWithoutSaving) {
+            if (!Editor.isConfigured()) {
+              toast.show({
+                message: "Set VISUAL or EDITOR to open the transcript in your editor",
+                variant: "warning",
+              })
+              dialog.clear()
+              return
+            }
             // Just open in editor without saving
             await Editor.open({ value: transcript, renderer })
           } else {
@@ -887,7 +895,7 @@ export function Session() {
             await Filesystem.write(filepath, transcript)
 
             // Open with EDITOR if available
-            const result = await Editor.open({ value: transcript, renderer })
+            const result = Editor.isConfigured() ? await Editor.open({ value: transcript, renderer }) : undefined
             if (result !== undefined) {
               await Filesystem.write(filepath, result)
             }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -877,14 +877,6 @@ export function Session() {
           )
 
           if (options.openWithoutSaving) {
-            if (!Editor.isConfigured()) {
-              toast.show({
-                message: "Set VISUAL or EDITOR to open the transcript in your editor",
-                variant: "warning",
-              })
-              dialog.clear()
-              return
-            }
             // Just open in editor without saving
             await Editor.open({ value: transcript, renderer })
           } else {
@@ -895,7 +887,7 @@ export function Session() {
             await Filesystem.write(filepath, transcript)
 
             // Open with EDITOR if available
-            const result = Editor.isConfigured() ? await Editor.open({ value: transcript, renderer }) : undefined
+            const result = await Editor.open({ value: transcript, renderer })
             if (result !== undefined) {
               await Filesystem.write(filepath, result)
             }

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -7,6 +7,13 @@ import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
 export const AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS = ["openai", "anthropic"] as const
 
 type ProviderAuthMap = Record<string, ProviderAuthMethod[]>
+type AuthProvider = {
+  id: string
+  env: string[]
+  key?: string
+  source?: string
+  options?: Record<string, unknown>
+}
 
 export function hasUsableProvider(
   providers: Provider[],
@@ -34,9 +41,52 @@ function hasCredential(provider: Provider, providerAuth: ProviderAuthMap = {}) {
   return hasStoredProviderCredential([provider], providerAuth, provider.id)
 }
 
-export function isSupportedAgencyAuthProvider(providerID: string) {
+function hasConfiguredAPIStyleCredential(provider: AuthProvider | undefined) {
+  if (!provider) return false
+  if (provider.key) return true
+  if (provider.source === "api") return true
+  const options = provider.options ?? {}
+  return [options["apiKey"], options["api_key"], options["key"], options["token"]].some(
+    (item) => typeof item === "string" && item.length > 0,
+  )
+}
+
+function hasAPIStyleEnv(provider: AuthProvider | undefined) {
+  if (!provider) return false
+  return provider.env.some((name) => /(^|_)(API_KEY|API_TOKEN|PAT|TOKEN)$/.test(name))
+}
+
+function isLoopbackBaseURL(baseURL: string) {
+  try {
+    const parsed = new URL(baseURL)
+    return (
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "0.0.0.0" ||
+      parsed.hostname === "localhost" ||
+      parsed.hostname === "::1" ||
+      parsed.hostname === "[::1]"
+    )
+  } catch {
+    return false
+  }
+}
+
+function usesLocalAgencyProviderAuth(providers: Provider[]) {
+  const agencyProvider = providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
+  const rawBaseURL = agencyProvider?.options?.["baseURL"]
+  const baseURL = typeof rawBaseURL === "string" && rawBaseURL.trim() ? rawBaseURL : AgencySwarmAdapter.DEFAULT_BASE_URL
+  return isLoopbackBaseURL(baseURL)
+}
+
+export function isSupportedAgencyAuthProvider(
+  providerID: string,
+  provider?: AuthProvider,
+  methods: ProviderAuthMethod[] = [],
+) {
   if ((AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS as readonly string[]).includes(providerID)) return true
-  return mapProviderIDToLiteLLMProvider(providerID) !== undefined
+  if (mapProviderIDToLiteLLMProvider(providerID) === undefined) return false
+  if (methods.some((method) => method.type === "api")) return true
+  return hasAPIStyleEnv(provider) || hasConfiguredAPIStyleCredential(provider)
 }
 
 function isAgencyProviderCredentialFailure(message: string) {
@@ -48,8 +98,9 @@ function isAgencyProviderCredentialFailure(message: string) {
 function hasSupportedAgencyCredential(providers: Provider[], providerAuth: ProviderAuthMap = {}) {
   return providers.some((provider) => {
     if (provider.id === AgencySwarmAdapter.PROVIDER_ID) return false
-    if (!isSupportedAgencyAuthProvider(provider.id)) return false
-    return hasCredential(provider, providerAuth)
+    if (!isSupportedAgencyAuthProvider(provider.id, provider, providerAuth[provider.id] ?? [])) return false
+    if (provider.id === "openai") return hasCredential(provider, providerAuth)
+    return hasConfiguredAPIStyleCredential(provider)
   })
 }
 
@@ -77,6 +128,7 @@ export function shouldOpenStartupAuthDialog(input: {
   if (agencyProvider && (hasCredential(agencyProvider, input.providerAuth) || hasExplicitAgencyClientConfig(agencyProvider))) {
     return false
   }
+  if (!usesLocalAgencyProviderAuth(input.providers)) return false
 
   return !hasSupportedAgencyCredential(input.providers, input.providerAuth)
 }

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,9 +1,10 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { mapProviderIDToLiteLLMProvider } from "@/agency-swarm/litellm-provider"
 import { hasClientConfigCredential } from "@/agency-swarm/client-config"
 import { hasStoredProviderCredential } from "@tui/util/provider-auth"
 import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
 
-export const AGENCY_SWARM_AUTH_PROVIDER_IDS = ["openai", "anthropic"] as const
+export const AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS = ["openai", "anthropic"] as const
 
 type ProviderAuthMap = Record<string, ProviderAuthMethod[]>
 
@@ -33,8 +34,9 @@ function hasCredential(provider: Provider, providerAuth: ProviderAuthMap = {}) {
   return hasStoredProviderCredential([provider], providerAuth, provider.id)
 }
 
-function isSupportedAgencyAuthProvider(providerID: string) {
-  return (AGENCY_SWARM_AUTH_PROVIDER_IDS as readonly string[]).includes(providerID)
+export function isSupportedAgencyAuthProvider(providerID: string) {
+  if ((AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS as readonly string[]).includes(providerID)) return true
+  return mapProviderIDToLiteLLMProvider(providerID) !== undefined
 }
 
 function isAgencyProviderCredentialFailure(message: string) {
@@ -120,7 +122,7 @@ export function shouldOpenAgencyAuthDialog(input: { providerID?: string; message
 
 export function describeAgencyAuthFailure(message: string) {
   if (/missing provider credentials|client_config/i.test(message)) {
-    return "Add an OpenAI or Anthropic credential before sending a message."
+    return "Add a supported provider credential before sending a message."
   }
   if (/unauthori[sz]ed|forbidden|invalid api key|auth failed|\b401\b|\b403\b/i.test(message)) {
     return "The current provider credential was rejected. Reconnect OpenAI or Anthropic and try again."

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,21 +1,54 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { hasClientConfigCredential } from "@/agency-swarm/client-config"
-import type { Provider } from "@opencode-ai/sdk/v2"
+import { hasStoredProviderCredential } from "@tui/util/provider-auth"
+import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
 
-export function hasUsableProvider(providers: Provider[], credentialed = false) {
+export const AGENCY_SWARM_AUTH_PROVIDER_IDS = ["openai", "anthropic"] as const
+
+type ProviderAuthMap = Record<string, ProviderAuthMethod[]>
+
+export function hasUsableProvider(
+  providers: Provider[],
+  credentialed = false,
+  providerAuth: ProviderAuthMap = {},
+) {
   return providers.some((provider) => {
-    if (provider.id !== "opencode") return credentialed ? hasCredential(provider) : true
+    if (provider.id !== "opencode") return credentialed ? hasCredential(provider, providerAuth) : true
     return Object.values(provider.models).some((model) => model.cost?.input !== 0)
   })
 }
 
-function hasCredential(provider: Provider) {
+function hasCredential(provider: Provider, providerAuth: ProviderAuthMap = {}) {
   if (provider.key) return true
   if (provider.source === "api") return true
   const options = provider.options ?? {}
-  return [options["apiKey"], options["api_key"], options["key"], options["token"]].some(
-    (item) => typeof item === "string" && item.length > 0,
+  if (
+    [options["apiKey"], options["api_key"], options["key"], options["token"]].some(
+      (item) => typeof item === "string" && item.length > 0,
+    )
+  ) {
+    return true
+  }
+
+  return hasStoredProviderCredential([provider], providerAuth, provider.id)
+}
+
+function isSupportedAgencyAuthProvider(providerID: string) {
+  return (AGENCY_SWARM_AUTH_PROVIDER_IDS as readonly string[]).includes(providerID)
+}
+
+function isAgencyProviderCredentialFailure(message: string) {
+  return /missing provider credentials|client_config|invalid api key|api key rejected|authentication failed|auth failed|access token/i.test(
+    message,
   )
+}
+
+function hasSupportedAgencyCredential(providers: Provider[], providerAuth: ProviderAuthMap = {}) {
+  return providers.some((provider) => {
+    if (provider.id === AgencySwarmAdapter.PROVIDER_ID) return false
+    if (!isSupportedAgencyAuthProvider(provider.id)) return false
+    return hasCredential(provider, providerAuth)
+  })
 }
 
 function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
@@ -31,19 +64,66 @@ export function isAgencySwarmFrameworkMode(input: { currentProviderID?: string; 
   return input.configuredModel?.split("/")[0] === AgencySwarmAdapter.PROVIDER_ID
 }
 
-export function shouldOpenStartupAuthDialog(input: { providers: Provider[]; frameworkMode: boolean }) {
-  if (!input.frameworkMode) return !hasUsableProvider(input.providers)
+export function shouldOpenStartupAuthDialog(input: {
+  providers: Provider[]
+  providerAuth?: ProviderAuthMap
+  frameworkMode: boolean
+}) {
+  if (!input.frameworkMode) return !hasUsableProvider(input.providers, false, input.providerAuth)
 
   const agencyProvider = input.providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
-  if (agencyProvider && (hasCredential(agencyProvider) || hasExplicitAgencyClientConfig(agencyProvider))) return false
+  if (agencyProvider && (hasCredential(agencyProvider, input.providerAuth) || hasExplicitAgencyClientConfig(agencyProvider))) {
+    return false
+  }
 
-  return !hasUsableProvider(
-    input.providers.filter((provider) => provider.id !== AgencySwarmAdapter.PROVIDER_ID),
-    true,
-  )
+  return !hasSupportedAgencyCredential(input.providers, input.providerAuth)
+}
+
+export function shouldBlockAgencyPromptSend(input: {
+  currentProviderID?: string
+  configuredModel?: string
+  providers: Provider[]
+  providerAuth?: ProviderAuthMap
+}) {
+  if (!isAgencySwarmFrameworkMode(input)) return false
+  return shouldOpenStartupAuthDialog({
+    providers: input.providers,
+    providerAuth: input.providerAuth,
+    frameworkMode: true,
+  })
+}
+
+export function shouldBlockAgencyPromptSubmit(input: {
+  currentProviderID?: string
+  configuredModel?: string
+  providers: Provider[]
+  providerAuth?: ProviderAuthMap
+  mode: "normal" | "shell"
+  isSlashCommand: boolean
+}) {
+  if (input.mode === "shell" || input.isSlashCommand) return false
+  return shouldBlockAgencyPromptSend(input)
 }
 
 export function shouldOpenAgencyConnectDialog(input: { providerID?: string; message: string }) {
   if (input.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
-  return /cannot reach agency-swarm backend/i.test(input.message)
+  if (/cannot reach agency-swarm backend/i.test(input.message)) return true
+  if (isAgencyProviderCredentialFailure(input.message)) return false
+  return /unauthori[sz]ed|forbidden|\b401\b|\b403\b/i.test(input.message)
+}
+
+export function shouldOpenAgencyAuthDialog(input: { providerID?: string; message: string }) {
+  if (input.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
+  if (shouldOpenAgencyConnectDialog(input)) return false
+  return isAgencyProviderCredentialFailure(input.message)
+}
+
+export function describeAgencyAuthFailure(message: string) {
+  if (/missing provider credentials|client_config/i.test(message)) {
+    return "Add an OpenAI or Anthropic credential before sending a message."
+  }
+  if (/unauthori[sz]ed|forbidden|invalid api key|auth failed|\b401\b|\b403\b/i.test(message)) {
+    return "The current provider credential was rejected. Reconnect OpenAI or Anthropic and try again."
+  }
+  return message
 }

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -11,7 +11,7 @@ export function hasUsableProvider(providers: Provider[], credentialed = false) {
 
 function hasCredential(provider: Provider) {
   if (provider.key) return true
-  if (provider.source === "api" || provider.source === "env") return true
+  if (provider.source === "api") return true
   const options = provider.options ?? {}
   return [options["apiKey"], options["api_key"], options["key"], options["token"]].some(
     (item) => typeof item === "string" && item.length > 0,

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,17 +1,34 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import type { Provider } from "@opencode-ai/sdk/v2"
 
-export function hasUsableProvider(providers: Provider[]) {
+export function hasUsableProvider(providers: Provider[], credentialed = false) {
   return providers.some((provider) => {
-    if (provider.id !== "opencode") return true
+    if (provider.id !== "opencode") return credentialed ? hasCredential(provider) : true
     return Object.values(provider.models).some((model) => model.cost?.input !== 0)
   })
+}
+
+function hasCredential(provider: Provider) {
+  if (provider.key) return true
+  if (provider.source === "api" || provider.source === "env") return true
+  const options = provider.options ?? {}
+  return [options["apiKey"], options["api_key"], options["key"], options["token"]].some(
+    (item) => typeof item === "string" && item.length > 0,
+  )
 }
 
 function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
   const raw = provider?.options?.["clientConfig"] ?? provider?.options?.["client_config"]
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return false
-  return Object.keys(raw).length > 0
+  return hasClientConfigCredential(raw as Record<string, unknown>)
+}
+
+function hasClientConfigCredential(config: Record<string, unknown>) {
+  if (typeof config["api_key"] === "string" && config["api_key"]) return true
+  if (typeof config["apiKey"] === "string" && config["apiKey"]) return true
+  const litellmKeys = config["litellm_keys"] ?? config["litellmKeys"]
+  if (!litellmKeys || typeof litellmKeys !== "object" || Array.isArray(litellmKeys)) return false
+  return Object.values(litellmKeys).some((item) => typeof item === "string" && item.length > 0)
 }
 
 export function shouldOpenStartupAuthDialog(input: { providers: Provider[]; frameworkMode: boolean }) {
@@ -20,7 +37,10 @@ export function shouldOpenStartupAuthDialog(input: { providers: Provider[]; fram
   const agencyProvider = input.providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
   if (hasExplicitAgencyClientConfig(agencyProvider)) return false
 
-  return !hasUsableProvider(input.providers.filter((provider) => provider.id !== AgencySwarmAdapter.PROVIDER_ID))
+  return !hasUsableProvider(
+    input.providers.filter((provider) => provider.id !== AgencySwarmAdapter.PROVIDER_ID),
+    true,
+  )
 }
 
 export function shouldOpenAgencyConnectDialog(input: { providerID?: string; message: string }) {

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -73,7 +73,7 @@ function isLoopbackBaseURL(baseURL: string) {
 
 function usesLocalAgencyProviderAuth(providers: Provider[]) {
   const agencyProvider = providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
-  const rawBaseURL = agencyProvider?.options?.["baseURL"]
+  const rawBaseURL = agencyProvider?.options?.["baseURL"] ?? agencyProvider?.options?.["base_url"]
   const baseURL = typeof rawBaseURL === "string" && rawBaseURL.trim() ? rawBaseURL : AgencySwarmAdapter.DEFAULT_BASE_URL
   return isLoopbackBaseURL(baseURL)
 }

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,4 +1,5 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { hasClientConfigCredential } from "@/agency-swarm/client-config"
 import type { Provider } from "@opencode-ai/sdk/v2"
 
 export function hasUsableProvider(providers: Provider[], credentialed = false) {
@@ -21,14 +22,6 @@ function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
   const raw = provider?.options?.["clientConfig"] ?? provider?.options?.["client_config"]
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return false
   return hasClientConfigCredential(raw as Record<string, unknown>)
-}
-
-function hasClientConfigCredential(config: Record<string, unknown>) {
-  if (typeof config["api_key"] === "string" && config["api_key"]) return true
-  if (typeof config["apiKey"] === "string" && config["apiKey"]) return true
-  const litellmKeys = config["litellm_keys"] ?? config["litellmKeys"]
-  if (!litellmKeys || typeof litellmKeys !== "object" || Array.isArray(litellmKeys)) return false
-  return Object.values(litellmKeys).some((item) => typeof item === "string" && item.length > 0)
 }
 
 export function shouldOpenStartupAuthDialog(input: { providers: Provider[]; frameworkMode: boolean }) {

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -24,11 +24,16 @@ function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
   return hasClientConfigCredential(raw as Record<string, unknown>)
 }
 
+export function isAgencySwarmFrameworkMode(input: { currentProviderID?: string; configuredModel?: string }) {
+  if (input.currentProviderID === AgencySwarmAdapter.PROVIDER_ID) return true
+  return input.configuredModel?.split("/")[0] === AgencySwarmAdapter.PROVIDER_ID
+}
+
 export function shouldOpenStartupAuthDialog(input: { providers: Provider[]; frameworkMode: boolean }) {
   if (!input.frameworkMode) return !hasUsableProvider(input.providers)
 
   const agencyProvider = input.providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
-  if (hasExplicitAgencyClientConfig(agencyProvider)) return false
+  if (agencyProvider && (hasCredential(agencyProvider) || hasExplicitAgencyClientConfig(agencyProvider))) return false
 
   return !hasUsableProvider(
     input.providers.filter((provider) => provider.id !== AgencySwarmAdapter.PROVIDER_ID),

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -25,7 +25,9 @@ function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
 }
 
 export function isAgencySwarmFrameworkMode(input: { currentProviderID?: string; configuredModel?: string }) {
-  if (input.currentProviderID === AgencySwarmAdapter.PROVIDER_ID) return true
+  if (input.currentProviderID) {
+    return input.currentProviderID === AgencySwarmAdapter.PROVIDER_ID
+  }
   return input.configuredModel?.split("/")[0] === AgencySwarmAdapter.PROVIDER_ID
 }
 

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -17,7 +17,13 @@ import { TuiConfig } from "@/config/tui"
 import { Instance } from "@/project/instance"
 import { writeHeapSnapshot } from "v8"
 import { AgencyProduct } from "@/agency-swarm/product"
-import { prepareNpxLaunch, shouldRunNpxOnboarding } from "@/agency-swarm/npx"
+import {
+  prepareNpxLaunch,
+  prepareProjectLaunch,
+  resolveNpxAutoProject,
+  shouldRunNpxOnboarding,
+} from "@/agency-swarm/npx"
+import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -141,13 +147,32 @@ export const TuiThreadCommand = cmd({
         prompt: args.prompt,
         agent: args.agent,
       })
-      const prepared = shouldBootstrap ? await prepareNpxLaunch(selectedProject) : undefined
-      if (shouldBootstrap && !prepared) {
+      const project = shouldBootstrap
+        ? undefined
+        : await resolveNpxAutoProject({
+            directory: selectedProject,
+            env: process.env,
+            model: args.model,
+            continue: args.continue,
+            fork: args.fork,
+            session: args.session,
+            prompt: args.prompt,
+            agent: args.agent,
+          })
+      const prepared = shouldBootstrap
+        ? await prepareNpxLaunch(selectedProject)
+        : project
+          ? await prepareProjectLaunch(project)
+          : undefined
+      if ((shouldBootstrap || project) && !prepared) {
         return
       }
       cleanup = prepared?.cleanup
       if (prepared?.configContent) {
         process.env.OPENCODE_CONFIG_CONTENT = prepared.configContent
+      }
+      if (prepared?.runProjectDirectory) {
+        process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV] = Filesystem.resolve(prepared.runProjectDirectory)
       }
       const next = prepared?.directory ? Filesystem.resolve(prepared.directory) : selectedProject
       const file = await target()

--- a/packages/opencode/src/cli/cmd/tui/util/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/editor.ts
@@ -7,10 +7,6 @@ import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
 
 export namespace Editor {
-  export function isConfigured() {
-    return Boolean(process.env["VISUAL"] || process.env["EDITOR"])
-  }
-
   export async function open(opts: { value: string; renderer: CliRenderer }): Promise<string | undefined> {
     const editor = process.env["VISUAL"] || process.env["EDITOR"]
     if (!editor) return

--- a/packages/opencode/src/cli/cmd/tui/util/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/editor.ts
@@ -7,6 +7,10 @@ import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
 
 export namespace Editor {
+  export function isConfigured() {
+    return Boolean(process.env["VISUAL"] || process.env["EDITOR"])
+  }
+
   export async function open(opts: { value: string; renderer: CliRenderer }): Promise<string | undefined> {
     const editor = process.env["VISUAL"] || process.env["EDITOR"]
     if (!editor) return

--- a/packages/opencode/src/cli/cmd/tui/util/provider-auth.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/provider-auth.ts
@@ -11,3 +11,13 @@ export function hasStoredProviderCredential(
   if (provider.source !== "custom") return false
   return (methods[providerID] ?? []).some((item) => item.type === "oauth")
 }
+
+export function getVisibleProviderAuthMethods(
+  providerID: string,
+  methods: ProviderAuthMethod[],
+  options?: { frameworkMode?: boolean },
+) {
+  if (!options?.frameworkMode) return methods
+  if (providerID !== "openai") return methods
+  return methods.filter((item) => !(item.type === "oauth" && /headless/i.test(item.label)))
+}

--- a/packages/opencode/src/cli/cmd/tui/util/provider-auth.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/provider-auth.ts
@@ -20,6 +20,8 @@ export function getVisibleProviderAuthMethods(
   options?: { frameworkMode?: boolean },
 ) {
   if (!options?.frameworkMode) return methods
-  if (providerID !== "openai") return methods
-  return methods.filter((item) => !(item.type === "oauth" && /headless/i.test(item.label)))
+  if (providerID === "openai") {
+    return methods.filter((item) => !(item.type === "oauth" && /headless/i.test(item.label)))
+  }
+  return methods.filter((item) => item.type === "api")
 }

--- a/packages/opencode/src/cli/cmd/tui/util/provider-auth.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/provider-auth.ts
@@ -2,14 +2,16 @@ import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
 
 export function hasStoredProviderCredential(
   providers: Provider[],
-  methods: Record<string, ProviderAuthMethod[]>,
+  _methods: Record<string, ProviderAuthMethod[]>,
   providerID: string,
 ) {
   const provider = providers.find((item) => item.id === providerID)
   if (!provider) return false
   if (provider.source === "api") return true
   if (provider.source !== "custom") return false
-  return (methods[providerID] ?? []).some((item) => item.type === "oauth")
+  const options = provider.options ?? {}
+  if (provider.id === "opencode" && options["apiKey"] === "public") return false
+  return Object.keys(options).length > 0
 }
 
 export function getVisibleProviderAuthMethods(

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -12,7 +12,8 @@ const log = Log.create({ service: "plugin.codex" })
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const ISSUER = "https://auth.openai.com"
-const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
+export const CODEX_API_BASE_URL = "https://chatgpt.com/backend-api/codex"
+const CODEX_API_ENDPOINT = `${CODEX_API_BASE_URL}/responses`
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
 
@@ -129,7 +130,7 @@ async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: Pk
   return response.json()
 }
 
-async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
+export async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
   const response = await fetch(`${ISSUER}/oauth/token`, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -136,7 +136,7 @@ export namespace SessionAgencySwarm {
 
     const explicitBaseURL = asString(explicit["base_url"]) ?? asString(explicit["baseURL"])
     const generatedBaseURL = asString(generated["base_url"])
-    if (explicitBaseURL && (explicitAPIKey || generatedBaseURL !== CODEX_API_BASE_URL)) {
+    if (explicitBaseURL) {
       merged["base_url"] = explicitBaseURL
     } else if (generatedBaseURL) {
       merged["base_url"] = generatedBaseURL

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1709,9 +1709,7 @@ export namespace SessionAgencySwarm {
       break
     }
 
-    if (start < 0) return
-
-    return input.msgs.slice(start).flatMap((msg) => {
+    return input.msgs.slice(start < 0 ? 0 : start).flatMap((msg) => {
       if (msg.info.id === input.currentID) return []
 
       if (msg.info.role === "user") {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1731,6 +1731,7 @@ export namespace SessionAgencySwarm {
       break
     }
 
+    if (start < 0) return
     const slice = input.msgs.slice(start < 0 ? 0 : start)
     if (slice.some((msg) => msg.info.id !== input.currentID && !isAgencySwarmMessage(msg))) return
 

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -209,7 +209,13 @@ export namespace SessionAgencySwarm {
 
       if (providerID === "openai" && auth.type === "oauth") {
         if (options.skipOpenAI || !options.allowStoredOpenAIOAuth) continue
-        Object.assign(payload, await buildOpenAIOAuthClientConfig(auth))
+        try {
+          Object.assign(payload, await buildOpenAIOAuthClientConfig(auth))
+        } catch (error) {
+          log.warn("failed to refresh stored OpenAI OAuth for local agency run; skipping it", {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
         continue
       }
 

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -3,6 +3,7 @@ import { AgencySwarmHistory } from "@/agency-swarm/history"
 import { mapProviderIDToLiteLLMProvider } from "@/agency-swarm/litellm-provider"
 import { Auth } from "@/auth"
 import { Env } from "@/env"
+import { CODEX_API_BASE_URL, extractAccountId, refreshAccessToken } from "@/plugin/codex"
 import { Provider } from "@/provider/provider"
 import { Session } from "@/session"
 import { MessageV2 } from "@/session/message-v2"
@@ -109,7 +110,12 @@ export namespace SessionAgencySwarm {
     config: Record<string, unknown> | undefined,
   ): Promise<Record<string, unknown> | undefined> {
     const generated = isLoopbackBaseURL(baseURL)
-      ? buildAuthClientConfig(await Auth.all(), await listProvidersForEnvCheck(), getEnvForClientConfig())
+      ? await buildAuthClientConfig(
+          await Auth.all(),
+          await listProvidersForEnvCheck(),
+          getEnvForClientConfig(),
+          hasExplicitOpenAIConfig(config),
+        )
       : undefined
     if (!config) return generated
     if (!generated) return config
@@ -122,17 +128,20 @@ export namespace SessionAgencySwarm {
       ...explicit,
     }
 
-    const explicitBaseURL = asString(explicit["base_url"]) ?? asString(explicit["baseURL"])
-    if (explicitBaseURL) {
-      merged["base_url"] = explicitBaseURL
-    }
-    delete merged["baseURL"]
-
     const explicitAPIKey = asString(explicit["api_key"]) ?? asString(explicit["apiKey"])
     if (explicitAPIKey) {
       merged["api_key"] = explicitAPIKey
     }
     delete merged["apiKey"]
+
+    const explicitBaseURL = asString(explicit["base_url"]) ?? asString(explicit["baseURL"])
+    const generatedBaseURL = asString(generated["base_url"])
+    if (explicitBaseURL && (explicitAPIKey || generatedBaseURL !== CODEX_API_BASE_URL)) {
+      merged["base_url"] = explicitBaseURL
+    } else if (generatedBaseURL) {
+      merged["base_url"] = generatedBaseURL
+    }
+    delete merged["baseURL"]
 
     const generatedLiteLLMKeys = asRecord(generated["litellm_keys"])
     const explicitLiteLLMKeys = asRecord(explicit["litellm_keys"]) ?? asRecord(explicit["litellmKeys"])
@@ -144,24 +153,58 @@ export namespace SessionAgencySwarm {
     }
     delete merged["litellmKeys"]
 
+    const generatedHeaders = readStringRecord(generated["default_headers"])
+    const explicitHeaders =
+      readStringRecord(explicit["default_headers"]) ?? readStringRecord(explicit["defaultHeaders"])
+    if (generatedHeaders || explicitHeaders) {
+      merged["default_headers"] = {
+        ...(generatedHeaders ?? {}),
+        ...(explicitHeaders ?? {}),
+      }
+    }
+    delete merged["defaultHeaders"]
+
     return merged
   }
 
-  function buildAuthClientConfig(
+  async function buildAuthClientConfig(
     auths: Record<string, Auth.Info>,
     providers: Record<string, Provider.Info> | undefined,
     env: Record<string, string | undefined>,
-  ): Record<string, unknown> | undefined {
+    skipOpenAI: boolean,
+  ): Promise<Record<string, unknown> | undefined> {
     const litellmKeys: Record<string, string> = {}
     const payload: Record<string, unknown> = {}
 
-    for (const [providerID, auth] of Object.entries(auths)) {
+    for (const [providerID, provider] of Object.entries(providers ?? {})) {
       if (providerID === AgencySwarmAdapter.PROVIDER_ID) continue
-      if (auth.type !== "api") continue
-      if (hasEnvCredential(providerID, providers, env)) continue
+      const key = getEnvCredential(provider, env)
+      if (!key) continue
 
       if (providerID === "openai") {
-        payload["api_key"] = auth.key
+        if (!skipOpenAI) payload["api_key"] = key
+        continue
+      }
+
+      const litellmProvider = mapProviderIDToLiteLLMProvider(providerID)
+      if (!litellmProvider) continue
+      litellmKeys[litellmProvider] = key
+    }
+
+    for (const [providerID, auth] of Object.entries(auths)) {
+      if (providerID === AgencySwarmAdapter.PROVIDER_ID) continue
+      if (hasEnvCredential(providerID, providers, env)) continue
+
+      if (providerID === "openai" && auth.type === "oauth") {
+        if (skipOpenAI) continue
+        Object.assign(payload, await buildOpenAIOAuthClientConfig(auth))
+        continue
+      }
+
+      if (auth.type !== "api") continue
+
+      if (providerID === "openai") {
+        if (!skipOpenAI) payload["api_key"] = auth.key
         continue
       }
 
@@ -177,6 +220,44 @@ export namespace SessionAgencySwarm {
     return Object.keys(payload).length > 0 ? payload : undefined
   }
 
+  async function buildOpenAIOAuthClientConfig(auth: Auth.Oauth): Promise<Record<string, unknown>> {
+    const current =
+      auth.expires < Date.now()
+        ? await refreshAccessToken(auth.refresh).then(async (tokens) => {
+            const accountID = extractAccountId(tokens) ?? auth.accountId
+            const next = {
+              type: "oauth" as const,
+              refresh: tokens.refresh_token,
+              access: tokens.access_token,
+              expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+              ...(accountID ? { accountId: accountID } : {}),
+            }
+            await Auth.set("openai", next)
+            return next
+          })
+        : auth
+    const headers: Record<string, string> = {}
+    if (current.accountId) headers["ChatGPT-Account-Id"] = current.accountId
+    return {
+      api_key: current.access,
+      base_url: CODEX_API_BASE_URL,
+      ...(Object.keys(headers).length > 0 ? { default_headers: headers } : {}),
+    }
+  }
+
+  function readStringRecord(value: unknown): Record<string, string> | undefined {
+    const record = asRecord(value)
+    if (!record) return undefined
+    const result = Object.fromEntries(
+      Object.entries(record).flatMap(([key, item]) => (typeof item === "string" ? [[key, item]] : [])),
+    )
+    return Object.keys(result).length > 0 ? result : undefined
+  }
+
+  function hasExplicitOpenAIConfig(config: Record<string, unknown> | undefined) {
+    return !!(asString(config?.["api_key"]) ?? asString(config?.["apiKey"]))
+  }
+
   function hasEnvCredential(
     providerID: string,
     providers: Record<string, Provider.Info> | undefined,
@@ -185,7 +266,17 @@ export namespace SessionAgencySwarm {
     if (!providers) return false
     const provider = providers[providerID]
     if (!provider) return false
-    return provider.env.some((key) => Boolean(env[key]))
+    return !!getEnvCredential(provider, env)
+  }
+
+  function getEnvCredential(provider: Provider.Info, env: Record<string, string | undefined>) {
+    if (provider.env.length === 0) return undefined
+    if (!provider.env.every(isAPIKeyEnvName)) return undefined
+    return provider.env.map((key) => env[key]).find(Boolean)
+  }
+
+  function isAPIKeyEnvName(name: string) {
+    return /(^|_)(API_KEY|API_TOKEN|PAT|TOKEN)$/.test(name)
   }
 
   async function listProvidersForEnvCheck(): Promise<Record<string, Provider.Info> | undefined> {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1,4 +1,8 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import {
+  hasExplicitOpenAIClientConfig,
+  readStringRecord,
+} from "@/agency-swarm/client-config"
 import { AgencySwarmHistory } from "@/agency-swarm/history"
 import { mapProviderIDToLiteLLMProvider } from "@/agency-swarm/litellm-provider"
 import { Auth } from "@/auth"
@@ -114,7 +118,7 @@ export namespace SessionAgencySwarm {
           await Auth.all(),
           await listProvidersForEnvCheck(),
           getEnvForClientConfig(),
-          hasExplicitOpenAIConfig(config),
+          hasExplicitOpenAIClientConfig(config),
         )
       : undefined
     if (!config) return generated
@@ -243,19 +247,6 @@ export namespace SessionAgencySwarm {
       base_url: CODEX_API_BASE_URL,
       ...(Object.keys(headers).length > 0 ? { default_headers: headers } : {}),
     }
-  }
-
-  function readStringRecord(value: unknown): Record<string, string> | undefined {
-    const record = asRecord(value)
-    if (!record) return undefined
-    const result = Object.fromEntries(
-      Object.entries(record).flatMap(([key, item]) => (typeof item === "string" ? [[key, item]] : [])),
-    )
-    return Object.keys(result).length > 0 ? result : undefined
-  }
-
-  function hasExplicitOpenAIConfig(config: Record<string, unknown> | undefined) {
-    return !!(asString(config?.["api_key"]) ?? asString(config?.["apiKey"]))
   }
 
   function hasEnvCredential(

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -113,18 +113,23 @@ export namespace SessionAgencySwarm {
     baseURL: string,
     config: Record<string, unknown> | undefined,
   ): Promise<Record<string, unknown> | undefined> {
+    const explicit = asRecord(config)
+    const explicitUpstreamBaseURL = readConfiguredBaseURL(explicit)
     const generated = isLoopbackBaseURL(baseURL)
       ? await buildAuthClientConfig(
           await Auth.all(),
           await listProvidersForEnvCheck(),
           getEnvForClientConfig(),
-          hasExplicitOpenAIClientConfig(config),
+          {
+            skipOpenAI: hasExplicitOpenAIClientConfig(config),
+            allowStoredOpenAIOAuth:
+              !explicitUpstreamBaseURL || isCodexAPIBaseURL(explicitUpstreamBaseURL),
+          },
         )
       : undefined
     if (!config) return generated
     if (!generated) return config
 
-    const explicit = asRecord(config)
     if (!explicit) return generated
 
     const merged: Record<string, unknown> = {
@@ -175,7 +180,10 @@ export namespace SessionAgencySwarm {
     auths: Record<string, Auth.Info>,
     providers: Record<string, Provider.Info> | undefined,
     env: Record<string, string | undefined>,
-    skipOpenAI: boolean,
+    options: {
+      skipOpenAI: boolean
+      allowStoredOpenAIOAuth: boolean
+    },
   ): Promise<Record<string, unknown> | undefined> {
     const litellmKeys: Record<string, string> = {}
     const payload: Record<string, unknown> = {}
@@ -186,7 +194,7 @@ export namespace SessionAgencySwarm {
       if (!key) continue
 
       if (providerID === "openai") {
-        if (!skipOpenAI) payload["api_key"] = key
+        if (!options.skipOpenAI) payload["api_key"] = key
         continue
       }
 
@@ -200,7 +208,7 @@ export namespace SessionAgencySwarm {
       if (hasEnvCredential(providerID, providers, env)) continue
 
       if (providerID === "openai" && auth.type === "oauth") {
-        if (skipOpenAI) continue
+        if (options.skipOpenAI || !options.allowStoredOpenAIOAuth) continue
         Object.assign(payload, await buildOpenAIOAuthClientConfig(auth))
         continue
       }
@@ -208,7 +216,7 @@ export namespace SessionAgencySwarm {
       if (auth.type !== "api") continue
 
       if (providerID === "openai") {
-        if (!skipOpenAI) payload["api_key"] = auth.key
+        if (!options.skipOpenAI) payload["api_key"] = auth.key
         continue
       }
 
@@ -247,6 +255,14 @@ export namespace SessionAgencySwarm {
       base_url: CODEX_API_BASE_URL,
       ...(Object.keys(headers).length > 0 ? { default_headers: headers } : {}),
     }
+  }
+
+  function readConfiguredBaseURL(config: Record<string, unknown> | undefined) {
+    return asString(config?.["base_url"]) ?? asString(config?.["baseURL"])
+  }
+
+  function isCodexAPIBaseURL(value: string) {
+    return value.replace(/\/+$/, "") === CODEX_API_BASE_URL
   }
 
   function hasEnvCredential(
@@ -1709,7 +1725,10 @@ export namespace SessionAgencySwarm {
       break
     }
 
-    return input.msgs.slice(start < 0 ? 0 : start).flatMap((msg) => {
+    const slice = input.msgs.slice(start < 0 ? 0 : start)
+    if (slice.some((msg) => msg.info.id !== input.currentID && !isAgencySwarmMessage(msg))) return
+
+    return slice.flatMap((msg) => {
       if (msg.info.id === input.currentID) return []
 
       if (msg.info.role === "user") {
@@ -1745,6 +1764,13 @@ export namespace SessionAgencySwarm {
         },
       ]
     })
+  }
+
+  function isAgencySwarmMessage(msg: MessageV2.WithParts) {
+    if (msg.info.role === "assistant") {
+      return msg.info.providerID === AgencySwarmAdapter.PROVIDER_ID
+    }
+    return msg.info.model.providerID === AgencySwarmAdapter.PROVIDER_ID
   }
 
   function extractRecipientMap(metadata: AgencySwarmAdapter.AgencyMetadata): Map<string, string> {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -33,6 +33,7 @@ import { ModelID, ProviderID } from "@/provider/schema"
 import { Permission } from "@/permission"
 import { Global } from "@/global"
 import { AgencyBrand } from "@/agency-swarm/brand"
+import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
 import type { LanguageModelV2Usage } from "@ai-sdk/provider"
 import { Effect, Layer, Scope, ServiceMap } from "effect"
 import { makeRuntime } from "@/effect/run-service"
@@ -403,6 +404,10 @@ export namespace Session {
         log.info("created", result)
 
         yield* Effect.sync(() => SyncEvent.run(Event.Created, { sessionID: result.id, info: result }))
+        const runProject = process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
+        if (runProject && path.resolve(runProject) === path.resolve(result.directory)) {
+          yield* Effect.promise(() => AgencySwarmRunSession.mark({ sessionID: result.id, directory: result.directory }))
+        }
 
         const cfg = yield* config.get()
         if (!result.parentID && (Flag.OPENCODE_AUTO_SHARE || cfg.share === "auto")) {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -33,7 +33,6 @@ import { ModelID, ProviderID } from "@/provider/schema"
 import { Permission } from "@/permission"
 import { Global } from "@/global"
 import { AgencyBrand } from "@/agency-swarm/brand"
-import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
 import type { LanguageModelV2Usage } from "@ai-sdk/provider"
 import { Effect, Layer, Scope, ServiceMap } from "effect"
 import { makeRuntime } from "@/effect/run-service"
@@ -404,10 +403,6 @@ export namespace Session {
         log.info("created", result)
 
         yield* Effect.sync(() => SyncEvent.run(Event.Created, { sessionID: result.id, info: result }))
-        const runProject = process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
-        if (runProject && path.resolve(runProject) === path.resolve(result.directory)) {
-          yield* Effect.promise(() => AgencySwarmRunSession.mark({ sessionID: result.id, directory: result.directory }))
-        }
 
         const cfg = yield* config.get()
         if (!result.parentID && (Flag.OPENCODE_AUTO_SHARE || cfg.share === "auto")) {

--- a/packages/opencode/test/agency-swarm/adapter.test.ts
+++ b/packages/opencode/test/agency-swarm/adapter.test.ts
@@ -184,6 +184,9 @@ describe("agency-swarm.adapter", () => {
       clientConfig: {
         baseURL: "https://proxy.example.com/v1",
         apiKey: "secret",
+        defaultHeaders: {
+          "ChatGPT-Account-Id": "acct_123",
+        },
         litellmKeys: {
           anthropic: "ant-secret",
         },
@@ -208,6 +211,9 @@ describe("agency-swarm.adapter", () => {
       client_config: {
         base_url: "https://proxy.example.com/v1",
         api_key: "secret",
+        default_headers: {
+          "ChatGPT-Account-Id": "acct_123",
+        },
         litellm_keys: {
           anthropic: "ant-secret",
         },

--- a/packages/opencode/test/agency-swarm/client-config.test.ts
+++ b/packages/opencode/test/agency-swarm/client-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import { hasClientConfigCredential, hasExplicitOpenAIClientConfig } from "../../src/agency-swarm/client-config"
+
+describe("agency-swarm client config credentials", () => {
+  test("treats api_key and LiteLLM keys as credentials", () => {
+    expect(hasClientConfigCredential({ api_key: "sk-openai" })).toBe(true)
+    expect(
+      hasClientConfigCredential({
+        litellm_keys: {
+          anthropic: "sk-ant",
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test("treats Authorization headers as credentials", () => {
+    expect(
+      hasClientConfigCredential({
+        default_headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      }),
+    ).toBe(true)
+    expect(
+      hasExplicitOpenAIClientConfig({
+        default_headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test("ignores non-auth headers", () => {
+    expect(
+      hasClientConfigCredential({
+        default_headers: {
+          "x-proxy": "1",
+        },
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/opencode/test/agency-swarm/client-config.test.ts
+++ b/packages/opencode/test/agency-swarm/client-config.test.ts
@@ -39,4 +39,21 @@ describe("agency-swarm client config credentials", () => {
       }),
     ).toBe(false)
   })
+
+  test("ignores empty auth-like headers", () => {
+    expect(
+      hasClientConfigCredential({
+        default_headers: {
+          Authorization: "",
+        },
+      }),
+    ).toBe(false)
+    expect(
+      hasExplicitOpenAIClientConfig({
+        default_headers: {
+          Authorization: "",
+        },
+      }),
+    ).toBe(false)
+  })
 })

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -236,6 +236,82 @@ describe("agency-swarm npx onboarding", () => {
     expect(project?.directory).toBe(dir.path)
   })
 
+  test("resolveNpxAutoProject ignores legacy history for remote agencies", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(Storage, "list").mockResolvedValue([["agency_swarm_history", "legacy"]])
+    spyOn(Storage, "read").mockResolvedValue({
+      scope: "https://remote.example|my-remote-agency|ses_123",
+      chat_history: [],
+      updated_at: 1,
+    } as never)
+
+    const project = await resolveNpxAutoProject({
+      directory: "/tmp/elsewhere",
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject ignores older local history when newer remote history exists", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(Storage, "list").mockResolvedValue([
+      ["agency_swarm_history", "older-local"],
+      ["agency_swarm_history", "newer-remote"],
+    ])
+    spyOn(Storage, "read").mockImplementation(async (key) => {
+      if (key.at(-1) === "older-local") {
+        return {
+          scope: "http://127.0.0.1:8123|local-agency|ses_123",
+          chat_history: [],
+          updated_at: 1,
+        } as never
+      }
+      return {
+        scope: "https://remote.example|remote-agency|ses_123",
+        chat_history: [],
+        updated_at: 2,
+      } as never
+    })
+
+    const project = await resolveNpxAutoProject({
+      directory: "/tmp/elsewhere",
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
   test("resolveNpxAutoProject does not fallback when explicit session is stale", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -365,6 +441,50 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject ignores local-agency history when the newest scope is remote", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(Storage, "list").mockResolvedValue([
+      ["agency_swarm_history", "old-local"],
+      ["agency_swarm_history", "newer-remote-local-agency"],
+    ])
+    spyOn(Storage, "read").mockImplementation(async (key) => {
+      if (key.at(-1) === "old-local") {
+        return {
+          scope: "http://127.0.0.1:8123|local-agency|ses_legacy",
+          chat_history: [],
+          updated_at: 1,
+        } as never
+      }
+      return {
+        scope: "https://remote.example|local-agency|ses_legacy",
+        chat_history: [],
+        updated_at: 2,
+      } as never
+    })
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      sessions: [
+        {
+          id: "ses_legacy" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project).toBeUndefined()
   })
 
   test("resolveNpxAutoProject falls back to current project when continue has no local session", async () => {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -312,6 +312,50 @@ describe("agency-swarm npx onboarding", () => {
     expect(project).toBeUndefined()
   })
 
+  test("resolveNpxAutoProject does not use legacy local history after an explicit session switches providers", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(Storage, "list").mockResolvedValue([["agency_swarm_history", "legacy"]])
+    spyOn(Storage, "read").mockResolvedValue({
+      scope: "http://127.0.0.1:8123|local-agency|ses_123",
+      chat_history: [],
+      updated_at: 1,
+    } as never)
+    spyOn(Session, "messages").mockResolvedValue([
+      {
+        info: {
+          role: "user",
+          model: {
+            providerID: "openai",
+            modelID: "gpt-5",
+          },
+        },
+        parts: [],
+      } as never,
+    ])
+
+    const project = await resolveNpxAutoProject({
+      directory: "/tmp/elsewhere",
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
   test("resolveNpxAutoProject does not fallback when explicit session is stale", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -441,6 +485,48 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject does not use legacy local history for continue after switching providers", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(Storage, "list").mockResolvedValue([["agency_swarm_history", "legacy"]])
+    spyOn(Storage, "read").mockResolvedValue({
+      scope: "http://127.0.0.1:8123|local-agency|ses_legacy",
+      chat_history: [],
+      updated_at: 1,
+    } as never)
+    spyOn(Session, "messages").mockResolvedValue([
+      {
+        info: {
+          role: "assistant",
+          providerID: "openai",
+          modelID: "gpt-5",
+        },
+        parts: [],
+      } as never,
+    ])
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      sessions: [
+        {
+          id: "ses_legacy" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project).toBeUndefined()
   })
 
   test("resolveNpxAutoProject ignores local-agency history when the newest scope is remote", async () => {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -7,9 +7,13 @@ import {
   detectAgencyProject,
   formatProjectLabel,
   LAUNCHER_ENTRY_ENV,
+  resolveNpxAutoProject,
   shouldRunNpxOnboarding,
   validateStarterName,
 } from "../../src/agency-swarm/npx"
+import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
 import { tmpdir } from "../fixture/fixture"
 
 describe("agency-swarm npx onboarding", () => {
@@ -146,6 +150,274 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(validateStarterName(dir.path, "my-agency")).toBe("A folder with this name already exists")
     expect(validateStarterName(dir.path, "new-agency")).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject uses session directory for explicit session resumes", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: "/tmp/elsewhere",
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [{ sessionID: "ses_123", directory: dir.path }],
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject does not auto-start explicit sessions without run metadata", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject does not fallback when explicit session is stale", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_missing",
+      sessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject does not fallback when explicit session is not an agency project", async () => {
+    await using dir = await tmpdir()
+    await using other = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: other.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [{ sessionID: "ses_123", directory: other.path }],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject uses latest local root session for continue", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      sessions: [
+        {
+          id: "ses_old" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+        {
+          id: "ses_new" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 2,
+            updated: 2,
+          },
+        },
+      ],
+      runSessions: [{ sessionID: "ses_new", directory: dir.path }],
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject does not auto-start continue sessions without run metadata", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      sessions: [
+        {
+          id: "ses_remote" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject falls back to current project when continue has no local session", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      sessions: [],
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject does not fallback when forking continue without a local session", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      fork: true,
+      sessions: [],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject starts current project for prompt launch", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      prompt: "hello",
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject starts current project for agent launch", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      agent: "build",
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject starts current project for agency-swarm model launch", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      model: "agency-swarm/default",
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject skips non agency-swarm model overrides", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      model: "openai/gpt-5",
+    })
+
+    expect(project).toBeUndefined()
+  })
+
+  test("created run-mode sessions can be resumed by explicit session id", async () => {
+    await using dir = await tmpdir({ git: true })
+    await writeAgency(dir.path)
+    const runProject = process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
+
+    try {
+      process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV] = dir.path
+      let session: Session.Info | undefined
+      await Instance.provide({
+        directory: dir.path,
+        fn: async () => {
+          session = await Session.create({})
+        },
+      })
+
+      if (!session) throw new Error("Expected session")
+      const current = session
+      expect((await AgencySwarmRunSession.get(current.id))?.directory).toBe(dir.path)
+
+      const project = await resolveNpxAutoProject({
+        directory: "/tmp/elsewhere",
+        env: { [LAUNCHER_ENTRY_ENV]: "1" },
+        session: current.id,
+      })
+
+      expect(project?.directory).toBe(dir.path)
+      await Instance.provide({
+        directory: dir.path,
+        fn: async () => {
+          await Session.remove(current.id)
+        },
+      })
+    } finally {
+      if (runProject === undefined) delete process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
+      else process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV] = runProject
+    }
   })
 })
 

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import {
@@ -14,12 +14,14 @@ import {
 import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
+import { Storage } from "../../src/storage/storage"
 import { tmpdir } from "../fixture/fixture"
 
 describe("agency-swarm npx onboarding", () => {
   const originalEnv = process.env[LAUNCHER_ENTRY_ENV]
 
   afterEach(() => {
+    mock.restore()
     if (originalEnv === undefined) delete process.env[LAUNCHER_ENTRY_ENV]
     else process.env[LAUNCHER_ENTRY_ENV] = originalEnv
   })
@@ -202,6 +204,38 @@ describe("agency-swarm npx onboarding", () => {
     expect(project).toBeUndefined()
   })
 
+  test("resolveNpxAutoProject uses legacy local-agency history for explicit session resumes", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(Storage, "list").mockResolvedValue([["agency_swarm_history", "legacy"]])
+    spyOn(Storage, "read").mockResolvedValue({
+      scope: "http://127.0.0.1:8123|local-agency|ses_123",
+      chat_history: [],
+      updated_at: 1,
+    } as never)
+
+    const project = await resolveNpxAutoProject({
+      directory: "/tmp/elsewhere",
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project?.directory).toBe(dir.path)
+  })
+
   test("resolveNpxAutoProject does not fallback when explicit session is stale", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -299,6 +333,38 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject uses legacy local-agency history for continue", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(Storage, "list").mockResolvedValue([["agency_swarm_history", "legacy"]])
+    spyOn(Storage, "read").mockResolvedValue({
+      scope: "http://127.0.0.1:8123|local-agency|ses_legacy",
+      chat_history: [],
+      updated_at: 1,
+    } as never)
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      sessions: [
+        {
+          id: "ses_legacy" as any,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project?.directory).toBe(dir.path)
   })
 
   test("resolveNpxAutoProject falls back to current project when continue has no local session", async () => {

--- a/packages/opencode/test/agency-swarm/run-session.test.ts
+++ b/packages/opencode/test/agency-swarm/run-session.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
+import { Filesystem } from "../../src/util/filesystem"
+
+describe("agency-swarm run session state", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test("sync stores local-project metadata only for agency-swarm sessions", async () => {
+    const readJson = spyOn(Filesystem, "readJson").mockRejectedValue(new Error("missing"))
+    const writeJson = spyOn(Filesystem, "writeJson").mockResolvedValue(undefined as never)
+
+    await AgencySwarmRunSession.sync({
+      sessionID: "ses_123",
+      providerID: "agency-swarm",
+      directory: "/tmp/project",
+    })
+
+    expect(readJson).toHaveBeenCalledTimes(1)
+    expect(writeJson).toHaveBeenCalledTimes(1)
+    expect(writeJson.mock.calls[0]?.[1]).toEqual({
+      ses_123: {
+        mode: "local-project",
+        directory: "/tmp/project",
+      },
+    })
+  })
+
+  test("sync clears stale local-project metadata for non-agency sessions", async () => {
+    spyOn(Filesystem, "readJson").mockResolvedValue({
+      ses_123: {
+        mode: "local-project",
+        directory: "/tmp/project",
+      },
+    } as never)
+    const writeJson = spyOn(Filesystem, "writeJson").mockResolvedValue(undefined as never)
+
+    await AgencySwarmRunSession.sync({
+      sessionID: "ses_123",
+      providerID: "openai",
+      directory: "/tmp/project",
+    })
+
+    expect(writeJson).toHaveBeenCalledTimes(1)
+    expect(writeJson.mock.calls[0]?.[1]).toEqual({})
+  })
+})

--- a/packages/opencode/test/cli/tui/dialog-provider.test.ts
+++ b/packages/opencode/test/cli/tui/dialog-provider.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
+import { listRemovableAuthProviders } from "../../../src/cli/cmd/tui/component/dialog-provider"
+
+describe("dialog provider auth management", () => {
+  test("keeps stored oauth-only providers removable in framework auth mode", () => {
+    const providers = [
+      {
+        id: "github-copilot",
+        name: "GitHub Copilot",
+        source: "custom",
+        env: [],
+        options: {
+          accessToken: "copilot-token",
+        },
+        models: {},
+      },
+    ] satisfies Provider[]
+    const methods = {
+      "github-copilot": [
+        {
+          type: "oauth",
+          label: "GitHub sign-in",
+        },
+      ],
+    } satisfies Record<string, ProviderAuthMethod[]>
+
+    expect(
+      listRemovableAuthProviders({
+        all: [{ id: "github-copilot", name: "GitHub Copilot" }],
+        providers,
+        providerAuth: methods,
+        consoleManagedProviders: [],
+      }).map((provider) => provider.id),
+    ).toEqual(["github-copilot"])
+  })
+})

--- a/packages/opencode/test/cli/tui/local.test.ts
+++ b/packages/opencode/test/cli/tui/local.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+import { isUsableModel } from "../../../src/cli/cmd/tui/context/local"
+
+describe("tui local model selection", () => {
+  test("keeps agency-swarm launcher model usable before provider metadata loads", () => {
+    expect(
+      isUsableModel({
+        model: {
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        configModel: "agency-swarm/default",
+        configuredProviders: {
+          "agency-swarm": {
+            name: "Agency Swarm",
+            options: {},
+          },
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test("keeps explicit agency-swarm args.model usable before provider metadata loads", () => {
+    expect(
+      isUsableModel({
+        model: {
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        argModel: "agency-swarm/default",
+        configuredProviders: {
+          "agency-swarm": {
+            name: "Agency Swarm",
+            options: {},
+          },
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test("does not treat unrelated missing models as usable", () => {
+    expect(
+      isUsableModel({
+        model: {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        configModel: "agency-swarm/default",
+        configuredProviders: {
+          "agency-swarm": {
+            name: "Agency Swarm",
+            options: {},
+          },
+        },
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/opencode/test/cli/tui/provider-auth.test.ts
+++ b/packages/opencode/test/cli/tui/provider-auth.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { hasStoredProviderCredential } from "../../../src/cli/cmd/tui/util/provider-auth"
+import { getVisibleProviderAuthMethods, hasStoredProviderCredential } from "../../../src/cli/cmd/tui/util/provider-auth"
 
 test("detects stored api credentials", () => {
   expect(
@@ -84,4 +84,37 @@ test("does not treat opencode public mode as a stored credential", () => {
       "opencode",
     ),
   ).toBe(false)
+})
+
+test("hides openai headless auth in agency-swarm framework mode", () => {
+  expect(
+    getVisibleProviderAuthMethods(
+      "openai",
+      [
+        { type: "oauth", label: "ChatGPT Pro/Plus (browser)" },
+        { type: "oauth", label: "ChatGPT Pro/Plus (headless)" },
+        { type: "api", label: "Manually enter API Key" },
+      ],
+      { frameworkMode: true },
+    ),
+  ).toEqual([
+    { type: "oauth", label: "ChatGPT Pro/Plus (browser)" },
+    { type: "api", label: "Manually enter API Key" },
+  ])
+})
+
+test("keeps openai headless auth outside agency-swarm framework mode", () => {
+  expect(
+    getVisibleProviderAuthMethods(
+      "openai",
+      [
+        { type: "oauth", label: "ChatGPT Pro/Plus (browser)" },
+        { type: "oauth", label: "ChatGPT Pro/Plus (headless)" },
+      ],
+      { frameworkMode: false },
+    ),
+  ).toEqual([
+    { type: "oauth", label: "ChatGPT Pro/Plus (browser)" },
+    { type: "oauth", label: "ChatGPT Pro/Plus (headless)" },
+  ])
 })

--- a/packages/opencode/test/cli/tui/provider-auth.test.ts
+++ b/packages/opencode/test/cli/tui/provider-auth.test.ts
@@ -139,3 +139,16 @@ test("keeps openai headless auth outside agency-swarm framework mode", () => {
     { type: "oauth", label: "ChatGPT Pro/Plus (headless)" },
   ])
 })
+
+test("keeps only API auth methods for non-openai providers in agency-swarm framework mode", () => {
+  expect(
+    getVisibleProviderAuthMethods(
+      "github-copilot",
+      [
+        { type: "oauth", label: "GitHub sign-in" },
+        { type: "api", label: "API key" },
+      ],
+      { frameworkMode: true },
+    ),
+  ).toEqual([{ type: "api", label: "API key" }])
+})

--- a/packages/opencode/test/cli/tui/provider-auth.test.ts
+++ b/packages/opencode/test/cli/tui/provider-auth.test.ts
@@ -48,6 +48,27 @@ test("detects stored oauth credentials for custom providers", () => {
           name: "OpenAI",
           source: "custom",
           env: [],
+          options: {
+            apiKey: "codex-dummy",
+          },
+          models: {},
+        },
+      ],
+      {},
+      "openai",
+    ),
+  ).toBe(true)
+})
+
+test("does not treat auth method catalogs as stored credentials", () => {
+  expect(
+    hasStoredProviderCredential(
+      [
+        {
+          id: "openai",
+          name: "OpenAI",
+          source: "custom",
+          env: [],
           options: {},
           models: {},
         },
@@ -62,7 +83,7 @@ test("detects stored oauth credentials for custom providers", () => {
       },
       "openai",
     ),
-  ).toBe(true)
+  ).toBe(false)
 })
 
 test("does not treat opencode public mode as a stored credential", () => {

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -128,10 +128,18 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
-  test("framework mode stays enabled when the configured model is agency-swarm", () => {
+  test("framework mode follows the current provider override away from agency-swarm", () => {
     expect(
       isAgencySwarmFrameworkMode({
         currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode falls back to the configured agency-swarm model when no current provider is selected", () => {
+    expect(
+      isAgencySwarmFrameworkMode({
         configuredModel: "agency-swarm/default",
       }),
     ).toBe(true)

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test"
+import type { Provider } from "@opencode-ai/sdk/v2"
 import {
+  shouldBlockAgencyPromptSubmit,
+  shouldBlockAgencyPromptSend,
+  shouldOpenAgencyAuthDialog,
   hasUsableProvider,
   isAgencySwarmFrameworkMode,
   shouldOpenAgencyConnectDialog,
@@ -395,6 +399,14 @@ describe("agency session errors", () => {
     expect(
       shouldOpenStartupAuthDialog({
         frameworkMode: true,
+        providerAuth: {
+          openai: [
+            {
+              type: "oauth",
+              label: "ChatGPT",
+            },
+          ],
+        },
         providers: [
           {
             id: "agency-swarm",
@@ -409,9 +421,7 @@ describe("agency session errors", () => {
             name: "OpenAI",
             source: "custom",
             env: [],
-            options: {
-              apiKey: "oauth-dummy",
-            },
+            options: {},
             models: {},
           },
         ],
@@ -437,11 +447,183 @@ describe("agency session errors", () => {
             name: "OpenAI",
             source: "api",
             env: ["OPENAI_API_KEY"],
+            key: "sk-openai",
             options: {},
             models: {},
           },
         ],
       }),
     ).toBe(false)
+  })
+
+  test("framework mode still opens auth when an unsupported provider is credentialed", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "google",
+            name: "Google",
+            source: "api",
+            env: ["GOOGLE_API_KEY"],
+            key: "google-key",
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  test("blocks the first agency prompt when supported auth is missing", () => {
+    expect(
+      shouldBlockAgencyPromptSend({
+        currentProviderID: "agency-swarm",
+        configuredModel: "agency-swarm/default",
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  test("does not block the first agency prompt when supported auth exists", () => {
+    expect(
+      shouldBlockAgencyPromptSend({
+        currentProviderID: "agency-swarm",
+        configuredModel: "agency-swarm/default",
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "anthropic",
+            name: "Anthropic",
+            source: "api",
+            env: ["ANTHROPIC_API_KEY"],
+            key: "sk-ant",
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("does not block shell mode or slash commands during agency auth gating", () => {
+    const input = {
+      currentProviderID: "agency-swarm",
+      configuredModel: "agency-swarm/default",
+      providers: [
+        {
+          id: "agency-swarm",
+          name: "Agency Swarm",
+          source: "config",
+          env: [],
+          options: {},
+          models: {},
+        },
+        {
+          id: "openai",
+          name: "OpenAI",
+          source: "config",
+          env: ["OPENAI_API_KEY"],
+          options: {},
+          models: {},
+        },
+      ] satisfies Provider[],
+    }
+
+    expect(
+      shouldBlockAgencyPromptSubmit({
+        ...input,
+        mode: "shell",
+        isSlashCommand: false,
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldBlockAgencyPromptSubmit({
+        ...input,
+        mode: "normal",
+        isSlashCommand: true,
+      }),
+    ).toBe(false)
+  })
+
+  test("opens auth dialog for agency auth failures", () => {
+    expect(
+      shouldOpenAgencyAuthDialog({
+        providerID: "agency-swarm",
+        message: "Streaming request failed (401): Missing provider credentials in client_config",
+      }),
+    ).toBe(true)
+
+    expect(
+      shouldOpenAgencyAuthDialog({
+        providerID: "agency-swarm",
+        message: "cannot reach agency-swarm backend at http://127.0.0.1:8000/openapi.json",
+      }),
+    ).toBe(false)
+  })
+
+  test("opens connect instead of auth for agency server authorization failures", () => {
+    expect(
+      shouldOpenAgencyConnectDialog({
+        providerID: "agency-swarm",
+        message: "Streaming request failed (401): Unauthorized",
+      }),
+    ).toBe(true)
+
+    expect(
+      shouldOpenAgencyAuthDialog({
+        providerID: "agency-swarm",
+        message: "Streaming request failed (401): Unauthorized",
+      }),
+    ).toBe(false)
+  })
+
+  test("keeps provider credential rejection routed to auth", () => {
+    expect(
+      shouldOpenAgencyConnectDialog({
+        providerID: "agency-swarm",
+        message: "Streaming request failed (403): Invalid API key for OpenAI",
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldOpenAgencyAuthDialog({
+        providerID: "agency-swarm",
+        message: "Streaming request failed (403): Invalid API key for OpenAI",
+      }),
+    ).toBe(true)
   })
 })

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -399,6 +399,34 @@ describe("agency session errors", () => {
     expect(
       shouldOpenStartupAuthDialog({
         frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "custom",
+            env: [],
+            options: {
+              apiKey: "codex-dummy",
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode still opens auth when only oauth methods are available", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
         providerAuth: {
           openai: [
             {
@@ -426,7 +454,7 @@ describe("agency session errors", () => {
           },
         ],
       }),
-    ).toBe(false)
+    ).toBe(true)
   })
 
   test("framework mode skips auth when stored api credentials are available", () => {

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -498,6 +498,33 @@ describe("agency session errors", () => {
             models: {},
           },
           {
+            id: "unsupported-provider",
+            name: "Unsupported Provider",
+            source: "api",
+            env: ["UNSUPPORTED_API_KEY"],
+            key: "unsupported-key",
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  test("framework mode skips auth when another LiteLLM-compatible provider is credentialed", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
             id: "google",
             name: "Google",
             source: "api",
@@ -508,7 +535,7 @@ describe("agency session errors", () => {
           },
         ],
       }),
-    ).toBe(true)
+    ).toBe(false)
   })
 
   test("blocks the first agency prompt when supported auth is missing", () => {

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -132,6 +132,34 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
+  test("framework mode skips local provider auth for remote agency-swarm backends", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              baseURL: "https://agency.example.com",
+            },
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
   test("framework mode follows the current provider override away from agency-swarm", () => {
     expect(
       isAgencySwarmFrameworkMode({
@@ -536,6 +564,42 @@ describe("agency session errors", () => {
         ],
       }),
     ).toBe(false)
+  })
+
+  test("framework mode still opens auth when a LiteLLM provider only has oauth methods", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providerAuth: {
+          "github-copilot": [
+            {
+              type: "oauth",
+              label: "GitHub sign-in",
+            },
+          ],
+        },
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "github-copilot",
+            name: "GitHub Copilot",
+            source: "custom",
+            env: [],
+            options: {
+              fetch: () => Promise.resolve(new Response()),
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
   })
 
   test("blocks the first agency prompt when supported auth is missing", () => {

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -160,6 +160,34 @@ describe("agency session errors", () => {
     ).toBe(false)
   })
 
+  test("framework mode also skips local provider auth for remote agency-swarm backends using base_url", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              base_url: "https://agency.example.com",
+            },
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
   test("framework mode follows the current provider override away from agency-swarm", () => {
     expect(
       isAgencySwarmFrameworkMode({

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -295,12 +295,39 @@ describe("agency session errors", () => {
             name: "OpenAI",
             source: "env",
             env: ["OPENAI_API_KEY"],
+            key: "env-openai",
             options: {},
             models: {},
           },
         ],
       }),
     ).toBe(false)
+  })
+
+  test("framework mode opens auth when env-backed provider only has non-secret config", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "azure",
+            name: "Azure OpenAI",
+            source: "env",
+            env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
   })
 
   test("framework mode skips auth when a configured provider carries an env key", () => {

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   hasUsableProvider,
+  isAgencySwarmFrameworkMode,
   shouldOpenAgencyConnectDialog,
   shouldOpenStartupAuthDialog,
 } from "../../../src/cli/cmd/tui/session-error"
@@ -127,6 +128,15 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
+  test("framework mode stays enabled when the configured model is agency-swarm", () => {
+    expect(
+      isAgencySwarmFrameworkMode({
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+      }),
+    ).toBe(true)
+  })
+
   test("framework mode skips auth when explicit client_config exists", () => {
     expect(
       shouldOpenStartupAuthDialog({
@@ -142,6 +152,25 @@ describe("agency session errors", () => {
                 api_key: "manual-openai",
               },
             },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode skips auth when agency-swarm already has a token", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            key: "server-token",
+            options: {},
             models: {},
           },
         ],

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -149,6 +149,55 @@ describe("agency session errors", () => {
     ).toBe(false)
   })
 
+  test("framework mode skips auth when explicit client_config has LiteLLM keys", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              clientConfig: {
+                litellm_keys: {
+                  anthropic: "manual-ant",
+                },
+              },
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode opens auth when explicit client_config has no credentials", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              clientConfig: {
+                base_url: "https://proxy.example.com/v1",
+                default_headers: {
+                  "x-proxy": "1",
+                },
+              },
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
   test("framework mode skips auth when another provider is available", () => {
     expect(
       shouldOpenStartupAuthDialog({
@@ -166,6 +215,113 @@ describe("agency session errors", () => {
             id: "openai",
             name: "OpenAI",
             source: "env",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode skips auth when a configured provider carries an env key", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            key: "env-openai",
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode opens auth when another provider has no credential", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  test("framework mode skips auth when stored oauth credentials are available", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "custom",
+            env: [],
+            options: {
+              apiKey: "oauth-dummy",
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode skips auth when stored api credentials are available", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "api",
             env: ["OPENAI_API_KEY"],
             options: {},
             models: {},

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -223,6 +223,31 @@ describe("agency session errors", () => {
     ).toBe(false)
   })
 
+  test("framework mode opens auth when auth-like headers are empty", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              clientConfig: {
+                base_url: "https://proxy.example.com/v1",
+                default_headers: {
+                  Authorization: "",
+                },
+              },
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
   test("framework mode skips auth when another provider is available", () => {
     expect(
       shouldOpenStartupAuthDialog({

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -198,6 +198,31 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
+  test("framework mode skips auth when explicit client_config authenticates through headers", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              clientConfig: {
+                base_url: "https://proxy.example.com/v1",
+                default_headers: {
+                  Authorization: "Bearer proxy-token",
+                },
+              },
+            },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
   test("framework mode skips auth when another provider is available", () => {
     expect(
       shouldOpenStartupAuthDialog({

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -10,11 +10,14 @@ import * as Network from "../../../src/cli/network"
 import * as Win32 from "../../../src/cli/cmd/tui/win32"
 import { TuiConfig } from "../../../src/config/tui"
 import { Instance } from "../../../src/project/instance"
+import { AgencySwarmRunSession } from "../../../src/agency-swarm/run-session"
 
 const stop = new Error("stop")
 const seen = {
   tui: [] as string[],
   inst: [] as string[],
+  config: [] as Array<string | undefined>,
+  runEnv: [] as Array<string | undefined>,
 }
 
 function setup() {
@@ -45,6 +48,8 @@ function setup() {
   spyOn(TuiConfig, "get").mockResolvedValue({})
   spyOn(Instance, "provide").mockImplementation(async (input) => {
     seen.inst.push(input.directory)
+    seen.config.push(process.env.OPENCODE_CONFIG_CONTENT)
+    seen.runEnv.push(process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV])
     return input.fn()
   })
 }
@@ -54,7 +59,7 @@ describe("tui thread", () => {
     mock.restore()
   })
 
-  async function call(project?: string) {
+  async function call(project?: string, overrides: Record<string, unknown> = {}) {
     const { TuiThreadCommand } = await import("../../../src/cli/cmd/tui/thread")
     const args: Parameters<NonNullable<typeof TuiThreadCommand.handler>>[0] = {
       _: [],
@@ -72,6 +77,7 @@ describe("tui thread", () => {
       "mdns-domain": "opencode.local",
       mdnsDomain: "opencode.local",
       cors: [],
+      ...overrides,
     }
     return TuiThreadCommand.handler(args)
   }
@@ -87,6 +93,8 @@ describe("tui thread", () => {
     const type = process.platform === "win32" ? "junction" : "dir"
     seen.tui.length = 0
     seen.inst.length = 0
+    seen.config.length = 0
+    seen.runEnv.length = 0
     await fs.symlink(tmp.path, link, type)
 
     Object.defineProperty(process.stdin, "isTTY", {
@@ -125,4 +133,76 @@ describe("tui thread", () => {
   test("uses the real cwd after resolving a relative project from PWD", async () => {
     await check(".")
   })
+
+  test("prepares detected project before prompt launch", async () => {
+    setup()
+    const Npx = await import("../../../src/agency-swarm/npx")
+    await using tmp = await tmpdir({ git: true })
+    await writeAgency(tmp.path)
+    const cwd = process.cwd()
+    const pwd = process.env.PWD
+    const launcher = process.env[Npx.LAUNCHER_ENTRY_ENV]
+    const config = process.env.OPENCODE_CONFIG_CONTENT
+    const worker = globalThis.Worker
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+    const cleanup = mock(async () => {})
+    seen.tui.length = 0
+    seen.inst.length = 0
+    seen.config.length = 0
+    seen.runEnv.length = 0
+
+    spyOn(Npx, "prepareProjectLaunch").mockResolvedValue({
+      directory: tmp.path,
+      runProjectDirectory: tmp.path,
+      configContent: "project-config",
+      cleanup,
+    })
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+    globalThis.Worker = class extends EventTarget {
+      onerror = null
+      onmessage = null
+      onmessageerror = null
+      postMessage() {}
+      terminate() {}
+    } as unknown as typeof Worker
+
+    try {
+      process.chdir(tmp.path)
+      process.env.PWD = tmp.path
+      process.env[Npx.LAUNCHER_ENTRY_ENV] = "1"
+      await expect(call()).rejects.toBe(stop)
+      expect(Npx.prepareProjectLaunch).toHaveBeenCalledTimes(1)
+      expect(seen.config[0]).toBe("project-config")
+      expect(seen.runEnv[0]).toBe(tmp.path)
+      expect(seen.inst[0]).toBe(tmp.path)
+      expect(seen.tui[0]).toBe(tmp.path)
+      expect(cleanup).toHaveBeenCalledTimes(1)
+    } finally {
+      process.chdir(cwd)
+      if (pwd === undefined) delete process.env.PWD
+      else process.env.PWD = pwd
+      if (launcher === undefined) delete process.env[Npx.LAUNCHER_ENTRY_ENV]
+      else process.env[Npx.LAUNCHER_ENTRY_ENV] = launcher
+      if (config === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+      else process.env.OPENCODE_CONFIG_CONTENT = config
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+      globalThis.Worker = worker
+    }
+  })
 })
+
+async function writeAgency(dir: string) {
+  await fs.writeFile(
+    path.join(dir, "agency.py"),
+    [
+      "from agency_swarm import Agency",
+      "",
+      "def create_agency(load_threads_callback=None):",
+      "    return Agency()",
+    ].join("\n"),
+  )
+}

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1155,7 +1155,7 @@ describe("session.agency-swarm", () => {
     ])
   })
 
-  test("compactHistory rebuilds visible history when no compaction summary exists", () => {
+  test("compactHistory falls back when no compaction summary exists", () => {
     const msgs = [
       {
         info: {
@@ -1202,24 +1202,7 @@ describe("session.agency-swarm", () => {
       },
     ] as any
 
-    expect(SessionAgencySwarm.compactHistory({ msgs, currentID: "current" })).toEqual([
-      {
-        type: "message",
-        role: "user",
-        content: [{ type: "input_text", text: "first question" }],
-        agent: "build",
-        callerAgent: null,
-        timestamp: 1,
-      },
-      {
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "first answer" }],
-        agent: "Reviewer",
-        callerAgent: null,
-        timestamp: 2,
-      },
-    ])
+    expect(SessionAgencySwarm.compactHistory({ msgs, currentID: "current" })).toBeUndefined()
   })
 
   test("compactHistory falls back when visible history mixes providers", () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -24,6 +24,7 @@ describe("session.agency-swarm", () => {
   const originalAuthAll = Auth.all
   const originalEnvAll = Env.all
   const originalProviderList = Provider.list
+  const originalFetch = globalThis.fetch
 
   afterEach(() => {
     AgencySwarmAdapter.discover = originalDiscover
@@ -36,6 +37,7 @@ describe("session.agency-swarm", () => {
     Auth.all = originalAuthAll
     Env.all = originalEnvAll
     Provider.list = originalProviderList
+    globalThis.fetch = originalFetch
   })
 
   const helper = () => {
@@ -639,6 +641,38 @@ describe("session.agency-swarm", () => {
       base_url: "https://chatgpt.com/backend-api/codex/",
       default_headers: {
         "ChatGPT-Account-Id": "acct_123",
+      },
+    })
+  })
+
+  test("stream skips failing stored OpenAI OAuth refresh when other local credentials exist", async () => {
+    mockHistory()
+    Auth.all = (async () => ({
+      openai: {
+        type: "oauth",
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: 1,
+      } as any,
+      anthropic: { type: "api", key: "stored-anthropic" } as any,
+    })) as typeof Auth.all
+    globalThis.fetch = (async () => new Response("{}", { status: 401 })) as unknown as typeof globalThis.fetch
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      litellm_keys: {
+        anthropic: "stored-anthropic",
       },
     })
   })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -388,6 +388,82 @@ describe("session.agency-swarm", () => {
     }
   })
 
+  test("stream sends explicit header-based client_config to a real local agency server", async () => {
+    mockHistory()
+    await Auth.set("openai", {
+      type: "oauth",
+      access: "oauth-access",
+      refresh: "oauth-refresh",
+      expires: Date.now() + 60_000,
+      accountId: "acct_123",
+    } as any)
+
+    let body: Record<string, unknown> | undefined
+    const server = createServer(async (request, response) => {
+      if (request.url !== "/builder/get_response_stream") {
+        response.writeHead(404)
+        response.end("not found")
+        return
+      }
+
+      const chunks: Buffer[] = []
+      for await (const chunk of request) {
+        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+        else chunks.push(Buffer.from(chunk))
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+      })
+      response.end(
+        [
+          'data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"ok"}}}\n\n',
+          "event: end\ndata: [DONE]\n\n",
+        ].join(""),
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      server.close()
+      throw new Error("Expected local test server address")
+    }
+
+    try {
+      const { input } = helper()
+      input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      input.options.clientConfig = {
+        base_url: "https://proxy.example.com/v1",
+        default_headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      }
+      const stream = await SessionAgencySwarm.stream(input)
+      const text: string[] = []
+      for await (const event of stream.fullStream) {
+        if (event.type === "text-delta") text.push(event.text)
+      }
+
+      expect(text).toEqual(["ok"])
+      expect(body?.["client_config"]).toEqual({
+        base_url: "https://proxy.example.com/v1",
+        default_headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+      await Auth.remove("openai")
+    }
+  })
+
   test("stream prefers env auth over stored auth for providers already covered by env", async () => {
     mockHistory()
     Auth.all = (async () => ({
@@ -528,6 +604,44 @@ describe("session.agency-swarm", () => {
     expect(captured).toEqual({
       api_key: "oauth-access",
       base_url: "https://proxy.example.com/v1",
+    })
+  })
+
+  test("stream preserves explicit header-based OpenAI auth without merging stored OAuth", async () => {
+    mockHistory()
+    Auth.all = (async () => ({
+      openai: {
+        type: "oauth",
+        access: "oauth-access",
+        refresh: "oauth-refresh",
+        expires: Date.now() + 60_000,
+      } as any,
+    })) as typeof Auth.all
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.clientConfig = {
+      base_url: "https://proxy.example.com/v1",
+      default_headers: {
+        Authorization: "Bearer proxy-token",
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      base_url: "https://proxy.example.com/v1",
+      default_headers: {
+        Authorization: "Bearer proxy-token",
+      },
     })
   })
 

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -498,7 +498,7 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream keeps generated OpenAI OAuth bound to Codex base URL", async () => {
+  test("stream keeps explicit base_url when stored OpenAI OAuth exists", async () => {
     mockHistory()
     Auth.all = (async () => ({
       openai: {
@@ -527,7 +527,7 @@ describe("session.agency-swarm", () => {
 
     expect(captured).toEqual({
       api_key: "oauth-access",
-      base_url: "https://chatgpt.com/backend-api/codex",
+      base_url: "https://proxy.example.com/v1",
     })
   })
 

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1085,6 +1085,73 @@ describe("session.agency-swarm", () => {
     ])
   })
 
+  test("compactHistory rebuilds visible history when no compaction summary exists", () => {
+    const msgs = [
+      {
+        info: {
+          id: "user_1",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 1 },
+        },
+        parts: [{ type: "text", text: "first question", ignored: false }],
+      },
+      {
+        info: {
+          id: "assistant_1",
+          role: "assistant",
+          parentID: "user_1",
+          providerID: "agency-swarm",
+          modelID: "default",
+          mode: "Default",
+          agent: "Reviewer",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: { created: 2 },
+          sessionID: "session_1",
+        },
+        parts: [{ type: "text", text: "first answer" }],
+      },
+      {
+        info: {
+          id: "current",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 3 },
+        },
+        parts: [{ type: "text", text: "current prompt", ignored: false }],
+      },
+    ] as any
+
+    expect(SessionAgencySwarm.compactHistory({ msgs, currentID: "current" })).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "first question" }],
+        agent: "build",
+        callerAgent: null,
+        timestamp: 1,
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "first answer" }],
+        agent: "Reviewer",
+        callerAgent: null,
+        timestamp: 2,
+      },
+    ])
+  })
+
   test("stream resolves configured recipient alias to live agent id from metadata", async () => {
     mockHistory()
     let sentRecipient: string | undefined

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -390,6 +390,72 @@ describe("session.agency-swarm", () => {
     }
   })
 
+  test("stream sends stored Anthropic API auth to a real local agency server", async () => {
+    mockHistory()
+    await Auth.set("anthropic", {
+      type: "api",
+      key: "anthropic-live",
+    } as any)
+
+    let body: Record<string, unknown> | undefined
+    const server = createServer(async (request, response) => {
+      if (request.url !== "/builder/get_response_stream") {
+        response.writeHead(404)
+        response.end("not found")
+        return
+      }
+
+      const chunks: Buffer[] = []
+      for await (const chunk of request) {
+        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+        else chunks.push(Buffer.from(chunk))
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+      })
+      response.end(
+        [
+          'data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"ok"}}}\n\n',
+          "event: end\ndata: [DONE]\n\n",
+        ].join(""),
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      server.close()
+      throw new Error("Expected local test server address")
+    }
+
+    try {
+      const { input } = helper()
+      input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      const stream = await SessionAgencySwarm.stream(input)
+      const text: string[] = []
+      for await (const event of stream.fullStream) {
+        if (event.type === "text-delta") text.push(event.text)
+      }
+
+      expect(text).toEqual(["ok"])
+      expect(body?.["client_config"]).toEqual({
+        litellm_keys: {
+          anthropic: "anthropic-live",
+        },
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+      await Auth.remove("anthropic")
+    }
+  })
+
   test("stream sends explicit header-based client_config to a real local agency server", async () => {
     mockHistory()
     await Auth.set("openai", {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -602,8 +602,44 @@ describe("session.agency-swarm", () => {
     }
 
     expect(captured).toEqual({
-      api_key: "oauth-access",
       base_url: "https://proxy.example.com/v1",
+    })
+  })
+
+  test("stream preserves stored OpenAI OAuth when explicit base_url still targets Codex", async () => {
+    mockHistory()
+    Auth.all = (async () => ({
+      openai: {
+        type: "oauth",
+        access: "oauth-access",
+        refresh: "oauth-refresh",
+        expires: Date.now() + 60_000,
+        accountId: "acct_123",
+      } as any,
+    })) as typeof Auth.all
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.clientConfig = {
+      base_url: "https://chatgpt.com/backend-api/codex/",
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "oauth-access",
+      base_url: "https://chatgpt.com/backend-api/codex/",
+      default_headers: {
+        "ChatGPT-Account-Id": "acct_123",
+      },
     })
   })
 
@@ -1150,6 +1186,89 @@ describe("session.agency-swarm", () => {
         timestamp: 2,
       },
     ])
+  })
+
+  test("compactHistory falls back when visible history mixes providers", () => {
+    const msgs = [
+      {
+        info: {
+          id: "user_1",
+          role: "user",
+          agent: "build",
+          model: { providerID: "openai", modelID: "gpt-5" },
+          time: { created: 1 },
+        },
+        parts: [{ type: "text", text: "first question", ignored: false }],
+      },
+      {
+        info: {
+          id: "assistant_1",
+          role: "assistant",
+          parentID: "user_1",
+          providerID: "openai",
+          modelID: "gpt-5",
+          mode: "Default",
+          agent: "Assistant",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: { created: 2 },
+          sessionID: "session_1",
+        },
+        parts: [{ type: "text", text: "first answer" }],
+      },
+      {
+        info: {
+          id: "user_2",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 3 },
+        },
+        parts: [{ type: "text", text: "agency prompt", ignored: false }],
+      },
+      {
+        info: {
+          id: "assistant_2",
+          role: "assistant",
+          parentID: "user_2",
+          providerID: "agency-swarm",
+          modelID: "default",
+          mode: "Default",
+          agent: "Reviewer",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: { created: 4 },
+          sessionID: "session_1",
+        },
+        parts: [{ type: "text", text: "agency answer" }],
+      },
+      {
+        info: {
+          id: "current",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 5 },
+        },
+        parts: [{ type: "text", text: "current prompt", ignored: false }],
+      },
+    ] as any
+
+    expect(SessionAgencySwarm.compactHistory({ msgs, currentID: "current" })).toBeUndefined()
   })
 
   test("stream resolves configured recipient alias to live agent id from metadata", async () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { createServer } from "node:http"
+import type { AddressInfo } from "node:net"
 import { Auth } from "../../src/auth"
 import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
 import { AgencySwarmHistory } from "../../src/agency-swarm/history"
@@ -315,14 +317,89 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream does not forward stored auth for providers already covered by env", async () => {
+  test("stream sends stored OpenAI OAuth auth to a real local agency server", async () => {
+    mockHistory()
+    await Auth.set("openai", {
+      type: "oauth",
+      access: "oauth-access",
+      refresh: "oauth-refresh",
+      expires: Date.now() + 60_000,
+      accountId: "acct_123",
+    } as any)
+
+    let body: Record<string, unknown> | undefined
+    const server = createServer(async (request, response) => {
+      if (request.url !== "/builder/get_response_stream") {
+        response.writeHead(404)
+        response.end("not found")
+        return
+      }
+
+      const chunks: Buffer[] = []
+      for await (const chunk of request) {
+        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+        else chunks.push(Buffer.from(chunk))
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+      })
+      response.end(
+        [
+          'data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"ok"}}}\n\n',
+          "event: end\ndata: [DONE]\n\n",
+        ].join(""),
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      server.close()
+      throw new Error("Expected local test server address")
+    }
+
+    try {
+      const { input } = helper()
+      input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      const stream = await SessionAgencySwarm.stream(input)
+      const text: string[] = []
+      for await (const event of stream.fullStream) {
+        if (event.type === "text-delta") text.push(event.text)
+      }
+
+      expect(text).toEqual(["ok"])
+      expect(body?.["client_config"]).toEqual({
+        api_key: "oauth-access",
+        base_url: "https://chatgpt.com/backend-api/codex",
+        default_headers: {
+          "ChatGPT-Account-Id": "acct_123",
+        },
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+      await Auth.remove("openai")
+    }
+  })
+
+  test("stream prefers env auth over stored auth for providers already covered by env", async () => {
     mockHistory()
     Auth.all = (async () => ({
       openai: { type: "api", key: "stored-openai" } as any,
       anthropic: { type: "api", key: "stored-anthropic" } as any,
+      azure: { type: "api", key: "stored-azure" } as any,
     })) as typeof Auth.all
     Env.all = (() => ({
       OPENAI_API_KEY: "env-openai",
+      AZURE_RESOURCE_NAME: "azure-resource",
+      AZURE_API_KEY: "env-azure",
+      GOOGLE_GENERATIVE_AI_API_KEY: "env-google",
     })) as typeof Env.all
     Provider.list = (async () => ({
       openai: {
@@ -338,6 +415,22 @@ describe("session.agency-swarm", () => {
         name: "Anthropic",
         source: "api",
         env: ["ANTHROPIC_API_KEY"],
+        options: {},
+        models: {},
+      },
+      azure: {
+        id: "azure",
+        name: "Azure",
+        source: "api",
+        env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+        options: {},
+        models: {},
+      },
+      google: {
+        id: "google",
+        name: "Google",
+        source: "api",
+        env: ["GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"],
         options: {},
         models: {},
       },
@@ -364,9 +457,77 @@ describe("session.agency-swarm", () => {
     }
 
     expect(captured).toEqual({
+      api_key: "env-openai",
       litellm_keys: {
         anthropic: "stored-anthropic",
+        azure: "stored-azure",
+        gemini: "env-google",
       },
+    })
+  })
+
+  test("stream does not refresh stored OpenAI OAuth when explicit OpenAI client_config exists", async () => {
+    mockHistory()
+    Auth.all = (async () => ({
+      openai: {
+        type: "oauth",
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: 1,
+      } as any,
+    })) as typeof Auth.all
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.clientConfig = {
+      api_key: "manual-openai",
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "manual-openai",
+    })
+  })
+
+  test("stream keeps generated OpenAI OAuth bound to Codex base URL", async () => {
+    mockHistory()
+    Auth.all = (async () => ({
+      openai: {
+        type: "oauth",
+        access: "oauth-access",
+        refresh: "oauth-refresh",
+        expires: Date.now() + 60_000,
+      } as any,
+    })) as typeof Auth.all
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.clientConfig = {
+      base_url: "https://proxy.example.com/v1",
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "oauth-access",
+      base_url: "https://chatgpt.com/backend-api/codex",
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #41

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This tightens the Agent Swarm auth path without changing upstream provider support globally.

It blocks the first normal message send until supported auth exists, keeps the Agent Swarm auth UI limited to OpenAI and Anthropic for now, routes provider-credential failures back into `/auth`, routes agency-server auth failures back into `/connect`, and deletes a newly created empty session if the first prompt fails immediately.

It also improves the browser-auth UX in Agent Swarm mode by opening the default browser, showing clearer inline/toast errors, and keeping unsupported upstream provider code untouched.

### How did you verify your code works?

- `bun test test/cli/tui/session-error.test.ts test/cli/tui/provider-auth.test.ts`
- `bun test test/session/agency-swarm.test.ts --test-name-pattern 'stream sends stored OpenAI OAuth auth to a real local agency server|stream sends stored Anthropic API auth to a real local agency server'`
- `bun run typecheck`

### Screenshots / recordings

- Not included yet.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
