### PR TITLE
fix: surface browser-auth launch failures in agent swarm mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -253,7 +253,9 @@ export function DialogAuth() {
   )
   const providerIDs = frameworkMode()
     ? sync.data.provider_next.all
-        .filter((provider) => isSupportedAgencyAuthProvider(provider.id, provider, sync.data.provider_auth[provider.id] ?? []))
+        .filter((provider) =>
+          isSupportedAgencyAuthProvider(provider.id, provider, sync.data.provider_auth[provider.id] ?? []),
+        )
         .map((provider) => provider.id)
     : undefined
   const providerOptions = createDialogProviderOptionsWithFilter({ providerIDs })
@@ -280,7 +282,9 @@ export function DialogAuth() {
     ]
   })
 
-  return <DialogSelect title={frameworkMode() ? "Manage Agent Swarm auth" : "Manage provider auth"} options={options()} />
+  return (
+    <DialogSelect title={frameworkMode() ? "Manage Agent Swarm auth" : "Manage provider auth"} options={options()} />
+  )
 }
 
 type Option =
@@ -479,8 +483,9 @@ export function DialogAgencySwarmConnect() {
       localServers: remembered,
       discoveryTimeoutMs: current.discoveryTimeoutMs,
       agency: sameServer ? (readString(current.options["agency"]) ?? null) : null,
-      recipientAgent:
-        sameServer ? (readString(current.options["recipientAgent"]) ?? readString(current.options["recipient_agent"]) ?? null) : null,
+      recipientAgent: sameServer
+        ? (readString(current.options["recipientAgent"]) ?? readString(current.options["recipient_agent"]) ?? null)
+        : null,
     }
     if (!current.configToken) nextOptions["token"] = null
 
@@ -636,6 +641,38 @@ interface AutoMethodProps {
   title: string
   authorization: ProviderAuthAuthorization
 }
