### PR TITLE
fix: address Codex pre-release P1/P2 findings

### DIFF
--- a/packages/opencode/script/auth-smoke-test.py
+++ b/packages/opencode/script/auth-smoke-test.py
@@ -153,7 +153,13 @@ def send_probe(port: int, client_config: dict, label: str, recipient: str = "Exa
                     event = json.loads(body)
                 except Exception:
                     continue
-                data = event.get("data") if isinstance(event, dict) else None
+                if not isinstance(event, dict):
+                    continue
+                top_error = event.get("error")
+                if top_error:
+                    log(label, f"TOP-LEVEL ERROR frame: {top_error}")
+                    saw_error = True
+                data = event.get("data")
                 if not isinstance(data, dict):
                     continue
                 if data.get("type") == "error":
@@ -264,9 +270,17 @@ def main() -> int:
     for name in skipped:
         log("summary", f"  {name}: SKIPPED (no credentials in env)")
 
-    if not executed:
-        log("summary", "no auth method had credentials — nothing to prove. exit 0.")
-        return 0
+    if os.environ.get("AUTH_SMOKE_ALLOW_NO_CREDS") == "1":
+        if not executed:
+            log("summary", "no auth method had credentials — AUTH_SMOKE_ALLOW_NO_CREDS=1 set, exiting 0 for local dev.")
+            return 0
+    elif not executed:
+        log(
+            "summary",
+            "no auth method had credentials — release gate requires at least one. "
+            "Set AUTH_SMOKE_ALLOW_NO_CREDS=1 only for local dev without secrets.",
+        )
+        return 1
     if all(executed.values()):
         log("summary", "all executed auth methods PASS")
         return 0

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -541,6 +541,7 @@ export async function prepareProjectLaunch(project: AgencyProject): Promise<Prep
 async function ensureProjectPython(directory: string) {
   const venvPython = getVenvPythonPath(directory)
   let selfHealing = false
+  let corruptedVenv = false
   const hasVenv = await Filesystem.exists(venvPython)
   if (hasVenv) {
     const info = await inspectPython([venvPython])
@@ -548,16 +549,25 @@ async function ensureProjectPython(directory: string) {
     await ensureLatestAgencySwarm(directory, [venvPython])
     const healthy = await venvCanaryPasses([venvPython])
     if (healthy) return [venvPython]
-    prompts.log.warn("Project `.venv` is missing module sources (corrupted install). Rebuilding...")
-    await rm(path.join(directory, ".venv"), { recursive: true, force: true })
-    selfHealing = true
+    corruptedVenv = true
   }
 
   const detected = await findPythonExecutable()
   if (!detected) {
+    if (corruptedVenv) {
+      throw new Error(
+        "Project `.venv` appears corrupted, and no replacement Python 3.12+ was found on PATH to rebuild it. Install Python 3.12+ and rerun.",
+      )
+    }
     throw new Error("Python 3.12 or newer was not found. Install Python, then rerun `npx @vrsen/agentswarm`.")
   }
   prompts.log.info(`Detected Python: ${formatPython(detected, detected.cmd)}`)
+
+  if (corruptedVenv) {
+    prompts.log.warn("Project `.venv` is missing module sources (corrupted install). Rebuilding...")
+    await rm(path.join(directory, ".venv"), { recursive: true, force: true })
+    selfHealing = true
+  }
 
   if (!selfHealing) {
     const createVenv = await prompts.confirm({


### PR DESCRIPTION
## Summary

Three fixes surfaced by Codex xhigh pre-release review of v1.4.17..dev:

1. **P1** — `auth-smoke-test.py`: release gate no longer returns success when zero credentials are configured. A missing or renamed secret now blocks the release instead of silently disabling the check. Opt-out env var `AUTH_SMOKE_ALLOW_NO_CREDS=1` for local dev without secrets.

2. **P2** — `auth-smoke-test.py`: top-level bridge `{"error": ...}` frames now count as failures. Previously the parser only checked nested `data.type == "error"`, so a bridge error after some partial assistant text could be reported as PASS.

3. **P2** — `npx.ts`: venv self-heal no longer deletes `.venv` before confirming a replacement Python 3.12+ exists on PATH. On machines whose only usable interpreter is the project venv, the previous code turned a recoverable bad-env case into a hard failure.

## Test plan
- [ ] CI (auth-smoke with secrets present: PASS)
- [ ] Local: run with no creds and no opt-out → expect exit 1
- [ ] Local: run with `AUTH_SMOKE_ALLOW_NO_CREDS=1` and no creds → expect exit 0
- [ ] Trigger a corrupted-venv canary while no system Python is available → verify the descriptive error, and that `.venv` is preserved