### PR TITLE
fix: stabilize the input-focus e2e on Windows

### DIFF
--- a/packages/app/e2e/commands/input-focus.spec.ts
+++ b/packages/app/e2e/commands/input-focus.spec.ts
@@ -1,3 +1,4 @@
+import { defocus } from "../actions"
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 
@@ -7,7 +8,7 @@ test("ctrl+l focuses the prompt", async ({ page, gotoSession }) => {
   const prompt = page.locator(promptSelector)
   await expect(prompt).toBeVisible()
 
-  await page.locator("main").click({ position: { x: 5, y: 5 } })
+  await defocus(page)
   await expect(prompt).not.toBeFocused()
 
   await page.keyboard.press("Control+L")


### PR DESCRIPTION
### Issue for this PR

Closes #47

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This replaces the brittle outside click in the input-focus Playwright spec with the shared `defocus(page)` helper. The prompt is a `contenteditable` editor, so Chromium on Windows can keep it focused after clicking a non-focusable container. The shortcut behavior was fine; the setup step was not stable.

### How did you verify your code works?

- `bun run test:e2e e2e/commands/input-focus.spec.ts`

### Screenshots / recordings

- Not needed. This is a focused test-only fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
