### PR TITLE
fix(tui): always default to the Agent Swarm opencode palette

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -103,8 +103,8 @@ const [store, setStore] = createStore<State>({
   ready: false,
 })
 
-export function defaultThemeName(input?: { termProgram?: string; background?: string }) {
-  return input?.termProgram === "Apple_Terminal" && isDarkTerminalBackground(input) ? "system" : "opencode"
+export function defaultThemeName(_input?: { termProgram?: string; background?: string }) {
+  return "opencode"
 }
 
 export function canSelectBuiltInThemeName(

--- a/packages/opencode/test/cli/tui/theme-store.test.ts
+++ b/packages/opencode/test/cli/tui/theme-store.test.ts
@@ -46,11 +46,12 @@ test("hasTheme checks theme presence", () => {
   expect(hasTheme(name)).toBe(true)
 })
 
-test("defaultThemeName only prefers the system palette for dark Apple Terminal themes", () => {
+test("defaultThemeName always returns the Agent Swarm opencode palette regardless of terminal", () => {
   expect(defaultThemeName({ termProgram: "Apple_Terminal" })).toBe("opencode")
-  expect(defaultThemeName({ termProgram: "Apple_Terminal", background: "#101010" })).toBe("system")
+  expect(defaultThemeName({ termProgram: "Apple_Terminal", background: "#101010" })).toBe("opencode")
   expect(defaultThemeName({ termProgram: "Apple_Terminal", background: "#f5f5f5" })).toBe("opencode")
   expect(defaultThemeName({ termProgram: "iTerm.app" })).toBe("opencode")
+  expect(defaultThemeName()).toBe("opencode")
 })
 
 test("built-in theme selection only allows opencode plus dark Apple Terminal system", () => {


### PR DESCRIPTION
## Summary

Restore the curated opencode palette as the default TUI theme on every terminal.

A recent change started routing dark-background Apple Terminal sessions to the generated `system` theme, which derives its colors from the terminal's ANSI palette and can produce a washed / off-palette UI on common profiles.

## Fix

Always default to `opencode` (the curated dark-navy + yellow palette) regardless of `TERM_PROGRAM`. Users who want the ANSI-generated palette can still pick `system` manually from the theme picker.

## Test plan

- [x] `bun test test/cli/tui/theme-store.test.ts` green
- [x] `bun typecheck` green