### PR TITLE
fix: stabilize agency-swarm/default startup and auth forwarding

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -27,11 +27,15 @@ export function isUsableModel(input: {
   argModel?: string
   configModel?: string
   configuredProviders?: Record<string, unknown>
+  enabledProviders?: string[]
+  disabledProviders?: string[]
 }) {
   const provider = input.providers.find((x) => x.id === input.model.providerID)
   if (provider?.models[input.model.modelID]) return true
   if (input.model.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
   if (input.model.modelID !== AgencySwarmAdapter.DEFAULT_MODEL_ID) return false
+  if (input.enabledProviders && !input.enabledProviders.includes(AgencySwarmAdapter.PROVIDER_ID)) return false
+  if (input.disabledProviders?.includes(AgencySwarmAdapter.PROVIDER_ID)) return false
   const selectedAgencySwarmModel = [input.argModel, input.configModel].some(
     (value) => value === `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`,
   )
@@ -57,6 +61,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         argModel: args.model,
         configModel: sync.data.config.model,
         configuredProviders: sync.data.config.provider,
+        enabledProviders: sync.data.config.enabled_providers,
+        disabledProviders: sync.data.config.disabled_providers,
       })
     }
 

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -36,7 +36,7 @@ export function isUsableModel(input: {
     (value) => value === `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`,
   )
   if (!selectedAgencySwarmModel) return false
-  return !!input.configuredProviders?.[AgencySwarmAdapter.PROVIDER_ID]
+  return true
 }
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1344,16 +1344,29 @@ export namespace Config {
           const deps: Promise<void>[] = []
 
           for (const dir of unique(directories)) {
+            let needsDependencies = dir === Flag.OPENCODE_CONFIG_DIR
+
             if (dir.endsWith(AgencyBrand.workspace) || dir === Flag.OPENCODE_CONFIG_DIR) {
               for (const file of AgencyBrand.configFiles) {
                 const source = path.join(dir, file)
                 log.debug(`loading config from ${source}`)
-                merge(source, yield* loadFile(source))
+                const next = yield* loadFile(source)
+                merge(source, next)
+                if (next.plugin?.length) needsDependencies = true
                 result.agent ??= {}
                 result.mode ??= {}
                 result.plugin ??= []
               }
             }
+
+            result.command = mergeDeep(result.command ?? {}, yield* Effect.promise(() => loadCommand(dir)))
+            result.agent = mergeDeep(result.agent, yield* Effect.promise(() => loadAgent(dir)))
+            result.agent = mergeDeep(result.agent, yield* Effect.promise(() => loadMode(dir)))
+            const list = yield* Effect.promise(() => loadPlugin(dir))
+            if (list.length) needsDependencies = true
+            track(dir, list)
+
+            if (!needsDependencies) continue
 
             const dep = iife(async () => {
               await installDependencies(dir)
@@ -1362,12 +1375,6 @@ export namespace Config {
               log.warn("background dependency install failed", { dir, error: err })
             })
             deps.push(dep)
-
-            result.command = mergeDeep(result.command ?? {}, yield* Effect.promise(() => loadCommand(dir)))
-            result.agent = mergeDeep(result.agent, yield* Effect.promise(() => loadAgent(dir)))
-            result.agent = mergeDeep(result.agent, yield* Effect.promise(() => loadMode(dir)))
-            const list = yield* Effect.promise(() => loadPlugin(dir))
-            track(dir, list)
           }
 
           if (process.env.OPENCODE_CONFIG_CONTENT) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1555,9 +1555,6 @@ export namespace Provider {
         const s = yield* InstanceState.get(state)
         const provider = s.providers[providerID]
         if (!provider) {
-          if (providerID === AgencySwarmAdapter.PROVIDER_ID && modelID === AgencySwarmAdapter.DEFAULT_MODEL_ID) {
-            return createAgencySwarmProvider().models[ModelID.make(AgencySwarmAdapter.DEFAULT_MODEL_ID)]
-          }
           const available = Object.keys(s.providers)
           const matches = fuzzysort.go(providerID, available, { limit: 3, threshold: -10000 })
           throw new ModelNotFoundError({ providerID, modelID, suggestions: matches.map((m) => m.target) })

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1299,6 +1299,18 @@ export namespace Provider {
             mergeProvider(providerID, partial)
           }
 
+          const agencySwarmProviderID = ProviderID.make(AgencySwarmAdapter.PROVIDER_ID)
+          const shouldLoadAgencySwarmProvider =
+            isProviderAllowed(agencySwarmProviderID) &&
+            !providers[agencySwarmProviderID] &&
+            (cfg.provider?.[AgencySwarmAdapter.PROVIDER_ID] !== undefined ||
+              auths[AgencySwarmAdapter.PROVIDER_ID] !== undefined ||
+              cfg.model === `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`)
+
+          if (shouldLoadAgencySwarmProvider) {
+            mergeProvider(agencySwarmProviderID, { source: "config" })
+          }
+
           const gitlab = ProviderID.make("gitlab")
           if (discoveryLoaders[gitlab] && providers[gitlab] && isProviderAllowed(gitlab)) {
             yield* Effect.promise(async () => {
@@ -1543,6 +1555,9 @@ export namespace Provider {
         const s = yield* InstanceState.get(state)
         const provider = s.providers[providerID]
         if (!provider) {
+          if (providerID === AgencySwarmAdapter.PROVIDER_ID && modelID === AgencySwarmAdapter.DEFAULT_MODEL_ID) {
+            return createAgencySwarmProvider().models[ModelID.make(AgencySwarmAdapter.DEFAULT_MODEL_ID)]
+          }
           const available = Object.keys(s.providers)
           const matches = fuzzysort.go(providerID, available, { limit: 3, threshold: -10000 })
           throw new ModelNotFoundError({ providerID, modelID, suggestions: matches.map((m) => m.target) })

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -4,7 +4,6 @@ import {
   readStringRecord,
 } from "@/agency-swarm/client-config"
 import { AgencySwarmHistory } from "@/agency-swarm/history"
-import { mapProviderIDToLiteLLMProvider } from "@/agency-swarm/litellm-provider"
 import { Auth } from "@/auth"
 import { Env } from "@/env"
 import { CODEX_API_BASE_URL, extractAccountId, refreshAccessToken } from "@/plugin/codex"
@@ -185,26 +184,22 @@ export namespace SessionAgencySwarm {
       allowStoredOpenAIOAuth: boolean
     },
   ): Promise<Record<string, unknown> | undefined> {
-    const litellmKeys: Record<string, string> = {}
     const payload: Record<string, unknown> = {}
 
+    // Keep automatic request-scoped auth limited to OpenAI. Local Agency Swarm
+    // backends already inherit process.env, and many do not accept LiteLLM config.
     for (const [providerID, provider] of Object.entries(providers ?? {})) {
       if (providerID === AgencySwarmAdapter.PROVIDER_ID) continue
+      if (providerID !== "openai") continue
       const key = getEnvCredential(provider, env)
       if (!key) continue
 
-      if (providerID === "openai") {
-        if (!options.skipOpenAI) payload["api_key"] = key
-        continue
-      }
-
-      const litellmProvider = mapProviderIDToLiteLLMProvider(providerID)
-      if (!litellmProvider) continue
-      litellmKeys[litellmProvider] = key
+      if (!options.skipOpenAI) payload["api_key"] = key
     }
 
     for (const [providerID, auth] of Object.entries(auths)) {
       if (providerID === AgencySwarmAdapter.PROVIDER_ID) continue
+      if (providerID !== "openai") continue
       if (hasEnvCredential(providerID, providers, env)) continue
 
       if (providerID === "openai" && auth.type === "oauth") {
@@ -221,18 +216,7 @@ export namespace SessionAgencySwarm {
 
       if (auth.type !== "api") continue
 
-      if (providerID === "openai") {
-        if (!options.skipOpenAI) payload["api_key"] = auth.key
-        continue
-      }
-
-      const litellmProvider = mapProviderIDToLiteLLMProvider(providerID)
-      if (!litellmProvider) continue
-      litellmKeys[litellmProvider] = auth.key
-    }
-
-    if (Object.keys(litellmKeys).length > 0) {
-      payload["litellm_keys"] = litellmKeys
+      if (!options.skipOpenAI) payload["api_key"] = auth.key
     }
 
     return Object.keys(payload).length > 0 ? payload : undefined

--- a/packages/opencode/test/cli/tui/local.test.ts
+++ b/packages/opencode/test/cli/tui/local.test.ts
@@ -74,6 +74,48 @@ describe("tui local model selection", () => {
     ).toBe(true)
   })
 
+  test("does not keep agency-swarm usable when disabled_providers filters it out", () => {
+    expect(
+      isUsableModel({
+        model: {
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        configModel: "agency-swarm/default",
+        disabledProviders: ["agency-swarm"],
+      }),
+    ).toBe(false)
+  })
+
+  test("does not keep agency-swarm usable when enabled_providers excludes it", () => {
+    expect(
+      isUsableModel({
+        model: {
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        argModel: "agency-swarm/default",
+        enabledProviders: ["openai"],
+      }),
+    ).toBe(false)
+  })
+
   test("does not treat unrelated missing models as usable", () => {
     expect(
       isUsableModel({

--- a/packages/opencode/test/cli/tui/local.test.ts
+++ b/packages/opencode/test/cli/tui/local.test.ts
@@ -54,6 +54,26 @@ describe("tui local model selection", () => {
     ).toBe(true)
   })
 
+  test("keeps explicit agency-swarm args.model usable before provider config loads", () => {
+    expect(
+      isUsableModel({
+        model: {
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        argModel: "agency-swarm/default",
+      }),
+    ).toBe(true)
+  })
+
   test("does not treat unrelated missing models as usable", () => {
     expect(
       isUsableModel({

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -858,6 +858,40 @@ test("installs dependencies in writable OPENCODE_CONFIG_DIR", async () => {
   }
 })
 
+test("skips installing dependencies for workspace dirs without config or plugins", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const workspaceDir = path.join(dir, AgencyBrand.workspace)
+      await fs.mkdir(path.join(workspaceDir, "skills", "requirement-ledger", "scripts"), { recursive: true })
+      await Filesystem.write(path.join(workspaceDir, ".gitignore"), "node_modules\n")
+      await Filesystem.write(path.join(workspaceDir, "skills", "requirement-ledger", "SKILL.md"), "# skill\n")
+      await Filesystem.write(
+        path.join(workspaceDir, "skills", "requirement-ledger", "scripts", "requirement_ledger.py"),
+        "print('ok')\n",
+      )
+    },
+  })
+
+  const install = spyOn(Npm, "install").mockImplementation(async () => {
+    throw new Error("workspace dependency install should not run")
+  })
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Config.get()
+        await Config.waitForDependencies()
+      },
+    })
+  } finally {
+    install.mockRestore()
+  }
+
+  expect(install).not.toHaveBeenCalled()
+})
+
 test("dedupes concurrent config dependency installs for the same dir", async () => {
   await using tmp = await tmpdir()
   const dir = path.join(tmp.path, "a")

--- a/packages/opencode/test/provider/agency-swarm-provider.test.ts
+++ b/packages/opencode/test/provider/agency-swarm-provider.test.ts
@@ -1,28 +1,66 @@
 import { expect, test } from "bun:test"
+import path from "node:path"
 import { Provider } from "../../src/provider/provider"
 import { Instance } from "../../src/project/instance"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { tmpdir } from "../fixture/fixture"
 
-test("Agency Swarm provider boots with the default model", async () => {
+test("Agency Swarm launch config keeps the default model addressable", async () => {
   await using tmp = await tmpdir({
-    config: {
-      enabled_providers: ["agency-swarm"],
-      provider: {
-        "agency-swarm": {},
-      },
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "agentswarm.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          model: "agency-swarm/default",
+          enabled_providers: ["agency-swarm"],
+          provider: {
+            "agency-swarm": {
+              options: {
+                baseURL: "http://127.0.0.1:8000",
+              },
+            },
+          },
+        }),
+      )
     },
   })
 
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
-      const provider = providers[ProviderID.make("agency-swarm")]
-      expect(provider).toBeDefined()
-      const model = provider?.models[ModelID.make("default")]
+      const selected = await Provider.defaultModel()
+      expect(String(selected.providerID)).toBe("agency-swarm")
+      expect(String(selected.modelID)).toBe("default")
+
+      const model = await Provider.getModel(selected.providerID, selected.modelID)
+      expect(String(model.providerID)).toBe("agency-swarm")
+      expect(String(model.id)).toBe("default")
+    },
+  })
+})
+
+test("Agency Swarm default model resolves when it is the active model without provider metadata", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "agentswarm.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          model: "agency-swarm/default",
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = await Provider.getModel(ProviderID.make("agency-swarm"), ModelID.make("default"))
+
       expect(model).toBeDefined()
-      expect(String(model?.id)).toBe("default")
+      expect(String(model.providerID)).toBe("agency-swarm")
+      expect(String(model.id)).toBe("default")
     },
   })
 })

--- a/packages/opencode/test/provider/agency-swarm-provider.test.ts
+++ b/packages/opencode/test/provider/agency-swarm-provider.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import path from "node:path"
+import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
 import { Provider } from "../../src/provider/provider"
 import { Instance } from "../../src/project/instance"
 import { ModelID, ProviderID } from "../../src/provider/schema"
@@ -40,7 +41,7 @@ test("Agency Swarm launch config keeps the default model addressable", async () 
   })
 })
 
-test("Agency Swarm default model resolves when it is the active model without provider metadata", async () => {
+test("Agency Swarm selected model bootstraps provider runtime state without explicit provider config", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -56,11 +57,54 @@ test("Agency Swarm default model resolves when it is the active model without pr
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const model = await Provider.getModel(ProviderID.make("agency-swarm"), ModelID.make("default"))
+      const selected = await Provider.defaultModel()
+      expect(String(selected.providerID)).toBe("agency-swarm")
+      expect(String(selected.modelID)).toBe("default")
+
+      const model = await Provider.getModel(selected.providerID, selected.modelID)
+      const provider = await Provider.getProvider(selected.providerID)
+      const language = await Provider.getLanguage(model)
 
       expect(model).toBeDefined()
       expect(String(model.providerID)).toBe("agency-swarm")
       expect(String(model.id)).toBe("default")
+      expect(provider).toBeDefined()
+      expect(provider?.options.baseURL).toBe(AgencySwarmAdapter.DEFAULT_BASE_URL)
+      expect(language).toBeDefined()
+    },
+  })
+})
+
+test("Agency Swarm default model fails cleanly when provider filters exclude it", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "agentswarm.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          model: "agency-swarm/default",
+          disabled_providers: ["agency-swarm"],
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const selected = await Provider.defaultModel()
+
+      expect(String(selected.providerID)).toBe("agency-swarm")
+      expect(String(selected.modelID)).toBe("default")
+
+      try {
+        await Provider.getModel(selected.providerID, selected.modelID)
+        expect.unreachable("expected Provider.getModel() to reject when agency-swarm is filtered out")
+      } catch (error: any) {
+        expect(error?.name).toBe("ProviderModelNotFoundError")
+        expect(error?.data?.providerID).toBe("agency-swarm")
+        expect(error?.data?.modelID).toBe("default")
+      }
     },
   })
 })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -203,7 +203,7 @@ describe("session.agency-swarm", () => {
     expect(options.token).toBe("auth-token")
   })
 
