### PR TITLE
fix(tui): navigate to session before first prompt stream

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -724,6 +724,7 @@ export function Prompt(props: PromptProps) {
 
     let sessionID = props.sessionID
     let createdSessionID: string | undefined
+    let navigateTimer: ReturnType<typeof setTimeout> | undefined
     if (sessionID == null) {
       const res = await sdk.client.session.create({
         workspaceID: props.workspaceID,
@@ -744,7 +745,8 @@ export function Prompt(props: PromptProps) {
 
       // temporary hack to make sure the message is sent
       if (!props.sessionID)
-        setTimeout(() => {
+        navigateTimer = setTimeout(() => {
+          navigateTimer = undefined
           route.navigate({
             type: "session",
             sessionID: newSessionID,
@@ -823,6 +825,10 @@ export function Prompt(props: PromptProps) {
           providerID: selectedModel.providerID,
           message,
         })
+        if (navigateTimer) {
+          clearTimeout(navigateTimer)
+          navigateTimer = undefined
+        }
         if (createdSessionID) {
           route.navigate({ type: "home" })
           if (shouldReopenAuth) {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -829,13 +829,10 @@ export function Prompt(props: PromptProps) {
           clearTimeout(navigateTimer)
           navigateTimer = undefined
         }
-        if (createdSessionID) {
-          route.navigate({ type: "home" })
-          if (shouldReopenAuth) {
-            void sdk.client.session.delete({
-              sessionID: createdSessionID,
-            })
-          }
+        if (createdSessionID && shouldReopenAuth) {
+          void sdk.client.session.delete({
+            sessionID: createdSessionID,
+          })
         }
         if (shouldReopenAuth) {
           toast.show({

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -746,7 +746,7 @@ export function Prompt(props: PromptProps) {
         setTimeout(() => {
           route.navigate({
             type: "session",
-            sessionID: createdSessionID!,
+            sessionID,
           })
         }, 50)
     }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -740,6 +740,15 @@ export function Prompt(props: PromptProps) {
 
       sessionID = res.data.id
       createdSessionID = sessionID
+
+      // temporary hack to make sure the message is sent
+      if (!props.sessionID)
+        setTimeout(() => {
+          route.navigate({
+            type: "session",
+            sessionID: createdSessionID!,
+          })
+        }, 50)
     }
 
     const messageID = MessageID.ascending()
@@ -834,15 +843,6 @@ export function Prompt(props: PromptProps) {
       }
     }
     clearSubmittedPrompt(currentMode)
-
-    // temporary hack to make sure the message is sent
-    if (!props.sessionID)
-      setTimeout(() => {
-        route.navigate({
-          type: "session",
-          sessionID,
-        })
-      }, 50)
   }
   const exit = useExit()
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -823,8 +823,13 @@ export function Prompt(props: PromptProps) {
           providerID: selectedModel.providerID,
           message,
         })
-        if (createdSessionID && shouldReopenAuth) {
-          void sdk.client.session.delete({ sessionID: createdSessionID })
+        if (createdSessionID) {
+          route.navigate({ type: "home" })
+          if (shouldReopenAuth) {
+            void sdk.client.session.delete({
+              sessionID: createdSessionID,
+            })
+          }
         }
         if (shouldReopenAuth) {
           toast.show({

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -740,13 +740,14 @@ export function Prompt(props: PromptProps) {
 
       sessionID = res.data.id
       createdSessionID = sessionID
+      const newSessionID = sessionID
 
       // temporary hack to make sure the message is sent
       if (!props.sessionID)
         setTimeout(() => {
           route.navigate({
             type: "session",
-            sessionID,
+            sessionID: newSessionID,
           })
         }, 50)
     }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -13,7 +13,7 @@ import { useRoute } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { MessageID, PartID } from "@/session/schema"
 import { displayAgentName } from "@/agent/display"
-import { createStore, produce } from "solid-js/store"
+import { createStore, produce, unwrap } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
 import { usePromptHistory, type PromptInfo } from "./history"
 import { assign } from "./part"
@@ -83,6 +83,31 @@ const money = new Intl.NumberFormat("en-US", {
 function randomIndex(count: number) {
   if (count <= 0) return 0
   return Math.floor(Math.random() * count)
+}
+
+function waitForSessionPromptProgress(sdk: ReturnType<typeof useSDK>, sessionID: string) {
+  let done = false
+  let offMessage = () => {}
+
+  const cleanup = () => {
+    if (done) return
+    done = true
+    offMessage()
+  }
+
+  const promise = new Promise<void>((resolve) => {
+    offMessage = sdk.event.on("message.updated", (evt) => {
+      if (evt.properties.info.sessionID !== sessionID) return
+      if (evt.properties.info.role !== "assistant") return
+      cleanup()
+      resolve()
+    })
+  })
+
+  return {
+    promise,
+    cleanup,
+  }
 }
 
 export function Prompt(props: PromptProps) {
@@ -721,10 +746,12 @@ export function Prompt(props: PromptProps) {
       agencyConnection.openConnectDialog()
       return
     }
-
+    const submittedPrompt = structuredClone(unwrap(store.prompt))
     let sessionID = props.sessionID
     let createdSessionID: string | undefined
+    let navigatedToCreatedSession = false
     let navigateTimer: ReturnType<typeof setTimeout> | undefined
+    let promptProgress: ReturnType<typeof waitForSessionPromptProgress> | undefined
     if (sessionID == null) {
       const res = await sdk.client.session.create({
         workspaceID: props.workspaceID,
@@ -741,17 +768,7 @@ export function Prompt(props: PromptProps) {
 
       sessionID = res.data.id
       createdSessionID = sessionID
-      const newSessionID = sessionID
-
-      // temporary hack to make sure the message is sent
-      if (!props.sessionID)
-        navigateTimer = setTimeout(() => {
-          navigateTimer = undefined
-          route.navigate({
-            type: "session",
-            sessionID: newSessionID,
-          })
-        }, 50)
+      promptProgress = waitForSessionPromptProgress(sdk, sessionID)
     }
 
     const messageID = MessageID.ascending()
@@ -796,7 +813,7 @@ export function Prompt(props: PromptProps) {
     } else {
       const savedPrompt = { input: store.prompt.input, parts: [...store.prompt.parts] }
       try {
-        await sdk.client.session.prompt({
+        const promptTask = sdk.client.session.prompt({
           sessionID,
           ...selectedModel,
           messageID,
@@ -812,6 +829,23 @@ export function Prompt(props: PromptProps) {
             ...nonTextParts.map(assign),
           ],
         })
+
+        if (createdSessionID) {
+          const newSessionID = createdSessionID
+          await Promise.race([promptTask, promptProgress!.promise])
+
+          // temporary hack to make sure the message is sent
+          navigateTimer = setTimeout(() => {
+            navigateTimer = undefined
+            navigatedToCreatedSession = true
+            route.navigate({
+              type: "session",
+              sessionID: newSessionID,
+            })
+          }, 50)
+        }
+
+        await promptTask
       } catch (error) {
         // Fork-only: surface auth errors via the connect/auth dialog and restore the
         // composer state so the user can retry. Rebuilding extmarks from the saved parts
@@ -830,6 +864,13 @@ export function Prompt(props: PromptProps) {
           navigateTimer = undefined
         }
         if (createdSessionID && shouldReopenAuth) {
+          if (navigatedToCreatedSession) {
+            route.navigate({
+              type: "home",
+              workspaceID: props.workspaceID,
+              initialPrompt: submittedPrompt,
+            })
+          }
           void sdk.client.session.delete({
             sessionID: createdSessionID,
           })
@@ -849,6 +890,8 @@ export function Prompt(props: PromptProps) {
           duration: 5000,
         })
         return
+      } finally {
+        promptProgress?.cleanup()
       }
     }
     clearSubmittedPrompt(currentMode)

--- a/packages/opencode/test/cli/tui/prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt.test.tsx
@@ -7,6 +7,7 @@ import * as AutocompleteModule from "../../../src/cli/cmd/tui/component/prompt/a
 import * as CommandDialogModule from "../../../src/cli/cmd/tui/component/dialog-command"
 import type { PromptRef } from "../../../src/cli/cmd/tui/component/prompt"
 import * as ExitContext from "../../../src/cli/cmd/tui/context/exit"
+import * as AgencySwarmConnectionContext from "../../../src/cli/cmd/tui/context/agency-swarm-connection"
 import * as KeybindContext from "../../../src/cli/cmd/tui/context/keybind"
 import * as KVContext from "../../../src/cli/cmd/tui/context/kv"
 import * as LocalContext from "../../../src/cli/cmd/tui/context/local"
@@ -115,6 +116,14 @@ describe("prompt auth rejection handling", () => {
         },
       }) as any,
     )
+    spyOn(AgencySwarmConnectionContext, "useAgencySwarmConnection").mockReturnValue({
+      requiresReconnect: () => false,
+      openConnectDialog: () => false,
+      status: () => "connected",
+      baseURL: () => undefined,
+      failureCount: () => 0,
+      frameworkMode: () => true,
+    } as any)
     spyOn(KeybindContext, "useKeybind").mockReturnValue({
       leader: false,
       match: () => false,

--- a/packages/opencode/test/cli/tui/prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt.test.tsx
@@ -1,0 +1,319 @@
+/** @jsxImportSource @opentui/solid */
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { RGBA } from "@opentui/core"
+import { testRender } from "@opentui/solid"
+import { createEffect } from "solid-js"
+import * as AutocompleteModule from "../../../src/cli/cmd/tui/component/prompt/autocomplete"
+import * as CommandDialogModule from "../../../src/cli/cmd/tui/component/dialog-command"
+import type { PromptRef } from "../../../src/cli/cmd/tui/component/prompt"
+import * as ExitContext from "../../../src/cli/cmd/tui/context/exit"
+import * as KeybindContext from "../../../src/cli/cmd/tui/context/keybind"
+import * as KVContext from "../../../src/cli/cmd/tui/context/kv"
+import * as LocalContext from "../../../src/cli/cmd/tui/context/local"
+import { RouteProvider, useRoute } from "../../../src/cli/cmd/tui/context/route"
+import * as SDKContext from "../../../src/cli/cmd/tui/context/sdk"
+import * as SyncContext from "../../../src/cli/cmd/tui/context/sync"
+import * as ThemeContext from "../../../src/cli/cmd/tui/context/theme"
+import * as TuiConfigContext from "../../../src/cli/cmd/tui/context/tui-config"
+import * as PromptHistoryModule from "../../../src/cli/cmd/tui/component/prompt/history"
+import * as PromptStashModule from "../../../src/cli/cmd/tui/component/prompt/stash"
+import * as TextareaKeybindingsModule from "../../../src/cli/cmd/tui/component/textarea-keybindings"
+import { DialogProvider, useDialog } from "../../../src/cli/cmd/tui/ui/dialog"
+import * as ToastModule from "../../../src/cli/cmd/tui/ui/toast"
+import { AgencySwarmRunSession } from "../../../src/agency-swarm/run-session"
+
+function flushEffects() {
+  return Promise.resolve().then(() => Promise.resolve())
+}
+
+function createEventBus() {
+  const listeners = new Map<string, Set<(event: any) => void>>()
+
+  return {
+    on(type: string, handler: (event: any) => void) {
+      let bucket = listeners.get(type)
+      if (!bucket) {
+        bucket = new Set()
+        listeners.set(type, bucket)
+      }
+      bucket.add(handler)
+      return () => {
+        bucket?.delete(handler)
+        if (bucket?.size === 0) listeners.delete(type)
+      }
+    },
+    emit(type: string, event: any) {
+      const bucket = listeners.get(type)
+      if (!bucket) return
+      for (const handler of bucket) {
+        handler(event)
+      }
+    },
+  }
+}
+
+describe("prompt auth rejection handling", () => {
+  afterEach(() => {
+    mock.restore()
+    delete process.env.OPENAI_API_KEY
+  })
+
+  test("keeps the first draft on home when a slow auth rejection lands before streaming starts", async () => {
+    process.env.OPENAI_API_KEY = "sk-test"
+
+    const routeStates: string[] = []
+    const dialogDepth: number[] = []
+    const toasts: Array<{ duration?: number; variant?: string; message?: string }> = []
+    const events = createEventBus()
+    const promptError = new Error("Streaming request failed (403): Invalid API key for OpenAI")
+    const createSession = spyOn(
+      {
+        create: async () => ({
+          data: {
+            id: "session_auth_race",
+          },
+        }),
+      },
+      "create",
+    )
+    const deleteSession = spyOn(
+      {
+        delete: async () => ({}),
+      },
+      "delete",
+    )
+    const promptSession = spyOn(
+      {
+        prompt: async () => {
+          await Bun.sleep(75)
+          throw promptError
+        },
+      },
+      "prompt",
+    )
+
+    spyOn(AgencySwarmRunSession, "sync").mockResolvedValue(undefined)
+    spyOn(AutocompleteModule, "Autocomplete").mockImplementation((props: any) => {
+      props.ref?.({
+        onInput() {},
+        onKeyDown() {},
+        visible: false,
+      })
+      return <box />
+    })
+    spyOn(CommandDialogModule, "useCommandDialog").mockReturnValue({
+      register: () => () => {},
+      slashes: () => [],
+      trigger: () => {},
+    } as any)
+    spyOn(ExitContext, "useExit").mockReturnValue(
+      Object.assign(async () => {}, {
+        message: {
+          set: () => () => {},
+          clear: () => {},
+          get: () => undefined,
+        },
+      }) as any,
+    )
+    spyOn(KeybindContext, "useKeybind").mockReturnValue({
+      leader: false,
+      match: () => false,
+      print: () => "",
+    } as any)
+    spyOn(KVContext, "useKV").mockReturnValue({
+      get: (_key: string, fallback?: unknown) => fallback,
+    } as any)
+    spyOn(LocalContext, "useLocal").mockReturnValue({
+      agent: {
+        current: () => ({
+          name: "builder",
+          model: {
+            providerID: "agency-swarm",
+            modelID: "default",
+          },
+        }),
+        list: () => [{ name: "builder" }],
+        set: () => {},
+        color: () => RGBA.fromHex("#38bdf8"),
+      },
+      model: {
+        current: () => ({
+          providerID: "agency-swarm",
+          modelID: "default",
+        }),
+        parsed: () => ({
+          provider: "Agency Swarm",
+          model: "default",
+        }),
+        set: () => {},
+        variant: {
+          current: () => undefined,
+          list: () => [],
+          set: () => {},
+        },
+      },
+    } as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({
+      client: {
+        session: {
+          create: createSession,
+          prompt: promptSession,
+          delete: deleteSession,
+        },
+      },
+      event: events,
+    } as any)
+    spyOn(SyncContext, "useSync").mockReturnValue({
+      data: {
+        command: [],
+        config: {
+          model: "agency-swarm/default",
+          experimental: {},
+        },
+        console_state: {
+          activeOrgName: "",
+          consoleManagedProviders: [],
+          switchableOrgCount: 0,
+        },
+        message: {},
+        provider: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+        provider_auth: {
+          openai: [{ type: "api", label: "API key" }],
+        },
+        provider_next: {
+          all: [{ id: "openai", name: "OpenAI" }],
+          connected: [],
+          default: {},
+        },
+        session_status: {},
+      },
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {
+        _hasSelectedListItemText: false,
+        accent: RGBA.fromHex("#14b8a6"),
+        background: RGBA.fromHex("#020617"),
+        backgroundElement: RGBA.fromHex("#111827"),
+        backgroundPanel: RGBA.fromHex("#0f172a"),
+        border: RGBA.fromHex("#334155"),
+        error: RGBA.fromHex("#ef4444"),
+        primary: RGBA.fromHex("#38bdf8"),
+        selectedListItemText: RGBA.fromHex("#f8fafc"),
+        success: RGBA.fromHex("#22c55e"),
+        text: RGBA.fromHex("#f8fafc"),
+        textMuted: RGBA.fromHex("#94a3b8"),
+        warning: RGBA.fromHex("#f59e0b"),
+      },
+      syntax: () => ({
+        getStyleId: () => 1,
+      }),
+    } as any)
+    spyOn(TuiConfigContext, "useTuiConfig").mockReturnValue({} as any)
+    spyOn(PromptHistoryModule, "usePromptHistory").mockReturnValue({
+      move: () => undefined,
+      append: () => {},
+    } as any)
+    spyOn(PromptStashModule, "usePromptStash").mockReturnValue({
+      list: () => [],
+      push: () => {},
+      pop: () => undefined,
+      remove: () => {},
+    } as any)
+    spyOn(TextareaKeybindingsModule, "useTextareaKeybindings").mockReturnValue(() => [] as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: (input: { variant?: string; message?: string }) => {
+        toasts.push(input)
+      },
+      error: (error: Error) => {
+        toasts.push({
+          variant: "error",
+          message: error.message,
+        })
+      },
+      currentToast: null,
+    } as any)
+
+    const { Prompt } = await import("../../../src/cli/cmd/tui/component/prompt")
+
+    let promptRef: PromptRef | undefined
+
+    const Capture = () => {
+      const route = useRoute()
+      const dialog = useDialog()
+
+      createEffect(() => {
+        const current = route.data
+        routeStates.push(current.type === "session" ? `session:${current.sessionID}` : "home")
+      })
+
+      createEffect(() => {
+        dialogDepth.push(dialog.stack.length)
+      })
+
+      return <box />
+    }
+
+    await testRender(() => (
+      <RouteProvider>
+        <DialogProvider>
+          <Capture />
+          <Prompt ref={(value) => (promptRef = value)} workspaceID="workspace_auth_race" placeholders={{ normal: [] }} />
+        </DialogProvider>
+      </RouteProvider>
+    ))
+
+    expect(promptRef).toBeDefined()
+
+    promptRef!.set({
+      input: "recover this draft",
+      parts: [],
+    })
+    promptRef!.focus()
+    await flushEffects()
+
+    expect(promptRef!.focused).toBe(true)
+
+    promptRef!.submit()
+    await flushEffects()
+    await Bun.sleep(90)
+    await flushEffects()
+
+    expect(createSession).toHaveBeenCalledWith({
+      workspaceID: "workspace_auth_race",
+    })
+    expect(promptSession).toHaveBeenCalledTimes(1)
+    expect(deleteSession).toHaveBeenCalledWith({
+      sessionID: "session_auth_race",
+    })
+    expect(routeStates.some((state) => state.startsWith("session:"))).toBe(false)
+    expect(routeStates.at(-1)).toBe("home")
+    expect(promptRef!.current).toEqual({
+      input: "recover this draft",
+      parts: [],
+    })
+    expect(promptRef!.focused).toBe(false)
+    expect(dialogDepth.at(-1)).toBe(1)
+    expect(toasts.at(-1)).toEqual({
+      variant: "error",
+      message: "The current provider credential was rejected. Reconnect OpenAI or Anthropic and try again.",
+      duration: 5000,
+    })
+  })
+})


### PR DESCRIPTION
Closes #100

### Issue for this PR

Closes #100 — first-message splash screen does not dismiss on Enter.

### Type of change

- [x] Bug fix

### What does this PR do?

Moves `route.navigate({ type: 'session', sessionID })` to fire immediately after session creation, before the `await sdk.client.session.prompt(...)` call. Previously navigation was queued AFTER the await so the home/splash route stayed rendered until the stream finished. On first-send failure the catch block now navigates back to home and cancels the pending navigate timer to avoid the user landing on a just-deleted session.

### How did you verify your code works?

- `bun typecheck` green
- Local Codex CLI review round 3 clean verdict
- CI: typecheck + unit (linux/windows) + e2e (linux) green

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR