### PR TITLE
fix(agency-swarm): surface bridge error-type stream frames

### DIFF
--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1305,6 +1305,13 @@ export namespace SessionAgencySwarm {
           await applyAssistantLabel(input.assistantMessage, eventMeta)
 
           const kind = asString(frame.payload["type"])
+          if (kind === "error") {
+            const content = asString(frame.payload["content"]) ?? ""
+            streamError = new Error(
+              content || "Agency Swarm backend returned an error without a message",
+            )
+            break
+          }
           if (kind === "agent_updated_stream_event") {
             const next = asRecord(frame.payload["new_agent"])
             const maybeName = next ? asString(next["name"]) : undefined

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -2590,6 +2590,35 @@ describe("session.agency-swarm", () => {
     expect(events.some((event) => event.type === "finish")).toBeFalse()
   })
 
+  test("stream surfaces bridge data-frame error payloads instead of silently dropping them", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "error",
+          content: "Error code: 400 - The 'gpt-5' model is not supported when using Codex with a ChatGPT account.",
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: any[] = []
+    for await (const event of stream.fullStream) {
+      events.push(event)
+    }
+
+    const errorEvent = events.find((event) => event.type === "error")
+    expect(errorEvent).toBeDefined()
+    expect(String(errorEvent.error?.message ?? errorEvent.error ?? "")).toContain(
+      "The 'gpt-5' model is not supported when using Codex with a ChatGPT account.",
+    )
+    expect(events.some((event) => event.type === "finish-step")).toBeFalse()
+    expect(events.some((event) => event.type === "finish")).toBeFalse()
+  })
+
   test("stream does not complete function_call on response.function_call.completed before output", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {


### PR DESCRIPTION
## Summary

When the local Agency Swarm bridge emits a data frame shaped `{type: "error", content: "..."}` mid-run, the CLI previously only matched `frame.type === "error"` (adapter-level) and silently dropped the payload-level error. Users saw empty assistant turns with 0 tokens spent and no indication anything went wrong.

End-user-verified repro (before this fix):
- User authenticates OpenAI via browser OAuth, agent model is `gpt-5`
- Direct POST to bridge shows: `data: {"data": {"type": "error", "content": "Error code: 400 - The 'gpt-5' model is not supported when using Codex with a ChatGPT account."}}`
- TUI shows ExampleAgent running for 810ms with 0 tokens and zero visible output

After this fix the same error reaches the TUI verbatim, so the user can act on it (switch model, switch auth provider, etc.).

## Test plan

- [x] `bun test test/session/agency-swarm.test.ts` — 51 pass including the new data-frame error regression test
- [x] `bun typecheck` green