### PR TITLE
fix: address Codex pre-release P1/P2 round-2 findings

### DIFF
--- a/packages/opencode/script/auth-smoke-test.py
+++ b/packages/opencode/script/auth-smoke-test.py
@@ -75,9 +75,10 @@ def ensure_venv(project: Path) -> Path:
     req = project / "requirements.txt"
     if req.exists():
         run([str(python), "-m", "pip", "install", "-r", "requirements.txt"], cwd=str(project))
-    # Ensure litellm extra too so Anthropic client_config forwarding doesn't 422.
+    # Install the litellm extra only (no --upgrade) so Anthropic client_config
+    # forwarding works without overriding the framework version the template pins.
     run(
-        [str(python), "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]"],
+        [str(python), "-m", "pip", "install", "agency-swarm[fastapi,litellm]"],
         cwd=str(project),
     )
     return python

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -628,7 +628,11 @@ async function installProjectDependencies(directory: string, python: string[]) {
 }
 
 async function venvCanaryPasses(python: string[]) {
-  const result = await runCommand([...python, "-c", "import agency_swarm, rich, pygments, pathspec"])
+  const result = await runCommand([
+    ...python,
+    "-c",
+    "from agency_swarm.integrations.fastapi import run_fastapi",
+  ])
   return result.code === 0
 }
 


### PR DESCRIPTION
## Summary

Two additional fixes surfaced by Codex xhigh re-review of v1.4.17..dev (after PR #77 landed):

1. **P1** — `npx.ts` venv canary: collapse to a single transitive import that actually exercises bridge startup (`from agency_swarm.integrations.fastapi import run_fastapi`). The round-1 canary also imported `rich`, `pygments`, `pathspec`, but those are not direct deps of the fallback installer, so minimal venvs that never needed them were false-flagged as corrupted and would have been rebuilt on every launch.

2. **P2** — `auth-smoke-test.py`: drop `--upgrade` when installing the `litellm` extra. The starter template pins the framework version, and forcing an upgrade made this release gate fail for unrelated agency-swarm regressions. Install the extra without overriding the template's pin so the smoke exercises exactly the dependency set a user actually sees.

## Test plan
- [ ] Local: canary passes on a fresh template venv that was never given pathspec/rich/pygments
- [ ] Local: canary still catches httpx-style corruption (verified against a corrupted my-agency .venv)
- [ ] CI: auth-smoke still exercises OAuth + Anthropic + OpenAI API key end-to-end