### PR TITLE
fix(tui): gate /models and /editor to Agent Builder in framework mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -533,8 +533,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       keybind: "model_list",
       suggested: true,
       category: "Agent",
-      enabled: !frameworkMode(),
-      hidden: frameworkMode(),
+      enabled: !frameworkMode() || local.agent.current()?.name === "build",
+      hidden: frameworkMode() && local.agent.current()?.name !== "build",
       slash: {
         name: "models",
       },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -32,6 +32,7 @@ import { formatDuration } from "@/util/format"
 import { createColors, createFrames } from "../../ui/spinner.ts"
 import { useDialog } from "@tui/ui/dialog"
 import { DialogAgencySwarmConnect, DialogAuth, DialogProvider as DialogProviderConnect } from "../dialog-provider"
+import { isAgencySwarmFrameworkMode } from "../../session-error"
 import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
@@ -305,6 +306,16 @@ export function Prompt(props: PromptProps) {
         slash: {
           name: "editor",
         },
+        enabled:
+          !isAgencySwarmFrameworkMode({
+            currentProviderID: local.model.current()?.providerID,
+            configuredModel: sync.data.config.model,
+          }) || local.agent.current()?.name === "build",
+        hidden:
+          isAgencySwarmFrameworkMode({
+            currentProviderID: local.model.current()?.providerID,
+            configuredModel: sync.data.config.model,
+          }) && local.agent.current()?.name !== "build",
         onSelect: async (dialog) => {
           dialog.clear()
 


### PR DESCRIPTION
## Summary

In Agency Swarm framework mode, `/models` was already hidden because the model is pinned on the agency-side agent definition and switching it at the TUI layer does nothing useful. Extend the same gate to `/editor`, and loosen both so they remain available when the current agent is `build` (Agent Builder).

Effect in framework mode:
- **Agent Builder** (`build`): both `/models` and `/editor` available, as today for `/models`, newly available for `/editor`.
- **Plan** (`plan`) and any future fork agent: both hidden.

Outside framework mode, upstream behavior is unchanged — both commands available as before.

## Test plan
- [ ] Launch in framework mode with current agent `build`: `/models` and `/editor` both appear in the command list
- [ ] Switch to `plan` (Tab): both commands disappear
- [ ] Launch in non-framework mode: both commands available as upstream