### PR TITLE
fix: round-11 pre-release findings for 1.4.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,6 @@ jobs:
           PLAYWRIGHT_WORKERS: ${{ runner.os == 'Windows' && '1' || '2' }}
           PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-${{ matrix.settings.name }}.xml
         timeout-minutes: 30
-        continue-on-error: ${{ matrix.settings.name == 'windows' }}
 
       - name: Upload Playwright artifacts
         if: always()

--- a/packages/opencode/script/auth-smoke-test.py
+++ b/packages/opencode/script/auth-smoke-test.py
@@ -43,6 +43,10 @@ import urllib.request
 from pathlib import Path
 
 TEMPLATE_URL = "https://github.com/agency-ai-solutions/agency-starter-template.git"
+# Pin the starter template to a known-good SHA so unrelated upstream changes cannot
+# flip this release gate red on agentswarm-cli pushes. Bump deliberately when a new
+# template revision is required and re-run this workflow against it.
+TEMPLATE_REV = "c45541fb5ca182dbebca23ddc8bbc933acd83d32"
 DEFAULT_PORT_BASE = 59970
 SPAWN_READY_TIMEOUT_S = 60
 SEND_TIMEOUT_S = 120
@@ -59,8 +63,9 @@ def run(cmd: list[str], cwd: str | None = None, check: bool = True) -> subproces
 
 def clone_template(workdir: Path) -> Path:
     target = workdir / "agency-starter-template"
-    log("clone", f"{TEMPLATE_URL} -> {target}")
-    run(["git", "clone", "--depth", "1", TEMPLATE_URL, str(target)])
+    log("clone", f"{TEMPLATE_URL}@{TEMPLATE_REV} -> {target}")
+    run(["git", "clone", TEMPLATE_URL, str(target)])
+    run(["git", "checkout", TEMPLATE_REV], cwd=str(target))
     return target
 
 

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -770,9 +770,10 @@ async function findPythonExecutable(excludeUnder?: string) {
 
   const excludeRoot = excludeUnder ? path.resolve(excludeUnder) : undefined
   const excludePrefix = excludeRoot ? excludeRoot + path.sep : undefined
+  const spawnEnv = excludeRoot ? stripVenvFromEnv(process.env, excludeRoot) : undefined
 
   for (const candidate of candidates) {
-    const info = await inspectPython(candidate)
+    const info = await inspectPython(candidate, spawnEnv)
     if (!info) continue
     if (excludeRoot && excludePrefix) {
       const resolved = path.resolve(info.executable)
@@ -786,8 +787,34 @@ async function findPythonExecutable(excludeUnder?: string) {
   }
 }
 
-async function inspectPython(cmd: string[]): Promise<PythonInfo | undefined> {
-  const result = await runCommand([...cmd, "-c", "import sys; print(sys.executable); print(sys.version.split()[0])"])
+function stripVenvFromEnv(env: NodeJS.ProcessEnv, venvRoot: string): NodeJS.ProcessEnv {
+  const venvBin = path.join(venvRoot, process.platform === "win32" ? "Scripts" : "bin")
+  const venvBinResolved = path.resolve(venvBin)
+  const pathKey = process.platform === "win32" ? "Path" : "PATH"
+  const rawPath = env[pathKey] ?? env.PATH ?? ""
+  const sep = process.platform === "win32" ? ";" : ":"
+  const filtered = rawPath
+    .split(sep)
+    .filter((entry) => {
+      if (!entry) return false
+      try {
+        const resolved = path.resolve(entry)
+        return resolved !== venvBinResolved && !resolved.startsWith(venvBinResolved + path.sep)
+      } catch {
+        return true
+      }
+    })
+    .join(sep)
+  const next = { ...env, [pathKey]: filtered }
+  delete next.VIRTUAL_ENV
+  return next
+}
+
+async function inspectPython(cmd: string[], env?: NodeJS.ProcessEnv): Promise<PythonInfo | undefined> {
+  const result = await runCommand(
+    [...cmd, "-c", "import sys; print(sys.executable); print(sys.version.split()[0])"],
+    env ? { env } : undefined,
+  )
   if (result.code !== 0) return
   const [executable, version] = result.stdout.trim().split(/\r?\n/)
   if (!executable || !version) return
@@ -829,13 +856,16 @@ async function getFreePort() {
   })
 }
 
-async function runCommand(cmd: string[], options?: { cwd?: string }): Promise<CommandResult> {
+async function runCommand(
+  cmd: string[],
+  options?: { cwd?: string; env?: NodeJS.ProcessEnv },
+): Promise<CommandResult> {
   const proc = Bun.spawn({
     cmd,
     cwd: options?.cwd,
     stdout: "pipe",
     stderr: "pipe",
-    env: process.env,
+    env: options?.env ?? process.env,
   })
 
   const [code, stdout, stderr] = await Promise.all([


### PR DESCRIPTION
Codex xhigh review of dev tip 36f9fdf05 flagged three issues. This PR addresses all of them.

### P1 — Windows e2e must fail the matrix leg (test.yml)
`continue-on-error: windows` silenced Windows-only regressions. Per user directive 'Windows e2e is mandatory to be green when it comes to releasing the package', revert to blocking semantics. Trade-off: Windows-flake rerun loop comes back to PR feedback; correctness wins.

### P2 — Recovery-python search must escape the activated .venv (npx.ts)
When the user runs `source .venv/bin/activate && agentswarm` against a corrupted venv, every `python3/python` candidate resolves to the same broken `.venv/bin/python*` via PATH. The prior exclude-by-resolved-path skipped those hits but never discovered the system interpreter. Strip the `.venv/bin` entry from PATH and unset `VIRTUAL_ENV` in the spawn env so candidates resolve to real system binaries.

### P2 — Pin starter-template SHA in auth-smoke (auth-smoke-test.py)
Floating `main` clone meant unrelated template changes could flip this release gate. Pinned to `c45541fb5ca182dbebca23ddc8bbc933acd83d32`; bump deliberately when a new template revision is needed.