### PR TITLE
fix: preserve caller agent in compacted agency history

### DIFF
--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1,8 +1,5 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
-import {
-  hasExplicitOpenAIClientConfig,
-  readStringRecord,
-} from "@/agency-swarm/client-config"
+import { hasExplicitOpenAIClientConfig, readStringRecord } from "@/agency-swarm/client-config"
 import { AgencySwarmHistory } from "@/agency-swarm/history"
 import { Auth } from "@/auth"
 import { Env } from "@/env"
@@ -115,16 +112,10 @@ export namespace SessionAgencySwarm {
     const explicit = asRecord(config)
     const explicitUpstreamBaseURL = readConfiguredBaseURL(explicit)
     const generated = isLoopbackBaseURL(baseURL)
-      ? await buildAuthClientConfig(
-          await Auth.all(),
-          await listProvidersForEnvCheck(),
-          getEnvForClientConfig(),
-          {
-            skipOpenAI: hasExplicitOpenAIClientConfig(config),
-            allowStoredOpenAIOAuth:
-              !explicitUpstreamBaseURL || isCodexAPIBaseURL(explicitUpstreamBaseURL),
-          },
-        )
+      ? await buildAuthClientConfig(await Auth.all(), await listProvidersForEnvCheck(), getEnvForClientConfig(), {
+          skipOpenAI: hasExplicitOpenAIClientConfig(config),
+          allowStoredOpenAIOAuth: !explicitUpstreamBaseURL || isCodexAPIBaseURL(explicitUpstreamBaseURL),
+        })
       : undefined
     if (!config) return generated
     if (!generated) return config
@@ -1750,11 +1741,23 @@ export namespace SessionAgencySwarm {
           role: "assistant",
           content: [{ type: "output_text", text }],
           agent: msg.info.agent,
-          callerAgent: null,
+          callerAgent: extractCallerAgent(msg),
           timestamp: msg.info.time.created,
         },
       ]
     })
+  }
+
+  function extractCallerAgent(msg: MessageV2.WithParts): string | null {
+    for (let i = msg.parts.length - 1; i >= 0; i--) {
+      const part = msg.parts[i]
+      if (part.type !== "text" && part.type !== "reasoning") continue
+      const metadata = asRecord(part.metadata)
+      if (!metadata || !Object.prototype.hasOwnProperty.call(metadata, "callerAgent")) continue
+      if (metadata["callerAgent"] === null) return null
+      return normalizeCallerAgentValue(asString(metadata["callerAgent"])) ?? null
+    }
+    return null
   }
 
   function isAgencySwarmMessage(msg: MessageV2.WithParts) {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1292,6 +1292,116 @@ describe("session.agency-swarm", () => {
     ])
   })
 
+  test("compactHistory preserves assistant caller agent metadata", () => {
+    const msgs = [
+      {
+        info: {
+          id: "compact_user",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 1 },
+        },
+        parts: [{ type: "compaction", auto: true, overflow: true }],
+      },
+      {
+        info: {
+          id: "summary",
+          role: "assistant",
+          parentID: "compact_user",
+          providerID: "agency-swarm",
+          modelID: "default",
+          mode: "Default",
+          agent: "Planner",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          summary: true,
+          finish: "end_turn",
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: { created: 2 },
+          sessionID: "session_1",
+        },
+        parts: [{ type: "text", text: "summary body", metadata: { agent: "Planner", callerAgent: null } }],
+      },
+      {
+        info: {
+          id: "user_2",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 3 },
+        },
+        parts: [{ type: "text", text: "next question", ignored: false }],
+      },
+      {
+        info: {
+          id: "assistant_2",
+          role: "assistant",
+          parentID: "user_2",
+          providerID: "agency-swarm",
+          modelID: "default",
+          mode: "Default",
+          agent: "Reviewer",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: { created: 4 },
+          sessionID: "session_1",
+        },
+        parts: [{ type: "text", text: "next answer", metadata: { agent: "Reviewer", callerAgent: "Planner" } }],
+      },
+      {
+        info: {
+          id: "current",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 5 },
+        },
+        parts: [{ type: "text", text: "current prompt", ignored: false }],
+      },
+    ] as any
+
+    expect(SessionAgencySwarm.compactHistory({ msgs, currentID: "current" })).toEqual([
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "summary body" }],
+        agent: "Planner",
+        callerAgent: null,
+        timestamp: 2,
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "next question" }],
+        agent: "build",
+        callerAgent: null,
+        timestamp: 3,
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "next answer" }],
+        agent: "Reviewer",
+        callerAgent: "Planner",
+        timestamp: 4,
+      },
+    ])
+  })
+
   test("compactHistory falls back when no compaction summary exists", () => {
     const msgs = [
       {


### PR DESCRIPTION
### Issue for this PR

Closes #58

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reopened compacted Agent Swarm sessions were restoring the visible transcript but dropping assistant `callerAgent` metadata when rebuilding compacted history. That flattened the backend history and could lose handoff memory after close/reopen.

This change keeps `callerAgent` from the stored message-part metadata instead of hardcoding it to `null`, and adds a regression test for the reopened-session case where a `Reviewer` reply must keep `callerAgent: "Planner"`.

### How did you verify your code works?

- reproduced the bug with a focused test on latest `origin/dev`; before the fix it failed because `callerAgent` came back `null`
- `bun test test/session/agency-swarm.test.ts --timeout 30000 --test-name-pattern "compactHistory"`
- `bun test test/session/agency-swarm.test.ts --timeout 30000`
- `bun test test/agency-swarm/history.test.ts --timeout 30000`
- `bun run typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
