### PR TITLE
fix(tui): unfreeze first-message transition to conversation screen

### DIFF
--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -410,7 +410,6 @@ export namespace SessionAgencySwarm {
 
     const streamAbort = new AbortController()
     const streamSignal = AbortSignal.any([input.abort, streamAbort.signal])
-    const clientConfig = await resolveClientConfig(input.options.baseURL, input.options.clientConfig)
 
     const mergeMeta = (meta: AgencySwarmEventMeta, extra?: Record<string, unknown>) => {
       return {
@@ -1268,6 +1267,8 @@ export namespace SessionAgencySwarm {
       yield { type: "start" }
       yield { type: "start-step" }
       let streamError: Error | undefined
+
+      const clientConfig = await resolveClientConfig(input.options.baseURL, input.options.clientConfig)
 
       try {
         for await (const frame of AgencySwarmAdapter.streamRun({


### PR DESCRIPTION
## Summary

The TUI froze for several seconds on the very first message in a connected agency session, and the transition to the conversation screen only occurred after the freeze ended. Subsequent messages were unaffected.

## Root cause

`AgencySwarmAdapter.stream()` in `packages/opencode/src/session/agency-swarm.ts` awaited `resolveClientConfig()` before returning its async generator. That call chain ends in `refreshAccessToken()` against the Codex OAuth endpoint (network round-trip on the first send of a fresh session). Because the generator wasn't returned until that await finished, no frames reached the TUI renderer — including the initial `start` / `start-step` frames that trigger the onboarding→conversation screen swap.

Once the OAuth token is cached in memory, subsequent messages skip the network call, which is why only the first send was visibly frozen.

## Fix

Move the `resolveClientConfig` await from outside the generator into the generator body, right after the initial `start` and `start-step` yields. The conversation screen now mounts immediately; the OAuth refresh still blocks the first data delta, but the TUI can now render its pending/streaming indicator while that happens.

## Test plan
- [ ] Launch `agentswarm` against a local agency with a cold OAuth session
- [ ] Send a first message; confirm the conversation screen transitions immediately
- [ ] Confirm the assistant reply still streams end-to-end
- [ ] Send a second message; no regression