### PR TITLE
docs: clarify subagent handoff context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ North Star: keep the user's general intent and direction clear; read intent betw
 - If one subagent cannot cover the task cleanly, split the work into two scoped subagents instead of broadening one mandate.
 - Why: recent broad manager-owned edits made request ownership hard to trace and burned main-thread context.
 - After delegating work, do not interrupt, rush, or repeatedly ping subagents; block and wait for their result unless the user changes scope or you have clear evidence of a hard failure.
-- Start every subagent task with background explaining what went wrong. Include enough context for the handoff, with no fixed length requirement.
+- Start every subagent task with enough context for the handoff: the task, relevant background, and the higher-level intent it serves.
 - Keep subagent prompts goal-based and avoid unnecessary scripting; do not script exact file edits. If the exact edit is already known, apply it in the main thread and use the subagent for review or finalization.
 - PR-specific work belongs to subagents, not the manager. If no suitable native subagent is available, stop and surface the blocker or use Codex CLI only as the fallback review path.
 - Default native-subagent model policy: use `gpt-5.4` with `high` reasoning unless the user explicitly overrides it.


### PR DESCRIPTION
## Summary
- clarify the subagent handoff rule so it asks for the task, relevant background, and the higher-level intent it serves
- keep the end-user QA proof rule unchanged as a single requirement where applicable

## Validation
- `markdownlint-cli --disable MD001 MD012 MD013 MD022 MD025 MD032 MD033 -- AGENTS.md`
