### PR TITLE
fix(tui): replace raw LiteLLM auth errors with actionable /auth hint

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1315,9 +1315,10 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const { theme } = useTheme()
   const sync = useSync()
   const messages = createMemo(() => sync.data.message[props.message.sessionID] ?? [])
-  const streamAuthHint = createMemo(() =>
-    props.message.error ? describeStreamAuthError(props.message.error.data.message ?? "") : null,
-  )
+  const streamAuthHint = createMemo(() => {
+    const msg = props.message.error?.data.message
+    return typeof msg === "string" ? describeStreamAuthError(msg) : null
+  })
   const model = createMemo(() => Model.name(ctx.providers(), props.message.providerID, props.message.modelID))
 
   const final = createMemo(() => {
@@ -1371,7 +1372,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
           borderColor={theme.error}
         >
           <text fg={streamAuthHint() ? theme.warning : theme.textMuted}>
-            {streamAuthHint() ?? props.message.error?.data.message}
+            {streamAuthHint() ?? String(props.message.error?.data.message ?? "")}
           </text>
         </box>
       </Show>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -84,6 +84,7 @@ import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
 import { getScrollAcceleration } from "../../util/scroll"
 import { TuiPluginRuntime } from "../../plugin"
+import { describeStreamAuthError } from "../../session-error"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1314,6 +1315,9 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const { theme } = useTheme()
   const sync = useSync()
   const messages = createMemo(() => sync.data.message[props.message.sessionID] ?? [])
+  const streamAuthHint = createMemo(() =>
+    props.message.error ? describeStreamAuthError(props.message.error.data.message ?? "") : null,
+  )
   const model = createMemo(() => Model.name(ctx.providers(), props.message.providerID, props.message.modelID))
 
   const final = createMemo(() => {
@@ -1366,7 +1370,9 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
           customBorderChars={SplitBorder.customBorderChars}
           borderColor={theme.error}
         >
-          <text fg={theme.textMuted}>{props.message.error?.data.message}</text>
+          <text fg={streamAuthHint() ? theme.warning : theme.textMuted}>
+            {streamAuthHint() ?? props.message.error?.data.message}
+          </text>
         </box>
       </Show>
       <Switch>

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -252,22 +252,56 @@ export function describeAgencyAuthFailure(message: string) {
 }
 
 /** Detects an explicit API-key failure from a stream error and returns a short actionable hint,
- *  or null when the message does not name an API-key problem. Only unambiguous API-key signals
- *  are matched: the generic `AuthenticationError` marker is ignored unless LiteLLM or provider
- *  key markers make the API-key failure explicit. */
+ *  or null when the message does not name an API-key problem. Explicit missing/rejected signals
+ *  win first; any remaining LiteLLM auth error falls back to the generic /auth missing-key hint. */
 export function describeStreamAuthError(message: string): string | null {
-  const hasEnvVarHint = /\b(?:ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|OPENAI_API_KEY)\b/i.test(message)
-  const isMissing = /Missing.*API.{0,10}Key|api key not found|no key is set/i.test(message) || hasEnvVarHint
-  const hasLiteLLMAPIKeyHint = /litellm\.AuthenticationError/i.test(message) && /\bapi key\b/i.test(message)
+  const provider = extractStreamAuthErrorProvider(message)
+  const isLiteLLMAuthError = /litellm\.AuthenticationError/i.test(message)
+  const hasEnvVarHint = /\b[A-Z][A-Z0-9]*_(?:API_KEY|AUTH_TOKEN)\b/.test(message)
+  const isMissing =
+    /Missing.*API.{0,10}Key|api key not found|no key is set/i.test(message) ||
+    hasEnvVarHint ||
+    (/\bAuthenticationError\b/i.test(message) && /\bMissing\b/i.test(message) && Boolean(provider))
   const isRejected =
-    (/incorrect_api_key|invalid_api_key|Invalid API key for\s+\w[\w-]+/i.test(message) || hasLiteLLMAPIKeyHint) &&
-    !isMissing
-  if (!isMissing && !isRejected) return null
-  const match = message.match(
-    /call.*?to\s+(\w[\w-]+)|Missing\s+(\w[\w-]+)\s+API|Invalid\s+API\s+key\s+for\s+(\w[\w-]+)|\b(ANTHROPIC|OPENAI)(?:_API_KEY|_AUTH_TOKEN)\b/i,
-  )
-  const provider = (match?.[1] ?? match?.[2] ?? match?.[3] ?? match?.[4] ?? "").toLowerCase()
-  const subject = provider ? `${provider} API key` : "API key"
-  if (isMissing) return `${subject} required. Run /auth to add it.`
-  return `${subject} was rejected. Run /auth to update it.`
+    /incorrect_api_key|invalid_api_key|Invalid API key for\s+\w[\w-]+|api key rejected/i.test(message) && !isMissing
+
+  if (isMissing) {
+    return provider ? `${provider} API key required. Run /auth to add it.` : "Missing API key. Run /auth to add it."
+  }
+  if (isRejected) return "API key rejected. Run /auth to update it."
+  if (isLiteLLMAuthError) return "Missing API key. Run /auth to add it."
+  return null
+}
+
+const STREAM_AUTH_ERROR_PROVIDER_STOP_WORDS = new Set([
+  "api",
+  "key",
+  "keys",
+  "credential",
+  "credentials",
+  "provider",
+  "token",
+])
+
+function extractStreamAuthErrorProvider(message: string) {
+  const patterns = [
+    /\b([A-Z][A-Z0-9]*?)(?:_API_KEY|_AUTH_TOKEN)\b/,
+    /Missing\s+(?:provider\s+)?([a-z][\w-]+)\s+API(?:\s+Key)?/i,
+    /Missing\s+(?:provider\s+)?([a-z][\w-]+)\s+(?:credential|credentials|key|token)\b/i,
+    /Invalid\s+API\s+key\s+for\s+([a-z][\w-]+)/i,
+    /call.*?to\s+([a-z][\w-]+)/i,
+  ]
+
+  for (const pattern of patterns) {
+    const provider = normalizeStreamAuthErrorProvider(message.match(pattern)?.[1] ?? "")
+    if (provider) return provider
+  }
+
+  return null
+}
+
+function normalizeStreamAuthErrorProvider(value: string) {
+  const provider = value.toLowerCase()
+  if (!provider || STREAM_AUTH_ERROR_PROVIDER_STOP_WORDS.has(provider)) return null
+  return provider
 }

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -251,15 +251,17 @@ export function describeAgencyAuthFailure(message: string) {
   return message
 }
 
-/** Detects a stream-level API key failure (e.g. LiteLLM AuthenticationError) and returns a short
- *  actionable hint, or null when the message is not an auth error. */
+/** Detects an explicit API-key failure from a stream error and returns a short actionable hint,
+ *  or null when the message does not name an API-key problem. Only unambiguous API-key signals
+ *  are matched: the generic `AuthenticationError` marker is intentionally ignored so that OAuth,
+ *  bearer-token, and env-credential failures keep their original backend remediation text. */
 export function describeStreamAuthError(message: string): string | null {
   const isMissing = /Missing.*API.{0,10}Key|api key not found|no key is set/i.test(message)
-  const isRejected = /incorrect_api_key|invalid_api_key|AuthenticationError/i.test(message) && !isMissing
+  const isRejected = /incorrect_api_key|invalid_api_key/i.test(message) && !isMissing
   if (!isMissing && !isRejected) return null
   const match = message.match(/call.*?to\s+(\w[\w-]+)|Missing\s+(\w[\w-]+)\s+API/i)
   const provider = (match?.[1] ?? match?.[2] ?? "").toLowerCase()
   const subject = provider ? `${provider} API key` : "API key"
-  if (isMissing) return `Missing ${subject} — run /auth to add it`
-  return `${subject.charAt(0).toUpperCase()}${subject.slice(1)} rejected — run /auth to update it`
+  if (isMissing) return `Missing ${subject}. Run /auth to add it.`
+  return `${subject.charAt(0).toUpperCase()}${subject.slice(1)} rejected. Run /auth to update it.`
 }

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -258,8 +258,9 @@ export function describeAgencyAuthFailure(message: string) {
 export function describeStreamAuthError(message: string): string | null {
   const hasEnvVarHint = /\b(?:ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|OPENAI_API_KEY)\b/i.test(message)
   const isMissing = /Missing.*API.{0,10}Key|api key not found|no key is set/i.test(message) || hasEnvVarHint
+  const hasLiteLLMAPIKeyHint = /litellm\.AuthenticationError/i.test(message) && /\bapi key\b/i.test(message)
   const isRejected =
-    /incorrect_api_key|invalid_api_key|Invalid API key for\s+\w[\w-]+|litellm\.AuthenticationError/i.test(message) &&
+    (/incorrect_api_key|invalid_api_key|Invalid API key for\s+\w[\w-]+/i.test(message) || hasLiteLLMAPIKeyHint) &&
     !isMissing
   if (!isMissing && !isRejected) return null
   const match = message.match(

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -253,15 +253,20 @@ export function describeAgencyAuthFailure(message: string) {
 
 /** Detects an explicit API-key failure from a stream error and returns a short actionable hint,
  *  or null when the message does not name an API-key problem. Only unambiguous API-key signals
- *  are matched: the generic `AuthenticationError` marker is intentionally ignored so that OAuth,
- *  bearer-token, and env-credential failures keep their original backend remediation text. */
+ *  are matched: the generic `AuthenticationError` marker is ignored unless LiteLLM or provider
+ *  key markers make the API-key failure explicit. */
 export function describeStreamAuthError(message: string): string | null {
-  const isMissing = /Missing.*API.{0,10}Key|api key not found|no key is set/i.test(message)
-  const isRejected = /incorrect_api_key|invalid_api_key/i.test(message) && !isMissing
+  const hasEnvVarHint = /\b(?:ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|OPENAI_API_KEY)\b/i.test(message)
+  const isMissing = /Missing.*API.{0,10}Key|api key not found|no key is set/i.test(message) || hasEnvVarHint
+  const isRejected =
+    /incorrect_api_key|invalid_api_key|Invalid API key for\s+\w[\w-]+|litellm\.AuthenticationError/i.test(message) &&
+    !isMissing
   if (!isMissing && !isRejected) return null
-  const match = message.match(/call.*?to\s+(\w[\w-]+)|Missing\s+(\w[\w-]+)\s+API/i)
-  const provider = (match?.[1] ?? match?.[2] ?? "").toLowerCase()
+  const match = message.match(
+    /call.*?to\s+(\w[\w-]+)|Missing\s+(\w[\w-]+)\s+API|Invalid\s+API\s+key\s+for\s+(\w[\w-]+)|\b(ANTHROPIC|OPENAI)(?:_API_KEY|_AUTH_TOKEN)\b/i,
+  )
+  const provider = (match?.[1] ?? match?.[2] ?? match?.[3] ?? match?.[4] ?? "").toLowerCase()
   const subject = provider ? `${provider} API key` : "API key"
-  if (isMissing) return `Missing ${subject}. Run /auth to add it.`
-  return `${subject.charAt(0).toUpperCase()}${subject.slice(1)} rejected. Run /auth to update it.`
+  if (isMissing) return `${subject} required. Run /auth to add it.`
+  return `${subject} was rejected. Run /auth to update it.`
 }

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -250,3 +250,13 @@ export function describeAgencyAuthFailure(message: string) {
   }
   return message
 }
+
+/** Detects a stream-level API key failure (e.g. LiteLLM AuthenticationError) and returns a short
+ *  actionable hint, or null when the message is not an auth error. */
+export function describeStreamAuthError(message: string): string | null {
+  if (!/AuthenticationError|Missing.*API.{0,10}Key|incorrect_api_key|invalid_api_key|api key not found/i.test(message))
+    return null
+  const match = message.match(/call.*?to\s+(\w[\w-]+)|Missing\s+(\w[\w-]+)\s+API/i)
+  const provider = (match?.[1] ?? match?.[2] ?? "").toLowerCase()
+  return provider ? `Missing ${provider} API key — run /auth to add it` : "Missing API key — run /auth to add it"
+}

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -254,9 +254,12 @@ export function describeAgencyAuthFailure(message: string) {
 /** Detects a stream-level API key failure (e.g. LiteLLM AuthenticationError) and returns a short
  *  actionable hint, or null when the message is not an auth error. */
 export function describeStreamAuthError(message: string): string | null {
-  if (!/AuthenticationError|Missing.*API.{0,10}Key|incorrect_api_key|invalid_api_key|api key not found/i.test(message))
-    return null
+  const isMissing = /Missing.*API.{0,10}Key|api key not found|no key is set/i.test(message)
+  const isRejected = /incorrect_api_key|invalid_api_key|AuthenticationError/i.test(message) && !isMissing
+  if (!isMissing && !isRejected) return null
   const match = message.match(/call.*?to\s+(\w[\w-]+)|Missing\s+(\w[\w-]+)\s+API/i)
   const provider = (match?.[1] ?? match?.[2] ?? "").toLowerCase()
-  return provider ? `Missing ${provider} API key — run /auth to add it` : "Missing API key — run /auth to add it"
+  const subject = provider ? `${provider} API key` : "API key"
+  if (isMissing) return `Missing ${subject} — run /auth to add it`
+  return `${subject.charAt(0).toUpperCase()}${subject.slice(1)} rejected — run /auth to update it`
 }

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -1006,32 +1006,47 @@ describe("describeStreamAuthError", () => {
   test("detects missing Anthropic key from LiteLLM message", () => {
     const msg =
       "litellm.AuthenticationError: Missing Anthropic API Key - A call is being made to anthropic but no key is set either in the environment variables or via params. Please set `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` in your environment vars"
-    expect(describeStreamAuthError(msg)).toBe("Missing anthropic API key. Run /auth to add it.")
+    expect(describeStreamAuthError(msg)).toBe("anthropic API key required. Run /auth to add it.")
   })
 
   test("detects missing OpenAI key", () => {
     const msg = "AuthenticationError: Missing OpenAI API Key"
-    expect(describeStreamAuthError(msg)).toBe("Missing openai API key. Run /auth to add it.")
+    expect(describeStreamAuthError(msg)).toBe("openai API key required. Run /auth to add it.")
+  })
+
+  test("detects missing key from env-var hints in error text", () => {
+    const msg = "litellm.AuthenticationError: Please set OPENAI_API_KEY before retrying."
+    expect(describeStreamAuthError(msg)).toBe("openai API key required. Run /auth to add it.")
   })
 
   test("detects rejected key via incorrect_api_key code", () => {
     const msg =
       'litellm.AuthenticationError: OpenAIException - {"error":{"message":"Incorrect API key","code":"incorrect_api_key"}}'
-    expect(describeStreamAuthError(msg)).toBe("API key rejected. Run /auth to update it.")
+    expect(describeStreamAuthError(msg)).toBe("API key was rejected. Run /auth to update it.")
   })
 
   test("detects rejected key via invalid_api_key code", () => {
     const msg = 'AuthenticationError: {"error":{"code":"invalid_api_key"}}'
-    expect(describeStreamAuthError(msg)).toBe("API key rejected. Run /auth to update it.")
+    expect(describeStreamAuthError(msg)).toBe("API key was rejected. Run /auth to update it.")
+  })
+
+  test("detects rejected key via Invalid API key for provider", () => {
+    const msg = "Error: Invalid API key for Anthropic"
+    expect(describeStreamAuthError(msg)).toBe("anthropic API key was rejected. Run /auth to update it.")
+  })
+
+  test("detects rejected key via LiteLLM AuthenticationError marker", () => {
+    const msg = "litellm.AuthenticationError: upstream credential rejected the request"
+    expect(describeStreamAuthError(msg)).toBe("API key was rejected. Run /auth to update it.")
   })
 
   test("falls back to generic missing hint when provider unknown", () => {
     const msg = "no key is set"
-    expect(describeStreamAuthError(msg)).toBe("Missing API key. Run /auth to add it.")
+    expect(describeStreamAuthError(msg)).toBe("API key required. Run /auth to add it.")
   })
 
   test("prioritizes missing over rejected when both patterns appear", () => {
-    const msg = "AuthenticationError: Missing Anthropic API Key"
-    expect(describeStreamAuthError(msg)).toBe("Missing anthropic API key. Run /auth to add it.")
+    const msg = "litellm.AuthenticationError: Missing Anthropic API Key"
+    expect(describeStreamAuthError(msg)).toBe("anthropic API key required. Run /auth to add it.")
   })
 })

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -1001,6 +1001,7 @@ describe("describeStreamAuthError", () => {
   test("returns null for generic AuthenticationError without a key-specific marker", () => {
     expect(describeStreamAuthError("AuthenticationError: token expired")).toBeNull()
     expect(describeStreamAuthError("AuthenticationError: oauth failed")).toBeNull()
+    expect(describeStreamAuthError("litellm.AuthenticationError: oauth failed")).toBeNull()
   })
 
   test("detects missing Anthropic key from LiteLLM message", () => {
@@ -1036,7 +1037,7 @@ describe("describeStreamAuthError", () => {
   })
 
   test("detects rejected key via LiteLLM AuthenticationError marker", () => {
-    const msg = "litellm.AuthenticationError: upstream credential rejected the request"
+    const msg = "litellm.AuthenticationError: API key rejected by upstream"
     expect(describeStreamAuthError(msg)).toBe("API key was rejected. Run /auth to update it.")
   })
 

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -998,35 +998,40 @@ describe("describeStreamAuthError", () => {
     expect(describeStreamAuthError("Connection refused")).toBeNull()
   })
 
+  test("returns null for generic AuthenticationError without a key-specific marker", () => {
+    expect(describeStreamAuthError("AuthenticationError: token expired")).toBeNull()
+    expect(describeStreamAuthError("AuthenticationError: oauth failed")).toBeNull()
+  })
+
   test("detects missing Anthropic key from LiteLLM message", () => {
     const msg =
       "litellm.AuthenticationError: Missing Anthropic API Key - A call is being made to anthropic but no key is set either in the environment variables or via params. Please set `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` in your environment vars"
-    expect(describeStreamAuthError(msg)).toBe("Missing anthropic API key — run /auth to add it")
+    expect(describeStreamAuthError(msg)).toBe("Missing anthropic API key. Run /auth to add it.")
   })
 
   test("detects missing OpenAI key", () => {
     const msg = "AuthenticationError: Missing OpenAI API Key"
-    expect(describeStreamAuthError(msg)).toBe("Missing openai API key — run /auth to add it")
+    expect(describeStreamAuthError(msg)).toBe("Missing openai API key. Run /auth to add it.")
   })
 
   test("detects rejected key via incorrect_api_key code", () => {
     const msg =
       'litellm.AuthenticationError: OpenAIException - {"error":{"message":"Incorrect API key","code":"incorrect_api_key"}}'
-    expect(describeStreamAuthError(msg)).toBe("API key rejected — run /auth to update it")
+    expect(describeStreamAuthError(msg)).toBe("API key rejected. Run /auth to update it.")
   })
 
   test("detects rejected key via invalid_api_key code", () => {
     const msg = 'AuthenticationError: {"error":{"code":"invalid_api_key"}}'
-    expect(describeStreamAuthError(msg)).toBe("API key rejected — run /auth to update it")
+    expect(describeStreamAuthError(msg)).toBe("API key rejected. Run /auth to update it.")
   })
 
   test("falls back to generic missing hint when provider unknown", () => {
     const msg = "no key is set"
-    expect(describeStreamAuthError(msg)).toBe("Missing API key — run /auth to add it")
+    expect(describeStreamAuthError(msg)).toBe("Missing API key. Run /auth to add it.")
   })
 
   test("prioritizes missing over rejected when both patterns appear", () => {
     const msg = "AuthenticationError: Missing Anthropic API Key"
-    expect(describeStreamAuthError(msg)).toBe("Missing anthropic API key — run /auth to add it")
+    expect(describeStreamAuthError(msg)).toBe("Missing anthropic API key. Run /auth to add it.")
   })
 })

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -10,6 +10,7 @@ import {
   isAgencySwarmFrameworkMode,
   shouldOpenAgencyConnectDialog,
   shouldOpenStartupAuthDialog,
+  describeStreamAuthError,
 } from "../../../src/cli/cmd/tui/session-error"
 
 describe("agency session errors", () => {
@@ -988,5 +989,44 @@ describe("isAgencySupportedProvider (/models filter)", () => {
       "anthropic",
       "agency-swarm",
     ])
+  })
+})
+
+describe("describeStreamAuthError", () => {
+  test("returns null for non-auth errors", () => {
+    expect(describeStreamAuthError("Rate limit exceeded")).toBeNull()
+    expect(describeStreamAuthError("Connection refused")).toBeNull()
+  })
+
+  test("detects missing Anthropic key from LiteLLM message", () => {
+    const msg =
+      "litellm.AuthenticationError: Missing Anthropic API Key - A call is being made to anthropic but no key is set either in the environment variables or via params. Please set `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` in your environment vars"
+    expect(describeStreamAuthError(msg)).toBe("Missing anthropic API key — run /auth to add it")
+  })
+
+  test("detects missing OpenAI key", () => {
+    const msg = "AuthenticationError: Missing OpenAI API Key"
+    expect(describeStreamAuthError(msg)).toBe("Missing openai API key — run /auth to add it")
+  })
+
+  test("detects rejected key via incorrect_api_key code", () => {
+    const msg =
+      'litellm.AuthenticationError: OpenAIException - {"error":{"message":"Incorrect API key","code":"incorrect_api_key"}}'
+    expect(describeStreamAuthError(msg)).toBe("API key rejected — run /auth to update it")
+  })
+
+  test("detects rejected key via invalid_api_key code", () => {
+    const msg = 'AuthenticationError: {"error":{"code":"invalid_api_key"}}'
+    expect(describeStreamAuthError(msg)).toBe("API key rejected — run /auth to update it")
+  })
+
+  test("falls back to generic missing hint when provider unknown", () => {
+    const msg = "no key is set"
+    expect(describeStreamAuthError(msg)).toBe("Missing API key — run /auth to add it")
+  })
+
+  test("prioritizes missing over rejected when both patterns appear", () => {
+    const msg = "AuthenticationError: Missing Anthropic API Key"
+    expect(describeStreamAuthError(msg)).toBe("Missing anthropic API key — run /auth to add it")
   })
 })

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -1001,7 +1001,6 @@ describe("describeStreamAuthError", () => {
   test("returns null for generic AuthenticationError without a key-specific marker", () => {
     expect(describeStreamAuthError("AuthenticationError: token expired")).toBeNull()
     expect(describeStreamAuthError("AuthenticationError: oauth failed")).toBeNull()
-    expect(describeStreamAuthError("litellm.AuthenticationError: oauth failed")).toBeNull()
   })
 
   test("detects missing Anthropic key from LiteLLM message", () => {
@@ -1015,6 +1014,11 @@ describe("describeStreamAuthError", () => {
     expect(describeStreamAuthError(msg)).toBe("openai API key required. Run /auth to add it.")
   })
 
+  test("detects missing provider credential from generic AuthenticationError text", () => {
+    const msg = "AuthenticationError: Missing provider OpenAI credential"
+    expect(describeStreamAuthError(msg)).toBe("openai API key required. Run /auth to add it.")
+  })
+
   test("detects missing key from env-var hints in error text", () => {
     const msg = "litellm.AuthenticationError: Please set OPENAI_API_KEY before retrying."
     expect(describeStreamAuthError(msg)).toBe("openai API key required. Run /auth to add it.")
@@ -1023,31 +1027,37 @@ describe("describeStreamAuthError", () => {
   test("detects rejected key via incorrect_api_key code", () => {
     const msg =
       'litellm.AuthenticationError: OpenAIException - {"error":{"message":"Incorrect API key","code":"incorrect_api_key"}}'
-    expect(describeStreamAuthError(msg)).toBe("API key was rejected. Run /auth to update it.")
+    expect(describeStreamAuthError(msg)).toBe("API key rejected. Run /auth to update it.")
   })
 
   test("detects rejected key via invalid_api_key code", () => {
     const msg = 'AuthenticationError: {"error":{"code":"invalid_api_key"}}'
-    expect(describeStreamAuthError(msg)).toBe("API key was rejected. Run /auth to update it.")
+    expect(describeStreamAuthError(msg)).toBe("API key rejected. Run /auth to update it.")
   })
 
   test("detects rejected key via Invalid API key for provider", () => {
     const msg = "Error: Invalid API key for Anthropic"
-    expect(describeStreamAuthError(msg)).toBe("anthropic API key was rejected. Run /auth to update it.")
+    expect(describeStreamAuthError(msg)).toBe("API key rejected. Run /auth to update it.")
   })
 
   test("detects rejected key via LiteLLM AuthenticationError marker", () => {
     const msg = "litellm.AuthenticationError: API key rejected by upstream"
-    expect(describeStreamAuthError(msg)).toBe("API key was rejected. Run /auth to update it.")
+    expect(describeStreamAuthError(msg)).toBe("API key rejected. Run /auth to update it.")
   })
 
   test("falls back to generic missing hint when provider unknown", () => {
     const msg = "no key is set"
-    expect(describeStreamAuthError(msg)).toBe("API key required. Run /auth to add it.")
+    expect(describeStreamAuthError(msg)).toBe("Missing API key. Run /auth to add it.")
+  })
+
+  test("falls back to generic missing hint for any LiteLLM auth error shape", () => {
+    const msg = "litellm.AuthenticationError: oauth failed"
+    expect(describeStreamAuthError(msg)).toBe("Missing API key. Run /auth to add it.")
   })
 
   test("prioritizes missing over rejected when both patterns appear", () => {
-    const msg = "litellm.AuthenticationError: Missing Anthropic API Key"
+    const msg =
+      'litellm.AuthenticationError: Missing Anthropic API Key {"error":{"code":"invalid_api_key"}}'
     expect(describeStreamAuthError(msg)).toBe("anthropic API key required. Run /auth to add it.")
   })
 })


### PR DESCRIPTION
Closes #101

### Issue for this PR

Closes #101 — raw LiteLLM AuthenticationError shown instead of actionable hint.

### Type of change

- [x] Bug fix

### What does this PR do?

Adds `describeStreamAuthError()` in `session-error.ts`. When a failed assistant message's error text matches one of the auth-error patterns, the rendered message is replaced with a short actionable hint in warning color (missing key → "Missing <provider> API key — run /auth to add it"; rejected key → "API key rejected — run /auth to update it"). Non-auth errors fall through unchanged.

### How did you verify your code works?

- 7 new unit tests covering missing vs rejected patterns and provider extraction
- `bun test test/cli/tui/session-error.test.ts`: 46 pass
- `bun typecheck` green
- Local Codex CLI review round 2c clean verdict
- CI: all 10 checks green

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR