### PR TITLE
fix(cli): auto-upgrade agency-swarm in project venv on each launch

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -544,6 +544,7 @@ async function ensureProjectPython(directory: string) {
   if (hasVenv) {
     const info = await inspectPython([venvPython])
     prompts.log.info(`Using project Python: ${formatPython(info, [venvPython])}`)
+    await ensureLatestAgencySwarm(directory, [venvPython])
     return [venvPython]
   }
 
@@ -594,19 +595,37 @@ async function ensureProjectPython(directory: string) {
 async function installProjectDependencies(directory: string, python: string[]) {
   const requirements = path.join(directory, "requirements.txt")
   if (await Filesystem.exists(requirements)) {
-    return runCommand([...python, "-m", "pip", "install", "-r", "requirements.txt"], {
+    return runCommand([...python, "-m", "pip", "install", "--upgrade", "-r", "requirements.txt"], {
       cwd: directory,
     })
   }
 
   const pyproject = path.join(directory, "pyproject.toml")
   if (await Filesystem.exists(pyproject)) {
-    return runCommand([...python, "-m", "pip", "install", "-e", "."], {
+    return runCommand([...python, "-m", "pip", "install", "--upgrade", "-e", "."], {
       cwd: directory,
     })
   }
 
-  return runCommand([...python, "-m", "pip", "install", "agency-swarm[fastapi,litellm]>=1.8.1"])
+  return runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.1"])
+}
+
+async function ensureLatestAgencySwarm(directory: string, python: string[]) {
+  try {
+    const result = await runCommand(
+      [...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]"],
+      { cwd: directory },
+    )
+    if (result.code !== 0) {
+      prompts.log.warn(
+        "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
+      )
+    }
+  } catch {
+    prompts.log.warn(
+      "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
+    )
+  }
 }
 
 async function startProjectServer(directory: string, python: string[]) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -154,7 +154,8 @@ describe("agency-swarm npx onboarding", () => {
       "-m",
       "pip",
       "install",
-      "agency-swarm[fastapi,litellm]>=1.8.1",
+      "--upgrade",
+      "agency-swarm[fastapi,litellm]>=1.9.1",
     ])
   })
 


### PR DESCRIPTION
## Summary

A project venv left with an old agency-swarm (e.g. 1.8.1) silently defeats bug fixes in newer releases — bridge runs stale code and the user sees the 'fixed' bug still biting. Real example: 1.4.13 shipped the browser-auth fix in agency-swarm 1.9.1, but users whose venv was pinned to 1.8.1 never saw the fix.

## Fix

- On launches where a project venv already exists, run `pip install --upgrade agency-swarm[fastapi,litellm]` before spawning the bridge. Failure logs a warning and does not block startup.
- For first-time installs (requirements.txt / pyproject.toml / fallback), add `--upgrade` so subsequent runs in the same venv keep pace with newer floors.
- Bump the fallback-install floor to 1.9.1.

## Test plan

- [x] `bun test test/agency-swarm/npx.test.ts` — 32 pass (test updated to assert `--upgrade`)
- [x] `bun typecheck` green