-  test("stream forwards stored API auth as request-scoped client_config", async () => {
+  test("stream preserves explicit client_config without auto-merging LiteLLM auth", async () => {
     mockHistory()
     Auth.all = (async () => ({
       openai: { type: "api", key: "sk-openai" } as any,
@@ -243,20 +243,11 @@ describe("session.agency-swarm", () => {
     }
 
     expect(captured).toEqual({
-      api_key: "manual-openai",
+      apiKey: "manual-openai",
       base_url: "https://proxy.example.com/v1",
       litellm_keys: {
-        amazon_nova: "nova-key",
         anthropic: "manual-ant",
-        bedrock: "bedrock-key",
-        friendliai: "friendli-key",
-        github: "github-models-key",
         groq: "manual-groq",
-        lm_studio: "lmstudio-key",
-        openrouter: "openrouter-key",
-        together_ai: "together-key",
-        vercel_ai_gateway: "vercel-key",
-        vertex_ai: "vertex-key",
       },
     })
   })
@@ -313,9 +304,6 @@ describe("session.agency-swarm", () => {
 
     expect(captured).toEqual({
       api_key: "sk-openai",
-      litellm_keys: {
-        anthropic: "sk-ant",
-      },
     })
   })
 
@@ -390,12 +378,100 @@ describe("session.agency-swarm", () => {
     }
   })
 
-  test("stream sends stored Anthropic API auth to a real local agency server", async () => {
+  test("stream keeps stored OpenAI auth working when an Anthropic env key exists", async () => {
     mockHistory()
-    await Auth.set("anthropic", {
-      type: "api",
-      key: "anthropic-live",
-    } as any)
+    Auth.all = (async () => ({
+      openai: { type: "api", key: "stored-openai" } as any,
+    })) as typeof Auth.all
+    Env.all = (() => ({
+      ANTHROPIC_API_KEY: "env-anthropic",
+    })) as typeof Env.all
+    Provider.list = (async () => ({
+      openai: {
+        id: "openai",
+        name: "OpenAI",
+        source: "api",
+        env: ["OPENAI_API_KEY"],
+        options: {},
+        models: {},
+      },
+      anthropic: {
+        id: "anthropic",
+        name: "Anthropic",
+        source: "api",
+        env: ["ANTHROPIC_API_KEY"],
+        options: {},
+        models: {},
+      },
+    })) as typeof Provider.list
+
+    let body: Record<string, unknown> | undefined
+    const server = createServer(async (request, response) => {
+      if (request.url !== "/builder/get_response_stream") {
+        response.writeHead(404)
+        response.end("not found")
+        return
+      }
+
+      const chunks: Buffer[] = []
+      for await (const chunk of request) {
+        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+        else chunks.push(Buffer.from(chunk))
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+      const clientConfig = body["client_config"] as Record<string, unknown> | undefined
+      if (clientConfig?.["litellm_keys"]) {
+        response.writeHead(422, {
+          "Content-Type": "application/json",
+        })
+        response.end(JSON.stringify({ detail: "litellm is not installed" }))
+        return
+      }
+
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+      })
+      response.end(
+        [
+          'data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"ok"}}}\n\n',
+          "event: end\ndata: [DONE]\n\n",
+        ].join(""),
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      server.close()
+      throw new Error("Expected local test server address")
+    }
+
+    try {
+      const { input } = helper()
+      input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      const stream = await SessionAgencySwarm.stream(input)
+      const text: string[] = []
+      for await (const event of stream.fullStream) {
+        if (event.type === "text-delta") text.push(event.text)
+      }
+
+      expect(text).toEqual(["ok"])
+      expect(body?.["client_config"]).toEqual({
+        api_key: "stored-openai",
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    }
+  })
+
+  test("stream sends explicit LiteLLM client_config to a real local agency server", async () => {
+    mockHistory()
 
     let body: Record<string, unknown> | undefined
     const server = createServer(async (request, response) => {
@@ -438,6 +514,11 @@ describe("session.agency-swarm", () => {
     try {
       const { input } = helper()
       input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      input.options.clientConfig = {
+        litellm_keys: {
+          anthropic: "manual-ant",
+        },
+      }
       const stream = await SessionAgencySwarm.stream(input)
       const text: string[] = []
       for await (const event of stream.fullStream) {
@@ -447,12 +528,11 @@ describe("session.agency-swarm", () => {
       expect(text).toEqual(["ok"])
       expect(body?.["client_config"]).toEqual({
         litellm_keys: {
-          anthropic: "anthropic-live",
+          anthropic: "manual-ant",
         },
       })
     } finally {
       await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
-      await Auth.remove("anthropic")
     }
   })
 
@@ -532,7 +612,7 @@ describe("session.agency-swarm", () => {
     }
   })
 
-  test("stream prefers env auth over stored auth for providers already covered by env", async () => {
+  test("stream prefers env OpenAI auth without auto-forwarding other providers", async () => {
     mockHistory()
     Auth.all = (async () => ({
       openai: { type: "api", key: "stored-openai" } as any,
@@ -602,11 +682,6 @@ describe("session.agency-swarm", () => {
 
     expect(captured).toEqual({
       api_key: "env-openai",
-      litellm_keys: {
-        anthropic: "stored-anthropic",
-        azure: "stored-azure",
-        gemini: "env-google",
-      },
     })
   })
 
@@ -711,7 +786,7 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream skips failing stored OpenAI OAuth refresh when other local credentials exist", async () => {
+  test("stream skips failing stored OpenAI OAuth refresh when only non-OpenAI local credentials remain", async () => {
     mockHistory()
     Auth.all = (async () => ({
       openai: {
@@ -736,11 +811,7 @@ describe("session.agency-swarm", () => {
       // consume
     }
 
-    expect(captured).toEqual({
-      litellm_keys: {
-        anthropic: "stored-anthropic",
-      },
-    })
+    expect(captured).toBeUndefined()
   })
 
   test("stream preserves explicit header-based OpenAI auth without merging stored OAuth", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #54

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This keeps `agency-swarm/default` usable through the startup path, respects provider filters in the TUI fallback path, and stops auto-forwarding loopback LiteLLM auth that breaks local Agency Swarm backends without LiteLLM installed.

### How did you verify your code works?

- focused Bun tests for `local.test.ts`, `agency-swarm-provider.test.ts`, and `agency-swarm.test.ts`
- local `typecheck`
- real local-backend QA on the branch head:
  - OpenAI-backed first send no longer hits `ProviderModelNotFoundError` or FastAPI `422`; it now reaches the backend and only fails on the current account quota
  - Anthropic-backed first send is blocked by missing LiteLLM in the local Agency Swarm backend environment, which is tracked separately

### Screenshots / recordings

- Not needed. This is a focused logic and request-shaping fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR