### PR TITLE
fix: keep configured agentswarm mode ahead of stale model state

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -118,10 +118,9 @@ export function selectCurrentModel(input: {
     }
   }
 
-  if (shouldPreferConfiguredAgencySwarmModel(input)) {
+  if (shouldPreferConfiguredAgencySwarmModel(input) && !input.storedModel) {
     return getFirstValidModel(
       fallbackModel,
-      () => input.storedModel,
       () => input.agentModel,
     )
   }

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -39,6 +39,100 @@ export function isUsableModel(input: {
   return !!input.configuredProviders?.[AgencySwarmAdapter.PROVIDER_ID]
 }
 
+export function selectCurrentModel(input: {
+  storedModel?: {
+    providerID: string
+    modelID: string
+  }
+  agentModel?: {
+    providerID: string
+    modelID: string
+  }
+  recentModels?: {
+    providerID: string
+    modelID: string
+  }[]
+  providers: {
+    id: string
+    models: Record<string, unknown>
+  }[]
+  providerDefaults?: Record<string, string>
+  argModel?: string
+  configModel?: string
+  configuredProviders?: Record<string, unknown>
+}) {
+  function isModelValid(model: { providerID: string; modelID: string }) {
+    return isUsableModel({
+      model,
+      providers: input.providers,
+      argModel: input.argModel,
+      configModel: input.configModel,
+      configuredProviders: input.configuredProviders,
+    })
+  }
+
+  function getFirstValidModel(...modelFns: (() => { providerID: string; modelID: string } | undefined)[]) {
+    for (const modelFn of modelFns) {
+      const model = modelFn()
+      if (!model) continue
+      if (isModelValid(model)) return model
+    }
+  }
+
+  const fallbackModel = () => {
+    if (input.argModel) {
+      const { providerID, modelID } = Provider.parseModel(input.argModel)
+      if (isModelValid({ providerID, modelID })) {
+        return {
+          providerID,
+          modelID,
+        }
+      }
+    }
+
+    if (input.configModel) {
+      const { providerID, modelID } = Provider.parseModel(input.configModel)
+      if (isModelValid({ providerID, modelID })) {
+        return {
+          providerID,
+          modelID,
+        }
+      }
+    }
+
+    for (const item of input.recentModels ?? []) {
+      if (isModelValid(item)) {
+        return item
+      }
+    }
+
+    const provider = input.providers[0]
+    if (!provider) return undefined
+    const defaultModel = input.providerDefaults?.[provider.id]
+    const firstModel = Object.values(provider.models)[0] as { id?: string } | undefined
+    const model = defaultModel ?? firstModel?.id
+    if (!model) return undefined
+    return {
+      providerID: provider.id,
+      modelID: model,
+    }
+  }
+
+  if (shouldPreferConfiguredAgencySwarmModel(input)) {
+    return getFirstValidModel(
+      fallbackModel,
+      () => input.storedModel,
+      () => input.agentModel,
+    )
+  }
+
+  return getFirstValidModel(
+    () => input.storedModel,
+    () => input.agentModel,
+    fallbackModel,
+  )
+}
+
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
   init: () => {
@@ -58,14 +152,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         configModel: sync.data.config.model,
         configuredProviders: sync.data.config.provider,
       })
-    }
-
-    function getFirstValidModel(...modelFns: (() => { providerID: string; modelID: string } | undefined)[]) {
-      for (const modelFn of modelFns) {
-        const model = modelFn()
-        if (!model) continue
-        if (isModelValid(model)) return model
-      }
     }
 
     const agent = iife(() => {
@@ -184,54 +270,21 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (state.pending) save()
         })
 