+
+function describeBrowserOpenFailure(error: unknown) {
+  const detail = toErrorMessage(error)
+  if (!detail) return "Could not open your default browser automatically. Open the link above to continue."
+  return `Could not open your default browser automatically. Open the link above to continue. ${detail}`
+}
+
+function watchBrowserOpen(url: string, onFailure: (message: string) => void) {
+  return open(url)
+    .then((subprocess) => {
+      let settled = false
+      const fail = (error: unknown) => {
+        if (settled) return
+        settled = true
+        onFailure(describeBrowserOpenFailure(error))
+      }
+      const timer = setTimeout(() => {
+        settled = true
+      }, 500)
+      subprocess.once?.("error", (error) => {
+        clearTimeout(timer)
+        fail(error)
+      })
+      subprocess.once?.("exit", (code) => {
+        if (code === null || code === 0) return
+        clearTimeout(timer)
+        fail(new Error(`Browser open failed with exit code ${code}`))
+      })
+    })
+    .catch((error) => onFailure(describeBrowserOpenFailure(error)))
+}
+
 function AutoMethod(props: AutoMethodProps) {
   const { theme } = useTheme()
   const sdk = useSDK()
@@ -662,7 +699,14 @@ function AutoMethod(props: AutoMethodProps) {
 
   onMount(async () => {
     if (frameworkMode()) {
-      void open(props.authorization.url).catch(() => undefined)
+      void watchBrowserOpen(props.authorization.url, (message) => {
+        setError(message)
+        toast.show({
+          variant: "warning",
+          message,
+          duration: 7000,
+        })
+      })
     }
     const result = await sdk.client.provider.oauth.callback({
       providerID: props.providerID,
@@ -716,9 +760,7 @@ function AutoMethod(props: AutoMethodProps) {
           ? "Your default browser should open. If it does not, use the link above."
           : "Finish sign-in in your browser, then wait here."}
       </text>
-      <Show when={error()}>
-        {(message) => <text fg={theme.error}>{message()}</text>}
-      </Show>
+      <Show when={error()}>{(message) => <text fg={theme.error}>{message()}</text>}</Show>
       <text fg={theme.text}>
         c <span style={{ fg: theme.textMuted }}>copy</span>
       </text>
@@ -789,9 +831,7 @@ function CodeMethod(props: CodeMethodProps) {
         <box gap={1}>
           <text fg={theme.textMuted}>{props.authorization.instructions}</text>
           <Link href={props.authorization.url} fg={theme.primary} />
-          <Show when={error()}>
-            {(message) => <text fg={theme.error}>{message()}</text>}
-          </Show>
+          <Show when={error()}>{(message) => <text fg={theme.error}>{message()}</text>}</Show>
         </box>
       )}
     />
@@ -823,8 +863,7 @@ function ApiMethod(props: ApiMethodProps) {
         opencode: (
           <box gap={1}>
             <text fg={theme.textMuted}>
-              OpenCode Zen gives you access to all the best coding models at the cheapest prices with a single API
-              key.
+              OpenCode Zen gives you access to all the best coding models at the cheapest prices with a single API key.
             </text>
             <text fg={theme.text}>
               Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> to get a key
@@ -847,9 +886,7 @@ function ApiMethod(props: ApiMethodProps) {
     return (
       <box gap={1}>
         {builtin}
-        <Show when={error()}>
-          {(message) => <text fg={theme.error}>{message()}</text>}
-        </Show>
+        <Show when={error()}>{(message) => <text fg={theme.error}>{message()}</text>}</Show>
       </box>
     )
   }

--- a/packages/opencode/test/cli/tui/dialog-provider-browser.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-provider-browser.test.tsx
@@ -1,0 +1,140 @@
+/** @jsxImportSource @opentui/solid */
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { RGBA } from "@opentui/core"
+import { testRender } from "@opentui/solid"
+import { EventEmitter } from "events"
+import * as DialogContext from "../../../src/cli/cmd/tui/ui/dialog"
+import * as LocalContext from "../../../src/cli/cmd/tui/context/local"
+import * as SDKContext from "../../../src/cli/cmd/tui/context/sdk"
+import * as SyncContext from "../../../src/cli/cmd/tui/context/sync"
+import * as ThemeContext from "../../../src/cli/cmd/tui/context/theme"
+import * as ToastModule from "../../../src/cli/cmd/tui/ui/toast"
+
+let openShouldFail = false
+let openCalledWith: string | undefined
+
+mock.module("open", () => ({
+  default: async (url: string) => {
+    openCalledWith = url
+    const subprocess = new EventEmitter()
+    if (openShouldFail) {
+      setTimeout(() => {
+        subprocess.emit("error", new Error("spawn open ENOENT"))
+      }, 10)
+    }
+    return subprocess
+  },
+}))
+
+const { createDialogProviderOptionsWithFilter } = await import("../../../src/cli/cmd/tui/component/dialog-provider")
+
+function flushEffects() {
+  return Promise.resolve().then(() => Promise.resolve())
+}
+
+describe("dialog provider browser auth", () => {
+  afterEach(() => {
+    mock.restore()
+    openShouldFail = false
+    openCalledWith = undefined
+  })
+
+  test("framework oauth warns when the default browser fails to open", async () => {
+    const toastMessages: Array<{ variant?: string; message?: string }> = []
+    let dialogContent: (() => any) | undefined
+    let options!: ReturnType<typeof createDialogProviderOptionsWithFilter>
+
+    spyOn(DialogContext, "useDialog").mockReturnValue({
+      replace: (next: () => any) => {
+        dialogContent = next
+      },
+      clear: () => {},
+    } as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({
+      client: {
+        provider: {
+          oauth: {
+            authorize: async () => ({
+              data: {
+                method: "auto",
+                url: "https://auth.example.com/authorize",
+                instructions: "Open the browser to continue",
+              },
+            }),
+            callback: async () => new Promise<never>(() => {}),
+          },
+        },
+      },
+    } as any)
+    spyOn(SyncContext, "useSync").mockReturnValue({
+      data: {
+        provider_next: {
+          all: [{ id: "openai", name: "OpenAI" }],
+          connected: [],
+        },
+        provider_auth: {
+          openai: [{ type: "oauth", label: "ChatGPT Pro/Plus (browser)" }],
+        },
+        provider: [],
+        console_state: {
+          consoleManagedProviders: [],
+        },
+        config: {
+          model: "agency-swarm/default",
+        },
+      },
+      bootstrap: async () => {},
+    } as any)
+    spyOn(LocalContext, "useLocal").mockReturnValue({
+      model: {
+        current: () => ({ providerID: "agency-swarm", modelID: "default" }),
+      },
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {
+        text: RGBA.fromHex("#ffffff"),
+        textMuted: RGBA.fromHex("#999999"),
+        primary: RGBA.fromHex("#00a3ff"),
+        error: RGBA.fromHex("#ff5555"),
+        success: RGBA.fromHex("#22c55e"),
+        warning: RGBA.fromHex("#f59e0b"),
+        secondary: RGBA.fromHex("#8b5cf6"),
+        accent: RGBA.fromHex("#14b8a6"),
+        info: RGBA.fromHex("#38bdf8"),
+      },
+    } as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: (input: { variant?: string; message?: string }) => {
+        toastMessages.push(input)
+      },
+      error: (error: Error) => {
+        toastMessages.push({
+          variant: "error",
+          message: error.message,
+        })
+      },
+      currentToast: null,
+    } as any)
+
+    const Capture = () => {
+      options = createDialogProviderOptionsWithFilter({ providerIDs: ["openai"] })
+      return <box />
+    }
+
+    await testRender(() => <Capture />)
+    openShouldFail = true
+
+    await options()[0].onSelect?.()
+
+    expect(dialogContent).toBeDefined()
+
+    await testRender(() => dialogContent!())
+    await flushEffects()
+    await Bun.sleep(25)
+
+    expect(openCalledWith).toBe("https://auth.example.com/authorize")
+
+    const warningToast = toastMessages.find((item) => item.variant === "warning")
+    expect(warningToast?.message).toContain("Could not open your default browser")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #56

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This stops Agent Swarm browser OAuth from failing silently when the default browser cannot be launched. The dialog now watches the browser-open subprocess, surfaces launch errors directly in the TUI, and shows a warning toast instead of appearing to do nothing.

### How did you verify your code works?

- `bun test ./test/cli/tui/dialog-provider-browser.test.tsx` (fails before the fix on simulated browser-launch failure)
- `bun test ./test/cli/tui/dialog-provider.test.ts ./test/cli/tui/dialog-provider-browser.test.tsx`
- `bun run typecheck`

### Screenshots / recordings

- Not needed. This is a focused failure-handling fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
