### PR TITLE
fix: pre-release Codex P1/P2 on dev tip for 1.4.18

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -552,7 +552,8 @@ async function ensureProjectPython(directory: string) {
     corruptedVenv = true
   }
 
-  const detected = await findPythonExecutable()
+  const venvDir = path.resolve(path.join(directory, ".venv"))
+  const detected = await findPythonExecutable(corruptedVenv ? venvDir : undefined)
   if (!detected) {
     if (corruptedVenv) {
       throw new Error(
@@ -761,15 +762,22 @@ async function hasGitHubTemplateFlow() {
   return auth.code === 0
 }
 
-async function findPythonExecutable() {
+async function findPythonExecutable(excludeUnder?: string) {
   const candidates: string[][] =
     process.platform === "win32"
       ? [["py", "-3.13"], ["py", "-3.12"], ["python"], ["python3"]]
       : [["python3.13"], ["python3.12"], ["python3"], ["python"]]
 
+  const excludeRoot = excludeUnder ? path.resolve(excludeUnder) : undefined
+  const excludePrefix = excludeRoot ? excludeRoot + path.sep : undefined
+
   for (const candidate of candidates) {
     const info = await inspectPython(candidate)
     if (!info) continue
+    if (excludeRoot && excludePrefix) {
+      const resolved = path.resolve(info.executable)
+      if (resolved === excludeRoot || resolved.startsWith(excludePrefix)) continue
+    }
     const match = info.version.match(/^(\d+)\.(\d+)/)
     if (!match) continue
     const major = Number(match[1])

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -32,7 +32,6 @@ import { formatDuration } from "@/util/format"
 import { createColors, createFrames } from "../../ui/spinner.ts"
 import { useDialog } from "@tui/ui/dialog"
 import { DialogAgencySwarmConnect, DialogAuth, DialogProvider as DialogProviderConnect } from "../dialog-provider"
-import { isAgencySwarmFrameworkMode } from "../../session-error"
 import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
@@ -306,14 +305,6 @@ export function Prompt(props: PromptProps) {
         slash: {
           name: "editor",
         },
-        enabled: !isAgencySwarmFrameworkMode({
-          currentProviderID: local.model.current()?.providerID,
-          configuredModel: sync.data.config.model,
-        }),
-        hidden: isAgencySwarmFrameworkMode({
-          currentProviderID: local.model.current()?.providerID,
-          configuredModel: sync.data.config.model,
-        }),
         onSelect: async (dialog) => {
           dialog.clear()
 


### PR DESCRIPTION
## Summary

Two regressions caught by Codex xhigh pre-release review of dev tip 201fa5c8b:

### P1 — venv self-heal picks soon-to-be-deleted interpreter (npx.ts)
In the common `source .venv/bin/activate && agentswarm` flow, `findPythonExecutable()` resolves `python3` to a binary inside the corrupted `.venv`. The code then rm()s that directory, destroying the interpreter before `python -m venv .venv` can use it.

Teach `findPythonExecutable` to accept an exclude-root so any candidate whose resolved path lives under it is skipped. `ensureProjectPython` passes the project's `.venv` as that root when `corruptedVenv` is true. Healthy-venv flow is unchanged.

### P2 — /editor disappears during normal Agency Swarm startup (prompt/index.tsx)
The `/editor` gate from PR #81 uses `isAgencySwarmFrameworkMode` alone, which is true purely from `config.model = agency-swarm/...`. A fresh launcher session hides `/editor` even though no run session exists yet.

Revert the fork-added `/editor` gate entirely. The `/models` gate (which pre-existed on upstream) still behaves correctly. A proper `/editor` Run-mode gate will land with the three-mode UX when we can key off a real connected/run-session signal.

## Test plan
- [ ] corrupted-venv repro: simulate by removing `httpx/_transports/`; launch agentswarm — must NOT recursively kill its own interpreter
- [ ] `/editor` visible in fresh agentswarm launcher session (no agency connection)
- [ ] `/models` still hidden when framework mode is active (unchanged)
- [ ] typecheck green