### PR TITLE
fix: tighten agent swarm startup auth flow

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -13,7 +13,6 @@ import {
   onMount,
   batch,
   Show,
-  on,
   onCleanup,
 } from "solid-js"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
@@ -450,27 +449,21 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     })
   })
 
-  createEffect(
-    on(
-      () => {
-        return (
-          sync.status === "complete" &&
-          shouldOpenStartupAuthDialog({
-            providers: sync.data.provider,
-            providerAuth: sync.data.provider_auth,
-            frameworkMode: isAgencySwarmFrameworkMode({
-              currentProviderID: local.model.current()?.providerID,
-              configuredModel: sync.data.config.model,
-            }),
-          })
-        )
-      },
-      (needsAuth, previouslyNeededAuth) => {
-        if (!needsAuth || previouslyNeededAuth) return
-        dialog.replace(() => <DialogAuth />)
-      },
-    ),
-  )
+  createEffect(() => {
+    const needsAuth =
+      sync.status === "complete" &&
+      shouldOpenStartupAuthDialog({
+        providers: sync.data.provider,
+        providerAuth: sync.data.provider_auth,
+        frameworkMode: isAgencySwarmFrameworkMode({
+          currentProviderID: local.model.current()?.providerID,
+          configuredModel: sync.data.config.model,
+        }),
+      })
+
+    if (!needsAuth || dialog.stack.length > 0) return
+    dialog.replace(() => <DialogAuth />)
+  })
 
   const connected = useConnected()
   const frameworkMode = createMemo(() =>

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,5 +1,4 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
-import { mapProviderIDToLiteLLMProvider } from "@/agency-swarm/litellm-provider"
 import { hasClientConfigCredential } from "@/agency-swarm/client-config"
 import { hasStoredProviderCredential } from "@tui/util/provider-auth"
 import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
@@ -51,11 +50,6 @@ function hasConfiguredAPIStyleCredential(provider: AuthProvider | undefined) {
   )
 }
 
