### PR TITLE
fix(cli): add 'agency' alias for 'agencii' command group

### DIFF
--- a/packages/opencode/src/cli/cmd/agencii.ts
+++ b/packages/opencode/src/cli/cmd/agencii.ts
@@ -9,8 +9,8 @@ import { Config } from "@/config/config"
 import path from "path"
 
 export const AgenciiCommand = cmd({
-  command: "agencii",
-  describe: "Agency Swarm integration commands",
+  command: ["agency", "agencii"],
+  describe: "Agency Swarm backend management: connect, discover agencies, set default agency, Agent Builder helpers",
   builder: (yargs: Argv) =>
     yargs
       .command(AgenciiConnectCommand)


### PR DESCRIPTION
## Summary

User feedback: `agentswarm agencii` reads as outdated/unclear; `agency` is the natural name for the command group that manages the Agency Swarm backend connection, agency discovery, default-agency selection, and Agent Builder helpers.

## Fix

- Change `command: "agencii"` to `command: ["agency", "agencii"]` so yargs accepts either name. Existing users keep working; new users see and type `agency`.
- Refresh the `describe` string so the top-level `agentswarm --help` lists what the group actually does instead of the opaque label "Agency Swarm integration commands".

## Fork-discipline check

Files touched: 1 — `packages/opencode/src/cli/cmd/agencii.ts`, 2 lines changed. No upstream core files.

## Test plan

- [x] `bun typecheck` green
- [ ] Post-merge: `agentswarm agency --help` and `agentswarm agencii --help` both produce the same help output