### PR TITLE
fix: user msg duplication on tool use

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1375,11 +1375,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // Some providers return "stop" even when the assistant message contains tool calls.
             // Keep the loop running so tool results can be sent back to the model.
             const hasToolCalls = lastAssistantMsg?.parts.some((part) => part.type === "tool") ?? false
+            const isAgencySwarm = lastAssistant?.providerID === SessionAgencySwarm.PROVIDER_ID
 
             if (
               lastAssistant?.finish &&
               !["tool-calls"].includes(lastAssistant.finish) &&
-              !hasToolCalls &&
+              (!hasToolCalls || isAgencySwarm) &&
               lastUser.id < lastAssistant.id
             ) {
               log.info("exiting loop", { sessionID })


### PR DESCRIPTION
### Issue for this PR

Closes #63

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes an issue where, after an assistant response that included tool output, the CLI would incorrectly treat the turn as “not finished” and run the session loop again. That extra iteration re-issued the same user prompt to the agency-swarm backend, which looked like the user’s previous input was duplicated and sent again.

The fix makes the loop-exit logic aware of the agency-swarm provider: for this provider, the presence of tool parts in the last assistant message should not prevent exiting the loop when the assistant turn is otherwise finished. This prevents the unintended follow-up request and stops the duplicate prompt behavior.

### How did you verify your code works?

Built the Windows x64 executable and manually verified that bug is gone in the TUI

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