-function hasAPIStyleEnv(provider: AuthProvider | undefined) {
-  if (!provider) return false
-  return provider.env.some((name) => /(^|_)(API_KEY|API_TOKEN|PAT|TOKEN)$/.test(name))
-}
-
 function isLoopbackBaseURL(baseURL: string) {
   try {
     const parsed = new URL(baseURL)
@@ -80,13 +74,10 @@ function usesLocalAgencyProviderAuth(providers: Provider[]) {
 
 export function isSupportedAgencyAuthProvider(
   providerID: string,
-  provider?: AuthProvider,
-  methods: ProviderAuthMethod[] = [],
+  _provider?: AuthProvider,
+  _methods: ProviderAuthMethod[] = [],
 ) {
-  if ((AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS as readonly string[]).includes(providerID)) return true
-  if (mapProviderIDToLiteLLMProvider(providerID) === undefined) return false
-  if (methods.some((method) => method.type === "api")) return true
-  return hasAPIStyleEnv(provider) || hasConfiguredAPIStyleCredential(provider)
+  return (AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS as readonly string[]).includes(providerID)
 }
 
 function isAgencyProviderCredentialFailure(message: string) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -218,6 +218,7 @@ export namespace SessionPrompt {
           ? yield* provider.getModel(ag.model.providerID, ag.model.modelID)
           : ((yield* provider.getSmallModel(input.providerID)) ??
             (yield* provider.getModel(input.providerID, input.modelID)))
+        if (!ag.model && mdl.providerID === SessionAgencySwarm.PROVIDER_ID) return
         const msgs = onlySubtasks
           ? [{ role: "user" as const, content: subtasks.map((p) => p.prompt).join("\n") }]
           : yield* MessageV2.toModelMessagesEffect(context, mdl)

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -5,6 +5,7 @@ import {
   shouldBlockAgencyPromptSend,
   shouldOpenAgencyAuthDialog,
   hasUsableProvider,
+  isSupportedAgencyAuthProvider,
   isAgencySwarmFrameworkMode,
   shouldOpenAgencyConnectDialog,
   shouldOpenStartupAuthDialog,
@@ -567,7 +568,7 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
-  test("framework mode skips auth when another LiteLLM-compatible provider is credentialed", () => {
+  test("framework mode still opens auth when only a non-primary provider is credentialed", () => {
     expect(
       shouldOpenStartupAuthDialog({
         frameworkMode: true,
@@ -591,7 +592,14 @@ describe("agency session errors", () => {
           },
         ],
       }),
-    ).toBe(false)
+    ).toBe(true)
+  })
+
+  test("framework auth only supports openai and anthropic", () => {
+    expect(isSupportedAgencyAuthProvider("openai")).toBe(true)
+    expect(isSupportedAgencyAuthProvider("anthropic")).toBe(true)
+    expect(isSupportedAgencyAuthProvider("google")).toBe(false)
+    expect(isSupportedAgencyAuthProvider("github-copilot")).toBe(false)
   })
 
   test("framework mode still opens auth when a LiteLLM provider only has oauth methods", () => {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -5,9 +5,11 @@ import { fileURLToPath } from "url"
 import { Instance } from "../../src/project/instance"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session"
+import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
 import { Log } from "../../src/util/log"
+import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
 import { tmpdir } from "../fixture/fixture"
 
 Log.init({ print: false })
@@ -227,6 +229,75 @@ describe("session.prompt special characters", () => {
 })
 
 describe("session.prompt regression", () => {
+  test("skips fallback title generation for agency-swarm sessions", async () => {
+    const originalStreamRun = AgencySwarmAdapter.streamRun
+    const originalLLMStream = LLM.stream
+    const titleProviders: string[] = []
+
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "messages",
+        payload: {
+          run_id: "run_1",
+          new_messages: [
+            {
+              type: "message",
+              id: "msg_1",
+              content: [{ type: "output_text", text: "agency answer" }],
+            },
+          ],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    LLM.stream = (async (input) => {
+      titleProviders.push(String(input.model.providerID))
+      return { text: "unexpected title" } as unknown as Awaited<ReturnType<typeof LLM.stream>>
+    }) as typeof LLM.stream
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        config: {
+          model: "agency-swarm/default",
+          enabled_providers: ["agency-swarm"],
+          provider: {
+            "agency-swarm": {
+              options: {
+                baseURL: "http://127.0.0.1:8000",
+                agency: "builder",
+              },
+            },
+          },
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({})
+          const result = await SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: "build",
+            parts: [{ type: "text", text: "hello" }],
+          })
+
+          expect(result.info.role).toBe("assistant")
+          const messages = await Session.messages({ sessionID: session.id })
+          expect(messages.filter((message) => message.info.role === "assistant")).toHaveLength(1)
+
+          await new Promise((resolve) => setTimeout(resolve, 100))
+
+          expect(titleProviders).not.toContain(AgencySwarmAdapter.PROVIDER_ID)
+        },
+      })
+    } finally {
+      AgencySwarmAdapter.streamRun = originalStreamRun
+      LLM.stream = originalLLMStream
+    }
+  })
+
   test("does not loop empty assistant turns for a simple reply", async () => {
     let calls = 0
     const server = Bun.serve({


### PR DESCRIPTION
### Issue for this PR

Closes #61

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This tightens connected Agent Swarm startup in the installed CLI.

- startup auth now shows only the supported providers: OpenAI and Anthropic
- startup auth stays blocking while credentials are still missing
- implicit local title generation now skips the broken `agency-swarm/default` fallback instead of hitting the wrong `/chat/completions` transport on the local FastAPI backend

The fix is intentionally small and fork-contained. It does not change the main Agency Swarm response path, and it does not change explicit title-model overrides.

### How did you verify your code works?

- focused Bun regressions for `session-error` and `prompt`
- local typecheck
- Claude Opus 4.7 diff review with no findings
- real installed TTY QA against a local Agency Swarm project for OpenAI env-backed send, Anthropic env-backed send, and no-auth startup gating

### Screenshots / recordings

Not needed. This is a focused startup/auth logic fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR