### PR TITLE
fix: support built source installs for the agentswarm wrapper

### DIFF
--- a/packages/opencode/bin/agentswarm
+++ b/packages/opencode/bin/agentswarm
@@ -176,10 +176,17 @@ function findBinary(startDir) {
   }
 }
 
-const resolved = findBinary(scriptDir)
+function findBuiltBinary(startDir) {
+  for (const name of names) {
+    const candidate = path.join(startDir, "..", "dist", name, "bin", binary)
+    if (fs.existsSync(candidate)) return candidate
+  }
+}
+
+const resolved = findBinary(scriptDir) ?? findBuiltBinary(scriptDir)
 if (!resolved) {
   console.error(
-    "It seems that your package manager failed to install the right version of the agentswarm-cli package for your platform. You can try manually installing " +
+    "It seems that your package manager failed to install the right version of the agentswarm-cli package for your platform. If this is a local source install, build the current checkout first with \"bun run build -- --single\" before running \"npm install -g .\". Otherwise you can try manually installing " +
       packageNames.map((name) => `"${name}"`).join(" or ") +
       " package",
   )

--- a/packages/opencode/test/installation/source-install-wrapper.test.ts
+++ b/packages/opencode/test/installation/source-install-wrapper.test.ts
@@ -7,23 +7,21 @@ import { tmpdir } from "../fixture/fixture"
 const wrapperPath = fileURLToPath(new URL("../../bin/agentswarm", import.meta.url))
 
 function platformName() {
-  return (
-    {
-      darwin: "darwin",
-      linux: "linux",
-      win32: "windows",
-    }[process.platform] ?? process.platform
-  )
+  const names: Record<string, string> = {
+    darwin: "darwin",
+    linux: "linux",
+    win32: "windows",
+  }
+  return names[process.platform] ?? process.platform
 }
 
 function archName() {
-  return (
-    {
-      x64: "x64",
-      arm64: "arm64",
-      arm: "arm",
-    }[process.arch] ?? process.arch
-  )
+  const names: Record<string, string> = {
+    x64: "x64",
+    arm64: "arm64",
+    arm: "arm",
+  }
+  return names[process.arch] ?? process.arch
 }
 
 function possibleDistTargets() {

--- a/packages/opencode/test/installation/source-install-wrapper.test.ts
+++ b/packages/opencode/test/installation/source-install-wrapper.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test"
+import * as fs from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { tmpdir } from "../fixture/fixture"
+
+const wrapperPath = fileURLToPath(new URL("../../bin/agentswarm", import.meta.url))
+
+function platformName() {
+  return (
+    {
+      darwin: "darwin",
+      linux: "linux",
+      win32: "windows",
+    }[process.platform] ?? process.platform
+  )
+}
+
+function archName() {
+  return (
+    {
+      x64: "x64",
+      arm64: "arm64",
+      arm: "arm",
+    }[process.arch] ?? process.arch
+  )
+}
+
+function possibleDistTargets() {
+  const platform = platformName()
+  const arch = archName()
+  const base = `agentswarm-cli-${platform}-${arch}`
+
+  const names = new Set([base])
+  if (arch === "x64") {
+    names.add(`${base}-baseline`)
+    if (platform === "linux") {
+      names.add(`${base}-musl`)
+      names.add(`${base}-baseline-musl`)
+    }
+  } else if (platform === "linux") {
+    names.add(`${base}-musl`)
+  }
+  return [...names]
+}
+
+test("agentswarm wrapper falls back to a local dist binary for source installs", async () => {
+  if (process.platform === "win32") return
+
+  await using tmp = await tmpdir()
+  const packageRoot = path.join(tmp.path, "agentswarm-cli")
+  const binDir = path.join(packageRoot, "bin")
+  const binaryName = "agentswarm"
+
+  await fs.mkdir(binDir, { recursive: true })
+  await fs.copyFile(wrapperPath, path.join(binDir, binaryName))
+  await fs.chmod(path.join(binDir, binaryName), 0o755)
+  await fs.writeFile(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      name: "agentswarm-cli",
+      platformScope: "@vrsen",
+    }),
+  )
+
+  for (const target of possibleDistTargets()) {
+    const binaryPath = path.join(packageRoot, "dist", target, "bin", binaryName)
+    await fs.mkdir(path.dirname(binaryPath), { recursive: true })
+    await fs.writeFile(binaryPath, "#!/usr/bin/env node\nprocess.stdout.write('dist-fallback-ok')\n")
+    await fs.chmod(binaryPath, 0o755)
+  }
+
+  const result = Bun.spawnSync({
+    cmd: [process.execPath, path.join(binDir, binaryName), "--version"],
+    cwd: packageRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+  expect(result.exitCode).toBe(0)
+  expect(result.stderr.toString().trim()).toBe("")
+  expect(result.stdout.toString().trim()).toBe("dist-fallback-ok")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #49

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This lets the global `agentswarm` wrapper fall back to a locally built `dist/agentswarm-cli-<target>/bin/agentswarm` binary in the developer source-install case. That keeps built local QA working when `npm install -g .` is run from `packages/opencode`, where the source manifest does not include the publish-time platform optional dependencies.

### How did you verify your code works?

- `cd packages/opencode && bun test --timeout 30000 ./test/installation/source-install-wrapper.test.ts`
- local built-source install smoke path

### Screenshots / recordings

- Not needed. This is a focused install-path fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
