### PR TITLE
feat(ci): extend auth smoke to cover OpenAI API key path

### DIFF
--- a/.github/workflows/auth-smoke.yml
+++ b/.github/workflows/auth-smoke.yml
@@ -3,7 +3,7 @@ name: auth-smoke
 # Release-blocking happy-path test.
 # Runs AFTER a PR lands on dev (pre-release gate), never on pull_request itself,
 # to prevent an unreviewed PR from exfiltrating provider secrets via the injected
-# OPENAI_OAUTH_ACCESS_TOKEN / ANTHROPIC_API_KEY.
+# OPENAI_OAUTH_ACCESS_TOKEN / OPENAI_API_KEY / ANTHROPIC_API_KEY.
 on:
   push:
     branches:
@@ -35,6 +35,7 @@ jobs:
         env:
           OPENAI_OAUTH_ACCESS_TOKEN: ${{ secrets.OPENAI_OAUTH_ACCESS_TOKEN }}
           OPENAI_OAUTH_ACCOUNT_ID: ${{ secrets.OPENAI_OAUTH_ACCOUNT_ID }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           python3 packages/opencode/script/auth-smoke-test.py

--- a/packages/opencode/script/auth-smoke-test.py
+++ b/packages/opencode/script/auth-smoke-test.py
@@ -209,6 +209,17 @@ def test_anthropic_key(port: int) -> bool | None:
     return send_probe(port, cfg, "anthropic")
 
 
+def test_openai_api_key(port: int) -> bool | None:
+    key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if not key:
+        log("openai-api-key", "OPENAI_API_KEY not set — SKIP")
+        return None
+    cfg = {
+        "api_key": key,
+    }
+    return send_probe(port, cfg, "openai-api-key")
+
+
 def main() -> int:
     workdir = Path(tempfile.mkdtemp(prefix="agentswarm-smoke-"))
     log("setup", f"workdir {workdir}")
@@ -232,6 +243,7 @@ def main() -> int:
         wait_ready(port)
 
         results["openai-oauth"] = test_openai_oauth(port)
+        results["openai-api-key"] = test_openai_api_key(port)
         results["anthropic"] = test_anthropic_key(port)
     finally:
         if bridge is not None:


### PR DESCRIPTION
## Summary

Extend the auth happy-path smoke to cover the OpenAI API key path in addition to OpenAI OAuth and Anthropic.

## Changes

- Add `test_openai_api_key` probe to `auth-smoke-test.py`.
- Wire `OPENAI_API_KEY` secret into the workflow env.
- Header comment updated to list all three covered methods.

## Fork-discipline

2 files touched: `packages/opencode/script/auth-smoke-test.py` (+1 function), `.github/workflows/auth-smoke.yml` (+1 env line). No upstream code.

## Local usage

```
OPENAI_OAUTH_ACCESS_TOKEN=... \
OPENAI_API_KEY=sk-... \
ANTHROPIC_API_KEY=sk-ant-... \
python3 packages/opencode/script/auth-smoke-test.py
```