### PR TITLE
fix(tui): Anthropic duplicates, LiteLLM transport hygiene, framework-mode detection

### DIFF
--- a/packages/opencode/src/agency-swarm/adapter.ts
+++ b/packages/opencode/src/agency-swarm/adapter.ts
@@ -1,4 +1,5 @@
 import { Log } from "@/util/log"
+import { sanitizeClientConfigForTransport } from "./client-config"
 
 export namespace AgencySwarmAdapter {
   const log = Log.create({ service: "agency-swarm.adapter" })
@@ -496,14 +497,17 @@ export namespace AgencySwarmAdapter {
     const apiKey = asString(value["api_key"]) ?? asString(value["apiKey"])
     const litellmKeys = asRecord(value["litellm_keys"]) ?? asRecord(value["litellmKeys"])
     const headers = readStringRecord(value["default_headers"]) ?? readStringRecord(value["defaultHeaders"])
+    const model = asString(value["model"])
 
     const payload: Record<string, unknown> = {}
     if (baseURL) payload["base_url"] = baseURL
     if (apiKey) payload["api_key"] = apiKey
     if (litellmKeys && Object.keys(litellmKeys).length > 0) payload["litellm_keys"] = litellmKeys
     if (headers) payload["default_headers"] = headers
+    if (model) payload["model"] = model
 
-    return Object.keys(payload).length > 0 ? payload : undefined
+    if (Object.keys(payload).length === 0) return undefined
+    return sanitizeClientConfigForTransport(payload)
   }
 
   async function safeJSON(response: Response): Promise<unknown | undefined> {

--- a/packages/opencode/src/agency-swarm/client-config.ts
+++ b/packages/opencode/src/agency-swarm/client-config.ts
@@ -6,6 +6,56 @@ function asRecord(value: unknown) {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined
 }
 
+/** Strip CR/LF and trim — values become HTTP headers; LiteLLM rejects `\\r` / `\\n` as header injection. */
+export function sanitizeHeaderLikeString(value: string): string {
+  return value.replace(/\r\n?|\n/g, "").trim()
+}
+
+/** Sanitize `client_config` strings right before JSON transport to the agency-swarm server. */
+export function sanitizeClientConfigForTransport(config: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...config }
+
+  if (typeof out["api_key"] === "string") {
+    const s = sanitizeHeaderLikeString(out["api_key"])
+    if (s) out["api_key"] = s
+    else delete out["api_key"]
+  }
+
+  for (const key of ["base_url", "model"] as const) {
+    if (typeof out[key] !== "string") continue
+    const s = sanitizeHeaderLikeString(out[key] as string)
+    if (s) out[key] = s
+    else delete out[key]
+  }
+
+  const litellmRaw = asRecord(out["litellm_keys"]) ?? asRecord(out["litellmKeys"])
+  if (litellmRaw) {
+    const litellm: Record<string, string> = {}
+    for (const [k, v] of Object.entries(litellmRaw)) {
+      if (typeof v !== "string") continue
+      const s = sanitizeHeaderLikeString(v)
+      if (s) litellm[k] = s
+    }
+    if (Object.keys(litellm).length > 0) out["litellm_keys"] = litellm
+    else delete out["litellm_keys"]
+    delete out["litellmKeys"]
+  }
+
+  const headers = readStringRecord(out["default_headers"]) ?? readStringRecord(out["defaultHeaders"])
+  if (headers) {
+    const cleaned = Object.fromEntries(
+      Object.entries(headers)
+        .map(([k, v]) => [k, sanitizeHeaderLikeString(v)] as const)
+        .filter(([, v]) => v.length > 0),
+    )
+    if (Object.keys(cleaned).length > 0) out["default_headers"] = cleaned
+    else delete out["default_headers"]
+    delete out["defaultHeaders"]
+  }
+
+  return out
+}
+
 const AUTH_HEADER_PATTERN = /(^authorization$|(^|[-_])(api[-_]?key|token|auth[-_]?token)$)/i
 
 export function readStringRecord(value: unknown): Record<string, string> | undefined {
@@ -20,7 +70,8 @@ export function readStringRecord(value: unknown): Record<string, string> | undef
   return Object.keys(result).length > 0 ? result : undefined
 }
 
-export function readCredentialHeaders(config: Record<string, unknown>) {
+export function readCredentialHeaders(config: Record<string, unknown> | undefined) {
+  if (!config) return undefined
   const headers = readStringRecord(config["default_headers"]) ?? readStringRecord(config["defaultHeaders"])
   if (!headers) return undefined
   const result = Object.fromEntries(Object.entries(headers).filter(([key]) => AUTH_HEADER_PATTERN.test(key)))
@@ -38,4 +89,9 @@ export function hasClientConfigCredential(config: Record<string, unknown>) {
 
 export function hasExplicitOpenAIClientConfig(config: Record<string, unknown> | undefined) {
   return !!(config && (asString(config["api_key"]) ?? asString(config["apiKey"]) ?? readCredentialHeaders(config)))
+}
+
+/** True when user set an explicit `api_key` / `apiKey` field (not headers alone). */
+export function hasExplicitOpenAIApiKey(config: Record<string, unknown> | undefined) {
+  return !!(config && (asString(config["api_key"]) ?? asString(config["apiKey"])))
 }

--- a/packages/opencode/src/agency-swarm/litellm-provider.ts
+++ b/packages/opencode/src/agency-swarm/litellm-provider.ts
@@ -164,8 +164,13 @@ const OPENAI_LITELLM_ID = "openai"
 
 const LITELLM_OPENAI_PREFIX = "litellm/openai/"
 
-/** Strips `litellm/openai/` and `openai/` prefixes used when routing OpenAI models through LiteLLM. */
-function stripOpenAILiteLLMRoutePrefixes(t: string): string {
+/**
+ * Strip `litellm/openai/` or `openai/` only when the model id truly belongs to OpenAI.
+ * Guarded by `providerID` so OpenRouter-style ids like `openrouter/openai/gpt-5.2` keep
+ * their outer provider segment and do not get mis-routed to OpenAI.
+ */
+function stripOpenAILiteLLMRoutePrefixes(t: string, providerID: string): string {
+  if (providerID !== OPENAI_LITELLM_ID) return t
   if (t.startsWith(LITELLM_OPENAI_PREFIX)) {
     return t.slice(LITELLM_OPENAI_PREFIX.length)
   }
@@ -179,14 +184,23 @@ function stripOpenAILiteLLMRoutePrefixes(t: string): string {
  * Normalize optional `client_config.model` from JSON/config (may omit `litellm/`).
  * OpenAI upstream models are stored as the bare model id only (e.g. `gpt-4o`).
  * Other `provider/model` paths get a `litellm/` prefix for LiteLLM routing.
+ * Provider is inferred from the leading token so non-OpenAI namespaces (e.g. `openrouter/openai/...`)
+ * keep their outer segment intact.
  */
 export function normalizeExplicitClientConfigModel(raw: string): string {
   const t = raw.trim()
   if (!t) return t
-  const stripped = stripOpenAILiteLLMRoutePrefixes(t)
+  if (t.startsWith("litellm/")) {
+    const afterLitellm = t.slice("litellm/".length)
+    if (afterLitellm.startsWith(`${OPENAI_LITELLM_ID}/`)) return afterLitellm.slice(OPENAI_LITELLM_ID.length + 1)
+    return t
+  }
+  const slash = t.indexOf("/")
+  const leading = slash === -1 ? t : t.slice(0, slash)
+  const inferredProvider = mapProviderIDToLiteLLMProvider(leading) ?? leading
+  const stripped = stripOpenAILiteLLMRoutePrefixes(t, inferredProvider)
   if (stripped !== t) return stripped
-  if (t.startsWith("litellm/")) return t
-  if (t.includes("/")) return `litellm/${t}`
+  if (slash !== -1) return `litellm/${t}`
   return t
 }
 
@@ -194,14 +208,32 @@ export function normalizeExplicitClientConfigModel(raw: string): string {
  * Build `client_config.model` from the CLI session selection.
  * OpenAI models use the bare model id only (e.g. `gpt-4o`). Other providers use `litellm/<provider>/<model>`.
  * Skips when the session model is the agency-swarm placeholder (no LLM provider).
+ * The caller-supplied `providerID` decides the route: for OpenRouter-style ids like
+ * `openrouter/openai/gpt-5.2` (or bare `openai/gpt-5.2` with `providerID="openrouter"`),
+ * the inner `openai/` segment is preserved as part of the model name and not treated as the provider.
  */
 export function buildLitellmModelForClientConfig(providerID: string, modelID: string): string | undefined {
   if (providerID === AGENCY_SWARM_PROVIDER_ID) return undefined
   const t = modelID.trim()
   if (!t) return undefined
-  const stripped = stripOpenAILiteLLMRoutePrefixes(t)
+  const stripped = stripOpenAILiteLLMRoutePrefixes(t, providerID)
   if (stripped !== t) return stripped
   if (t.startsWith("litellm/")) return t
+
+  const mapped = mapProviderIDToLiteLLMProvider(providerID)
+  if (mapped) {
+    const slash = t.indexOf("/")
+    if (slash !== -1) {
+      const prefix = t.slice(0, slash)
+      const rest = t.slice(slash + 1)
+      if (prefix === mapped && rest) {
+        if (mapped === OPENAI_LITELLM_ID) return rest
+        return `litellm/${mapped}/${rest}`
+      }
+    }
+    if (mapped === OPENAI_LITELLM_ID) return t
+    return `litellm/${mapped}/${t}`
+  }
 
   const slash = t.indexOf("/")
   if (slash !== -1) {
@@ -209,17 +241,9 @@ export function buildLitellmModelForClientConfig(providerID: string, modelID: st
     const rest = t.slice(slash + 1)
     const mappedPrefix = mapProviderIDToLiteLLMProvider(prefix)
     if (mappedPrefix && rest) {
-      if (mappedPrefix === OPENAI_LITELLM_ID) {
-        return rest
-      }
+      if (mappedPrefix === OPENAI_LITELLM_ID) return rest
       return `litellm/${mappedPrefix}/${rest}`
     }
   }
-
-  const mapped = mapProviderIDToLiteLLMProvider(providerID)
-  if (!mapped) return undefined
-  if (mapped === OPENAI_LITELLM_ID) {
-    return t
-  }
-  return `litellm/${mapped}/${t}`
+  return undefined
 }

--- a/packages/opencode/src/agency-swarm/litellm-provider.ts
+++ b/packages/opencode/src/agency-swarm/litellm-provider.ts
@@ -157,3 +157,69 @@ export function mapProviderIDToLiteLLMProvider(providerID: string): string | und
 
   return undefined
 }
+
+const AGENCY_SWARM_PROVIDER_ID = "agency-swarm"
+
+const OPENAI_LITELLM_ID = "openai"
+
+const LITELLM_OPENAI_PREFIX = "litellm/openai/"
+
+/** Strips `litellm/openai/` and `openai/` prefixes used when routing OpenAI models through LiteLLM. */
+function stripOpenAILiteLLMRoutePrefixes(t: string): string {
+  if (t.startsWith(LITELLM_OPENAI_PREFIX)) {
+    return t.slice(LITELLM_OPENAI_PREFIX.length)
+  }
+  if (t.startsWith(`${OPENAI_LITELLM_ID}/`)) {
+    return t.slice(OPENAI_LITELLM_ID.length + 1)
+  }
+  return t
+}
+
+/**
+ * Normalize optional `client_config.model` from JSON/config (may omit `litellm/`).
+ * OpenAI upstream models are stored as the bare model id only (e.g. `gpt-4o`).
+ * Other `provider/model` paths get a `litellm/` prefix for LiteLLM routing.
+ */
+export function normalizeExplicitClientConfigModel(raw: string): string {
+  const t = raw.trim()
+  if (!t) return t
+  const stripped = stripOpenAILiteLLMRoutePrefixes(t)
+  if (stripped !== t) return stripped
+  if (t.startsWith("litellm/")) return t
+  if (t.includes("/")) return `litellm/${t}`
+  return t
+}
+
+/**
+ * Build `client_config.model` from the CLI session selection.
+ * OpenAI models use the bare model id only (e.g. `gpt-4o`). Other providers use `litellm/<provider>/<model>`.
+ * Skips when the session model is the agency-swarm placeholder (no LLM provider).
+ */
+export function buildLitellmModelForClientConfig(providerID: string, modelID: string): string | undefined {
+  if (providerID === AGENCY_SWARM_PROVIDER_ID) return undefined
+  const t = modelID.trim()
+  if (!t) return undefined
+  const stripped = stripOpenAILiteLLMRoutePrefixes(t)
+  if (stripped !== t) return stripped
+  if (t.startsWith("litellm/")) return t
+
+  const slash = t.indexOf("/")
+  if (slash !== -1) {
+    const prefix = t.slice(0, slash)
+    const rest = t.slice(slash + 1)
+    const mappedPrefix = mapProviderIDToLiteLLMProvider(prefix)
+    if (mappedPrefix && rest) {
+      if (mappedPrefix === OPENAI_LITELLM_ID) {
+        return rest
+      }
+      return `litellm/${mappedPrefix}/${rest}`
+    }
+  }
+
+  const mapped = mapProviderIDToLiteLLMProvider(providerID)
+  if (!mapped) return undefined
+  if (mapped === OPENAI_LITELLM_ID) {
+    return t
+  }
+  return `litellm/${mapped}/${t}`
+}

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -458,6 +458,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         frameworkMode: isAgencySwarmFrameworkMode({
           currentProviderID: local.model.current()?.providerID,
           configuredModel: sync.data.config.model,
+          agentModel: local.agent.current()?.model,
         }),
       })
 
@@ -470,6 +471,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     isAgencySwarmFrameworkMode({
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
+      agentModel: local.agent.current()?.model,
     }),
   )
   command.register(() => [

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -460,6 +460,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           configuredModel: sync.data.config.model,
           agentModel: local.agent.current()?.model,
         }),
+        env: process.env,
       })
 
     if (!needsAuth || dialog.stack.length > 0) return

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -40,6 +40,7 @@ export function DialogAgent() {
     isAgencySwarmFrameworkMode({
       currentProviderID: currentModel()?.providerID,
       configuredModel: sync.data.config.model,
+      agentModel: local.agent.current()?.model,
     }),
   )
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -66,6 +66,7 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
     isAgencySwarmFrameworkMode({
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
+      agentModel: local.agent.current()?.model,
     }),
   )
   const options = createMemo(() => {
@@ -249,6 +250,7 @@ export function DialogAuth() {
     isAgencySwarmFrameworkMode({
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
+      agentModel: local.agent.current()?.model,
     }),
   )
   const providerIDs = frameworkMode()
@@ -284,6 +286,35 @@ export function DialogAuth() {
 
   return (
     <DialogSelect title={frameworkMode() ? "Manage Agent Swarm auth" : "Manage provider auth"} options={options()} />
+  )
+}
+
+/** After auth in Agency Swarm mode, offer model selection (CLI model drives `client_config` for that provider). */
+function DialogPostAuthModelChoice(props: { providerID: string }) {
+  const dialog = useDialog()
+  const sync = useSync()
+  const providerName = createMemo(() => {
+    const p = sync.data.provider_next.all.find((x) => x.id === props.providerID)
+    return p?.name ?? props.providerID
+  })
+  return (
+    <DialogSelect
+      title={`${providerName()} connected`}
+      options={[
+        {
+          title: "Select model",
+          value: "model",
+          description: "Choose which model to use for this session",
+          onSelect: () => dialog.replace(() => <DialogModel providerID={props.providerID} />),
+        },
+        {
+          title: "Done",
+          value: "done",
+          description: "Keep your current model selection",
+          onSelect: () => dialog.clear(),
+        },
+      ]}
+    />
   )
 }
 
@@ -685,6 +716,7 @@ function AutoMethod(props: AutoMethodProps) {
     isAgencySwarmFrameworkMode({
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
+      agentModel: local.agent.current()?.model,
     }),
   )
 
@@ -726,7 +758,7 @@ function AutoMethod(props: AutoMethodProps) {
       await sdk.client.instance.dispose()
       await sync.bootstrap()
       if (frameworkMode()) {
-        dialog.clear()
+        dialog.replace(() => <DialogPostAuthModelChoice providerID={props.providerID} />)
         return
       }
       dialog.replace(() => <DialogModel providerID={props.providerID} />)
@@ -786,6 +818,7 @@ function CodeMethod(props: CodeMethodProps) {
     isAgencySwarmFrameworkMode({
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
+      agentModel: local.agent.current()?.model,
     }),
   )
 
@@ -804,7 +837,7 @@ function CodeMethod(props: CodeMethodProps) {
             await sdk.client.instance.dispose()
             await sync.bootstrap()
             if (frameworkMode()) {
-              dialog.clear()
+              dialog.replace(() => <DialogPostAuthModelChoice providerID={props.providerID} />)
               return
             }
             dialog.replace(() => <DialogModel providerID={props.providerID} />)
@@ -855,6 +888,7 @@ function ApiMethod(props: ApiMethodProps) {
     isAgencySwarmFrameworkMode({
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
+      agentModel: local.agent.current()?.model,
     }),
   )
   const description = () => {
@@ -920,7 +954,7 @@ function ApiMethod(props: ApiMethodProps) {
           await sdk.client.instance.dispose()
           await sync.bootstrap()
           if (frameworkMode()) {
-            dialog.clear()
+            dialog.replace(() => <DialogPostAuthModelChoice providerID={props.providerID} />)
             return
           }
           dialog.replace(() => <DialogModel providerID={props.providerID} />)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -40,7 +40,12 @@ import { DialogSkill } from "../dialog-skill"
 import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "@tui/util/provider-origin"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
-import { describeAgencyAuthFailure, shouldBlockAgencyPromptSubmit, shouldOpenAgencyAuthDialog } from "../../session-error"
+import {
+  describeAgencyAuthFailure,
+  isAgencySwarmFrameworkMode,
+  shouldBlockAgencyPromptSubmit,
+  shouldOpenAgencyAuthDialog,
+} from "../../session-error"
 import { errorMessage as toErrorMessage } from "@/util/error"
 
 export type PromptProps = {
@@ -305,6 +310,16 @@ export function Prompt(props: PromptProps) {
         slash: {
           name: "editor",
         },
+        enabled: !isAgencySwarmFrameworkMode({
+          currentProviderID: local.model.current()?.providerID,
+          configuredModel: sync.data.config.model,
+          agentModel: local.agent.current()?.model,
+        }),
+        hidden: isAgencySwarmFrameworkMode({
+          currentProviderID: local.model.current()?.providerID,
+          configuredModel: sync.data.config.model,
+          agentModel: local.agent.current()?.model,
+        }),
         onSelect: async (dialog) => {
           dialog.clear()
 
@@ -679,6 +694,7 @@ export function Prompt(props: PromptProps) {
       shouldBlockAgencyPromptSubmit({
         currentProviderID: selectedModel.providerID,
         configuredModel: sync.data.config.model,
+        agentModel: local.agent.current()?.model,
         providers: sync.data.provider,
         providerAuth: sync.data.provider_auth,
         mode: currentMode,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -699,6 +699,7 @@ export function Prompt(props: PromptProps) {
         providerAuth: sync.data.provider_auth,
         mode: currentMode,
         isSlashCommand: isServerSlashCommand,
+        env: process.env,
       })
     ) {
       toast.show({

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -101,11 +101,30 @@ function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
   return hasClientConfigCredential(raw as Record<string, unknown>)
 }
 
-export function isAgencySwarmFrameworkMode(input: { currentProviderID?: string; configuredModel?: string }) {
-  if (input.currentProviderID) {
-    return input.currentProviderID === AgencySwarmAdapter.PROVIDER_ID
+/**
+ * True when the app is running in Agent Swarm mode. Session `currentProviderID` may be `openai` or `anthropic`
+ * (upstream LiteLLM) while `config.model` / the agent default still use `agency-swarm` — those must keep framework mode so /auth stays OpenAI+Anthropic only.
+ *
+ * **Precedence (first match wins):** `configuredModel` → `agentModel` → `currentProviderID`.
+ * This differs from checking only `currentProviderID` first: e.g. when the session provider is already `openai`
+ * but the configured or agent model still points at `agency-swarm/...`, framework mode stays on so auth and
+ * provider UI stay aligned with Agent Swarm.
+ */
+export function isAgencySwarmFrameworkMode(input: {
+  currentProviderID?: string
+  configuredModel?: string
+  agentModel?: { providerID: string; modelID: string }
+}) {
+  if (input.configuredModel?.split("/")[0] === AgencySwarmAdapter.PROVIDER_ID) {
+    return true
   }
-  return input.configuredModel?.split("/")[0] === AgencySwarmAdapter.PROVIDER_ID
+  if (input.agentModel?.providerID === AgencySwarmAdapter.PROVIDER_ID) {
+    return true
+  }
+  if (input.currentProviderID === AgencySwarmAdapter.PROVIDER_ID) {
+    return true
+  }
+  return false
 }
 
 export function shouldOpenStartupAuthDialog(input: {
@@ -127,6 +146,7 @@ export function shouldOpenStartupAuthDialog(input: {
 export function shouldBlockAgencyPromptSend(input: {
   currentProviderID?: string
   configuredModel?: string
+  agentModel?: { providerID: string; modelID: string }
   providers: Provider[]
   providerAuth?: ProviderAuthMap
 }) {
@@ -141,6 +161,7 @@ export function shouldBlockAgencyPromptSend(input: {
 export function shouldBlockAgencyPromptSubmit(input: {
   currentProviderID?: string
   configuredModel?: string
+  agentModel?: { providerID: string; modelID: string }
   providers: Provider[]
   providerAuth?: ProviderAuthMap
   mode: "normal" | "shell"

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -96,13 +96,34 @@ function isAgencyProviderCredentialFailure(message: string) {
   )
 }
 
-function hasSupportedAgencyCredential(providers: Provider[], providerAuth: ProviderAuthMap = {}) {
-  return providers.some((provider) => {
+function hasSupportedAgencyCredential(
+  providers: Provider[],
+  providerAuth: ProviderAuthMap = {},
+  env: Record<string, string | undefined> = {},
+) {
+  const providerMatch = providers.some((provider) => {
     if (provider.id === AgencySwarmAdapter.PROVIDER_ID) return false
     if (!isSupportedAgencyAuthProvider(provider.id, provider, providerAuth[provider.id] ?? [])) return false
+    if (hasEnvCredentialForProvider(provider, env)) return true
     if (provider.id === "openai") return hasCredential(provider, providerAuth)
     return hasConfiguredAPIStyleCredential(provider)
   })
+  if (providerMatch) return true
+  // Mirror the bridge's direct env reads (SessionAgencySwarm.buildAuthClientConfig): primary-provider env vars
+  // are upstream creds even when the provider is filtered out of the enabled list.
+  return AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS.some((id) => isNonEmptyEnv(env[envNameForPrimaryProvider(id)]))
+}
+
+function hasEnvCredentialForProvider(provider: AuthProvider | Provider, env: Record<string, string | undefined>) {
+  return (provider.env ?? []).some((name) => isNonEmptyEnv(env[name]))
+}
+
+function isNonEmptyEnv(value: string | undefined) {
+  return typeof value === "string" && value.trim().length > 0
+}
+
+function envNameForPrimaryProvider(id: (typeof AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS)[number]) {
+  return id === "openai" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY"
 }
 
 function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
@@ -143,20 +164,25 @@ export function shouldOpenStartupAuthDialog(input: {
   frameworkMode: boolean
   /** Override for the upstream-credential forwarding path; when undefined the value is inferred from env + provider options. */
   forwardUpstreamCredentials?: boolean
+  /** Process env snapshot; production callers pass `process.env`, tests pass a controlled map. */
+  env?: Record<string, string | undefined>
 }) {
   if (!input.frameworkMode) return !hasUsableProvider(input.providers, false, input.providerAuth)
 
+  const env = input.env ?? {}
   const agencyProvider = input.providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
-  if (
-    agencyProvider &&
-    (hasCredential(agencyProvider, input.providerAuth) || hasExplicitAgencyClientConfig(agencyProvider))
-  ) {
-    return false
-  }
   const forwardingActive = isForwardUpstreamCredentialsActive(input.providers, input.forwardUpstreamCredentials)
+
+  // Explicit client_config on the agency-swarm provider carries upstream creds and satisfies either mode.
+  if (agencyProvider && hasExplicitAgencyClientConfig(agencyProvider)) return false
+
+  // A bridge token only authenticates the call to the bridge; under forwarding it does NOT stand in
+  // for the upstream OpenAI/Anthropic credential resolveClientConfig() still needs.
+  if (!forwardingActive && agencyProvider && hasCredential(agencyProvider, input.providerAuth)) return false
+
   if (!forwardingActive && !usesLocalAgencyProviderAuth(input.providers)) return false
 
-  return !hasSupportedAgencyCredential(input.providers, input.providerAuth)
+  return !hasSupportedAgencyCredential(input.providers, input.providerAuth, env)
 }
 
 export function shouldBlockAgencyPromptSend(input: {
@@ -165,12 +191,14 @@ export function shouldBlockAgencyPromptSend(input: {
   agentModel?: { providerID: string; modelID: string }
   providers: Provider[]
   providerAuth?: ProviderAuthMap
+  env?: Record<string, string | undefined>
 }) {
   if (!isAgencySwarmFrameworkMode(input)) return false
   return shouldOpenStartupAuthDialog({
     providers: input.providers,
     providerAuth: input.providerAuth,
     frameworkMode: true,
+    env: input.env,
   })
 }
 
@@ -182,6 +210,7 @@ export function shouldBlockAgencyPromptSubmit(input: {
   providerAuth?: ProviderAuthMap
   mode: "normal" | "shell"
   isSlashCommand: boolean
+  env?: Record<string, string | undefined>
 }) {
   if (input.mode === "shell" || input.isSlashCommand) return false
   return shouldBlockAgencyPromptSend(input)

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,5 +1,6 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { hasClientConfigCredential } from "@/agency-swarm/client-config"
+import { Flag } from "@/flag/flag"
 import { hasStoredProviderCredential } from "@tui/util/provider-auth"
 import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
 
@@ -14,11 +15,7 @@ type AuthProvider = {
   options?: Record<string, unknown>
 }
 
-export function hasUsableProvider(
-  providers: Provider[],
-  credentialed = false,
-  providerAuth: ProviderAuthMap = {},
-) {
+export function hasUsableProvider(providers: Provider[], credentialed = false, providerAuth: ProviderAuthMap = {}) {
   return providers.some((provider) => {
     if (provider.id !== "opencode") return credentialed ? hasCredential(provider, providerAuth) : true
     return Object.values(provider.models).some((model) => model.cost?.input !== 0)
@@ -70,6 +67,19 @@ function usesLocalAgencyProviderAuth(providers: Provider[]) {
   const rawBaseURL = agencyProvider?.options?.["baseURL"] ?? agencyProvider?.options?.["base_url"]
   const baseURL = typeof rawBaseURL === "string" && rawBaseURL.trim() ? rawBaseURL : AgencySwarmAdapter.DEFAULT_BASE_URL
   return isLoopbackBaseURL(baseURL)
+}
+
+/**
+ * Forwarding upstream credentials means the agency-swarm call depends on locally stored OpenAI/Anthropic
+ * credentials even against non-loopback base URLs (e.g. `host.docker.internal`, remote bridges).
+ * Active when the env flag is set, the caller passes the override, or the agency-swarm provider opts in.
+ */
+function isForwardUpstreamCredentialsActive(providers: Provider[], override?: boolean) {
+  if (override === true) return true
+  if (Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS) return true
+  const agency = providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
+  const opts = agency?.options ?? {}
+  return opts["forwardUpstreamCredentials"] === true || opts["forward_upstream_credentials"] === true
 }
 
 export function isSupportedAgencyAuthProvider(
@@ -131,14 +141,20 @@ export function shouldOpenStartupAuthDialog(input: {
   providers: Provider[]
   providerAuth?: ProviderAuthMap
   frameworkMode: boolean
+  /** Override for the upstream-credential forwarding path; when undefined the value is inferred from env + provider options. */
+  forwardUpstreamCredentials?: boolean
 }) {
   if (!input.frameworkMode) return !hasUsableProvider(input.providers, false, input.providerAuth)
 
   const agencyProvider = input.providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
-  if (agencyProvider && (hasCredential(agencyProvider, input.providerAuth) || hasExplicitAgencyClientConfig(agencyProvider))) {
+  if (
+    agencyProvider &&
+    (hasCredential(agencyProvider, input.providerAuth) || hasExplicitAgencyClientConfig(agencyProvider))
+  ) {
     return false
   }
-  if (!usesLocalAgencyProviderAuth(input.providers)) return false
+  const forwardingActive = isForwardUpstreamCredentialsActive(input.providers, input.forwardUpstreamCredentials)
+  if (!forwardingActive && !usesLocalAgencyProviderAuth(input.providers)) return false
 
   return !hasSupportedAgencyCredential(input.providers, input.providerAuth)
 }

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -84,6 +84,9 @@ export namespace Flag {
   export const OPENCODE_SKIP_MIGRATIONS = truthy("OPENCODE_SKIP_MIGRATIONS")
   export const OPENCODE_STRICT_CONFIG_DEPS = truthy("OPENCODE_STRICT_CONFIG_DEPS")
 
+  /** When set, merge stored/env LLM credentials into Agency Swarm `client_config` for non-loopback base URLs (default: off for safety). */
+  export const AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS = truthy("AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS")
+
   function number(key: string) {
     const value = process.env[key]
     if (!value) return undefined

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1,7 +1,17 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
-import { hasExplicitOpenAIClientConfig, readStringRecord } from "@/agency-swarm/client-config"
+import {
+  hasExplicitOpenAIApiKey,
+  hasExplicitOpenAIClientConfig,
+  readCredentialHeaders,
+  readStringRecord,
+} from "@/agency-swarm/client-config"
+import { Flag } from "@/flag/flag"
 import { AgencySwarmHistory } from "@/agency-swarm/history"
-import { mapProviderIDToLiteLLMProvider } from "@/agency-swarm/litellm-provider"
+import {
+  buildLitellmModelForClientConfig,
+  mapProviderIDToLiteLLMProvider,
+  normalizeExplicitClientConfigModel,
+} from "@/agency-swarm/litellm-provider"
 import { Auth } from "@/auth"
 import { Env } from "@/env"
 import { CODEX_API_BASE_URL, extractAccountId, refreshAccessToken } from "@/plugin/codex"
@@ -41,6 +51,8 @@ export namespace SessionAgencySwarm {
     fileIDs?: string[]
     generateChatName?: boolean
     clientConfig?: Record<string, unknown>
+    /** When true, merge stored/env credentials into client_config for non-local base URLs (see also AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS). */
+    forwardUpstreamCredentials?: boolean
     token?: string
     discoveryTimeoutMs: number
   }
@@ -51,6 +63,8 @@ export namespace SessionAgencySwarm {
     userMessage: MessageV2.WithParts
     options: RuntimeOptions
     abort: AbortSignal
+    /** Session UI model for this turn; forwarded as `client_config.model` (bare id for OpenAI, else `litellm/...`) for server-side override. */
+    sessionModel?: { providerID: string; modelID: string }
   }
 
   type Usage = {
@@ -86,6 +100,9 @@ export namespace SessionAgencySwarm {
       asBoolean(provider?.options?.["generateChatName"]) ?? asBoolean(provider?.options?.["generate_chat_name"])
     const rawClientConfig =
       asRecord(provider?.options?.["clientConfig"]) ?? asRecord(provider?.options?.["client_config"])
+    const opts = provider?.options
+    const rawForwardUpstream =
+      opts?.["forwardUpstreamCredentials"] === true || opts?.["forward_upstream_credentials"] === true
     const rawToken = asString(provider?.key) ?? asString(provider?.options?.["token"])
     const rawTimeout = provider?.options?.["discoveryTimeoutMs"]
 
@@ -98,6 +115,7 @@ export namespace SessionAgencySwarm {
       fileIDs: rawFileIDs.length > 0 ? rawFileIDs : undefined,
       generateChatName: rawGenerateChatName,
       clientConfig: rawClientConfig,
+      forwardUpstreamCredentials: rawForwardUpstream === true ? true : undefined,
       token: rawToken || undefined,
       discoveryTimeoutMs:
         typeof rawTimeout === "number" && Number.isFinite(rawTimeout) && rawTimeout > 0
@@ -106,22 +124,61 @@ export namespace SessionAgencySwarm {
     }
   }
 
+  function finalizeClientConfig(
+    merged: Record<string, unknown> | undefined,
+    explicitForModel: Record<string, unknown> | undefined,
+    sessionLitellmModel: string | undefined,
+  ): Record<string, unknown> | undefined {
+    const explicitModel = explicitForModel && asString(explicitForModel["model"])
+    if (merged && Object.keys(merged).length > 0) {
+      const out = { ...merged }
+      if (explicitModel) {
+        out["model"] = normalizeExplicitClientConfigModel(explicitModel)
+      } else if (sessionLitellmModel) {
+        out["model"] = sessionLitellmModel
+      }
+      return out
+    }
+    if (explicitModel) {
+      return { model: normalizeExplicitClientConfigModel(explicitModel) }
+    }
+    if (sessionLitellmModel) {
+      return { model: sessionLitellmModel }
+    }
+    return undefined
+  }
+
   async function resolveClientConfig(
     baseURL: string,
     config: Record<string, unknown> | undefined,
+    forwardUpstreamCredentials?: boolean,
+    sessionLitellmModel?: string,
   ): Promise<Record<string, unknown> | undefined> {
     const explicit = asRecord(config)
     const explicitUpstreamBaseURL = readConfiguredBaseURL(explicit)
-    const generated = isLoopbackBaseURL(baseURL)
+    const forwardGenerated =
+      isLocalAgencyUpstreamURL(baseURL) ||
+      Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS ||
+      forwardUpstreamCredentials === true
+    const skipOpenAIApiKey =
+      hasExplicitOpenAIApiKey(config) || !!readCredentialHeaders(config)
+    const generated = forwardGenerated
       ? await buildAuthClientConfig(await Auth.all(), await listProvidersForEnvCheck(), getEnvForClientConfig(), {
-          skipOpenAI: hasExplicitOpenAIClientConfig(config),
+          skipOpenAIApiKeyInjection: skipOpenAIApiKey,
+          skipOpenAIOAuthFromStored: hasExplicitOpenAIClientConfig(config),
           allowStoredOpenAIOAuth: !explicitUpstreamBaseURL || isCodexAPIBaseURL(explicitUpstreamBaseURL),
         })
       : undefined
-    if (!config) return generated
-    if (!generated) return config
+    if (!config) {
+      return finalizeClientConfig(generated, undefined, sessionLitellmModel)
+    }
+    if (!generated) {
+      return finalizeClientConfig(explicit, explicit, sessionLitellmModel)
+    }
 
-    if (!explicit) return generated
+    if (!explicit) {
+      return finalizeClientConfig(generated, undefined, sessionLitellmModel)
+    }
 
     const merged: Record<string, unknown> = {
       ...generated,
@@ -163,7 +220,7 @@ export namespace SessionAgencySwarm {
     }
     delete merged["defaultHeaders"]
 
-    return merged
+    return finalizeClientConfig(merged, explicit, sessionLitellmModel)
   }
 
   async function buildAuthClientConfig(
@@ -171,7 +228,8 @@ export namespace SessionAgencySwarm {
     providers: Record<string, Provider.Info> | undefined,
     env: Record<string, string | undefined>,
     options: {
-      skipOpenAI: boolean
+      skipOpenAIApiKeyInjection: boolean
+      skipOpenAIOAuthFromStored: boolean
       allowStoredOpenAIOAuth: boolean
     },
   ): Promise<Record<string, unknown> | undefined> {
@@ -184,7 +242,7 @@ export namespace SessionAgencySwarm {
       if (!key) continue
 
       if (providerID === "openai") {
-        if (!options.skipOpenAI) payload["api_key"] = key
+        if (!options.skipOpenAIApiKeyInjection) payload["api_key"] = key
         continue
       }
 
@@ -198,7 +256,7 @@ export namespace SessionAgencySwarm {
       if (hasEnvCredential(providerID, providers, env)) continue
 
       if (providerID === "openai" && auth.type === "oauth") {
-        if (options.skipOpenAI || !options.allowStoredOpenAIOAuth) continue
+        if (options.skipOpenAIOAuthFromStored || !options.allowStoredOpenAIOAuth) continue
         try {
           Object.assign(payload, await buildOpenAIOAuthClientConfig(auth))
         } catch (error) {
@@ -212,7 +270,7 @@ export namespace SessionAgencySwarm {
       if (auth.type !== "api") continue
 
       if (providerID === "openai") {
-        if (!options.skipOpenAI) payload["api_key"] = auth.key
+        if (!options.skipOpenAIApiKeyInjection) payload["api_key"] = auth.key
         continue
       }
 
@@ -223,6 +281,14 @@ export namespace SessionAgencySwarm {
 
     if (Object.keys(litellmKeys).length > 0) {
       payload["litellm_keys"] = litellmKeys
+    }
+
+    if (!options.skipOpenAIApiKeyInjection && !payload["api_key"]) {
+      const fromEnv = env["OPENAI_API_KEY"]
+      if (typeof fromEnv === "string") {
+        const trimmed = fromEnv.trim()
+        if (trimmed) payload["api_key"] = trimmed
+      }
     }
 
     return Object.keys(payload).length > 0 ? payload : undefined
@@ -298,14 +364,19 @@ export namespace SessionAgencySwarm {
     }
   }
 
-  function isLoopbackBaseURL(baseURL: string): boolean {
+  /** Loopback + common dev hostnames (Docker Desktop, etc.) where forwarding upstream API keys to a local bridge is expected. */
+  function isLocalAgencyUpstreamURL(baseURL: string) {
     try {
       const parsed = new URL(baseURL)
+      const h = parsed.hostname.toLowerCase()
       return (
-        parsed.hostname === "127.0.0.1" ||
-        parsed.hostname === "0.0.0.0" ||
-        parsed.hostname === "localhost" ||
-        parsed.hostname === "::1"
+        h === "127.0.0.1" ||
+        h === "0.0.0.0" ||
+        h === "localhost" ||
+        h === "::1" ||
+        h === "[::1]" ||
+        h === "host.docker.internal" ||
+        h === "kubernetes.docker.internal"
       )
     } catch {
       return false
@@ -403,6 +474,21 @@ export namespace SessionAgencySwarm {
     const textKey = (itemID: string, index?: number) => {
       const value = index ?? textIndex.get(itemID) ?? 0
       return `${itemID}:${value}`
+    }
+
+    /** Skip when the same body was already finalized from raw_response_event under another item id (stream vs `messages` / run_item ids often differ for Anthropic / LiteLLM). */
+    const shouldSkipDuplicateAssistantText = (itemID: string, index: number, text: string) => {
+      const key = textKey(itemID, index)
+      const current = textBuffer.get(key) || ""
+      if (current === text && !textOpen.has(key)) {
+        return true
+      }
+      for (const [bufferKey, bufferedText] of textBuffer) {
+        if (bufferKey !== key && bufferedText === text && !textOpen.has(bufferKey)) {
+          return true
+        }
+      }
+      return false
     }
 
     const reasoningKey = (itemID: string, index: number) => `${itemID}:${index}`
@@ -960,6 +1046,7 @@ export namespace SessionAgencySwarm {
         if (!itemID) continue
         const text = extractMessageText(message)
         if (!text) continue
+        if (shouldSkipDuplicateAssistantText(itemID, 0, text)) continue
         yield* finishText(itemID, 0, text, {}, { source: "messages" })
       }
     }
@@ -1139,7 +1226,11 @@ export namespace SessionAgencySwarm {
         if (!itemID) return []
         const text = extractMessageText(rawItem)
         if (!text) return []
-        return finishText(itemID, 0, text, eventMeta, { source: "run_item_stream_event" })
+        const index = 0
+        if (shouldSkipDuplicateAssistantText(itemID, index, text)) {
+          return []
+        }
+        return finishText(itemID, index, text, eventMeta, { source: "run_item_stream_event" })
       }
 
       if (name !== "reasoning_item_created" || itemType !== "reasoning") {
@@ -1269,7 +1360,15 @@ export namespace SessionAgencySwarm {
         mentionedRecipient,
         configuredRecipient: input.options.recipientAgent,
       })
-      const clientConfig = await resolveClientConfig(input.options.baseURL, input.options.clientConfig)
+      const sessionLitellmModel =
+        input.sessionModel &&
+        buildLitellmModelForClientConfig(input.sessionModel.providerID, input.sessionModel.modelID)
+      const clientConfig = await resolveClientConfig(
+        input.options.baseURL,
+        input.options.clientConfig,
+        input.options.forwardUpstreamCredentials,
+        sessionLitellmModel,
+      )
 
       try {
         for await (const frame of AgencySwarmAdapter.streamRun({

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -160,8 +160,7 @@ export namespace SessionAgencySwarm {
       isLocalAgencyUpstreamURL(baseURL) ||
       Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS ||
       forwardUpstreamCredentials === true
-    const skipOpenAIApiKey =
-      hasExplicitOpenAIApiKey(config) || !!readCredentialHeaders(config)
+    const skipOpenAIApiKey = hasExplicitOpenAIApiKey(config) || !!readCredentialHeaders(config)
     const generated = forwardGenerated
       ? await buildAuthClientConfig(await Auth.all(), await listProvidersForEnvCheck(), getEnvForClientConfig(), {
           skipOpenAIApiKeyInjection: skipOpenAIApiKey,
@@ -476,19 +475,11 @@ export namespace SessionAgencySwarm {
       return `${itemID}:${value}`
     }
 
-    /** Skip when the same body was already finalized from raw_response_event under another item id (stream vs `messages` / run_item ids often differ for Anthropic / LiteLLM). */
+    /** Skip only when the incoming event is a replay of the same `(itemID, index)` that is already closed. Body-only matches would drop legit later messages with a short repeat body like "Done" or "OK". */
     const shouldSkipDuplicateAssistantText = (itemID: string, index: number, text: string) => {
       const key = textKey(itemID, index)
       const current = textBuffer.get(key) || ""
-      if (current === text && !textOpen.has(key)) {
-        return true
-      }
-      for (const [bufferKey, bufferedText] of textBuffer) {
-        if (bufferKey !== key && bufferedText === text && !textOpen.has(bufferKey)) {
-          return true
-        }
-      }
-      return false
+      return current === text && !textOpen.has(key)
     }
 
     const reasoningKey = (itemID: string, index: number) => `${itemID}:${index}`
@@ -1016,6 +1007,13 @@ export namespace SessionAgencySwarm {
     const textItemID = (event: Record<string, unknown>) => asString(event["item_id"]) || lastTextItemID
     const reasoningItemID = (event: Record<string, unknown>) => asString(event["item_id"]) || lastReasoningItemID
 
+    /** Retire closed replay candidates when a new run starts so the dedupe buffer does not grow across runs. */
+    const retireClosedReplayCandidates = () => {
+      for (const key of Array.from(textBuffer.keys())) {
+        if (!textOpen.has(key)) textBuffer.delete(key)
+      }
+    }
+
     const handleMessagesPayload = async function* (payload: Record<string, unknown>) {
       const newMessages = Array.isArray(payload["new_messages"]) ? payload["new_messages"] : []
       await AgencySwarmHistory.appendMessages(scope, newMessages)
@@ -1023,6 +1021,7 @@ export namespace SessionAgencySwarm {
 
       const runFromMessages = asString(payload["run_id"])
       if (runFromMessages) {
+        if (runID && runID !== runFromMessages) retireClosedReplayCandidates()
         runID = runFromMessages
         if (cancelBeforeMetaTimer) {
           clearTimeout(cancelBeforeMetaTimer)
@@ -1387,6 +1386,7 @@ export namespace SessionAgencySwarm {
           abort: streamSignal,
         })) {
           if (frame.type === "meta") {
+            if (runID && runID !== frame.runID) retireClosedReplayCandidates()
             runID = frame.runID
             if (cancelBeforeMetaTimer) {
               clearTimeout(cancelBeforeMetaTimer)
@@ -1423,9 +1423,7 @@ export namespace SessionAgencySwarm {
           const kind = asString(frame.payload["type"])
           if (kind === "error") {
             const content = asString(frame.payload["content"]) ?? ""
-            streamError = new Error(
-              content || "Agency Swarm backend returned an error without a message",
-            )
+            streamError = new Error(content || "Agency Swarm backend returned an error without a message")
             break
           }
           if (kind === "agent_updated_stream_event") {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -88,7 +88,6 @@ export namespace SessionPrompt {
     Service,
     Effect.gen(function* () {
       const bus = yield* Bus.Service
-      const config = yield* Config.Service
       const status = yield* SessionStatus.Service
       const sessions = yield* Session.Service
       const agents = yield* Agent.Service
@@ -1401,20 +1400,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }).pipe(Effect.ignore, Effect.forkIn(scope))
 
             const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
-            const mergedCfg = yield* config.get()
-            const defaultModelFromConfig = mergedCfg.model ? Provider.parseModel(mergedCfg.model) : undefined
             // Use the Agency Swarm HTTP bridge when:
-            // - the message model is agency-swarm, or
-            // - the last assistant was from the bridge (see processorModel below), or
-            // - merged config default is still agency-swarm while the UI model is something else.
-            // After /connect, global `model` stays `agency-swarm/...` but the picker often switches to
-            // opencode/anthropic/etc. for upstream credentials — `model.providerID` is then non–agency-swarm
-            // with no prior assistant row yet, so we must key off config as well as lastAssistant.
+            // - the resolved turn model is agency-swarm, or
+            // - the last assistant was from the bridge (continuation of an ongoing agency-swarm session).
+            // Explicit non-agency-swarm overrides (agent/stored/CLI) must run direct — do not coerce based on
+            // config.model alone, since the resolved model already reflects selectCurrentModel's decision.
             const useAgencySwarmBridge =
               model.providerID === SessionAgencySwarm.PROVIDER_ID ||
               (lastAssistant?.providerID === SessionAgencySwarm.PROVIDER_ID &&
-                model.providerID !== SessionAgencySwarm.PROVIDER_ID) ||
-              (defaultModelFromConfig?.providerID === SessionAgencySwarm.PROVIDER_ID &&
                 model.providerID !== SessionAgencySwarm.PROVIDER_ID)
             // Persist assistant rows as agency-swarm when using the HTTP bridge. Otherwise the message would
             // carry the UI/credential model (e.g. opencode/anthropic) and the next turn would not match

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -31,6 +31,7 @@ import { ulid } from "ulid"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import * as Stream from "effect/Stream"
+import { Config } from "../config/config"
 import { Command } from "../command"
 import { pathToFileURL, fileURLToPath } from "url"
 import { ConfigMarkdown } from "../config/markdown"
@@ -50,6 +51,7 @@ import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Layer, Option, Scope, ServiceMap } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
+import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { SessionAgencySwarm } from "./agency-swarm"
 import { agentBuilderInstructions } from "./agent-builder"
 import { agentPlannerInstructions } from "./agent-planner"
@@ -86,6 +88,7 @@ export namespace SessionPrompt {
     Service,
     Effect.gen(function* () {
       const bus = yield* Bus.Service
+      const config = yield* Config.Service
       const status = yield* SessionStatus.Service
       const sessions = yield* Session.Service
       const agents = yield* Agent.Service
@@ -1398,6 +1401,31 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }).pipe(Effect.ignore, Effect.forkIn(scope))
 
             const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
+            const mergedCfg = yield* config.get()
+            const defaultModelFromConfig = mergedCfg.model ? Provider.parseModel(mergedCfg.model) : undefined
+            // Use the Agency Swarm HTTP bridge when:
+            // - the message model is agency-swarm, or
+            // - the last assistant was from the bridge (see processorModel below), or
+            // - merged config default is still agency-swarm while the UI model is something else.
+            // After /connect, global `model` stays `agency-swarm/...` but the picker often switches to
+            // opencode/anthropic/etc. for upstream credentials — `model.providerID` is then non–agency-swarm
+            // with no prior assistant row yet, so we must key off config as well as lastAssistant.
+            const useAgencySwarmBridge =
+              model.providerID === SessionAgencySwarm.PROVIDER_ID ||
+              (lastAssistant?.providerID === SessionAgencySwarm.PROVIDER_ID &&
+                model.providerID !== SessionAgencySwarm.PROVIDER_ID) ||
+              (defaultModelFromConfig?.providerID === SessionAgencySwarm.PROVIDER_ID &&
+                model.providerID !== SessionAgencySwarm.PROVIDER_ID)
+            // Persist assistant rows as agency-swarm when using the HTTP bridge. Otherwise the message would
+            // carry the UI/credential model (e.g. opencode/anthropic) and the next turn would not match
+            // `lastAssistant?.providerID === agency-swarm`, so the bridge would stop after one reply.
+            const processorModel = useAgencySwarmBridge
+              ? yield* getModel(
+                  ProviderID.make(SessionAgencySwarm.PROVIDER_ID),
+                  ModelID.make(AgencySwarmAdapter.DEFAULT_MODEL_ID),
+                  sessionID,
+                )
+              : model
             const task = tasks.pop()
 
             if (task?.type === "subtask") {
@@ -1448,8 +1476,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               path: { cwd: ctx.directory, root: ctx.worktree },
               cost: 0,
               tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-              modelID: model.id,
-              providerID: model.providerID,
+              modelID: processorModel.id,
+              providerID: processorModel.providerID,
               time: { created: Date.now() },
               sessionID,
             }
@@ -1457,7 +1485,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             const handle = yield* processor.create({
               assistantMessage: msg,
               sessionID,
-              model,
+              model: processorModel,
             })
 
             const outcome: "break" | "continue" = yield* Effect.onExit(
@@ -1466,8 +1494,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 const bypassAgentCheck = lastUserMsg?.parts.some((p) => p.type === "agent") ?? false
                 if (step === 1) SessionSummary.summarize({ sessionID, messageID: lastUser.id })
 
-                if (model.providerID === SessionAgencySwarm.PROVIDER_ID) {
-                  const cfg = yield* provider.getProvider(model.providerID)
+                if (useAgencySwarmBridge) {
+                  const cfg = yield* provider.getProvider(ProviderID.make(SessionAgencySwarm.PROVIDER_ID))
                   const user = msgs.findLast(
                     (item): item is MessageV2.WithParts => item.info.role === "user" && item.info.id === lastUser.id,
                   )
@@ -1482,7 +1510,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     system: [],
                     messages: [],
                     tools: {},
-                    model,
+                    model: processorModel,
                     createStream: (abort) =>
                       SessionAgencySwarm.stream({
                         sessionID,
@@ -1490,6 +1518,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                         userMessage: user,
                         options: SessionAgencySwarm.optionsFromProvider(cfg),
                         abort,
+                        sessionModel: {
+                          providerID: lastUser.model.providerID,
+                          modelID: lastUser.model.modelID,
+                        },
                       }),
                   })
                   if (result === "stop") return "break" as const
@@ -1781,6 +1813,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         Layer.provide(Agent.defaultLayer),
         Layer.provide(Bus.layer),
         Layer.provide(CrossSpawnSpawner.defaultLayer),
+        Layer.provide(Config.defaultLayer),
       ),
     ),
   )

--- a/packages/opencode/test/agency-swarm/client-config.test.ts
+++ b/packages/opencode/test/agency-swarm/client-config.test.ts
@@ -6,6 +6,10 @@ import {
   sanitizeClientConfigForTransport,
   sanitizeHeaderLikeString,
 } from "../../src/agency-swarm/client-config"
+import {
+  buildLitellmModelForClientConfig,
+  normalizeExplicitClientConfigModel,
+} from "../../src/agency-swarm/litellm-provider"
 
 describe("agency-swarm client config credentials", () => {
   test("treats api_key and LiteLLM keys as credentials", () => {
@@ -92,5 +96,34 @@ describe("agency-swarm client config credentials", () => {
         },
       }),
     ).toBe(false)
+  })
+})
+
+describe("agency-swarm litellm model routing", () => {
+  test("buildLitellmModelForClientConfig keeps the caller provider for OpenRouter-namespaced ids", () => {
+    expect(buildLitellmModelForClientConfig("openrouter", "openrouter/openai/gpt-5.2")).toBe(
+      "litellm/openrouter/openai/gpt-5.2",
+    )
+    expect(buildLitellmModelForClientConfig("openrouter", "openai/gpt-5.2")).toBe("litellm/openrouter/openai/gpt-5.2")
+  })
+
+  test("buildLitellmModelForClientConfig still strips openai/ prefixes when the provider is openai", () => {
+    expect(buildLitellmModelForClientConfig("openai", "openai/gpt-5")).toBe("gpt-5")
+    expect(buildLitellmModelForClientConfig("openai", "gpt-5")).toBe("gpt-5")
+    expect(buildLitellmModelForClientConfig("openai", "litellm/openai/gpt-5")).toBe("gpt-5")
+  })
+
+  test("buildLitellmModelForClientConfig uses litellm/<provider>/<model> for non-OpenAI providers", () => {
+    expect(buildLitellmModelForClientConfig("anthropic", "claude-3")).toBe("litellm/anthropic/claude-3")
+    expect(buildLitellmModelForClientConfig("anthropic", "anthropic/claude-3")).toBe("litellm/anthropic/claude-3")
+  })
+
+  test("normalizeExplicitClientConfigModel preserves non-OpenAI provider namespaces", () => {
+    expect(normalizeExplicitClientConfigModel("openrouter/openai/gpt-5.2")).toBe("litellm/openrouter/openai/gpt-5.2")
+    expect(normalizeExplicitClientConfigModel("litellm/openrouter/openai/gpt-5.2")).toBe(
+      "litellm/openrouter/openai/gpt-5.2",
+    )
+    expect(normalizeExplicitClientConfigModel("openai/gpt-5")).toBe("gpt-5")
+    expect(normalizeExplicitClientConfigModel("litellm/openai/gpt-5")).toBe("gpt-5")
   })
 })

--- a/packages/opencode/test/agency-swarm/client-config.test.ts
+++ b/packages/opencode/test/agency-swarm/client-config.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { hasClientConfigCredential, hasExplicitOpenAIClientConfig } from "../../src/agency-swarm/client-config"
+import {
+  hasClientConfigCredential,
+  hasExplicitOpenAIApiKey,
+  hasExplicitOpenAIClientConfig,
+  sanitizeClientConfigForTransport,
+  sanitizeHeaderLikeString,
+} from "../../src/agency-swarm/client-config"
 
 describe("agency-swarm client config credentials", () => {
   test("treats api_key and LiteLLM keys as credentials", () => {
@@ -38,6 +44,37 @@ describe("agency-swarm client config credentials", () => {
         },
       }),
     ).toBe(false)
+  })
+
+  test("hasExplicitOpenAIApiKey is false for header-only auth", () => {
+    expect(
+      hasExplicitOpenAIApiKey({
+        default_headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      }),
+    ).toBe(false)
+    expect(hasExplicitOpenAIApiKey({ api_key: "sk-123" })).toBe(true)
+  })
+
+  test("sanitizeHeaderLikeString strips CR/LF for LiteLLM header safety", () => {
+    expect(sanitizeHeaderLikeString("sk-ant-api03-secret\r\n")).toBe("sk-ant-api03-secret")
+    expect(sanitizeHeaderLikeString("a\nb")).toBe("ab")
+  })
+
+  test("sanitizeClientConfigForTransport cleans litellm_keys and default_headers", () => {
+    const out = sanitizeClientConfigForTransport({
+      litellm_keys: {
+        anthropic: "sk-ant-key\r",
+      },
+      default_headers: {
+        "x-api-key": "k\n",
+      },
+    })
+    expect(out).toEqual({
+      litellm_keys: { anthropic: "sk-ant-key" },
+      default_headers: { "x-api-key": "k" },
+    })
   })
 
   test("ignores empty auth-like headers", () => {

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -219,6 +219,116 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
+  test("framework mode skips auth when forwarding is active and OPENAI_API_KEY is set in env", () => {
+    const input = {
+      frameworkMode: true,
+      forwardUpstreamCredentials: true,
+      env: { OPENAI_API_KEY: "sk-from-env" } as Record<string, string | undefined>,
+      providers: [
+        {
+          id: "agency-swarm",
+          name: "Agency Swarm",
+          source: "config",
+          env: [],
+          options: { baseURL: "https://agency.example.com" },
+          models: {},
+        },
+        {
+          id: "openai",
+          name: "OpenAI",
+          source: "config",
+          env: ["OPENAI_API_KEY"],
+          options: {},
+          models: {},
+        },
+      ] satisfies Provider[],
+    }
+
+    expect(shouldOpenStartupAuthDialog(input)).toBe(false)
+    expect(
+      shouldBlockAgencyPromptSubmit({
+        currentProviderID: "agency-swarm",
+        configuredModel: "agency-swarm/default",
+        providers: input.providers,
+        env: input.env,
+        mode: "normal",
+        isSlashCommand: false,
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode skips auth when forwarding is active and ANTHROPIC_API_KEY is set in env", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        forwardUpstreamCredentials: true,
+        env: { ANTHROPIC_API_KEY: "sk-ant-env" },
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: { baseURL: "https://agency.example.com" },
+            models: {},
+          },
+          {
+            id: "anthropic",
+            name: "Anthropic",
+            source: "config",
+            env: ["ANTHROPIC_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode skips auth from env even when the primary provider is filtered out", () => {
+    // Mirrors SessionAgencySwarm.buildAuthClientConfig()'s direct OPENAI_API_KEY read:
+    // the bridge can authenticate via env even when openai is not in the enabled provider list.
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        forwardUpstreamCredentials: true,
+        env: { OPENAI_API_KEY: "sk-from-env" },
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: { baseURL: "https://agency.example.com" },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("framework mode opens auth when forwarding is active and only an agency-swarm bridge token is present", () => {
+    // A bridge token authenticates the call to the bridge, not the upstream OpenAI/Anthropic request.
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        forwardUpstreamCredentials: true,
+        env: {},
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            key: "bridge-token",
+            options: { baseURL: "https://agency.example.com" },
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
   test("framework mode also skips local provider auth for remote agency-swarm backends using base_url", () => {
     expect(
       shouldOpenStartupAuthDialog({

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -189,13 +189,23 @@ describe("agency session errors", () => {
     ).toBe(false)
   })
 
-  test("framework mode follows the current provider override away from agency-swarm", () => {
+  test("framework mode stays true when config default is agency-swarm even if session uses openai upstream", () => {
     expect(
       isAgencySwarmFrameworkMode({
         currentProviderID: "openai",
         configuredModel: "agency-swarm/default",
       }),
-    ).toBe(false)
+    ).toBe(true)
+  })
+
+  test("framework mode is true when agent default is agency-swarm but session model is openai", () => {
+    expect(
+      isAgencySwarmFrameworkMode({
+        currentProviderID: "openai",
+        configuredModel: undefined,
+        agentModel: { providerID: "agency-swarm", modelID: "default" },
+      }),
+    ).toBe(true)
   })
 
   test("framework mode falls back to the configured agency-swarm model when no current provider is selected", () => {

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -161,6 +161,64 @@ describe("agency session errors", () => {
     ).toBe(false)
   })
 
+  test("framework mode opens auth for non-loopback base URL when forwardUpstreamCredentials is on", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              baseURL: "http://host.docker.internal:8000",
+              forwardUpstreamCredentials: true,
+            },
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  test("framework mode opens auth for remote base URL when forwardUpstreamCredentials override is set", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        forwardUpstreamCredentials: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              baseURL: "https://agency.example.com",
+            },
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
   test("framework mode also skips local provider auth for remote agency-swarm backends using base_url", () => {
     expect(
       shouldOpenStartupAuthDialog({

--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -6,6 +6,7 @@ import { Effect, ServiceMap } from "effect"
 import type * as PlatformError from "effect/PlatformError"
 import type * as Scope from "effect/Scope"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { AgencyBrand } from "../../src/agency-swarm/brand"
 import type { Config } from "../../src/config/config"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import { Instance } from "../../src/project/instance"
@@ -56,7 +57,7 @@ export async function tmpdir<T>(options?: TmpDirOptions<T>) {
   }
   if (options?.config) {
     await Bun.write(
-      path.join(dirpath, "opencode.json"),
+      path.join(dirpath, `${AgencyBrand.config}.json`),
       JSON.stringify({
         $schema: "https://opencode.ai/config.json",
         ...options.config,
@@ -110,7 +111,7 @@ export function tmpdirScoped(options?: { git?: boolean; config?: Partial<Config.
     if (options?.config) {
       yield* Effect.promise(() =>
         fs.writeFile(
-          path.join(dir, "opencode.json"),
+          path.join(dir, `${AgencyBrand.config}.json`),
           JSON.stringify({ $schema: "https://opencode.ai/config.json", ...options.config }),
         ),
       )

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -2510,9 +2510,10 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["Hi, there!"])
   })
 
-  test("stream does not duplicate text when messages payload replays assistant body with different id after output_text", async () => {
+  test("stream keeps both distinct short assistant messages in the same run (no body-only dedupe)", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
+      yield { type: "meta", runID: "run_1" }
       yield {
         type: "data",
         payload: {
@@ -2520,7 +2521,7 @@ describe("session.agency-swarm", () => {
           data: {
             type: "response.output_item.added",
             output_index: "0",
-            item: { type: "message", id: "msg_stream" },
+            item: { type: "message", id: "msg_a" },
           },
         },
       }
@@ -2530,9 +2531,9 @@ describe("session.agency-swarm", () => {
           type: "raw_response_event",
           data: {
             type: "response.output_text.delta",
-            item_id: "msg_stream",
+            item_id: "msg_a",
             output_index: "0",
-            delta: "Anthropic via stream",
+            delta: "Done",
           },
         },
       }
@@ -2542,22 +2543,45 @@ describe("session.agency-swarm", () => {
           type: "raw_response_event",
           data: {
             type: "response.output_text.done",
-            item_id: "msg_stream",
+            item_id: "msg_a",
             output_index: "0",
-            text: "Anthropic via stream",
+            text: "Done",
           },
         },
       }
       yield {
-        type: "messages",
+        type: "data",
         payload: {
-          new_messages: [
-            {
-              type: "message",
-              id: "msg_from_messages_frame",
-              content: [{ type: "output_text", text: "Anthropic via stream" }],
-            },
-          ],
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_b" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_b",
+            output_index: "1",
+            delta: "Done",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_b",
+            output_index: "1",
+            text: "Done",
+          },
         },
       }
       yield { type: "end" }
@@ -2572,7 +2596,7 @@ describe("session.agency-swarm", () => {
       }
     }
 
-    expect(deltas).toEqual(["Anthropic via stream"])
+    expect(deltas).toEqual(["Done", "Done"])
   })
 
   test("stream does not duplicate reasoning when reasoning_item_created follows summary events", async () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -89,7 +89,7 @@ describe("session.agency-swarm", () => {
       } as any,
       options,
       abort: abort.signal,
-    } satisfies Parameters<typeof SessionAgencySwarm.stream>[0]
+    } as Parameters<typeof SessionAgencySwarm.stream>[0]
 
     return {
       input,
@@ -187,6 +187,32 @@ describe("session.agency-swarm", () => {
     expect(options.discoveryTimeoutMs).toBe(12000)
   })
 
+  test("optionsFromProvider maps forwardUpstreamCredentials", () => {
+    const on = SessionAgencySwarm.optionsFromProvider({
+      id: "agency-swarm" as any,
+      name: "Agency Swarm",
+      source: "config",
+      env: [],
+      models: {},
+      options: {
+        baseURL: "http://192.168.1.10:8000",
+        forwardUpstreamCredentials: true,
+      },
+    })
+    expect(on.forwardUpstreamCredentials).toBe(true)
+    const off = SessionAgencySwarm.optionsFromProvider({
+      id: "agency-swarm" as any,
+      name: "Agency Swarm",
+      source: "config",
+      env: [],
+      models: {},
+      options: {
+        baseURL: "http://192.168.1.10:8000",
+      },
+    })
+    expect(off.forwardUpstreamCredentials).toBeUndefined()
+  })
+
   test("optionsFromProvider prefers auth key token over config token", () => {
     const options = SessionAgencySwarm.optionsFromProvider({
       id: "agency-swarm" as any,
@@ -281,6 +307,32 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream forwards stored API auth to remote URL when forwardUpstreamCredentials is true", async () => {
+    mockHistory()
+    Auth.all = (async () => ({
+      openai: { type: "api", key: "sk-openai" } as any,
+    })) as typeof Auth.all
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.baseURL = "https://agency.example.com"
+    input.options.forwardUpstreamCredentials = true
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "sk-openai",
+    })
+  })
+
   test("stream forwards stored API auth to 0.0.0.0 local agency-swarm servers", async () => {
     mockHistory()
     Auth.all = (async () => ({
@@ -307,6 +359,31 @@ describe("session.agency-swarm", () => {
       litellm_keys: {
         anthropic: "sk-ant",
       },
+    })
+  })
+
+  test("stream forwards stored API auth to host.docker.internal (Docker Desktop)", async () => {
+    mockHistory()
+    Auth.all = (async () => ({
+      openai: { type: "api", key: "sk-openai" } as any,
+    })) as typeof Auth.all
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.baseURL = "http://host.docker.internal:8000"
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "sk-openai",
     })
   })
 
@@ -462,6 +539,195 @@ describe("session.agency-swarm", () => {
         litellm_keys: {
           anthropic: "env-anthropic",
         },
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    }
+  })
+
+  test("stream forwards session UI model as client_config.model (litellm/ for non-OpenAI)", async () => {
+    mockHistory()
+    Auth.all = (async () => ({})) as typeof Auth.all
+    Env.all = (() => ({})) as typeof Env.all
+    Provider.list = (async () => ({})) as typeof Provider.list
+
+    let body: Record<string, unknown> | undefined
+    const server = createServer(async (request, response) => {
+      if (request.url !== "/builder/get_response_stream") {
+        response.writeHead(404)
+        response.end("not found")
+        return
+      }
+
+      const chunks: Buffer[] = []
+      for await (const chunk of request) {
+        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+        else chunks.push(Buffer.from(chunk))
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+      })
+      response.end(
+        [
+          'data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"ok"}}}\n\n',
+          "event: end\ndata: [DONE]\n\n",
+        ].join(""),
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      server.close()
+      throw new Error("Expected local test server address")
+    }
+
+    try {
+      const { input } = helper()
+      input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      input.sessionModel = { providerID: "anthropic", modelID: "claude-sonnet-4-5" }
+      const stream = await SessionAgencySwarm.stream(input)
+      for await (const _ of stream.fullStream) {
+        /* drain */
+      }
+
+      expect(body?.["client_config"]).toEqual({
+        model: "litellm/anthropic/claude-sonnet-4-5",
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    }
+  })
+
+  test("stream forwards session UI OpenAI model as bare model id", async () => {
+    mockHistory()
+    Auth.all = (async () => ({})) as typeof Auth.all
+    Env.all = (() => ({})) as typeof Env.all
+    Provider.list = (async () => ({})) as typeof Provider.list
+
+    let body: Record<string, unknown> | undefined
+    const server = createServer(async (request, response) => {
+      if (request.url !== "/builder/get_response_stream") {
+        response.writeHead(404)
+        response.end("not found")
+        return
+      }
+
+      const chunks: Buffer[] = []
+      for await (const chunk of request) {
+        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+        else chunks.push(Buffer.from(chunk))
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+      })
+      response.end(
+        [
+          'data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"ok"}}}\n\n',
+          "event: end\ndata: [DONE]\n\n",
+        ].join(""),
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      server.close()
+      throw new Error("Expected local test server address")
+    }
+
+    try {
+      const { input } = helper()
+      input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      input.sessionModel = { providerID: "openai", modelID: "gpt-4o" }
+      const stream = await SessionAgencySwarm.stream(input)
+      for await (const _ of stream.fullStream) {
+        /* drain */
+      }
+
+      expect(body?.["client_config"]).toEqual({
+        model: "gpt-4o",
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    }
+  })
+
+  test("explicit client_config.model overrides session-derived model", async () => {
+    mockHistory()
+    Auth.all = (async () => ({})) as typeof Auth.all
+    Env.all = (() => ({})) as typeof Env.all
+    Provider.list = (async () => ({})) as typeof Provider.list
+
+    let body: Record<string, unknown> | undefined
+    const server = createServer(async (request, response) => {
+      if (request.url !== "/builder/get_response_stream") {
+        response.writeHead(404)
+        response.end("not found")
+        return
+      }
+
+      const chunks: Buffer[] = []
+      for await (const chunk of request) {
+        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+        else chunks.push(Buffer.from(chunk))
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+      })
+      response.end(
+        [
+          'data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"ok"}}}\n\n',
+          "event: end\ndata: [DONE]\n\n",
+        ].join(""),
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      server.close()
+      throw new Error("Expected local test server address")
+    }
+
+    try {
+      const { input } = helper()
+      input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      input.options.clientConfig = {
+        model: "gpt-4o",
+      }
+      input.sessionModel = { providerID: "anthropic", modelID: "claude-sonnet-4-5" }
+      const stream = await SessionAgencySwarm.stream(input)
+      for await (const _ of stream.fullStream) {
+        /* drain */
+      }
+
+      expect(body?.["client_config"]).toEqual({
+        model: "gpt-4o",
       })
     } finally {
       await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
@@ -2242,6 +2508,71 @@ describe("session.agency-swarm", () => {
     }
 
     expect(deltas).toEqual(["Hi, there!"])
+  })
+
+  test("stream does not duplicate text when messages payload replays assistant body with different id after output_text", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "message", id: "msg_stream" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_stream",
+            output_index: "0",
+            delta: "Anthropic via stream",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_stream",
+            output_index: "0",
+            text: "Anthropic via stream",
+          },
+        },
+      }
+      yield {
+        type: "messages",
+        payload: {
+          new_messages: [
+            {
+              type: "message",
+              id: "msg_from_messages_frame",
+              content: [{ type: "output_text", text: "Anthropic via stream" }],
+            },
+          ],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "text-delta") {
+        deltas.push(event.text)
+      }
+    }
+
+    expect(deltas).toEqual(["Anthropic via stream"])
   })
 
   test("stream does not duplicate reasoning when reasoning_item_created follows summary events", async () => {

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -190,7 +190,16 @@ const unix = process.platform !== "win32" ? it.live : it.live.skip
 
 // Config that registers a custom "test" provider with a "test-model" model
 // so Provider.getModel("test", "test-model") succeeds inside the loop.
+// Default `model` + `agent.build.model` pin prompts to the test provider: `createUserMessage`
+// uses `input.model ?? agent.model ?? lastModel`, so without `agent.build.model` the build
+// agent's default (often agency-swarm) would win and the loop would take the Agency Swarm bridge.
 const cfg = {
+  model: "test/test-model",
+  agent: {
+    build: {
+      model: "test/test-model",
+    },
+  },
   provider: {
     test: {
       name: "Test",
@@ -527,14 +536,18 @@ it.live("failed subtask preserves metadata on error tool state", () =>
     }),
     {
       git: true,
-      config: (url) => ({
-        ...providerCfg(url),
-        agent: {
-          general: {
-            model: "test/missing-model",
+      config: (url) => {
+        const base = providerCfg(url)
+        return {
+          ...base,
+          agent: {
+            ...base.agent,
+            general: {
+              model: "test/missing-model",
+            },
           },
-        },
-      }),
+        }
+      },
     },
   ),
 )

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -469,6 +469,46 @@ it.live("loop continues when finish is tool-calls", () =>
   ),
 )
 
+// Regression: config.model = "agency-swarm/default" must not coerce processorModel onto the bridge
+// when the turn is running through an explicit non-agency-swarm override (agent/stored/CLI).
+it.live("loop keeps explicit non-agency-swarm override direct when config default is agency-swarm", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      yield* llm.text("world")
+
+      const result = yield* prompt.loop({ sessionID: session.id })
+      expect(result.info.role).toBe("assistant")
+      if (result.info.role === "assistant") {
+        // If the removed fallback had fired, processorModel would have been coerced to
+        // agency-swarm/default and the assistant row would carry that providerID.
+        expect(result.info.providerID).toBe(ref.providerID)
+        expect(result.info.modelID).toBe(ref.modelID)
+      }
+      expect(yield* llm.hits).toHaveLength(1)
+    }),
+    {
+      git: true,
+      config: (url) => ({
+        ...providerCfg(url),
+        // Pin config.model to agency-swarm while keeping the build agent on the test provider.
+        model: "agency-swarm/default",
+      }),
+    },
+  ),
+)
+
 it.live("loop continues when finish is stop but assistant has tool parts", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -9,6 +9,7 @@ import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
 import { Log } from "../../src/util/log"
+import { AgencyBrand } from "../../src/agency-swarm/brand"
 import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
 import { tmpdir } from "../fixture/fixture"
 
@@ -320,7 +321,7 @@ describe("session.prompt regression", () => {
         git: true,
         init: async (dir) => {
           await Bun.write(
-            path.join(dir, "opencode.json"),
+            path.join(dir, `${AgencyBrand.config}.json`),
             JSON.stringify({
               $schema: "https://opencode.ai/config.json",
               enabled_providers: ["alibaba"],
@@ -389,7 +390,7 @@ describe("session.prompt regression", () => {
         git: true,
         init: async (dir) => {
           await Bun.write(
-            path.join(dir, "opencode.json"),
+            path.join(dir, `${AgencyBrand.config}.json`),
             JSON.stringify({
               $schema: "https://opencode.ai/config.json",
               enabled_providers: ["alibaba"],


### PR DESCRIPTION
### Issue for this PR

Closes #87 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a few Agent Swarm–related problems that showed up with real providers:

1. **Duplicate assistant output with Anthropic** — the same assistant text was appearing more than once; OpenAI was fine. The change tightens how that stream/session path emits or replays messages so the UI does not show duplicates.

2. **LiteLLM-backed providers** — values that flow into transport (e.g. client config) are sanitized so newlines and similar characters do not break requests or trigger header-related server errors. This keeps LiteLLM and model switching usable when configs or metadata are not perfectly “flat” strings.

3. **Wrong providers after auth / when switching models** — for Agent Swarm, only OpenAI and Anthropic should be offered once you’re authenticated; the UI could list every provider or get confused after the effective model/provider changed. Framework mode is detected in a way that still applies when you are on a LiteLLM route or have switched models, so the provider list and prompts stay consistent.

### How did you verify your code works?

Ran `bun turbo typecheck`. Manually checked Anthropic output, LiteLLM flows, model switching, and the Agent Swarm auth/provider list.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

Optional: provider picker or model switch if useful.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR