### PR TITLE
fix: round-12 pre-release findings for 1.4.18

### DIFF
--- a/packages/opencode/script/auth-smoke-test.py
+++ b/packages/opencode/script/auth-smoke-test.py
@@ -172,10 +172,15 @@ def send_probe(port: int, client_config: dict, label: str, recipient: str = "Exa
                     log(label, f"ERROR event: {data.get('content')}")
                     saw_error = True
                 nested = data.get("data")
-                if isinstance(nested, dict) and nested.get("type") == "response.output_text.delta":
-                    delta = nested.get("delta")
-                    if isinstance(delta, str):
-                        assistant_text.append(delta)
+                if isinstance(nested, dict):
+                    # raw_response_event frames can carry a nested type: 'error' after partial text.
+                    if nested.get("type") == "error":
+                        log(label, f"NESTED ERROR frame: {nested.get('content') or nested.get('message')}")
+                        saw_error = True
+                    elif nested.get("type") == "response.output_text.delta":
+                        delta = nested.get("delta")
+                        if isinstance(delta, str):
+                            assistant_text.append(delta)
     except urllib.error.HTTPError as e:
         body = e.read().decode(errors="replace")
         log(label, f"HTTPError {e.code}: {body[:300]}")

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -562,7 +562,11 @@ async function ensureProjectPython(directory: string) {
     }
     throw new Error("Python 3.12 or newer was not found. Install Python, then rerun `npx @vrsen/agentswarm`.")
   }
-  prompts.log.info(`Detected Python: ${formatPython(detected, detected.cmd)}`)
+  // During self-heal, invoke the resolved interpreter by its absolute path. The alias
+  // (python3 etc.) resolves via PATH and, in an activated broken venv, still points at
+  // the .venv binary we are about to delete.
+  const rebuildCmd = corruptedVenv ? [detected.executable] : detected.cmd
+  prompts.log.info(`Detected Python: ${formatPython(detected, rebuildCmd)}`)
 
   if (corruptedVenv) {
     prompts.log.warn("Project `.venv` is missing module sources (corrupted install). Rebuilding...")
@@ -579,19 +583,19 @@ async function ensureProjectPython(directory: string) {
       return
     }
     if (!createVenv) {
-      const check = await runCommand([...detected.cmd, "-c", "import agency_swarm"])
+      const check = await runCommand([...rebuildCmd, "-c", "import agency_swarm"])
       if (check.code !== 0) {
         throw new Error(
           "This project does not have a `.venv` yet, and the selected Python environment cannot import `agency_swarm`.",
         )
       }
-      return detected.cmd
+      return rebuildCmd
     }
   }
 
   const spinner = prompts.spinner()
   spinner.start("Creating `.venv`")
-  const created = await runCommand([...detected.cmd, "-m", "venv", ".venv"], {
+  const created = await runCommand([...rebuildCmd, "-m", "venv", ".venv"], {
     cwd: directory,
   })
   if (created.code !== 0) {


### PR DESCRIPTION
Codex xhigh review of dev tip flagged two remaining correctness issues.

### P1 — Self-heal must invoke python by absolute path (npx.ts)
After finding the sanitized recovery interpreter, the rebuild still invoked it via the original alias (`python3` etc.) under the unmodified process.env. In an activated broken venv, that alias resolves back to the `.venv` binary we are about to delete. Use `info.executable` (absolute path) for every rebuild command.

### P1 — Auth smoke must fail on nested raw_response_event errors (auth-smoke-test.py)
The bridge can emit `raw_response_event` frames whose nested payload is `type: 'error'` after partial assistant text has streamed. SessionAgencySwarm handles this; the release-gate probe missed it and could report PASS on a mid-stream error. Fail the probe on nested `type: 'error'` too.