-      const fallbackModel = createMemo(() => {
-        if (args.model) {
-          const { providerID, modelID } = Provider.parseModel(args.model)
-          if (isModelValid({ providerID, modelID })) {
-            return {
-              providerID,
-              modelID,
-            }
-          }
-        }
-
-        if (sync.data.config.model) {
-          const { providerID, modelID } = Provider.parseModel(sync.data.config.model)
-          if (isModelValid({ providerID, modelID })) {
-            return {
-              providerID,
-              modelID,
-            }
-          }
-        }
-
-        for (const item of modelStore.recent) {
-          if (isModelValid(item)) {
-            return item
-          }
-        }
-
-        const provider = sync.data.provider[0]
-        if (!provider) return undefined
-        const defaultModel = sync.data.provider_default[provider.id]
-        const firstModel = Object.values(provider.models)[0]
-        const model = defaultModel ?? firstModel?.id
-        if (!model) return undefined
-        return {
-          providerID: provider.id,
-          modelID: model,
-        }
-      })
-
       const currentModel = createMemo(() => {
         const a = agent.current()
-        return (
-          getFirstValidModel(
-            () => modelStore.model[a.name],
-            () => a.model,
-            fallbackModel,
-          ) ?? undefined
-        )
+        return selectCurrentModel({
+          storedModel: modelStore.model[a.name],
+          agentModel: a.model,
+          recentModels: modelStore.recent,
+          providers: sync.data.provider.map((item) => ({
+            id: item.id,
+            models: item.models,
+          })),
+          providerDefaults: sync.data.provider_default,
+          argModel: args.model,
+          configModel: sync.data.config.model,
+          configuredProviders: sync.data.config.provider,
+        })
       })
 
       return {
@@ -443,3 +496,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     return result
   },
 })
+
+function shouldPreferConfiguredAgencySwarmModel(input: { argModel?: string; configModel?: string }) {
+  const model = input.argModel ?? input.configModel
+  return model === `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`
+}

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -119,10 +119,7 @@ export function selectCurrentModel(input: {
   }
 
   if (shouldPreferConfiguredAgencySwarmModel(input) && !input.storedModel) {
-    return getFirstValidModel(
-      fallbackModel,
-      () => input.agentModel,
-    )
+    return getFirstValidModel(fallbackModel, () => input.agentModel)
   }
 
   return getFirstValidModel(
@@ -485,7 +482,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       },
     }
 
