### PR TITLE
fix(history): recover local agency memory across port changes

### DIFF
--- a/packages/opencode/src/agency-swarm/history.ts
+++ b/packages/opencode/src/agency-swarm/history.ts
@@ -3,6 +3,8 @@ import { Global } from "@/global"
 import path from "path"
 import { AgencySwarmAdapter } from "./adapter"
 
+const LOCAL_AGENCY_ID = "local-agency"
+
 export namespace AgencySwarmHistory {
   export type Scope = {
     baseURL: string
@@ -20,14 +22,18 @@ export namespace AgencySwarmHistory {
   export async function load(scope: Scope): Promise<Entry> {
     const key = storageKey(scope)
     const expectedScope = scopeKey(scope)
-    const current = normalize(
-      await Storage.read<Entry>(key).catch((error) => {
-        if (Storage.NotFoundError.isInstance(error)) return undefined
-        throw error
-      }),
-      expectedScope,
-    )
+    const current = normalize(await readEntry(key), expectedScope)
     if (current) return current
+
+    const recovered = await loadRecoveredLocalLoopback(scope)
+    if (recovered) {
+      const migrated = {
+        ...recovered,
+        scope: expectedScope,
+      } satisfies Entry
+      await save(scope, migrated)
+      return migrated
+    }
 
     const legacy = normalize(await loadLegacy(scope), expectedScope)
     if (!legacy) return empty(expectedScope)
@@ -74,6 +80,13 @@ export namespace AgencySwarmHistory {
     await Storage.write<Entry>(storageKey(scope), entry)
   }
 
+  async function readEntry(key: string[]) {
+    return Storage.read<Entry>(key).catch((error) => {
+      if (Storage.NotFoundError.isInstance(error)) return undefined
+      throw error
+    })
+  }
+
   function storageKey(scope: Scope): string[] {
     const scopedKey = scopeKey(scope)
     const hash = Bun.hash.xxHash32(scopedKey).toString(16).padStart(8, "0")
@@ -82,7 +95,9 @@ export namespace AgencySwarmHistory {
 
   function asHistory(input: unknown): Array<Record<string, unknown>> {
     if (!Array.isArray(input)) return []
-    return input.filter((item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item))
+    return input.filter(
+      (item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item),
+    )
   }
 
   async function loadLegacy(scope: Scope): Promise<Entry | undefined> {
@@ -97,13 +112,61 @@ export namespace AgencySwarmHistory {
     return path.join(path.dirname(Global.Path.data), "opencode", "storage", ...storageKey(scope)) + ".json"
   }
 
-  function normalize(existing: Entry | undefined, expectedScope: string): Entry | undefined {
-    if (!existing || existing.scope !== expectedScope) return
+  async function loadRecoveredLocalLoopback(scope: Scope): Promise<Entry | undefined> {
+    if (scope.agency !== LOCAL_AGENCY_ID || !isLoopbackBaseURL(scope.baseURL)) return
+
+    const keys = await Storage.list(["agency_swarm_history"]).catch(() => [] as string[][])
+    let newest: Entry | undefined
+
+    for (const key of keys) {
+      const existing = normalize(await readEntry(key))
+      const parsed = parseScope(existing?.scope)
+      if (!existing || !parsed) continue
+      if (parsed.sessionID !== scope.sessionID || parsed.agency !== scope.agency) continue
+      if (!isLoopbackBaseURL(parsed.baseURL)) continue
+      if (!newest || existing.updated_at > newest.updated_at) {
+        newest = existing
+      }
+    }
+
+    return newest
+  }
+
+  function normalize(existing: Entry | undefined, expectedScope?: string): Entry | undefined {
+    if (!existing) return
+    if (expectedScope && existing.scope !== expectedScope) return
     return {
       scope: existing.scope,
       chat_history: asHistory(existing.chat_history),
       last_run_id: typeof existing.last_run_id === "string" && existing.last_run_id ? existing.last_run_id : undefined,
       updated_at: typeof existing.updated_at === "number" ? existing.updated_at : Date.now(),
+    }
+  }
+
+  function parseScope(scope: string | undefined) {
+    if (!scope) return
+    const parts = scope.split("|")
+    const sessionID = parts.at(-1)
+    const agency = parts.at(-2)
+    if (!sessionID || !agency || parts.length < 3) return
+    return {
+      baseURL: parts.slice(0, -2).join("|"),
+      agency,
+      sessionID,
+    }
+  }
+
+  function isLoopbackBaseURL(baseURL: string) {
+    try {
+      const parsed = new URL(baseURL)
+      return (
+        parsed.hostname === "127.0.0.1" ||
+        parsed.hostname === "0.0.0.0" ||
+        parsed.hostname === "localhost" ||
+        parsed.hostname === "::1"
+      )
+    } catch {
+      return false
     }
   }
 }

--- a/packages/opencode/src/agency-swarm/history.ts
+++ b/packages/opencode/src/agency-swarm/history.ts
@@ -3,8 +3,6 @@ import { Global } from "@/global"
 import path from "path"
 import { AgencySwarmAdapter } from "./adapter"
 
-const LOCAL_AGENCY_ID = "local-agency"
-
 export namespace AgencySwarmHistory {
   export type Scope = {
     baseURL: string
@@ -25,7 +23,7 @@ export namespace AgencySwarmHistory {
     const current = normalize(await readEntry(key), expectedScope)
     if (current) return current
 
-    const recovered = await loadRecoveredLocalLoopback(scope)
+    const recovered = await loadRecoveredLoopback(scope)
     if (recovered) {
       const migrated = {
         ...recovered,
@@ -112,8 +110,8 @@ export namespace AgencySwarmHistory {
     return path.join(path.dirname(Global.Path.data), "opencode", "storage", ...storageKey(scope)) + ".json"
   }
 
-  async function loadRecoveredLocalLoopback(scope: Scope): Promise<Entry | undefined> {
-    if (scope.agency !== LOCAL_AGENCY_ID || !isLoopbackBaseURL(scope.baseURL)) return
+  async function loadRecoveredLoopback(scope: Scope): Promise<Entry | undefined> {
+    if (!isLoopbackBaseURL(scope.baseURL)) return
 
     const keys = await Storage.list(["agency_swarm_history"]).catch(() => [] as string[][])
     let newest: Entry | undefined

--- a/packages/opencode/test/agency-swarm/history.test.ts
+++ b/packages/opencode/test/agency-swarm/history.test.ts
@@ -4,11 +4,13 @@ import { Storage } from "../../src/storage/storage"
 
 const originalRead = Storage.read
 const originalWrite = Storage.write
+const originalList = Storage.list
 const originalFile = Bun.file
 
 afterEach(() => {
   Storage.read = originalRead
   Storage.write = originalWrite
+  Storage.list = originalList
   Bun.file = originalFile
 })
 
@@ -51,6 +53,94 @@ test("load falls back to legacy opencode storage and migrates entry", async () =
   expect(writes).toEqual([
     {
       key: ["agency_swarm_history", hash],
+      content: entry,
+    },
+  ])
+})
+
+test("load recovers latest local-agency loopback history across baseURL port changes", async () => {
+  const scope = {
+    baseURL: "http://127.0.0.1:8124",
+    agency: "local-agency",
+    sessionID: "session_1",
+  }
+  const previousScope = {
+    baseURL: "http://127.0.0.1:8123",
+    agency: "local-agency",
+    sessionID: "session_1",
+  }
+  const ignoredRemoteScope = {
+    baseURL: "https://remote.example.com",
+    agency: "local-agency",
+    sessionID: "session_1",
+  }
+  const ignoredAgencyScope = {
+    baseURL: "http://127.0.0.1:9000",
+    agency: "builder",
+    sessionID: "session_1",
+  }
+  const currentHash = Bun.hash.xxHash32(AgencySwarmHistory.scopeKey(scope)).toString(16).padStart(8, "0")
+  const previousHash = Bun.hash.xxHash32(AgencySwarmHistory.scopeKey(previousScope)).toString(16).padStart(8, "0")
+  const ignoredRemoteHash = Bun.hash
+    .xxHash32(AgencySwarmHistory.scopeKey(ignoredRemoteScope))
+    .toString(16)
+    .padStart(8, "0")
+  const ignoredAgencyHash = Bun.hash
+    .xxHash32(AgencySwarmHistory.scopeKey(ignoredAgencyScope))
+    .toString(16)
+    .padStart(8, "0")
+  const writes: Array<{ key: string[]; content: unknown }> = []
+
+  Storage.list = (async () => [
+    ["agency_swarm_history", previousHash],
+    ["agency_swarm_history", ignoredRemoteHash],
+    ["agency_swarm_history", ignoredAgencyHash],
+  ]) as typeof Storage.list
+  Storage.read = (async (key) => {
+    const hash = key.at(-1)
+    if (hash === currentHash) throw new Storage.NotFoundError({ message: "missing" })
+    if (hash === previousHash) {
+      return {
+        scope: AgencySwarmHistory.scopeKey(previousScope),
+        chat_history: [{ type: "message", role: "assistant", content: "kept" }],
+        last_run_id: "run_1",
+        updated_at: 123,
+      }
+    }
+    if (hash === ignoredRemoteHash) {
+      return {
+        scope: AgencySwarmHistory.scopeKey(ignoredRemoteScope),
+        chat_history: [{ type: "message", role: "assistant", content: "ignored remote" }],
+        updated_at: 999,
+      }
+    }
+    if (hash === ignoredAgencyHash) {
+      return {
+        scope: AgencySwarmHistory.scopeKey(ignoredAgencyScope),
+        chat_history: [{ type: "message", role: "assistant", content: "ignored agency" }],
+        updated_at: 998,
+      }
+    }
+    throw new Storage.NotFoundError({ message: "missing" })
+  }) as typeof Storage.read
+  Storage.write = (async (key, content) => {
+    writes.push({ key, content })
+  }) as typeof Storage.write
+  Bun.file = (() => ({
+    json: async () => undefined,
+  })) as unknown as typeof Bun.file
+
+  const entry = await AgencySwarmHistory.load(scope)
+
+  expect(entry).toEqual({
+    scope: AgencySwarmHistory.scopeKey(scope),
+    chat_history: [{ type: "message", role: "assistant", content: "kept" }],
+    last_run_id: "run_1",
+    updated_at: 123,
+  })
+  expect(writes).toEqual([
+    {
+      key: ["agency_swarm_history", currentHash],
       content: entry,
     },
   ])

--- a/packages/opencode/test/agency-swarm/history.test.ts
+++ b/packages/opencode/test/agency-swarm/history.test.ts
@@ -58,20 +58,20 @@ test("load falls back to legacy opencode storage and migrates entry", async () =
   ])
 })
 
-test("load recovers latest local-agency loopback history across baseURL port changes", async () => {
+test("load recovers latest loopback history across baseURL port changes for the same local agency", async () => {
   const scope = {
     baseURL: "http://127.0.0.1:8124",
-    agency: "local-agency",
+    agency: "QAAgency",
     sessionID: "session_1",
   }
   const previousScope = {
     baseURL: "http://127.0.0.1:8123",
-    agency: "local-agency",
+    agency: "QAAgency",
     sessionID: "session_1",
   }
   const ignoredRemoteScope = {
     baseURL: "https://remote.example.com",
-    agency: "local-agency",
+    agency: "QAAgency",
     sessionID: "session_1",
   }
   const ignoredAgencyScope = {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, spyOn, test } from "bun:test"
 import { createServer } from "node:http"
 import type { AddressInfo } from "node:net"
 import { Auth } from "../../src/auth"
@@ -1625,6 +1625,88 @@ describe("session.agency-swarm", () => {
     }
 
     expect(sentRecipient).toBe("MathAgent")
+  })
+
+  test("stream reuses stored history when compactHistory falls back", async () => {
+    const storedHistory = [{ type: "message", role: "assistant", content: "kept memory" }]
+    const mixedProviderMessages = [
+      {
+        info: {
+          id: "user_1",
+          role: "user",
+          agent: "build",
+          model: { providerID: "openai", modelID: "gpt-5" },
+          time: { created: 1 },
+        },
+        parts: [{ type: "text", text: "first question", ignored: false }],
+      },
+      {
+        info: {
+          id: "assistant_1",
+          role: "assistant",
+          parentID: "user_1",
+          providerID: "openai",
+          modelID: "gpt-5",
+          mode: "Default",
+          agent: "Assistant",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: { created: 2 },
+          sessionID: "session_1",
+        },
+        parts: [{ type: "text", text: "first answer" }],
+      },
+      {
+        info: {
+          id: "message_user_1",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 3 },
+        },
+        parts: [{ type: "text", text: "current prompt", ignored: false }],
+      },
+    ] as any
+
+    let sentHistory: unknown
+    AgencySwarmHistory.load = (async () => ({
+      scope: "http://127.0.0.1:8000|builder|session_1",
+      chat_history: storedHistory as any,
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.load
+    AgencySwarmHistory.appendMessages = (async () => ({
+      scope: "scope",
+      chat_history: [],
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.appendMessages
+    AgencySwarmHistory.setLastRunID = (async () => ({
+      scope: "scope",
+      chat_history: [],
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.setLastRunID
+    AgencySwarmAdapter.streamRun = async function* (args) {
+      sentHistory = args.chatHistory
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const messagesSpy = spyOn(Session, "messages").mockResolvedValue(mixedProviderMessages)
+    try {
+      const { input } = helper()
+      const stream = await SessionAgencySwarm.stream(input)
+      for await (const _ of stream.fullStream) {
+      }
+    } finally {
+      messagesSpy.mockRestore()
+    }
+
+    expect(sentHistory).toEqual(storedHistory)
   })
 
   test("stream persists handed off recipient from session history", async () => {


### PR DESCRIPTION
### Issue for this PR

No matching repo issue exists yet for this reopen-memory bug. This PR still needs a real linked issue before merge.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes Agency Swarm session memory loss after a local backend reopen changes the loopback port. The original history recovery only worked when the agency id was exactly `local-agency`, but real local runs use the actual agency name, so resumed sessions still lost the stored backend history. The fix broadens loopback recovery to any local agency with the same session id and agency name, then migrates the recovered history to the current scope key so later resumes use the fresh entry directly.

### How did you verify your code works?

- `bun test test/agency-swarm/history.test.ts test/session/agency-swarm.test.ts`
- `bun typecheck`
- Rebuilt the linked CLI locally and ran an installed-from-source proof:
  - first run on `http://127.0.0.1:55220` stored `"Remember the magic word is saffron."`
  - reopened the same CLI session with `-c` against `http://127.0.0.1:55221`
  - the resumed turn answered `saffron`
  - the new `agency_swarm_history` scope file contained both turns after migration

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
