### PR TITLE
fix(tui): default to system theme in Apple Terminal

### DIFF
--- a/packages/app/e2e/commands/input-focus.spec.ts
+++ b/packages/app/e2e/commands/input-focus.spec.ts
@@ -1,3 +1,4 @@
+import { defocus } from "../actions"
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 
@@ -7,7 +8,7 @@ test("ctrl+l focuses the prompt", async ({ page, gotoSession }) => {
   const prompt = page.locator(promptSelector)
   await expect(prompt).toBeVisible()
 
-  await page.locator("main").click({ position: { x: 5, y: 5 } })
+  await defocus(page)
   await expect(prompt).not.toBeFocused()
 
   await page.keyboard.press("Control+L")

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -844,4 +844,4 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "영구 프로젝트 아이콘 생성 실패",
   "error.childStore.storeCreateFailed": "저장소 생성 실패",
   "terminal.connectionLost.abnormalClose": "WebSocket이 비정상적으로 닫힘: {{code}}",
-}
+} satisfies Partial<Record<Keys, string>>

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -298,7 +298,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     renderer,
   })
   const [pluginsReady, setPluginsReady] = createSignal(false)
-  const ready = createMemo(() => pluginsReady() && themeState.ready)
+  const themePaintReady = createMemo(() => process.env.TERM_PROGRAM !== "Apple_Terminal" || themeState.ready)
+  const ready = createMemo(() => pluginsReady() && themePaintReady())
   TuiPluginRuntime.init(api)
     .catch((error) => {
       console.error("Failed to load TUI plugins", error)
@@ -943,7 +944,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     <box
       width={dimensions().width}
       height={dimensions().height}
-      backgroundColor={themeState.ready ? theme.background : undefined}
+      backgroundColor={themePaintReady() ? theme.background : undefined}
       onMouseDown={(evt) => {
         if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
         if (evt.button !== MouseButton.RIGHT) return
@@ -971,7 +972,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       <Show when={ready()}>
         <TuiPluginRuntime.Slot name="app" />
       </Show>
-      <StartupLoading ready={ready} themed={() => themeState.ready} />
+      <StartupLoading ready={ready} themed={themePaintReady} />
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -971,7 +971,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       <Show when={ready()}>
         <TuiPluginRuntime.Slot name="app" />
       </Show>
-      <StartupLoading ready={ready} enabled={() => themeState.ready} />
+      <StartupLoading ready={ready} themed={() => themeState.ready} />
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -297,13 +297,14 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     toast,
     renderer,
   })
-  const [ready, setReady] = createSignal(false)
+  const [pluginsReady, setPluginsReady] = createSignal(false)
+  const ready = createMemo(() => pluginsReady() && themeState.ready)
   TuiPluginRuntime.init(api)
     .catch((error) => {
       console.error("Failed to load TUI plugins", error)
     })
     .finally(() => {
-      setReady(true)
+      setPluginsReady(true)
     })
 
   useKeyboard((evt) => {
@@ -942,7 +943,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     <box
       width={dimensions().width}
       height={dimensions().height}
-      backgroundColor={theme.background}
+      backgroundColor={themeState.ready ? theme.background : undefined}
       onMouseDown={(evt) => {
         if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
         if (evt.button !== MouseButton.RIGHT) return
@@ -967,8 +968,10 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         </Switch>
       </Show>
       {plugin()}
-      <TuiPluginRuntime.Slot name="app" />
-      <StartupLoading ready={ready} />
+      <Show when={ready()}>
+        <TuiPluginRuntime.Slot name="app" />
+      </Show>
+      <StartupLoading ready={ready} enabled={() => themeState.ready} />
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -298,15 +298,21 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     renderer,
   })
   const [pluginsReady, setPluginsReady] = createSignal(false)
-  const themePaintReady = createMemo(() => process.env.TERM_PROGRAM !== "Apple_Terminal" || themeState.ready)
-  const ready = createMemo(() => pluginsReady() && themePaintReady())
-  TuiPluginRuntime.init(api)
-    .catch((error) => {
-      console.error("Failed to load TUI plugins", error)
-    })
-    .finally(() => {
-      setPluginsReady(true)
-    })
+  const themePaintReady = createMemo(() => process.env.TERM_PROGRAM !== "Apple_Terminal" || themeState.paintReady)
+  const ready = createMemo(() => themeState.ready && pluginsReady() && themePaintReady())
+  let pluginsStarted = false
+  createEffect(() => {
+    if (!themeState.ready) return
+    if (pluginsStarted) return
+    pluginsStarted = true
+    void TuiPluginRuntime.init(api)
+      .catch((error) => {
+        console.error("Failed to load TUI plugins", error)
+      })
+      .finally(() => {
+        setPluginsReady(true)
+      })
+  })
 
   useKeyboard((evt) => {
     if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return

--- a/packages/opencode/src/cli/cmd/tui/component/startup-loading.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/startup-loading.tsx
@@ -2,15 +2,29 @@ import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-j
 import { useTheme } from "../context/theme"
 import { Spinner } from "./spinner"
 
-export function StartupLoading(props: { ready: () => boolean }) {
+export function StartupLoading(props: { ready: () => boolean; enabled?: () => boolean }) {
   const theme = useTheme().theme
   const [show, setShow] = createSignal(false)
   const text = createMemo(() => (props.ready() ? "Finishing startup..." : "Loading plugins..."))
+  const enabled = () => props.enabled?.() ?? true
   let wait: NodeJS.Timeout | undefined
   let hold: NodeJS.Timeout | undefined
   let stamp = 0
 
   createEffect(() => {
+    if (!enabled()) {
+      if (wait) {
+        clearTimeout(wait)
+        wait = undefined
+      }
+      if (hold) {
+        clearTimeout(hold)
+        hold = undefined
+      }
+      if (show()) setShow(false)
+      return
+    }
+
     if (props.ready()) {
       if (wait) {
         clearTimeout(wait)

--- a/packages/opencode/src/cli/cmd/tui/component/startup-loading.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/startup-loading.tsx
@@ -2,17 +2,21 @@ import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-j
 import { useTheme } from "../context/theme"
 import { Spinner } from "./spinner"
 
-export function StartupLoading(props: { ready: () => boolean; enabled?: () => boolean }) {
+export function StartupLoading(props: { ready: () => boolean; themed?: () => boolean }) {
   const theme = useTheme().theme
   const [show, setShow] = createSignal(false)
-  const text = createMemo(() => (props.ready() ? "Finishing startup..." : "Loading plugins..."))
-  const enabled = () => props.enabled?.() ?? true
+  const themed = () => props.themed?.() ?? true
+  const text = createMemo(() => {
+    if (props.ready()) return "Finishing startup..."
+    if (!themed()) return "Loading theme..."
+    return "Loading plugins..."
+  })
   let wait: NodeJS.Timeout | undefined
   let hold: NodeJS.Timeout | undefined
   let stamp = 0
 
   createEffect(() => {
-    if (!enabled()) {
+    if (!themed()) {
       if (wait) {
         clearTimeout(wait)
         wait = undefined
@@ -21,7 +25,9 @@ export function StartupLoading(props: { ready: () => boolean; enabled?: () => bo
         clearTimeout(hold)
         hold = undefined
       }
-      if (show()) setShow(false)
+      if (show()) return
+      stamp = Date.now()
+      setShow(true)
       return
     }
 
@@ -68,9 +74,11 @@ export function StartupLoading(props: { ready: () => boolean; enabled?: () => bo
   return (
     <Show when={show()}>
       <box position="absolute" zIndex={5000} left={0} right={0} bottom={1} justifyContent="center" alignItems="center">
-        <box backgroundColor={theme.backgroundPanel} paddingLeft={1} paddingRight={1}>
-          <Spinner color={theme.textMuted}>{text()}</Spinner>
-        </box>
+        <Show when={themed()} fallback={<text>{text()}</text>}>
+          <box backgroundColor={theme.backgroundPanel} paddingLeft={1} paddingRight={1}>
+            <Spinner color={theme.textMuted}>{text()}</Spinner>
+          </box>
+        </Show>
       </box>
     </Show>
   )

--- a/packages/opencode/src/cli/cmd/tui/component/startup-loading.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/startup-loading.tsx
@@ -4,11 +4,11 @@ import { Spinner } from "./spinner"
 
 export function StartupLoading(props: { ready: () => boolean; themed?: () => boolean }) {
   const theme = useTheme().theme
-  const [show, setShow] = createSignal(false)
+  const [mode, setMode] = createSignal<"hidden" | "pretheme" | "plugin">("hidden")
   const themed = () => props.themed?.() ?? true
   const text = createMemo(() => {
     if (props.ready()) return "Finishing startup..."
-    if (!themed()) return "Loading theme..."
+    if (mode() === "pretheme" && !themed()) return "Loading theme..."
     return "Loading plugins..."
   })
   let wait: NodeJS.Timeout | undefined
@@ -16,6 +16,8 @@ export function StartupLoading(props: { ready: () => boolean; themed?: () => boo
   let stamp = 0
 
   createEffect(() => {
+    const current = mode()
+
     if (!themed()) {
       if (wait) {
         clearTimeout(wait)
@@ -25,9 +27,27 @@ export function StartupLoading(props: { ready: () => boolean; themed?: () => boo
         clearTimeout(hold)
         hold = undefined
       }
-      if (show()) return
-      stamp = Date.now()
-      setShow(true)
+      if (current === "pretheme") return
+      setMode("pretheme")
+      return
+    }
+
+    if (current === "pretheme") {
+      if (props.ready()) {
+        if (wait) {
+          clearTimeout(wait)
+          wait = undefined
+        }
+        setMode("hidden")
+        return
+      }
+      if (wait) return
+
+      wait = setTimeout(() => {
+        wait = undefined
+        stamp = Date.now()
+        setMode("plugin")
+      }, 500).unref()
       return
     }
 
@@ -36,18 +56,18 @@ export function StartupLoading(props: { ready: () => boolean; themed?: () => boo
         clearTimeout(wait)
         wait = undefined
       }
-      if (!show()) return
+      if (current !== "plugin") return
       if (hold) return
 
       const left = 3000 - (Date.now() - stamp)
       if (left <= 0) {
-        setShow(false)
+        setMode("hidden")
         return
       }
 
       hold = setTimeout(() => {
         hold = undefined
-        setShow(false)
+        setMode("hidden")
       }, left).unref()
       return
     }
@@ -56,13 +76,13 @@ export function StartupLoading(props: { ready: () => boolean; themed?: () => boo
       clearTimeout(hold)
       hold = undefined
     }
-    if (show()) return
+    if (current === "plugin") return
     if (wait) return
 
     wait = setTimeout(() => {
       wait = undefined
       stamp = Date.now()
-      setShow(true)
+      setMode("plugin")
     }, 500).unref()
   })
 
@@ -72,9 +92,9 @@ export function StartupLoading(props: { ready: () => boolean; themed?: () => boo
   })
 
   return (
-    <Show when={show()}>
+    <Show when={mode() !== "hidden"}>
       <box position="absolute" zIndex={5000} left={0} right={0} bottom={1} justifyContent="center" alignItems="center">
-        <Show when={themed()} fallback={<text>{text()}</text>}>
+        <Show when={mode() === "plugin"} fallback={<text>{text()}</text>}>
           <box backgroundColor={theme.backgroundPanel} paddingLeft={1} paddingRight={1}>
             <Spinner color={theme.textMuted}>{text()}</Spinner>
           </box>

--- a/packages/opencode/src/cli/cmd/tui/context/helper.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/helper.tsx
@@ -9,9 +9,16 @@ export function createSimpleContext<T, Props extends Record<string, any>>(input:
   return {
     provider: (props: ParentProps<Props>) => {
       const init = input.init(props)
+      const state = init as T & {
+        ready?: boolean
+        providerReady?: boolean
+      }
+      const isReady = () =>
+        state.providerReady === undefined
+          ? state.ready === undefined || state.ready === true
+          : state.providerReady === true
       return (
-        // @ts-expect-error
-        <Show when={init.ready === undefined || init.ready === true}>
+        <Show when={isReady()}>
           <ctx.Provider value={init}>{props.children}</ctx.Provider>
         </Show>
       )

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -68,6 +68,7 @@ type State = {
 const pluginThemes: Record<string, ThemeJson> = {}
 let customThemes: Record<string, ThemeJson> = {}
 let systemTheme: ThemeJson | undefined
+let allowSystemThemeSelection = false
 const fixed = "opencode"
 const reserved = new Set([fixed, "system"])
 
@@ -106,8 +107,17 @@ export function defaultThemeName(input?: { termProgram?: string; background?: st
   return input?.termProgram === "Apple_Terminal" && isDarkTerminalBackground(input) ? "system" : "opencode"
 }
 
-export function canSelectBuiltInThemeName(name: string, input?: { hasSystemTheme?: boolean }) {
-  return name === fixed || (name === "system" && input?.hasSystemTheme === true)
+export function canSelectBuiltInThemeName(
+  name: string,
+  input?: {
+    hasSystemTheme?: boolean
+    allowSystemThemeSelection?: boolean
+  },
+) {
+  return (
+    name === fixed ||
+    (name === "system" && input?.hasSystemTheme === true && input?.allowSystemThemeSelection === true)
+  )
 }
 
 export function allThemes() {
@@ -267,6 +277,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     const fallbackTheme = defaultThemeName({
       termProgram: process.env.TERM_PROGRAM,
     })
+    allowSystemThemeSelection = false
 
     setStore(
       produce((draft) => {
@@ -302,6 +313,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         })
         .then((colors: TerminalColors) => {
           if (!colors.palette[0]) {
+            allowSystemThemeSelection = false
             systemTheme = undefined
             syncThemes()
             if (store.active === "system") {
@@ -309,17 +321,20 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
             }
             return
           }
-          systemTheme = generateSystem(colors, mode)
-          syncThemes()
+          const background = colors.defaultBackground ?? colors.palette[0]
           const startupTheme = defaultThemeName({
             termProgram: process.env.TERM_PROGRAM,
-            background: colors.defaultBackground ?? colors.palette[0],
+            background,
           })
+          allowSystemThemeSelection = startupTheme === "system"
+          systemTheme = generateSystem(colors, mode)
+          syncThemes()
           if (startupTheme === "system" && store.active === fallbackTheme) {
             setStore("active", startupTheme)
           }
         })
         .catch(() => {
+          allowSystemThemeSelection = false
           systemTheme = undefined
           syncThemes()
           if (store.active === "system") {
@@ -375,7 +390,12 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         return
       },
       set(theme: string) {
-        if (!canSelectBuiltInThemeName(theme, { hasSystemTheme: systemTheme !== undefined })) {
+        if (
+          !canSelectBuiltInThemeName(theme, {
+            hasSystemTheme: systemTheme !== undefined,
+            allowSystemThemeSelection,
+          })
+        ) {
           return false
         }
         setStore("active", theme)

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -95,6 +95,10 @@ const [store, setStore] = createStore<State>({
   ready: false,
 })
 
+export function defaultThemeName(input?: { termProgram?: string }) {
+  return input?.termProgram === "Apple_Terminal" ? "system" : "opencode"
+}
+
 export function allThemes() {
   return store.themes
 }
@@ -242,12 +246,15 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   name: "Theme",
   init: (_props: { mode: "dark" | "light" }) => {
     const renderer = useRenderer()
+    const fallbackTheme = defaultThemeName({
+      termProgram: process.env.TERM_PROGRAM,
+    })
 
     setStore(
       produce((draft) => {
         draft.mode = "dark"
         draft.lock = "dark"
-        draft.active = "opencode"
+        draft.active = fallbackTheme
         draft.ready = false
       }),
     )
@@ -260,9 +267,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
             customThemes = custom
             syncThemes()
           })
-          .catch(() => {
-            setStore("active", "opencode")
-          }),
+          .catch(() => {}),
       ]).finally(() => {
         setStore("ready", true)
       })
@@ -297,7 +302,8 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     }
 
     const values = createMemo(() => {
-      return resolveTheme(store.themes.opencode)
+      const active = store.themes[store.active] ?? store.themes[fallbackTheme] ?? store.themes.opencode
+      return resolveTheme(active)
     })
 
     createEffect(() => {

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -101,6 +101,10 @@ export function defaultThemeName(input?: { termProgram?: string; background?: st
     : "opencode"
 }
 
+export function canSelectBuiltInThemeName(name: string, input?: { hasSystemTheme?: boolean }) {
+  return name === fixed || (name === "system" && input?.hasSystemTheme === true)
+}
+
 export function allThemes() {
   return store.themes
 }
@@ -364,7 +368,11 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         return
       },
       set(theme: string) {
-        return theme === "opencode"
+        if (!canSelectBuiltInThemeName(theme, { hasSystemTheme: systemTheme !== undefined })) {
+          return false
+        }
+        setStore("active", theme)
+        return true
       },
       get ready() {
         return store.ready

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -68,12 +68,21 @@ const pluginThemes: Record<string, ThemeJson> = {}
 let customThemes: Record<string, ThemeJson> = {}
 let systemTheme: ThemeJson | undefined
 const fixed = "opencode"
+const reserved = new Set([fixed, "system"])
+
+function isReservedThemeName(name: string) {
+  return reserved.has(name)
+}
+
+function withoutReservedThemeNames(themes: Record<string, ThemeJson>) {
+  return Object.fromEntries(Object.entries(themes).filter(([name]) => !isReservedThemeName(name)))
+}
 
 function listThemes() {
   // Priority: defaults < plugin installs < custom files < generated system.
   const themes = {
-    ...pluginThemes,
-    ...customThemes,
+    ...withoutReservedThemeNames(pluginThemes),
+    ...withoutReservedThemeNames(customThemes),
     ...DEFAULT_THEMES,
   }
   if (!systemTheme) return themes
@@ -95,8 +104,10 @@ const [store, setStore] = createStore<State>({
   ready: false,
 })
 
-export function defaultThemeName(input?: { termProgram?: string }) {
-  return input?.termProgram === "Apple_Terminal" ? "system" : "opencode"
+export function defaultThemeName(input?: { termProgram?: string; background?: string }) {
+  return input?.termProgram === "Apple_Terminal" && isDarkTerminalBackground(input)
+    ? "system"
+    : "opencode"
 }
 
 export function allThemes() {
@@ -118,7 +129,7 @@ export function addTheme(name: string, theme: unknown) {
   if (!name) return false
   if (!isTheme(theme)) return false
   if (hasTheme(name)) return false
-  if (name === fixed) return false
+  if (isReservedThemeName(name)) return false
   pluginThemes[name] = theme
   syncThemes()
   return true
@@ -127,7 +138,7 @@ export function addTheme(name: string, theme: unknown) {
 export function upsertTheme(name: string, theme: unknown) {
   if (!name) return false
   if (!isTheme(theme)) return false
-  if (name === fixed) return false
+  if (isReservedThemeName(name)) return false
   if (customThemes[name] !== undefined) {
     customThemes[name] = theme
   } else {
@@ -195,6 +206,13 @@ export function resolveTheme(theme: ThemeJson, _mode: "dark" | "light" = "dark")
     _hasSelectedListItemText: hasSelectedListItemText,
     thinkingOpacity,
   } as Theme
+}
+
+function isDarkTerminalBackground(input?: { background?: string }) {
+  if (!input?.background) return false
+  const color = RGBA.fromHex(input.background)
+  const luminance = 0.299 * color.r + 0.587 * color.g + 0.114 * color.b
+  return luminance < 0.5
 }
 
 function ansiToRgba(code: number): RGBA {
@@ -291,6 +309,13 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
           }
           systemTheme = generateSystem(colors, mode)
           syncThemes()
+          const startupTheme = defaultThemeName({
+            termProgram: process.env.TERM_PROGRAM,
+            background: colors.defaultBackground ?? colors.palette[0],
+          })
+          if (startupTheme === "system" && store.active === fallbackTheme) {
+            setStore("active", startupTheme)
+          }
         })
         .catch(() => {
           systemTheme = undefined

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -68,21 +68,12 @@ const pluginThemes: Record<string, ThemeJson> = {}
 let customThemes: Record<string, ThemeJson> = {}
 let systemTheme: ThemeJson | undefined
 const fixed = "opencode"
-const reserved = new Set([fixed, "system"])
-
-function isReservedThemeName(name: string) {
-  return reserved.has(name)
-}
-
-function withoutReservedThemeNames(themes: Record<string, ThemeJson>) {
-  return Object.fromEntries(Object.entries(themes).filter(([name]) => !isReservedThemeName(name)))
-}
 
 function listThemes() {
   // Priority: defaults < plugin installs < custom files < generated system.
   const themes = {
-    ...withoutReservedThemeNames(pluginThemes),
-    ...withoutReservedThemeNames(customThemes),
+    ...pluginThemes,
+    ...customThemes,
     ...DEFAULT_THEMES,
   }
   if (!systemTheme) return themes
@@ -129,7 +120,7 @@ export function addTheme(name: string, theme: unknown) {
   if (!name) return false
   if (!isTheme(theme)) return false
   if (hasTheme(name)) return false
-  if (isReservedThemeName(name)) return false
+  if (name === fixed) return false
   pluginThemes[name] = theme
   syncThemes()
   return true
@@ -138,7 +129,7 @@ export function addTheme(name: string, theme: unknown) {
 export function upsertTheme(name: string, theme: unknown) {
   if (!name) return false
   if (!isTheme(theme)) return false
-  if (isReservedThemeName(name)) return false
+  if (name === fixed) return false
   if (customThemes[name] !== undefined) {
     customThemes[name] = theme
   } else {

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -388,7 +388,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         return store.ready
       },
       get providerReady() {
-        return process.env.TERM_PROGRAM !== "Apple_Terminal" || store.paintReady
+        return true
       },
     }
   },

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -323,6 +323,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     })
 
     createEffect(() => {
+      if (!store.ready) return
       renderer.setBackgroundColor(values().background)
     })
 

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -273,17 +273,15 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     )
 
     function init() {
-      Promise.allSettled([
-        resolveSystemTheme("dark"),
-        getCustomThemes()
-          .then((custom) => {
-            customThemes = custom
-            syncThemes()
-          })
-          .catch(() => {}),
-      ]).finally(() => {
+      void resolveSystemTheme("dark").finally(() => {
         setStore("ready", true)
       })
+      void getCustomThemes()
+        .then((custom) => {
+          customThemes = custom
+          syncThemes()
+        })
+        .catch(() => {})
     }
 
     onMount(init)

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -61,6 +61,7 @@ type State = {
   mode: "dark" | "light"
   lock: "dark" | "light" | undefined
   active: string
+  paintReady: boolean
   ready: boolean
 }
 
@@ -97,13 +98,12 @@ const [store, setStore] = createStore<State>({
   mode: "dark",
   lock: undefined,
   active: "opencode",
+  paintReady: false,
   ready: false,
 })
 
 export function defaultThemeName(input?: { termProgram?: string; background?: string }) {
-  return input?.termProgram === "Apple_Terminal" && isDarkTerminalBackground(input)
-    ? "system"
-    : "opencode"
+  return input?.termProgram === "Apple_Terminal" && isDarkTerminalBackground(input) ? "system" : "opencode"
 }
 
 export function canSelectBuiltInThemeName(name: string, input?: { hasSystemTheme?: boolean }) {
@@ -273,20 +273,24 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         draft.mode = "dark"
         draft.lock = "dark"
         draft.active = fallbackTheme
+        draft.paintReady = false
         draft.ready = false
       }),
     )
 
     function init() {
-      void resolveSystemTheme("dark").finally(() => {
-        setStore("ready", true)
+      const palette = resolveSystemTheme("dark").finally(() => {
+        setStore("paintReady", true)
       })
-      void getCustomThemes()
+      const registry = getCustomThemes()
         .then((custom) => {
           customThemes = custom
           syncThemes()
         })
         .catch(() => {})
+      void Promise.allSettled([palette, registry]).finally(() => {
+        setStore("ready", true)
+      })
     }
 
     onMount(init)
@@ -330,7 +334,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     })
 
     createEffect(() => {
-      if (!store.ready) return
+      if (!store.paintReady) return
       renderer.setBackgroundColor(values().background)
     })
 
@@ -377,8 +381,14 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         setStore("active", theme)
         return true
       },
+      get paintReady() {
+        return store.paintReady
+      },
       get ready() {
         return store.ready
+      },
+      get providerReady() {
+        return process.env.TERM_PROGRAM !== "Apple_Terminal" || store.paintReady
       },
     }
   },

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -68,6 +68,11 @@ const pluginThemes: Record<string, ThemeJson> = {}
 let customThemes: Record<string, ThemeJson> = {}
 let systemTheme: ThemeJson | undefined
 const fixed = "opencode"
+const reserved = new Set([fixed, "system"])
+
+export function isReservedThemeName(name: string) {
+  return reserved.has(name)
+}
 
 function listThemes() {
   // Priority: defaults < plugin installs < custom files < generated system.
@@ -124,7 +129,7 @@ export function addTheme(name: string, theme: unknown) {
   if (!name) return false
   if (!isTheme(theme)) return false
   if (hasTheme(name)) return false
-  if (name === fixed) return false
+  if (isReservedThemeName(name)) return false
   pluginThemes[name] = theme
   syncThemes()
   return true
@@ -133,7 +138,7 @@ export function addTheme(name: string, theme: unknown) {
 export function upsertTheme(name: string, theme: unknown) {
   if (!name) return false
   if (!isTheme(theme)) return false
-  if (name === fixed) return false
+  if (isReservedThemeName(name)) return false
   if (customThemes[name] !== undefined) {
     customThemes[name] = theme
   } else {
@@ -399,6 +404,7 @@ async function getCustomThemes() {
       symlink: true,
     })) {
       const name = path.basename(item, ".json")
+      if (isReservedThemeName(name)) continue
       result[name] = await Filesystem.readJson(item)
     }
   }

--- a/packages/opencode/src/cli/cmd/tui/plugin/runtime.ts
+++ b/packages/opencode/src/cli/cmd/tui/plugin/runtime.ts
@@ -30,7 +30,7 @@ import {
 import { PluginLoader } from "@/plugin/loader"
 import { PluginMeta } from "@/plugin/meta"
 import { installPlugin as installModulePlugin, patchPluginConfig, readPluginManifest } from "@/plugin/install"
-import { hasTheme, upsertTheme } from "../context/theme"
+import { hasTheme, isReservedThemeName, upsertTheme } from "../context/theme"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 import { AgencyBrand } from "@/agency-swarm/brand"
@@ -157,6 +157,10 @@ function createThemeInstaller(
     const raw = file.startsWith("file://") ? fileURLToPath(file) : file
     const src = path.isAbsolute(raw) ? raw : path.resolve(root, raw)
     const name = path.basename(src, path.extname(src))
+    if (isReservedThemeName(name)) {
+      warn("reserved tui plugin theme name", { path: spec, theme: src, name })
+      return
+    }
     const source_dir = path.dirname(meta.source)
     const local_dir =
       path.basename(source_dir) === AgencyBrand.workspace

--- a/packages/opencode/test/cli/tui/plugin-loader.test.ts
+++ b/packages/opencode/test/cli/tui/plugin-loader.test.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { pathToFileURL } from "url"
 import { tmpdir } from "../../fixture/fixture"
 import { createTuiPluginApi } from "../../fixture/tui-plugin"
+import { AgencyBrand } from "../../../src/agency-swarm/brand"
 import { Global } from "../../../src/global"
 import { TuiConfig } from "../../../src/config/tui"
 import { Config } from "../../../src/config/config"
@@ -62,9 +63,9 @@ async function load(): Promise<Data> {
       const invalidThemePath = path.join(dir, invalidThemeFile)
       const globalThemePath = path.join(dir, globalThemeFile)
       const preloadedThemePath = path.join(dir, preloadedThemeFile)
-      const localDest = path.join(dir, ".opencode", "themes", localThemeFile)
+      const localDest = path.join(dir, AgencyBrand.workspace, "themes", localThemeFile)
       const globalDest = path.join(Global.Path.config, "themes", globalThemeFile)
-      const preloadedDest = path.join(dir, ".opencode", "themes", preloadedThemeFile)
+      const preloadedDest = path.join(dir, AgencyBrand.workspace, "themes", preloadedThemeFile)
       const fnMarker = path.join(dir, "function-called.txt")
       const localMarker = path.join(dir, "local-called.json")
       const invalidMarker = path.join(dir, "invalid-called.json")
@@ -389,7 +390,7 @@ export default {
       .then(() => true)
       .catch(() => false)
     const leaked_global_to_local = await fs
-      .stat(path.join(tmp.path, ".opencode", "themes", tmp.extra.globalThemeFile))
+      .stat(path.join(tmp.path, AgencyBrand.workspace, "themes", tmp.extra.globalThemeFile))
       .then(() => true)
       .catch(() => false)
 
@@ -670,7 +671,7 @@ test("updates installed theme when plugin metadata changes", async () => {
       const spec = pathToFileURL(pluginPath).href
       const themeFile = "theme-update.json"
       const themePath = path.join(dir, themeFile)
-      const dest = path.join(dir, ".opencode", "themes", themeFile)
+      const dest = path.join(dir, AgencyBrand.workspace, "themes", themeFile)
       const themeName = themeFile.replace(/\.json$/, "")
       const configPath = path.join(dir, "tui.json")
 

--- a/packages/opencode/test/cli/tui/theme-provider.test.tsx
+++ b/packages/opencode/test/cli/tui/theme-provider.test.tsx
@@ -76,3 +76,74 @@ test("ThemeProvider mounts after palette resolution but before theme.ready flips
     Filesystem.readJson = originalReadJson
   }
 })
+
+test("ThemeProvider mounts on Apple Terminal before palette paint completes", async () => {
+  const originalTermProgram = process.env.TERM_PROGRAM
+  const originalUp = Filesystem.up
+  const originalScan = Glob.scan
+
+  process.env.TERM_PROGRAM = "Apple_Terminal"
+  Filesystem.up = async function* () {}
+  Glob.scan = async () => []
+
+  let resolvePalette!: (colors: TerminalColors) => void
+  const palette = new Promise<TerminalColors>((resolve) => {
+    resolvePalette = resolve
+  })
+
+  const mounted: Array<{ ready: boolean; paintReady: boolean }> = []
+  const snapshots: Array<{ ready: boolean; paintReady: boolean }> = []
+
+  const Probe = () => {
+    const theme = useTheme()
+
+    onMount(() => {
+      mounted.push({
+        ready: theme.ready,
+        paintReady: theme.paintReady,
+      })
+    })
+
+    createEffect(() => {
+      snapshots.push({
+        ready: theme.ready,
+        paintReady: theme.paintReady,
+      })
+    })
+
+    return <box />
+  }
+
+  const App = () => {
+    const renderer = useRenderer()
+    renderer.getPalette = async () => palette
+
+    return (
+      <ThemeProvider mode="dark">
+        <Probe />
+      </ThemeProvider>
+    )
+  }
+
+  try {
+    await testRender(() => <App />)
+    await delay(10)
+
+    expect(mounted).toEqual([{ ready: false, paintReady: false }])
+    expect(snapshots.some((entry) => entry.ready === false && entry.paintReady === false)).toBe(true)
+
+    resolvePalette({
+      defaultBackground: undefined,
+      defaultForeground: undefined,
+      palette: [],
+    } as unknown as TerminalColors)
+    await delay(10)
+
+    expect(snapshots.some((entry) => entry.paintReady === true)).toBe(true)
+  } finally {
+    if (originalTermProgram === undefined) delete process.env.TERM_PROGRAM
+    else process.env.TERM_PROGRAM = originalTermProgram
+    Filesystem.up = originalUp
+    Glob.scan = originalScan
+  }
+})

--- a/packages/opencode/test/cli/tui/theme-provider.test.tsx
+++ b/packages/opencode/test/cli/tui/theme-provider.test.tsx
@@ -1,0 +1,78 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import type { TerminalColors } from "@opentui/core"
+import { testRender, useRenderer } from "@opentui/solid"
+import { createEffect, onMount } from "solid-js"
+import { ThemeProvider, DEFAULT_THEMES, useTheme } from "../../../src/cli/cmd/tui/context/theme"
+import { Filesystem } from "../../../src/util/filesystem"
+import { Glob } from "../../../src/util/glob"
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+test("ThemeProvider mounts after palette resolution but before theme.ready flips", async () => {
+  const name = `delayed-theme-${Date.now()}`
+  const customTheme = structuredClone(DEFAULT_THEMES.opencode)
+  customTheme.theme.primary = "#010203"
+
+  const originalUp = Filesystem.up
+  const originalScan = Glob.scan
+  const originalReadJson = Filesystem.readJson
+
+  Filesystem.up = async function* () {}
+  Glob.scan = async () => {
+    await delay(50)
+    return [`/tmp/${name}.json`]
+  }
+  Filesystem.readJson = async () => customTheme as never
+
+  const mounted: boolean[] = []
+  const snapshots: Array<{ ready: boolean; hasCustom: boolean }> = []
+
+  const Probe = () => {
+    const theme = useTheme()
+
+    onMount(() => {
+      mounted.push(theme.ready)
+    })
+
+    createEffect(() => {
+      snapshots.push({
+        ready: theme.ready,
+        hasCustom: theme.has(name),
+      })
+    })
+
+    return <box />
+  }
+
+  const App = () => {
+    const renderer = useRenderer()
+    renderer.getPalette = async () =>
+      ({
+        defaultBackground: undefined,
+        defaultForeground: undefined,
+        palette: [],
+      }) as unknown as TerminalColors
+
+    return (
+      <ThemeProvider mode="dark">
+        <Probe />
+      </ThemeProvider>
+    )
+  }
+
+  try {
+    await testRender(() => <App />)
+    await delay(100)
+
+    expect(mounted).toEqual([false])
+    expect(snapshots.some((entry) => entry.ready === false && entry.hasCustom === false)).toBe(true)
+    expect(snapshots.some((entry) => entry.ready === true && entry.hasCustom === true)).toBe(true)
+  } finally {
+    Filesystem.up = originalUp
+    Glob.scan = originalScan
+    Filesystem.readJson = originalReadJson
+  }
+})

--- a/packages/opencode/test/cli/tui/theme-provider.test.tsx
+++ b/packages/opencode/test/cli/tui/theme-provider.test.tsx
@@ -3,7 +3,6 @@ import { expect, test } from "bun:test"
 import type { TerminalColors } from "@opentui/core"
 import { testRender, useRenderer } from "@opentui/solid"
 import { createEffect, onMount } from "solid-js"
-import { ThemeProvider, DEFAULT_THEMES, useTheme } from "../../../src/cli/cmd/tui/context/theme"
 import { Filesystem } from "../../../src/util/filesystem"
 import { Glob } from "../../../src/util/glob"
 
@@ -11,7 +10,12 @@ function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function loadThemeModule() {
+  return import(`../../../src/cli/cmd/tui/context/theme.tsx?test=${Date.now()}-${Math.random()}`)
+}
+
 test("ThemeProvider mounts after palette resolution but before theme.ready flips", async () => {
+  const { ThemeProvider, DEFAULT_THEMES, useTheme } = await loadThemeModule()
   const name = `delayed-theme-${Date.now()}`
   const customTheme = structuredClone(DEFAULT_THEMES.opencode)
   customTheme.theme.primary = "#010203"
@@ -78,6 +82,7 @@ test("ThemeProvider mounts after palette resolution but before theme.ready flips
 })
 
 test("ThemeProvider mounts on Apple Terminal before palette paint completes", async () => {
+  const { ThemeProvider, useTheme } = await loadThemeModule()
   const originalTermProgram = process.env.TERM_PROGRAM
   const originalUp = Filesystem.up
   const originalScan = Glob.scan
@@ -149,6 +154,7 @@ test("ThemeProvider mounts on Apple Terminal before palette paint completes", as
 })
 
 test("ThemeProvider blocks system theme selection on light Apple Terminal palettes", async () => {
+  const { ThemeProvider, useTheme } = await loadThemeModule()
   const originalTermProgram = process.env.TERM_PROGRAM
   const originalUp = Filesystem.up
   const originalScan = Glob.scan

--- a/packages/opencode/test/cli/tui/theme-provider.test.tsx
+++ b/packages/opencode/test/cli/tui/theme-provider.test.tsx
@@ -1,27 +1,45 @@
 /** @jsxImportSource @opentui/solid */
-import { expect, test } from "bun:test"
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
+import * as fs from "fs/promises"
+import path from "path"
 import type { TerminalColors } from "@opentui/core"
 import { testRender, useRenderer } from "@opentui/solid"
 import { createEffect, onMount } from "solid-js"
-import { Filesystem } from "../../../src/util/filesystem"
-import { Glob } from "../../../src/util/glob"
+import { tmpdir } from "../../fixture/fixture"
 
-function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
 }
 
-async function waitFor(condition: () => boolean, timeout = 1000) {
-  const deadline = Date.now() + timeout
-  while (Date.now() < deadline) {
-    if (condition()) return
-    await delay(5)
+async function awaitSignal<T>(promise: Promise<T>, message: string, timeout = 2000) {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeout)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
   }
-  throw new Error("Timed out waiting for condition")
 }
 
 function loadThemeModule() {
   return import(`../../../src/cli/cmd/tui/context/theme.tsx?test=${Date.now()}-${Math.random()}`)
 }
+
+const originalTermProgram = process.env.TERM_PROGRAM
+
+afterEach(() => {
+  mock.restore()
+  if (originalTermProgram === undefined) delete process.env.TERM_PROGRAM
+  else process.env.TERM_PROGRAM = originalTermProgram
+})
 
 test.serial("ThemeProvider mounts after palette resolution but before theme.ready flips", async () => {
   const { ThemeProvider, DEFAULT_THEMES, useTheme } = await loadThemeModule()
@@ -29,32 +47,34 @@ test.serial("ThemeProvider mounts after palette resolution but before theme.read
   const customTheme = structuredClone(DEFAULT_THEMES.opencode)
   customTheme.theme.primary = "#010203"
 
-  const originalUp = Filesystem.up
-  const originalScan = Glob.scan
-  const originalReadJson = Filesystem.readJson
+  await using tmp = await tmpdir()
+  const themePath = path.join(tmp.path, ".agentswarm", "themes", `${name}.json`)
+  await fs.mkdir(path.dirname(themePath), { recursive: true })
+  await fs.writeFile(themePath, JSON.stringify(customTheme))
+  spyOn(process, "cwd").mockImplementation(() => tmp.path)
 
-  Filesystem.up = async function* () {}
-  Glob.scan = async () => {
-    await delay(50)
-    return [`/tmp/${name}.json`]
-  }
-  Filesystem.readJson = async () => customTheme as never
-
-  const mounted: boolean[] = []
-  const snapshots: Array<{ ready: boolean; hasCustom: boolean }> = []
+  const mounted = deferred<boolean>()
+  const missingCustom = deferred<void>()
+  const loadedCustom = deferred<void>()
+  let sawMissingCustom = false
+  let sawLoadedCustom = false
 
   const Probe = () => {
     const theme = useTheme()
 
     onMount(() => {
-      mounted.push(theme.ready)
+      mounted.resolve(theme.ready)
     })
 
     createEffect(() => {
-      snapshots.push({
-        ready: theme.ready,
-        hasCustom: theme.has(name),
-      })
+      if (!sawMissingCustom && theme.ready === false && theme.has(name) === false) {
+        sawMissingCustom = true
+        missingCustom.resolve()
+      }
+      if (!sawLoadedCustom && theme.ready === true && theme.has(name) === true) {
+        sawLoadedCustom = true
+        loadedCustom.resolve()
+      }
     })
 
     return <box />
@@ -76,53 +96,50 @@ test.serial("ThemeProvider mounts after palette resolution but before theme.read
     )
   }
 
-  try {
-    await testRender(() => <App />)
-    await waitFor(() => snapshots.some((entry) => entry.ready === true && entry.hasCustom === true))
+  await testRender(() => <App />)
 
-    expect(mounted).toEqual([false])
-    expect(snapshots.some((entry) => entry.ready === false && entry.hasCustom === false)).toBe(true)
-    expect(snapshots.some((entry) => entry.ready === true && entry.hasCustom === true)).toBe(true)
-  } finally {
-    Filesystem.up = originalUp
-    Glob.scan = originalScan
-    Filesystem.readJson = originalReadJson
-  }
+  expect(await awaitSignal(mounted.promise, "ThemeProvider did not mount")).toBe(false)
+  await awaitSignal(missingCustom.promise, "ThemeProvider never observed the pre-ready state")
+  await awaitSignal(loadedCustom.promise, "ThemeProvider never loaded the custom theme")
 })
 
 test.serial("ThemeProvider mounts on Apple Terminal before palette paint completes", async () => {
-  const { ThemeProvider, useTheme } = await loadThemeModule()
-  const originalTermProgram = process.env.TERM_PROGRAM
-  const originalUp = Filesystem.up
-  const originalScan = Glob.scan
-
   process.env.TERM_PROGRAM = "Apple_Terminal"
-  Filesystem.up = async function* () {}
-  Glob.scan = async () => []
+
+  const { ThemeProvider, useTheme } = await loadThemeModule()
+  await using tmp = await tmpdir()
+  spyOn(process, "cwd").mockImplementation(() => tmp.path)
 
   let resolvePalette!: (colors: TerminalColors) => void
   const palette = new Promise<TerminalColors>((resolve) => {
     resolvePalette = resolve
   })
 
-  const mounted: Array<{ ready: boolean; paintReady: boolean }> = []
-  const snapshots: Array<{ ready: boolean; paintReady: boolean }> = []
+  const mounted = deferred<{ ready: boolean; paintReady: boolean }>()
+  const initialSnapshot = deferred<void>()
+  const paintReadySnapshot = deferred<void>()
+  let sawInitialSnapshot = false
+  let sawPaintReady = false
 
   const Probe = () => {
     const theme = useTheme()
 
     onMount(() => {
-      mounted.push({
+      mounted.resolve({
         ready: theme.ready,
         paintReady: theme.paintReady,
       })
     })
 
     createEffect(() => {
-      snapshots.push({
-        ready: theme.ready,
-        paintReady: theme.paintReady,
-      })
+      if (!sawInitialSnapshot && theme.ready === false && theme.paintReady === false) {
+        sawInitialSnapshot = true
+        initialSnapshot.resolve()
+      }
+      if (!sawPaintReady && theme.paintReady === true) {
+        sawPaintReady = true
+        paintReadySnapshot.resolve()
+      }
     })
 
     return <box />
@@ -139,40 +156,31 @@ test.serial("ThemeProvider mounts on Apple Terminal before palette paint complet
     )
   }
 
-  try {
-    await testRender(() => <App />)
-    await waitFor(() => mounted.length === 1 && snapshots.some((entry) => entry.ready === false && entry.paintReady === false))
+  await testRender(() => <App />)
 
-    expect(mounted).toEqual([{ ready: false, paintReady: false }])
-    expect(snapshots.some((entry) => entry.ready === false && entry.paintReady === false)).toBe(true)
+  expect(await awaitSignal(mounted.promise, "ThemeProvider did not mount in Apple Terminal")).toEqual({
+    ready: false,
+    paintReady: false,
+  })
+  await awaitSignal(initialSnapshot.promise, "ThemeProvider never reported the pre-paint Apple Terminal state")
 
-    resolvePalette({
-      defaultBackground: undefined,
-      defaultForeground: undefined,
-      palette: [],
-    } as unknown as TerminalColors)
-    await waitFor(() => snapshots.some((entry) => entry.paintReady === true))
+  resolvePalette({
+    defaultBackground: undefined,
+    defaultForeground: undefined,
+    palette: [],
+  } as unknown as TerminalColors)
 
-    expect(snapshots.some((entry) => entry.paintReady === true)).toBe(true)
-  } finally {
-    if (originalTermProgram === undefined) delete process.env.TERM_PROGRAM
-    else process.env.TERM_PROGRAM = originalTermProgram
-    Filesystem.up = originalUp
-    Glob.scan = originalScan
-  }
+  await awaitSignal(paintReadySnapshot.promise, "ThemeProvider never became paint-ready")
 })
 
 test.serial("ThemeProvider blocks system theme selection on light Apple Terminal palettes", async () => {
-  const { ThemeProvider, useTheme } = await loadThemeModule()
-  const originalTermProgram = process.env.TERM_PROGRAM
-  const originalUp = Filesystem.up
-  const originalScan = Glob.scan
-
   process.env.TERM_PROGRAM = "Apple_Terminal"
-  Filesystem.up = async function* () {}
-  Glob.scan = async () => []
 
-  const attempts: Array<{ allowed: boolean; selected: string }> = []
+  const { ThemeProvider, useTheme } = await loadThemeModule()
+  await using tmp = await tmpdir()
+  spyOn(process, "cwd").mockImplementation(() => tmp.path)
+
+  const attempt = deferred<{ allowed: boolean; selected: string }>()
   let triedSystem = false
 
   const Probe = () => {
@@ -181,7 +189,7 @@ test.serial("ThemeProvider blocks system theme selection on light Apple Terminal
     createEffect(() => {
       if (!theme.paintReady || triedSystem) return
       triedSystem = true
-      attempts.push({
+      attempt.resolve({
         allowed: theme.set("system"),
         selected: theme.selected,
       })
@@ -206,15 +214,9 @@ test.serial("ThemeProvider blocks system theme selection on light Apple Terminal
     )
   }
 
-  try {
-    await testRender(() => <App />)
-    await waitFor(() => attempts.length === 1)
+  await testRender(() => <App />)
 
-    expect(attempts).toEqual([{ allowed: false, selected: "opencode" }])
-  } finally {
-    if (originalTermProgram === undefined) delete process.env.TERM_PROGRAM
-    else process.env.TERM_PROGRAM = originalTermProgram
-    Filesystem.up = originalUp
-    Glob.scan = originalScan
-  }
+  expect(
+    await awaitSignal(attempt.promise, "ThemeProvider never attempted to select the system theme"),
+  ).toEqual({ allowed: false, selected: "opencode" })
 })

--- a/packages/opencode/test/cli/tui/theme-provider.test.tsx
+++ b/packages/opencode/test/cli/tui/theme-provider.test.tsx
@@ -147,3 +147,59 @@ test("ThemeProvider mounts on Apple Terminal before palette paint completes", as
     Glob.scan = originalScan
   }
 })
+
+test("ThemeProvider blocks system theme selection on light Apple Terminal palettes", async () => {
+  const originalTermProgram = process.env.TERM_PROGRAM
+  const originalUp = Filesystem.up
+  const originalScan = Glob.scan
+
+  process.env.TERM_PROGRAM = "Apple_Terminal"
+  Filesystem.up = async function* () {}
+  Glob.scan = async () => []
+
+  const attempts: Array<{ allowed: boolean; selected: string }> = []
+  let triedSystem = false
+
+  const Probe = () => {
+    const theme = useTheme()
+
+    createEffect(() => {
+      if (!theme.paintReady || triedSystem) return
+      triedSystem = true
+      attempts.push({
+        allowed: theme.set("system"),
+        selected: theme.selected,
+      })
+    })
+
+    return <box />
+  }
+
+  const App = () => {
+    const renderer = useRenderer()
+    renderer.getPalette = async () =>
+      ({
+        defaultBackground: "#f5f5f5",
+        defaultForeground: "#101010",
+        palette: ["#f5f5f5", "#ff5555", "#50fa7b", "#f1fa8c", "#bd93f9", "#ff79c6", "#8be9fd", "#101010"],
+      }) as unknown as TerminalColors
+
+    return (
+      <ThemeProvider mode="dark">
+        <Probe />
+      </ThemeProvider>
+    )
+  }
+
+  try {
+    await testRender(() => <App />)
+    await delay(10)
+
+    expect(attempts).toEqual([{ allowed: false, selected: "opencode" }])
+  } finally {
+    if (originalTermProgram === undefined) delete process.env.TERM_PROGRAM
+    else process.env.TERM_PROGRAM = originalTermProgram
+    Filesystem.up = originalUp
+    Glob.scan = originalScan
+  }
+})

--- a/packages/opencode/test/cli/tui/theme-provider.test.tsx
+++ b/packages/opencode/test/cli/tui/theme-provider.test.tsx
@@ -10,11 +10,20 @@ function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+async function waitFor(condition: () => boolean, timeout = 1000) {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    if (condition()) return
+    await delay(5)
+  }
+  throw new Error("Timed out waiting for condition")
+}
+
 function loadThemeModule() {
   return import(`../../../src/cli/cmd/tui/context/theme.tsx?test=${Date.now()}-${Math.random()}`)
 }
 
-test("ThemeProvider mounts after palette resolution but before theme.ready flips", async () => {
+test.serial("ThemeProvider mounts after palette resolution but before theme.ready flips", async () => {
   const { ThemeProvider, DEFAULT_THEMES, useTheme } = await loadThemeModule()
   const name = `delayed-theme-${Date.now()}`
   const customTheme = structuredClone(DEFAULT_THEMES.opencode)
@@ -69,7 +78,7 @@ test("ThemeProvider mounts after palette resolution but before theme.ready flips
 
   try {
     await testRender(() => <App />)
-    await delay(100)
+    await waitFor(() => snapshots.some((entry) => entry.ready === true && entry.hasCustom === true))
 
     expect(mounted).toEqual([false])
     expect(snapshots.some((entry) => entry.ready === false && entry.hasCustom === false)).toBe(true)
@@ -81,7 +90,7 @@ test("ThemeProvider mounts after palette resolution but before theme.ready flips
   }
 })
 
-test("ThemeProvider mounts on Apple Terminal before palette paint completes", async () => {
+test.serial("ThemeProvider mounts on Apple Terminal before palette paint completes", async () => {
   const { ThemeProvider, useTheme } = await loadThemeModule()
   const originalTermProgram = process.env.TERM_PROGRAM
   const originalUp = Filesystem.up
@@ -132,7 +141,7 @@ test("ThemeProvider mounts on Apple Terminal before palette paint completes", as
 
   try {
     await testRender(() => <App />)
-    await delay(10)
+    await waitFor(() => mounted.length === 1 && snapshots.some((entry) => entry.ready === false && entry.paintReady === false))
 
     expect(mounted).toEqual([{ ready: false, paintReady: false }])
     expect(snapshots.some((entry) => entry.ready === false && entry.paintReady === false)).toBe(true)
@@ -142,7 +151,7 @@ test("ThemeProvider mounts on Apple Terminal before palette paint completes", as
       defaultForeground: undefined,
       palette: [],
     } as unknown as TerminalColors)
-    await delay(10)
+    await waitFor(() => snapshots.some((entry) => entry.paintReady === true))
 
     expect(snapshots.some((entry) => entry.paintReady === true)).toBe(true)
   } finally {
@@ -153,7 +162,7 @@ test("ThemeProvider mounts on Apple Terminal before palette paint completes", as
   }
 })
 
-test("ThemeProvider blocks system theme selection on light Apple Terminal palettes", async () => {
+test.serial("ThemeProvider blocks system theme selection on light Apple Terminal palettes", async () => {
   const { ThemeProvider, useTheme } = await loadThemeModule()
   const originalTermProgram = process.env.TERM_PROGRAM
   const originalUp = Filesystem.up
@@ -199,7 +208,7 @@ test("ThemeProvider blocks system theme selection on light Apple Terminal palett
 
   try {
     await testRender(() => <App />)
-    await delay(10)
+    await waitFor(() => attempts.length === 1)
 
     expect(attempts).toEqual([{ allowed: false, selected: "opencode" }])
   } finally {

--- a/packages/opencode/test/cli/tui/theme-store.test.ts
+++ b/packages/opencode/test/cli/tui/theme-store.test.ts
@@ -7,6 +7,7 @@ const {
   canSelectBuiltInThemeName,
   defaultThemeName,
   hasTheme,
+  isReservedThemeName,
   resolveTheme,
   upsertTheme,
 } = await import("../../../src/cli/cmd/tui/context/theme")
@@ -84,13 +85,16 @@ test("built-in opencode theme keeps the Agent Swarm dark palette", () => {
   expect(DEFAULT_THEMES.opencode.defs?.darkAccent).toBe("#e8d382")
 })
 
-test("system can be added while the built-in opencode theme stays protected", () => {
+test("system stays reserved while the built-in opencode theme stays protected", () => {
   const item = structuredClone(DEFAULT_THEMES.opencode)
   item.theme.primary = "#010203"
 
+  expect(isReservedThemeName("opencode")).toBe(true)
+  expect(isReservedThemeName("system")).toBe(true)
   expect(addTheme(`system-${Date.now()}`, item)).toBe(true)
-  expect(addTheme("system", item)).toBe(true)
-  expect(allThemes().system).toBeDefined()
+  expect(addTheme("system", item)).toBe(false)
+  expect(upsertTheme("system", item)).toBe(false)
+  expect(allThemes().system).toBeUndefined()
   expect(upsertTheme("opencode", item)).toBe(false)
   expect(resolveTheme(allThemes().opencode).primary.toString()).toBe(
     resolveTheme(DEFAULT_THEMES.opencode).primary.toString(),

--- a/packages/opencode/test/cli/tui/theme-store.test.ts
+++ b/packages/opencode/test/cli/tui/theme-store.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 
-const { DEFAULT_THEMES, allThemes, addTheme, hasTheme, resolveTheme, upsertTheme } = await import(
+const { DEFAULT_THEMES, allThemes, addTheme, defaultThemeName, hasTheme, resolveTheme, upsertTheme } = await import(
   "../../../src/cli/cmd/tui/context/theme"
 )
 
@@ -36,6 +36,11 @@ test("hasTheme checks theme presence", () => {
   expect(hasTheme(name)).toBe(false)
   expect(addTheme(name, DEFAULT_THEMES.opencode)).toBe(true)
   expect(hasTheme(name)).toBe(true)
+})
+
+test("defaultThemeName prefers the system palette in Apple Terminal", () => {
+  expect(defaultThemeName({ termProgram: "Apple_Terminal" })).toBe("system")
+  expect(defaultThemeName({ termProgram: "iTerm.app" })).toBe("opencode")
 })
 
 test("resolveTheme always uses the dark variant", () => {

--- a/packages/opencode/test/cli/tui/theme-store.test.ts
+++ b/packages/opencode/test/cli/tui/theme-store.test.ts
@@ -38,8 +38,10 @@ test("hasTheme checks theme presence", () => {
   expect(hasTheme(name)).toBe(true)
 })
 
-test("defaultThemeName prefers the system palette in Apple Terminal", () => {
-  expect(defaultThemeName({ termProgram: "Apple_Terminal" })).toBe("system")
+test("defaultThemeName only prefers the system palette for dark Apple Terminal themes", () => {
+  expect(defaultThemeName({ termProgram: "Apple_Terminal" })).toBe("opencode")
+  expect(defaultThemeName({ termProgram: "Apple_Terminal", background: "#101010" })).toBe("system")
+  expect(defaultThemeName({ termProgram: "Apple_Terminal", background: "#f5f5f5" })).toBe("opencode")
   expect(defaultThemeName({ termProgram: "iTerm.app" })).toBe("opencode")
 })
 
@@ -68,10 +70,12 @@ test("built-in opencode theme keeps the Agent Swarm dark palette", () => {
   expect(DEFAULT_THEMES.opencode.defs?.darkAccent).toBe("#e8d382")
 })
 
-test("upsertTheme cannot replace the built-in opencode theme", () => {
+test("reserved theme names cannot be replaced", () => {
   const item = structuredClone(DEFAULT_THEMES.opencode)
   item.theme.primary = "#010203"
 
+  expect(addTheme("system", item)).toBe(false)
+  expect(upsertTheme("system", item)).toBe(false)
   expect(upsertTheme("opencode", item)).toBe(false)
   expect(resolveTheme(allThemes().opencode).primary.toString()).toBe(
     resolveTheme(DEFAULT_THEMES.opencode).primary.toString(),

--- a/packages/opencode/test/cli/tui/theme-store.test.ts
+++ b/packages/opencode/test/cli/tui/theme-store.test.ts
@@ -53,10 +53,12 @@ test("defaultThemeName only prefers the system palette for dark Apple Terminal t
   expect(defaultThemeName({ termProgram: "iTerm.app" })).toBe("opencode")
 })
 
-test("built-in theme selection only allows opencode plus generated system", () => {
+test("built-in theme selection only allows opencode plus dark Apple Terminal system", () => {
   expect(canSelectBuiltInThemeName("opencode")).toBe(true)
   expect(canSelectBuiltInThemeName("system")).toBe(false)
-  expect(canSelectBuiltInThemeName("system", { hasSystemTheme: true })).toBe(true)
+  expect(canSelectBuiltInThemeName("system", { hasSystemTheme: true })).toBe(false)
+  expect(canSelectBuiltInThemeName("system", { hasSystemTheme: true, allowSystemThemeSelection: false })).toBe(false)
+  expect(canSelectBuiltInThemeName("system", { hasSystemTheme: true, allowSystemThemeSelection: true })).toBe(true)
   expect(canSelectBuiltInThemeName("solarized", { hasSystemTheme: true })).toBe(false)
 })
 

--- a/packages/opencode/test/cli/tui/theme-store.test.ts
+++ b/packages/opencode/test/cli/tui/theme-store.test.ts
@@ -1,8 +1,15 @@
 import { expect, test } from "bun:test"
 
-const { DEFAULT_THEMES, allThemes, addTheme, defaultThemeName, hasTheme, resolveTheme, upsertTheme } = await import(
-  "../../../src/cli/cmd/tui/context/theme"
-)
+const {
+  DEFAULT_THEMES,
+  allThemes,
+  addTheme,
+  canSelectBuiltInThemeName,
+  defaultThemeName,
+  hasTheme,
+  resolveTheme,
+  upsertTheme,
+} = await import("../../../src/cli/cmd/tui/context/theme")
 
 test("addTheme writes into module theme store", () => {
   const name = `plugin-theme-${Date.now()}`
@@ -43,6 +50,13 @@ test("defaultThemeName only prefers the system palette for dark Apple Terminal t
   expect(defaultThemeName({ termProgram: "Apple_Terminal", background: "#101010" })).toBe("system")
   expect(defaultThemeName({ termProgram: "Apple_Terminal", background: "#f5f5f5" })).toBe("opencode")
   expect(defaultThemeName({ termProgram: "iTerm.app" })).toBe("opencode")
+})
+
+test("built-in theme selection only allows opencode plus generated system", () => {
+  expect(canSelectBuiltInThemeName("opencode")).toBe(true)
+  expect(canSelectBuiltInThemeName("system")).toBe(false)
+  expect(canSelectBuiltInThemeName("system", { hasSystemTheme: true })).toBe(true)
+  expect(canSelectBuiltInThemeName("solarized", { hasSystemTheme: true })).toBe(false)
 })
 
 test("resolveTheme always uses the dark variant", () => {

--- a/packages/opencode/test/cli/tui/theme-store.test.ts
+++ b/packages/opencode/test/cli/tui/theme-store.test.ts
@@ -70,12 +70,13 @@ test("built-in opencode theme keeps the Agent Swarm dark palette", () => {
   expect(DEFAULT_THEMES.opencode.defs?.darkAccent).toBe("#e8d382")
 })
 
-test("reserved theme names cannot be replaced", () => {
+test("system can be added while the built-in opencode theme stays protected", () => {
   const item = structuredClone(DEFAULT_THEMES.opencode)
   item.theme.primary = "#010203"
 
-  expect(addTheme("system", item)).toBe(false)
-  expect(upsertTheme("system", item)).toBe(false)
+  expect(addTheme(`system-${Date.now()}`, item)).toBe(true)
+  expect(addTheme("system", item)).toBe(true)
+  expect(allThemes().system).toBeDefined()
   expect(upsertTheme("opencode", item)).toBe(false)
   expect(resolveTheme(allThemes().opencode).primary.toString()).toBe(
     resolveTheme(DEFAULT_THEMES.opencode).primary.toString(),


### PR DESCRIPTION
### Issue for this PR

Closes #44

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Defaults the TUI to the built-in `system` palette when it is running inside Apple Terminal, keeps that fallback if theme loading fails, and leaves other terminals on the Agent Swarm `opencode` dark palette. This keeps the fork dark-first while fixing unreadable text in the stock macOS Terminal.

### How did you verify your code works?

Ran `cd packages/opencode && bun test --timeout 30000 test/cli/tui/theme-store.test.ts` with the fresh branch checked out. Result: `9 pass`, `0 fail`.

### Screenshots / recordings

Not included in this PR. The regression was reproduced from Apple Terminal screenshots and this change only adjusts theme fallback selection.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
