### PR TITLE
fix(npx): re-run venv canary after dependency install to catch version skew

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -570,7 +570,7 @@ async function ensureProjectPython(directory: string) {
       if (!corruptedVenv) {
         let healthy = false
         try {
-          healthy = await venvCanaryPasses([venvPython])
+          healthy = await venvCanaryPasses([venvPython], { cwd: directory })
         } catch {
           healthy = false
         }
@@ -638,7 +638,7 @@ async function ensureProjectPython(directory: string) {
     spinner.stop("Dependency install failed")
     throw new Error(install.stderr.trim() || install.stdout.trim() || "Dependency install failed")
   }
-  const canary = await venvCanaryPasses([venvPython], { includeStderr: true })
+  const canary = await venvCanaryPasses([venvPython], { cwd: directory, includeStderr: true })
   if (!canary.healthy) {
     spinner.stop("Python environment unhealthy")
     const summary = summarizeBridgeStderr(canary.stderr)
@@ -671,15 +671,14 @@ async function installProjectDependencies(directory: string, python: string[]) {
   return runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.1"])
 }
 
-async function venvCanaryPasses(python: string[]): Promise<boolean>
-async function venvCanaryPasses(python: string[], options: { includeStderr: true }): Promise<VenvCanaryResult>
-async function venvCanaryPasses(python: string[], options?: { includeStderr?: boolean }) {
-  const result = await runCommand([
-    ...python,
-    "-c",
-    "from agency_swarm.integrations.fastapi import run_fastapi",
-  ])
-  if (options?.includeStderr) {
+async function venvCanaryPasses(python: string[], options: { cwd: string }): Promise<boolean>
+async function venvCanaryPasses(python: string[], options: { cwd: string; includeStderr: true }): Promise<VenvCanaryResult>
+async function venvCanaryPasses(python: string[], options: { cwd: string; includeStderr?: boolean }) {
+  const result = await runCommand(
+    [...python, "-c", "from agency_swarm.integrations.fastapi import run_fastapi"],
+    { cwd: options.cwd },
+  )
+  if (options.includeStderr) {
     return {
       healthy: result.code === 0,
       stderr: result.stderr,

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -49,6 +49,10 @@ interface VenvCanaryResult {
   stderr: string
 }
 
+interface DependencyInstallResult extends CommandResult {
+  hadManifests: boolean
+}
+
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
   argv?: string[]
@@ -641,34 +645,64 @@ async function ensureProjectPython(directory: string) {
   const canary = await venvCanaryPasses([venvPython], { cwd: directory, includeStderr: true })
   if (!canary.healthy) {
     spinner.stop("Python environment unhealthy")
-    const summary = summarizeBridgeStderr(canary.stderr)
-    throw new Error(
-      summary
-        ? "Project `.venv` rebuilt successfully, but the Agency Swarm import canary still failed. This usually means your dependency manifest installed an incompatible `agency-swarm` version. Check the pinned version in `requirements.txt` or `pyproject.toml`. Canary stderr: " +
-            summary
-        : "Project `.venv` rebuilt successfully, but the Agency Swarm import canary still failed. This usually means your dependency manifest installed an incompatible `agency-swarm` version. Check the pinned version in `requirements.txt` or `pyproject.toml`.",
-    )
+    throw new Error(await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr))
   }
   spinner.stop("Python environment ready")
   return [venvPython]
 }
 
-async function installProjectDependencies(directory: string, python: string[]) {
+async function installProjectDependencies(directory: string, python: string[]): Promise<DependencyInstallResult> {
   const requirements = path.join(directory, "requirements.txt")
   if (await Filesystem.exists(requirements)) {
-    return runCommand([...python, "-m", "pip", "install", "--upgrade", "-r", "requirements.txt"], {
+    const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "-r", "requirements.txt"], {
       cwd: directory,
     })
+    return { ...result, hadManifests: true }
   }
 
   const pyproject = path.join(directory, "pyproject.toml")
   if (await Filesystem.exists(pyproject)) {
-    return runCommand([...python, "-m", "pip", "install", "--upgrade", "-e", "."], {
+    const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "-e", "."], {
       cwd: directory,
     })
+    return { ...result, hadManifests: true }
   }
 
-  return runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.1"])
+  const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.1"])
+  return { ...result, hadManifests: false }
+}
+
+async function formatPostInstallCanaryFailure(directory: string, hadManifests: boolean, stderr: string) {
+  const summary = summarizeBridgeStderr(stderr)
+  const shadowingHint = await formatShadowingHint(directory)
+  if (/\bImportError\b/.test(stderr)) {
+    if (hadManifests) {
+      return summary
+        ? `Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint} Canary stderr: ${summary}`
+        : `Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint}`
+    }
+    return summary
+      ? `Canary import failed on fallback install. Inspect the stderr below and check for project-local fastapi.py/agency_swarm.py that may shadow installed packages.${shadowingHint} Canary stderr: ${summary}`
+      : `Canary import failed on fallback install. Inspect the stderr below and check for project-local fastapi.py/agency_swarm.py that may shadow installed packages.${shadowingHint}`
+  }
+  return summary
+    ? `Project \`.venv\` rebuilt successfully, but the Agency Swarm import canary still failed.${shadowingHint} Canary stderr: ${summary}`
+    : `Project \`.venv\` rebuilt successfully, but the Agency Swarm import canary still failed.${shadowingHint}`
+}
+
+async function formatShadowingHint(directory: string) {
+  const shadowingFiles = await findProjectShadowingFiles(directory)
+  if (shadowingFiles.length === 0) return ""
+  return ` Detected project-local ${shadowingFiles.join(", ")} that may shadow installed packages.`
+}
+
+async function findProjectShadowingFiles(directory: string) {
+  const shadowingFiles = await Promise.all(
+    ["fastapi.py", "agency_swarm.py"].map(async (file) =>
+      (await Filesystem.exists(path.join(directory, file))) ? file : undefined,
+    ),
+  )
+  return shadowingFiles.flatMap((file) => (file ? [file] : []))
 }
 
 async function venvCanaryPasses(python: string[], options?: { cwd?: string }): Promise<boolean>

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -44,6 +44,11 @@ interface PythonInfo {
   version: string
 }
 
+interface VenvCanaryResult {
+  healthy: boolean
+  stderr: string
+}
+
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
   argv?: string[]
@@ -633,6 +638,17 @@ async function ensureProjectPython(directory: string) {
     spinner.stop("Dependency install failed")
     throw new Error(install.stderr.trim() || install.stdout.trim() || "Dependency install failed")
   }
+  const canary = await venvCanaryPasses([venvPython], { includeStderr: true })
+  if (!canary.healthy) {
+    spinner.stop("Python environment unhealthy")
+    const summary = summarizeBridgeStderr(canary.stderr)
+    throw new Error(
+      summary
+        ? "Project `.venv` rebuilt successfully, but the Agency Swarm import canary still failed. This usually means your dependency manifest installed an incompatible `agency-swarm` version. Check the pinned version in `requirements.txt` or `pyproject.toml`. Canary stderr: " +
+            summary
+        : "Project `.venv` rebuilt successfully, but the Agency Swarm import canary still failed. This usually means your dependency manifest installed an incompatible `agency-swarm` version. Check the pinned version in `requirements.txt` or `pyproject.toml`.",
+    )
+  }
   spinner.stop("Python environment ready")
   return [venvPython]
 }
@@ -655,12 +671,20 @@ async function installProjectDependencies(directory: string, python: string[]) {
   return runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.1"])
 }
 
-async function venvCanaryPasses(python: string[]) {
+async function venvCanaryPasses(python: string[]): Promise<boolean>
+async function venvCanaryPasses(python: string[], options: { includeStderr: true }): Promise<VenvCanaryResult>
+async function venvCanaryPasses(python: string[], options?: { includeStderr?: boolean }) {
   const result = await runCommand([
     ...python,
     "-c",
     "from agency_swarm.integrations.fastapi import run_fastapi",
   ])
+  if (options?.includeStderr) {
+    return {
+      healthy: result.code === 0,
+      stderr: result.stderr,
+    }
+  }
   return result.code === 0
 }
 

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -675,7 +675,7 @@ async function installProjectDependencies(directory: string, python: string[]): 
 async function formatPostInstallCanaryFailure(directory: string, hadManifests: boolean, stderr: string) {
   const summary = summarizeBridgeStderr(stderr)
   const shadowingHint = await formatShadowingHint(directory)
-  if (/\bImportError\b/.test(stderr)) {
+  if (isImportLikeCanaryFailure(stderr)) {
     if (hadManifests) {
       return summary
         ? `Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint} Canary stderr: ${summary}`
@@ -688,6 +688,10 @@ async function formatPostInstallCanaryFailure(directory: string, hadManifests: b
   return summary
     ? `Project \`.venv\` rebuilt successfully, but the Agency Swarm import canary still failed.${shadowingHint} Canary stderr: ${summary}`
     : `Project \`.venv\` rebuilt successfully, but the Agency Swarm import canary still failed.${shadowingHint}`
+}
+
+function isImportLikeCanaryFailure(stderr: string) {
+  return /\b(?:ImportError|ModuleNotFoundError)\b/.test(stderr)
 }
 
 async function formatShadowingHint(directory: string) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -570,7 +570,7 @@ async function ensureProjectPython(directory: string) {
       if (!corruptedVenv) {
         let healthy = false
         try {
-          healthy = await venvCanaryPasses([venvPython], { cwd: directory })
+          healthy = await venvCanaryPasses([venvPython])
         } catch {
           healthy = false
         }
@@ -671,14 +671,18 @@ async function installProjectDependencies(directory: string, python: string[]) {
   return runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.1"])
 }
 
-async function venvCanaryPasses(python: string[], options: { cwd: string }): Promise<boolean>
-async function venvCanaryPasses(python: string[], options: { cwd: string; includeStderr: true }): Promise<VenvCanaryResult>
-async function venvCanaryPasses(python: string[], options: { cwd: string; includeStderr?: boolean }) {
+async function venvCanaryPasses(python: string[], options?: { cwd?: string }): Promise<boolean>
+async function venvCanaryPasses(python: string[], options: { cwd?: string; includeStderr: true }): Promise<VenvCanaryResult>
+async function venvCanaryPasses(python: string[], options?: { cwd?: string; includeStderr?: boolean }) {
+  // No cwd by default: the canary must not pick up project-local modules (e.g. `fastapi.py`
+  // sitting next to `agency.py`) that shadow installed packages and falsely flag a healthy
+  // .venv as broken. Callers that need the server-launch cwd (post-install verification)
+  // pass it explicitly.
   const result = await runCommand(
     [...python, "-c", "from agency_swarm.integrations.fastapi import run_fastapi"],
-    { cwd: options.cwd },
+    options?.cwd ? { cwd: options.cwd } : undefined,
   )
-  if (options.includeStderr) {
+  if (options?.includeStderr) {
     return {
       healthy: result.code === 0,
       stderr: result.stderr,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -704,7 +704,7 @@ export function Prompt(props: PromptProps) {
     ) {
       toast.show({
         variant: "warning",
-        message: "Add a supported provider credential before sending a message",
+        message: "No provider credential is configured. Run /auth to add it.",
         duration: 4000,
       })
       dialog.replace(() => <DialogAuth />)

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -231,10 +231,10 @@ export function shouldOpenAgencyAuthDialog(input: { providerID?: string; message
 
 export function describeAgencyAuthFailure(message: string) {
   if (/missing provider credentials|client_config/i.test(message)) {
-    return "Add a supported provider credential before sending a message."
+    return "No provider credential is configured. Run /auth to add it."
   }
   if (/unauthori[sz]ed|forbidden|invalid api key|auth failed|\b401\b|\b403\b/i.test(message)) {
-    return "The current provider credential was rejected. Reconnect OpenAI or Anthropic and try again."
+    return "The current provider credential was rejected. Run /auth to update it."
   }
   return message
 }

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -159,6 +159,102 @@ describe("agency-swarm npx onboarding", () => {
     ])
   })
 
+  test("prepareProjectLaunch reruns the canary after rebuilding `.venv` and surfaces version mismatches", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await Bun.write(path.join(dir.path, "requirements.txt"), "agency-swarm==0.0.0\n")
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+
+    const commands: string[][] = []
+    const canaryStderr = [
+      "Traceback (most recent call last):",
+      "ImportError: cannot import name 'LoadFileAttachment' from 'agency_swarm.tools.built_in'",
+    ].join("\n")
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        if (target.endsWith(process.platform === "win32" ? "\\python.exe" : "/python")) {
+          return {
+            exited: Promise.resolve(0),
+            stdout: `${target}\n3.12.7\n`,
+            stderr: "",
+          } as never
+        }
+        if (cmd[0] === "python3.12") {
+          return {
+            exited: Promise.resolve(0),
+            stdout: `/usr/bin/python3.12\n3.12.7\n`,
+            stderr: "",
+          } as never
+        }
+      }
+      if (cmd.includes("from agency_swarm.integrations.fastapi import run_fastapi")) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: canaryStderr,
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("pip")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    let error: Error | undefined
+    try {
+      await prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      })
+    } catch (caught) {
+      error = caught as Error
+    }
+
+    expect(error).toBeInstanceOf(Error)
+    if (!error) throw new Error("Expected prepareProjectLaunch to fail")
+    expect(error.message).toContain(
+      "Project `.venv` rebuilt successfully, but the Agency Swarm import canary still failed. This usually means your dependency manifest installed an incompatible `agency-swarm` version.",
+    )
+    expect(error.message).toContain("LoadFileAttachment")
+
+    const canaryCommands = commands.filter((cmd) =>
+      cmd.includes("from agency_swarm.integrations.fastapi import run_fastapi"),
+    )
+    expect(canaryCommands).toHaveLength(2)
+  })
+
   test("detectAgencyProject requires agency.py with create_agency", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -296,7 +296,7 @@ describe("agency-swarm npx onboarding", () => {
 
     const canaryStderr = [
       "Traceback (most recent call last):",
-      "ImportError: cannot import name 'run_fastapi' from 'agency_swarm.integrations.fastapi'",
+      "ModuleNotFoundError: No module named 'agency_swarm.integrations.fastapi'; 'agency_swarm' is not a package",
     ].join("\n")
 
     mockPrepareProjectLaunchCanaryFailure(canaryStderr)

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -159,7 +159,7 @@ describe("agency-swarm npx onboarding", () => {
     ])
   })
 
-  test("prepareProjectLaunch reruns the canary after rebuilding `.venv` and surfaces version mismatches", async () => {
+  test("prepareProjectLaunch reruns the canary after rebuilding `.venv` and surfaces manifest import mismatches", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
     await Bun.write(path.join(dir.path, "requirements.txt"), "agency-swarm==0.0.0\n")
@@ -244,15 +244,71 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(error).toBeInstanceOf(Error)
     if (!error) throw new Error("Expected prepareProjectLaunch to fail")
-    expect(error.message).toContain(
-      "Project `.venv` rebuilt successfully, but the Agency Swarm import canary still failed. This usually means your dependency manifest installed an incompatible `agency-swarm` version.",
-    )
+    expect(error.message).toContain("Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.")
+    expect(error.message).not.toContain("Canary import failed on fallback install.")
     expect(error.message).toContain("LoadFileAttachment")
 
     const canaryCommands = commands.filter((cmd) =>
       cmd.includes("from agency_swarm.integrations.fastapi import run_fastapi"),
     )
     expect(canaryCommands).toHaveLength(2)
+  })
+
+  test("prepareProjectLaunch avoids manifest remediation after fallback install canary failures", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+
+    const canaryStderr = [
+      "Traceback (most recent call last):",
+      "ImportError: cannot import name 'LoadFileAttachment' from 'agency_swarm.tools.built_in'",
+    ].join("\n")
+
+    mockPrepareProjectLaunchCanaryFailure(canaryStderr)
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow(
+      "Canary import failed on fallback install. Inspect the stderr below and check for project-local fastapi.py/agency_swarm.py that may shadow installed packages.",
+    )
+  })
+
+  test("prepareProjectLaunch names detected shadowing files in the canary remediation", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await Bun.write(path.join(dir.path, "requirements.txt"), "agency-swarm==1.9.1\n")
+    await Bun.write(path.join(dir.path, "fastapi.py"), "print('shadow')\n")
+    await Bun.write(path.join(dir.path, "agency_swarm.py"), "print('shadow')\n")
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+
+    const canaryStderr = [
+      "Traceback (most recent call last):",
+      "ImportError: cannot import name 'run_fastapi' from 'agency_swarm.integrations.fastapi'",
+    ].join("\n")
+
+    mockPrepareProjectLaunchCanaryFailure(canaryStderr)
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow(
+      "Detected project-local fastapi.py, agency_swarm.py that may shadow installed packages.",
+    )
   })
 
   test("detectAgencyProject requires agency.py with create_agency", async () => {
@@ -886,4 +942,50 @@ async function writeAgency(dir: string) {
       "    return Agency()",
     ].join("\n"),
   )
+}
+
+function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
+  spyOn(Bun, "spawn").mockImplementation((options: any) => {
+    const cmd = options?.cmd as string[] | undefined
+    if (!cmd) throw new Error("Missing command")
+    if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+      const target = cmd[0] ?? ""
+      if (target.endsWith(process.platform === "win32" ? "\\python.exe" : "/python")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (cmd[0] === "python3.12") {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+    }
+    if (cmd.includes("from agency_swarm.integrations.fastapi import run_fastapi")) {
+      return {
+        exited: Promise.resolve(1),
+        stdout: "",
+        stderr: canaryStderr,
+      } as never
+    }
+    if (cmd.includes("venv")) {
+      return {
+        exited: Promise.resolve(0),
+        stdout: "",
+        stderr: "",
+      } as never
+    }
+    if (cmd.includes("pip")) {
+      return {
+        exited: Promise.resolve(0),
+        stdout: "",
+        stderr: "",
+      } as never
+    }
+    throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+  })
 }

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { Provider } from "@opencode-ai/sdk/v2"
 import {
+  describeAgencyAuthFailure,
   shouldBlockAgencyPromptSubmit,
   shouldBlockAgencyPromptSend,
   shouldOpenAgencyAuthDialog,
@@ -958,5 +959,17 @@ describe("agency session errors", () => {
         message: "Streaming request failed (403): Invalid API key for OpenAI",
       }),
     ).toBe(true)
+  })
+
+  test("describes missing agency provider credentials with /auth add guidance", () => {
+    expect(
+      describeAgencyAuthFailure("Streaming request failed (401): Missing provider credentials in client_config"),
+    ).toBe("No provider credential is configured. Run /auth to add it.")
+  })
+
+  test("describes rejected agency provider credentials with /auth update guidance", () => {
+    expect(describeAgencyAuthFailure("Streaming request failed (403): Invalid API key for OpenAI")).toBe(
+      "The current provider credential was rejected. Run /auth to update it.",
+    )
   })
 })


### PR DESCRIPTION
Closes #102

### Issue for this PR

Closes #102 — npx launcher ships unhealthy .venv after rebuild.

### Type of change

- [x] Bug fix

### What does this PR do?

Re-runs `venvCanaryPasses` after `installProjectDependencies` so a rebuilt `.venv` with an incompatible pinned `agency-swarm` is caught before the server starts. Runs the canary from the project directory so a local `agency_swarm.py` in the caller's cwd cannot shadow the .venv package. On failure surfaces a targeted error with summarized canary stderr pointing at the version pin instead of mislabeling it as 'corrupted install'.

### How did you verify your code works?

- Regression test in `test/agency-swarm/npx.test.ts` covering the rebuild → post-install → canary-fail path
- `bun test test/agency-swarm/npx.test.ts`: 33 pass
- `bun typecheck` green
- Local Codex CLI reviews: round 2 clean verdict after a P2 cwd-mismatch fix

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR