### PR TITLE
fix(agency-swarm): restore Anthropic + LiteLLM credential forwarding

### DIFF
--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1,6 +1,7 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { hasExplicitOpenAIClientConfig, readStringRecord } from "@/agency-swarm/client-config"
 import { AgencySwarmHistory } from "@/agency-swarm/history"
+import { mapProviderIDToLiteLLMProvider } from "@/agency-swarm/litellm-provider"
 import { Auth } from "@/auth"
 import { Env } from "@/env"
 import { CODEX_API_BASE_URL, extractAccountId, refreshAccessToken } from "@/plugin/codex"
@@ -144,11 +145,10 @@ export namespace SessionAgencySwarm {
 
     const generatedLiteLLMKeys = asRecord(generated["litellm_keys"])
     const explicitLiteLLMKeys = asRecord(explicit["litellm_keys"]) ?? asRecord(explicit["litellmKeys"])
-    if (generatedLiteLLMKeys || explicitLiteLLMKeys) {
-      merged["litellm_keys"] = {
-        ...(generatedLiteLLMKeys ?? {}),
-        ...(explicitLiteLLMKeys ?? {}),
-      }
+    if (explicitLiteLLMKeys !== undefined) {
+      merged["litellm_keys"] = explicitLiteLLMKeys
+    } else if (generatedLiteLLMKeys) {
+      merged["litellm_keys"] = generatedLiteLLMKeys
     }
     delete merged["litellmKeys"]
 
@@ -176,21 +176,25 @@ export namespace SessionAgencySwarm {
     },
   ): Promise<Record<string, unknown> | undefined> {
     const payload: Record<string, unknown> = {}
+    const litellmKeys: Record<string, string> = {}
 
-    // Keep automatic request-scoped auth limited to OpenAI. Local Agency Swarm
-    // backends already inherit process.env, and many do not accept LiteLLM config.
     for (const [providerID, provider] of Object.entries(providers ?? {})) {
       if (providerID === AgencySwarmAdapter.PROVIDER_ID) continue
-      if (providerID !== "openai") continue
       const key = getEnvCredential(provider, env)
       if (!key) continue
 
-      if (!options.skipOpenAI) payload["api_key"] = key
+      if (providerID === "openai") {
+        if (!options.skipOpenAI) payload["api_key"] = key
+        continue
+      }
+
+      const litellmProvider = mapProviderIDToLiteLLMProvider(providerID)
+      if (!litellmProvider) continue
+      litellmKeys[litellmProvider] = key
     }
 
     for (const [providerID, auth] of Object.entries(auths)) {
       if (providerID === AgencySwarmAdapter.PROVIDER_ID) continue
-      if (providerID !== "openai") continue
       if (hasEnvCredential(providerID, providers, env)) continue
 
       if (providerID === "openai" && auth.type === "oauth") {
@@ -207,7 +211,18 @@ export namespace SessionAgencySwarm {
 
       if (auth.type !== "api") continue
 
-      if (!options.skipOpenAI) payload["api_key"] = auth.key
+      if (providerID === "openai") {
+        if (!options.skipOpenAI) payload["api_key"] = auth.key
+        continue
+      }
+
+      const litellmProvider = mapProviderIDToLiteLLMProvider(providerID)
+      if (!litellmProvider) continue
+      litellmKeys[litellmProvider] = auth.key
+    }
+
+    if (Object.keys(litellmKeys).length > 0) {
+      payload["litellm_keys"] = litellmKeys
     }
 
     return Object.keys(payload).length > 0 ? payload : undefined

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -243,7 +243,7 @@ describe("session.agency-swarm", () => {
     }
 
     expect(captured).toEqual({
-      apiKey: "manual-openai",
+      api_key: "manual-openai",
       base_url: "https://proxy.example.com/v1",
       litellm_keys: {
         anthropic: "manual-ant",
@@ -304,6 +304,9 @@ describe("session.agency-swarm", () => {
 
     expect(captured).toEqual({
       api_key: "sk-openai",
+      litellm_keys: {
+        anthropic: "sk-ant",
+      },
     })
   })
 
@@ -419,14 +422,6 @@ describe("session.agency-swarm", () => {
         else chunks.push(Buffer.from(chunk))
       }
       body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
-      const clientConfig = body["client_config"] as Record<string, unknown> | undefined
-      if (clientConfig?.["litellm_keys"]) {
-        response.writeHead(422, {
-          "Content-Type": "application/json",
-        })
-        response.end(JSON.stringify({ detail: "litellm is not installed" }))
-        return
-      }
 
       response.writeHead(200, {
         "Content-Type": "text/event-stream",
@@ -464,6 +459,9 @@ describe("session.agency-swarm", () => {
       expect(text).toEqual(["ok"])
       expect(body?.["client_config"]).toEqual({
         api_key: "stored-openai",
+        litellm_keys: {
+          anthropic: "env-anthropic",
+        },
       })
     } finally {
       await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
@@ -612,7 +610,7 @@ describe("session.agency-swarm", () => {
     }
   })
 
-  test("stream prefers env OpenAI auth without auto-forwarding other providers", async () => {
+  test("stream prefers env OpenAI auth and forwards stored non-openai keys as litellm_keys", async () => {
     mockHistory()
     Auth.all = (async () => ({
       openai: { type: "api", key: "stored-openai" } as any,
@@ -682,6 +680,11 @@ describe("session.agency-swarm", () => {
 
     expect(captured).toEqual({
       api_key: "env-openai",
+      litellm_keys: {
+        anthropic: "stored-anthropic",
+        azure: "stored-azure",
+        gemini: "env-google",
+      },
     })
   })
 
@@ -786,7 +789,7 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream skips failing stored OpenAI OAuth refresh when only non-OpenAI local credentials remain", async () => {
+  test("stream skips failing stored OpenAI OAuth refresh but still forwards non-OpenAI litellm keys", async () => {
     mockHistory()
     Auth.all = (async () => ({
       openai: {
@@ -811,7 +814,11 @@ describe("session.agency-swarm", () => {
       // consume
     }
 
-    expect(captured).toBeUndefined()
+    expect(captured).toEqual({
+      litellm_keys: {
+        anthropic: "stored-anthropic",
+      },
+    })
   })
 
   test("stream preserves explicit header-based OpenAI auth without merging stored OAuth", async () => {


### PR DESCRIPTION
## Summary

Commit 2a4928123 stripped the `mapProviderIDToLiteLLMProvider` branch in `buildAuthClientConfig`, so every non-OpenAI provider stopped being forwarded to the local Agency Swarm bridge. Users who only had an Anthropic API key (or any other LiteLLM-backed provider) in `/auth` saw empty assistant turns with 0 tokens because the bridge never received credentials for their model.

The earlier strip was intended as a safety net for bridges without the `[litellm]` extra installed. PR #67 (auto-upgrade `agency-swarm[fastapi,litellm]` on every launch) makes that extra guaranteed on 1.4.14+, so forwarding is safe again.

## Fix

- Re-add `mapProviderIDToLiteLLMProvider` branch for both env-provided and stored auths so Anthropic/etc. keys surface as `litellm_keys` in the request body.
- Tighten `resolveClientConfig` so an explicit `client_config.litellm_keys` fully overrides auto-generated keys instead of merging them, preserving the "explicit input wins" contract that the existing `preserves explicit client_config` test documents.
- Update the five tests that codified the stripped behavior so they assert the restored forwarding.

## Fork-discipline check

Files touched: 2 (`packages/opencode/src/session/agency-swarm.ts` + its test — both fork-specific). No upstream core files changed.

## Test plan

- [x] `bun test test/session/agency-swarm.test.ts` — 51 pass, 0 fail
- [x] `bun typecheck` green
- [ ] Post-merge: install v1.4.16 globally, re-auth with Anthropic-only, send a message in a local agency using `model='anthropic/...\'`, confirm response instead of empty turn