### PR TITLE
fix(tui): hide /models and /editor only in Run mode (connected to agency)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -533,8 +533,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       keybind: "model_list",
       suggested: true,
       category: "Agent",
-      enabled: !frameworkMode() || local.agent.current()?.name === "build",
-      hidden: frameworkMode() && local.agent.current()?.name !== "build",
+      enabled: !frameworkMode(),
+      hidden: frameworkMode(),
       slash: {
         name: "models",
       },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -306,16 +306,14 @@ export function Prompt(props: PromptProps) {
         slash: {
           name: "editor",
         },
-        enabled:
-          !isAgencySwarmFrameworkMode({
-            currentProviderID: local.model.current()?.providerID,
-            configuredModel: sync.data.config.model,
-          }) || local.agent.current()?.name === "build",
-        hidden:
-          isAgencySwarmFrameworkMode({
-            currentProviderID: local.model.current()?.providerID,
-            configuredModel: sync.data.config.model,
-          }) && local.agent.current()?.name !== "build",
+        enabled: !isAgencySwarmFrameworkMode({
+          currentProviderID: local.model.current()?.providerID,
+          configuredModel: sync.data.config.model,
+        }),
+        hidden: isAgencySwarmFrameworkMode({
+          currentProviderID: local.model.current()?.providerID,
+          configuredModel: sync.data.config.model,
+        }),
         onSelect: async (dialog) => {
           dialog.clear()
 


### PR DESCRIPTION
## Summary

Correct the PR #80 gating. The previous gate required the current agent to be `build` (Agent Builder) specifically, which also hid `/models` and `/editor` in **Plan** mode. Plan mode uses bare OpenCode just like Agent Builder — model switching and editor-open are valid there.

## Final behavior

- **Agent Builder** and **Plan** (both bare-OpenCode modes): `/models` and `/editor` available as usual.
- **Run** (connected to an Agency Swarm agency): both hidden, because the model is pinned by the agency-side agent definition.

## Test plan
- [ ] Launch agentswarm, stay in Agent Builder (no agency connection): both commands available
- [ ] Tab to Plan mode: both commands still available
- [ ] Connect to an agency (Run mode): both commands disappear