### PR TITLE
fix(cli): don't treat bridge stderr warnings as fatal startup errors

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -669,13 +669,18 @@ async function waitForServer(input: {
   child: ReturnType<typeof Bun.spawn>
   stderrPromise: Promise<string>
 }) {
-  const deadline = Date.now() + 15000
+  const deadline = Date.now() + 30000
   const metadataURL = `${input.baseURL}/${LOCAL_AGENCY_ID}/get_metadata`
   while (Date.now() < deadline) {
     const exited = await Promise.race([input.child.exited.then((code: number) => code), sleep(200).then(() => null)])
     if (typeof exited === "number") {
       const stderr = await input.stderrPromise
-      throw new Error(stderr.trim() || `Agency Swarm server exited with code ${exited}`)
+      const summary = summarizeBridgeStderr(stderr)
+      throw new Error(
+        summary
+          ? `Agency Swarm server exited with code ${exited}: ${summary}`
+          : `Agency Swarm server exited with code ${exited}`,
+      )
     }
 
     try {
@@ -688,7 +693,20 @@ async function waitForServer(input: {
 
   input.child.kill()
   const stderr = await input.stderrPromise
-  throw new Error(stderr.trim() || "Timed out waiting for the Agency Swarm server to start")
+  const summary = summarizeBridgeStderr(stderr)
+  throw new Error(
+    summary
+      ? `Timed out waiting for the Agency Swarm server to start. Last bridge output: ${summary}`
+      : "Timed out waiting for the Agency Swarm server to start",
+  )
+}
+
+export function summarizeBridgeStderr(stderr: string): string {
+  const trimmed = stderr.trim()
+  if (!trimmed) return ""
+  const lines = trimmed.split(/\r?\n/).filter((line) => line.trim().length > 0)
+  const tail = lines.slice(-5).join(" | ")
+  return tail.length > 500 ? `${tail.slice(0, 500)}...` : tail
 }
 
 async function hasGitHubTemplateFlow() {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -11,6 +11,7 @@ import {
   prepareProjectLaunch,
   resolveNpxAutoProject,
   shouldRunNpxOnboarding,
+  summarizeBridgeStderr,
   validateStarterName,
 } from "../../src/agency-swarm/npx"
 import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
@@ -753,6 +754,28 @@ describe("agency-swarm npx onboarding", () => {
       if (runProject === undefined) delete process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
       else process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV] = runProject
     }
+  })
+
+  test("summarizeBridgeStderr collapses multiline warnings into a concise tail", () => {
+    expect(summarizeBridgeStderr("")).toBe("")
+    expect(summarizeBridgeStderr("   \n  \n")).toBe("")
+
+    const warnings =
+      "Files folder '/project/example_agent/files' does not exist. Skipping...\n" +
+      "Files folder '/project/example_agent2/files' does not exist. Skipping..."
+    const summary = summarizeBridgeStderr(warnings)
+    expect(summary).toBe(
+      "Files folder '/project/example_agent/files' does not exist. Skipping... | Files folder '/project/example_agent2/files' does not exist. Skipping...",
+    )
+
+    const manyLines = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n")
+    const tail = summarizeBridgeStderr(manyLines)
+    expect(tail).toBe("line 15 | line 16 | line 17 | line 18 | line 19")
+
+    const huge = "x".repeat(2000)
+    const truncated = summarizeBridgeStderr(huge)
+    expect(truncated.endsWith("...")).toBe(true)
+    expect(truncated.length).toBeLessThanOrEqual(503)
   })
 })
 


### PR DESCRIPTION
## Summary

- Agency Swarm bridge often writes harmless warnings to stderr during startup (e.g. `Files folder does not exist. Skipping...`); the prior code promoted that full stderr buffer to the user-facing error message whenever the bridge hadn't served metadata within 15 seconds.
- Real failure mode hit by users in released 1.4.12: open a template-style agency project with no `files/` folders, run `agentswarm`, the bridge starts but slower than 15s on cold envs, we kill it, then surface the warnings as "Error: Files folder '…' does not exist" — misleading.
- Extracts `summarizeBridgeStderr` so timeout and early-exit branches emit a bounded tail prefixed with the actual cause (timeout or exit code).
- Bumps the readiness wait from 15s to 30s to accommodate cold Python environments.

## Test plan

- [x] `bun test test/agency-swarm/npx.test.ts` — 32 pass including the new `summarizeBridgeStderr` coverage
- [x] `bun typecheck` green
- [ ] Post-merge: release v1.4.13, reinstall, re-run `agentswarm` in a template agency, confirm TUI loads past bridge startup and first send produces a response