### PR TITLE
fix(tui): move recipient/history setup into generator to unfreeze first message

### DIFF
--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -364,27 +364,9 @@ export namespace SessionAgencySwarm {
       sessionID: input.sessionID,
     }
 
-    const history = await AgencySwarmHistory.load(scope)
     const outgoingMessage = buildOutgoingMessage(input.userMessage)
-    const chatHistory = await Session.messages({ sessionID: input.sessionID })
-      .then((msgs) => compactHistory({ msgs, currentID: input.userMessage.info.id }) ?? history.chat_history)
-      .catch((error) => {
-        log.warn("unable to rebuild compacted agency history; falling back to stored history", {
-          sessionID: input.sessionID,
-          error: error instanceof Error ? error.message : String(error),
-        })
-        return history.chat_history
-      })
-    const recipientAgent = await resolveRecipientAgent({
-      sessionID: input.sessionID,
-      baseURL: input.options.baseURL,
-      agency,
-      token: input.options.token,
-      timeoutMs: input.options.discoveryTimeoutMs,
-      mentionedRecipient: findRecipientAgent(input.userMessage),
-      configuredRecipient: input.options.recipientAgent,
-    })
     const fileURLs = collectFileURLs(input.userMessage)
+    const mentionedRecipient = findRecipientAgent(input.userMessage)
 
     const tools = new Map<string, Tool>()
     const callByItem = new Map<string, string>()
@@ -1268,6 +1250,25 @@ export namespace SessionAgencySwarm {
       yield { type: "start-step" }
       let streamError: Error | undefined
 
+      const history = await AgencySwarmHistory.load(scope)
+      const chatHistory = await Session.messages({ sessionID: input.sessionID })
+        .then((msgs) => compactHistory({ msgs, currentID: input.userMessage.info.id }) ?? history.chat_history)
+        .catch((error) => {
+          log.warn("unable to rebuild compacted agency history; falling back to stored history", {
+            sessionID: input.sessionID,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          return history.chat_history
+        })
+      const recipientAgent = await resolveRecipientAgent({
+        sessionID: input.sessionID,
+        baseURL: input.options.baseURL,
+        agency,
+        token: input.options.token,
+        timeoutMs: input.options.discoveryTimeoutMs,
+        mentionedRecipient,
+        configuredRecipient: input.options.recipientAgent,
+      })
       const clientConfig = await resolveClientConfig(input.options.baseURL, input.options.clientConfig)
 
       try {


### PR DESCRIPTION
## Summary

Complete the 1.4.18 streaming-freeze fix. PR #74 moved `resolveClientConfig` inside `fullStream` to unfreeze the onboarding→conversation transition on the first message, but user QA after 1.4.18 confirmed the animation is still frozen. Two more blocking awaits live in `stream()`'s outer scope before the generator returns:

1. `AgencySwarmHistory.load(scope)` + `Session.messages()` → `compactHistory`
2. `resolveRecipientAgent()` → `AgencySwarmAdapter.getMetadata()` HTTP GET against the local bridge (typically the slowest leg on first send)

Move all three inside the generator, after `yield { type: 'start' }` / `yield { type: 'start-step' }`. The TUI switches to the conversation screen on the first frame; the bridge metadata fetch now blocks only the first *data* frame, which the TUI surfaces as its pending/streaming indicator.

## Test plan
- [ ] Launch against a fresh project on cold OAuth: conversation screen must mount immediately after Enter
- [ ] Streaming text animation renders within the first ~1s as bridge metadata + OAuth refresh complete
- [ ] Subsequent messages behave identically (no regression)
- [ ] `bun typecheck` passes; `bun test packages/opencode/test/session/agency-swarm.test.ts` — 51/51 green locally