-    // Automatically update model when agent changes
+    // Current model already follows agent.model unless a local override exists.
+    // Keep this effect only for invalid-model warnings while following agent config.
     createEffect(() => {
       const value = agent.current()
       if (
@@ -497,18 +495,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       ) {
         return
       }
-      if (value.model) {
-        if (isModelValid(value.model))
-          model.set({
-            providerID: value.model.providerID,
-            modelID: value.model.modelID,
-          })
-        else
-          toast.show({
-            variant: "warning",
-            message: `Agent ${value.name}'s configured model ${value.model.providerID}/${value.model.modelID} is not valid`,
-            duration: 3000,
-          })
+      if (value.model && !isModelValid(value.model)) {
+        toast.show({
+          variant: "warning",
+          message: `Agent ${value.name}'s configured model ${value.model.providerID}/${value.model.modelID} is not valid`,
+          duration: 3000,
+        })
       }
     })
 

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -301,6 +301,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
       return {
         current: currentModel,
+        override(name: string) {
+          return modelStore.model[name]
+        },
         get ready() {
           return modelStore.ready
         },
@@ -487,7 +490,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const value = agent.current()
       if (
         !shouldSyncAgentModel({
-          storedModel: modelStore.model[value.name],
+          storedModel: model.override(value.name),
           argModel: args.model,
           configModel: sync.data.config.model,
         })

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -132,6 +132,19 @@ export function selectCurrentModel(input: {
   )
 }
 
+export function shouldSyncAgentModel(input: {
+  storedModel?: {
+    providerID: string
+    modelID: string
+  }
+  argModel?: string
+  configModel?: string
+}) {
+  if (input.storedModel) return false
+  if (shouldPreferConfiguredAgencySwarmModel(input)) return false
+  return true
+}
+
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
   init: () => {
@@ -472,6 +485,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     // Automatically update model when agent changes
     createEffect(() => {
       const value = agent.current()
+      if (
+        !shouldSyncAgentModel({
+          storedModel: modelStore.model[value.name],
+          argModel: args.model,
+          configModel: sync.data.config.model,
+        })
+      ) {
+        return
+      }
       if (value.model) {
         if (isModelValid(value.model))
           model.set({

--- a/packages/opencode/test/cli/tui/local-context.test.tsx
+++ b/packages/opencode/test/cli/tui/local-context.test.tsx
@@ -1,0 +1,117 @@
+/** @jsxImportSource @opentui/solid */
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { createStore } from "solid-js/store"
+import * as ArgsContext from "../../../src/cli/cmd/tui/context/args"
+import { LocalProvider, useLocal } from "../../../src/cli/cmd/tui/context/local"
+import * as SDKContext from "../../../src/cli/cmd/tui/context/sdk"
+import * as SyncContext from "../../../src/cli/cmd/tui/context/sync"
+import * as ThemeContext from "../../../src/cli/cmd/tui/context/theme"
+import * as ToastModule from "../../../src/cli/cmd/tui/ui/toast"
+import { Filesystem } from "../../../src/util/filesystem"
+
+function flushEffects() {
+  return Promise.resolve().then(() => Promise.resolve())
+}
+
+describe("tui local context model sync", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test("keeps following agent model changes without creating a local override", async () => {
+    const [syncData, setSyncData] = createStore<any>({
+      agent: [
+        {
+          name: "writer",
+          mode: "primary",
+          hidden: false,
+          model: {
+            providerID: "openai",
+            modelID: "gpt-5",
+          },
+        },
+      ],
+      provider: [
+        {
+          id: "openai",
+          name: "OpenAI",
+          models: {
+            "gpt-5": { id: "gpt-5", name: "GPT-5" },
+            "gpt-5.1": { id: "gpt-5.1", name: "GPT-5.1" },
+          },
+        },
+      ],
+      provider_default: {
+        openai: "gpt-5",
+      },
+      config: {
+        model: undefined,
+        provider: {},
+      },
+      mcp: {},
+    })
+
+    spyOn(SyncContext, "useSync").mockReturnValue({ data: syncData } as any)
+    spyOn(ArgsContext, "useArgs").mockReturnValue({} as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({
+      client: {
+        mcp: {
+          disconnect: async () => {},
+          connect: async () => {},
+        },
+      },
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {
+        secondary: {},
+        accent: {},
+        success: {},
+        warning: {},
+        primary: {},
+        error: {},
+        info: {},
+      },
+    } as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: () => {},
+      error: () => {},
+      currentToast: null,
+    } as any)
+    spyOn(Filesystem, "readJson").mockResolvedValue({})
+    spyOn(Filesystem, "writeJson").mockResolvedValue(undefined)
+
+    let local!: ReturnType<typeof useLocal>
+
+    const Capture = () => {
+      local = useLocal()
+      return <box />
+    }
+
+    await testRender(() => (
+      <LocalProvider>
+        <Capture />
+      </LocalProvider>
+    ))
+
+    await flushEffects()
+
+    expect(local.model.current()).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    })
+    expect(local.model.override("writer")).toBeUndefined()
+
+    setSyncData("agent", 0, "model", {
+      providerID: "openai",
+      modelID: "gpt-5.1",
+    })
+    await flushEffects()
+
+    expect(local.model.current()).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.1",
+    })
+    expect(local.model.override("writer")).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/cli/tui/local.test.ts
+++ b/packages/opencode/test/cli/tui/local.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { isUsableModel, selectCurrentModel } from "../../../src/cli/cmd/tui/context/local"
+import { isUsableModel, selectCurrentModel, shouldSyncAgentModel } from "../../../src/cli/cmd/tui/context/local"
 
 describe("tui local model selection", () => {
   test("keeps agency-swarm launcher model usable before provider metadata loads", () => {
@@ -205,5 +205,33 @@ describe("tui local model selection", () => {
       providerID: "openai",
       modelID: "gpt-5",
     })
+  })
+
+  test("does not sync stale agent models into startup state for agency-swarm launcher mode", () => {
+    expect(
+      shouldSyncAgentModel({
+        argModel: "agency-swarm/default",
+      }),
+    ).toBe(false)
+  })
+
+  test("does not sync agent models over explicit stored overrides", () => {
+    expect(
+      shouldSyncAgentModel({
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+        },
+        configModel: "agency-swarm/default",
+      }),
+    ).toBe(false)
+  })
+
+  test("still syncs agent models in normal startup mode with no override", () => {
+    expect(
+      shouldSyncAgentModel({
+        configModel: "openai/gpt-5",
+      }),
+    ).toBe(true)
   })
 })

--- a/packages/opencode/test/cli/tui/local.test.ts
+++ b/packages/opencode/test/cli/tui/local.test.ts
@@ -80,10 +80,10 @@ describe("tui local model selection", () => {
     ).toBe(false)
   })
 
-  test("prefers configured agency-swarm model over stale stored model state", () => {
+  test("prefers configured agency-swarm model over stale agent model before user override", () => {
     expect(
       selectCurrentModel({
-        storedModel: {
+        agentModel: {
           providerID: "openai",
           modelID: "gpt-5",
         },
@@ -106,6 +106,74 @@ describe("tui local model selection", () => {
     ).toEqual({
       providerID: "agency-swarm",
       modelID: "default",
+    })
+  })
+
+  test("keeps explicit stored model overrides over configured agency-swarm", () => {
+    expect(
+      selectCurrentModel({
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+        },
+        agentModel: {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+          {
+            id: "anthropic",
+            models: {
+              "claude-sonnet-4": {},
+            },
+          },
+        ],
+        configModel: "agency-swarm/default",
+        configuredProviders: {
+          "agency-swarm": {
+            name: "Agency Swarm",
+            options: {},
+          },
+        },
+      }),
+    ).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    })
+  })
+
+  test("keeps explicit stored model overrides over launcher agency-swarm args", () => {
+    expect(
+      selectCurrentModel({
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        argModel: "agency-swarm/default",
+        configuredProviders: {
+          "agency-swarm": {
+            name: "Agency Swarm",
+            options: {},
+          },
+        },
+      }),
+    ).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
     })
   })
 

--- a/packages/opencode/test/cli/tui/local.test.ts
+++ b/packages/opencode/test/cli/tui/local.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { isUsableModel } from "../../../src/cli/cmd/tui/context/local"
+import { isUsableModel, selectCurrentModel } from "../../../src/cli/cmd/tui/context/local"
 
 describe("tui local model selection", () => {
   test("keeps agency-swarm launcher model usable before provider metadata loads", () => {
@@ -78,5 +78,64 @@ describe("tui local model selection", () => {
         },
       }),
     ).toBe(false)
+  })
+
+  test("prefers configured agency-swarm model over stale stored model state", () => {
+    expect(
+      selectCurrentModel({
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        configModel: "agency-swarm/default",
+        configuredProviders: {
+          "agency-swarm": {
+            name: "Agency Swarm",
+            options: {},
+          },
+        },
+      }),
+    ).toEqual({
+      providerID: "agency-swarm",
+      modelID: "default",
+    })
+  })
+
+  test("keeps explicit args.model overrides away from agency-swarm", () => {
+    expect(
+      selectCurrentModel({
+        storedModel: {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        argModel: "openai/gpt-5",
+        configModel: "agency-swarm/default",
+        configuredProviders: {
+          "agency-swarm": {
+            name: "Agency Swarm",
+            options: {},
+          },
+        },
+      }),
+    ).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    })
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #48

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This keeps the configured `agency-swarm/default` model ahead of stale stored model state inside the local TUI provider. Without that, a remembered normal-provider model can pull the session out of Agent Swarm mode and break the intended auth/session flow. Explicit `--model` overrides still win.

### How did you verify your code works?

- `cd packages/opencode && bun test --timeout 30000 ./test/cli/tui/local.test.ts ./test/cli/tui/session-error.test.ts`

### Screenshots / recordings

- Not needed. This is a focused logic fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
