### PR TITLE
fix(tui): block prompt input when auth dialog open, close on Esc

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -246,6 +246,9 @@ export function DialogAuth() {
   const dialog = useDialog()
   const sync = useSync()
   const local = useLocal()
+  useKeyboard((evt) => {
+    closeDialogAuthOnEscape(dialog, evt)
+  })
   const frameworkMode = createMemo(() =>
     isAgencySwarmFrameworkMode({
       currentProviderID: local.model.current()?.providerID,
@@ -287,6 +290,21 @@ export function DialogAuth() {
   return (
     <DialogSelect title={frameworkMode() ? "Manage Agent Swarm auth" : "Manage provider auth"} options={options()} />
   )
+}
+
+export function closeDialogAuthOnEscape(
+  dialog: Pick<ReturnType<typeof useDialog>, "clear">,
+  evt: {
+    name?: string
+    preventDefault(): void
+    stopPropagation(): void
+  },
+) {
+  if (evt.name !== "escape") return false
+  evt.preventDefault()
+  evt.stopPropagation()
+  dialog.clear()
+  return true
 }
 
 /** After auth in Agency Swarm mode, offer model selection (CLI model drives `client_config` for that provider). */

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -482,6 +482,8 @@ export function Prompt(props: PromptProps) {
     }
   })
 
+  const isDialogBlockingPrompt = () => dialog.stack.length > 0
+
   function restoreExtmarksFromParts(parts: PromptInfo["parts"]) {
     input.extmarks.clear()
     setStore("extmarkToPartIndex", new Map())
@@ -617,6 +619,7 @@ export function Prompt(props: PromptProps) {
 
   async function submit() {
     if (props.disabled) return
+    if (isDialogBlockingPrompt()) return
     if (autocomplete?.visible) return
     if (!store.prompt.input) return
     const trimmed = store.prompt.input.trim()
@@ -1018,6 +1021,10 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
+                if (isDialogBlockingPrompt()) {
+                  if (e.name !== "escape") e.preventDefault()
+                  return
+                }
                 // Check clipboard for images before terminal-handled paste runs.
                 // This helps terminals that forward Ctrl+V to the app; Windows
                 // Terminal 1.25+ usually handles Ctrl+V before this path.
@@ -1094,6 +1101,10 @@ export function Prompt(props: PromptProps) {
               onSubmit={submit}
               onPaste={async (event: PasteEvent) => {
                 if (props.disabled) {
+                  event.preventDefault()
+                  return
+                }
+                if (isDialogBlockingPrompt()) {
                   event.preventDefault()
                   return
                 }

--- a/packages/opencode/test/cli/tui/dialog-auth-modal.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-auth-modal.test.tsx
@@ -1,0 +1,330 @@
+/** @jsxImportSource @opentui/solid */
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { RGBA } from "@opentui/core"
+import { testRender } from "@opentui/solid"
+import * as CommandDialogModule from "../../../src/cli/cmd/tui/component/dialog-command"
+import { closeDialogAuthOnEscape, DialogAuth } from "../../../src/cli/cmd/tui/component/dialog-provider"
+import { Prompt, type PromptRef } from "../../../src/cli/cmd/tui/component/prompt"
+import * as FrecencyModule from "../../../src/cli/cmd/tui/component/prompt/frecency"
+import * as PromptHistoryModule from "../../../src/cli/cmd/tui/component/prompt/history"
+import * as PromptStashModule from "../../../src/cli/cmd/tui/component/prompt/stash"
+import * as ExitContext from "../../../src/cli/cmd/tui/context/exit"
+import * as KVContext from "../../../src/cli/cmd/tui/context/kv"
+import * as LocalContext from "../../../src/cli/cmd/tui/context/local"
+import * as KeybindContext from "../../../src/cli/cmd/tui/context/keybind"
+import * as RouteContext from "../../../src/cli/cmd/tui/context/route"
+import * as SDKContext from "../../../src/cli/cmd/tui/context/sdk"
+import * as SyncContext from "../../../src/cli/cmd/tui/context/sync"
+import * as ThemeContext from "../../../src/cli/cmd/tui/context/theme"
+import { TuiConfigProvider } from "../../../src/cli/cmd/tui/context/tui-config"
+import { DialogProvider, useDialog } from "../../../src/cli/cmd/tui/ui/dialog"
+import * as ToastModule from "../../../src/cli/cmd/tui/ui/toast"
+
+function flushEffects() {
+  return Promise.resolve().then(() => Promise.resolve())
+}
+
+function createEscapeEvent() {
+  return {
+    name: "escape",
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true
+    },
+    stopPropagation() {},
+  }
+}
+
+function createTheme() {
+  return {
+    _hasSelectedListItemText: false,
+    background: RGBA.fromHex("#000000"),
+    backgroundElement: RGBA.fromHex("#111111"),
+    backgroundPanel: RGBA.fromHex("#1a1a1a"),
+    backgroundMenu: RGBA.fromHex("#1a1a1a"),
+    border: RGBA.fromHex("#333333"),
+    text: RGBA.fromHex("#ffffff"),
+    textMuted: RGBA.fromHex("#999999"),
+    primary: RGBA.fromHex("#00a3ff"),
+    success: RGBA.fromHex("#22c55e"),
+    warning: RGBA.fromHex("#f59e0b"),
+    error: RGBA.fromHex("#ff5555"),
+    info: RGBA.fromHex("#38bdf8"),
+    secondary: RGBA.fromHex("#8b5cf6"),
+    accent: RGBA.fromHex("#14b8a6"),
+  }
+}
+
+async function renderDialogAuthHarness() {
+  const toastMessages: Array<{ variant?: string; message?: string }> = []
+  const selectedModel = {
+    providerID: "agency-swarm",
+    modelID: "default",
+  }
+  const syncData = {
+    session_status: {},
+    message: {},
+    command: [],
+    session: [],
+    agent: [],
+    provider: [
+      {
+        id: "agency-swarm",
+        name: "Agent Swarm",
+        models: {
+          default: { id: "default", name: "Default" },
+        },
+        options: {
+          baseURL: "http://127.0.0.1:8000",
+        },
+      },
+    ],
+    provider_next: {
+      all: [
+        { id: "openai", name: "OpenAI" },
+        { id: "anthropic", name: "Anthropic" },
+      ],
+      connected: [],
+    },
+    provider_auth: {
+      openai: [{ type: "api", label: "API key" }],
+      anthropic: [{ type: "api", label: "API key" }],
+    },
+    provider_default: {},
+    console_state: {
+      activeOrgName: undefined,
+      switchableOrgCount: 0,
+      consoleManagedProviders: [],
+    },
+    config: {
+      model: "agency-swarm/default",
+      provider: {},
+    },
+    mcp: {},
+  }
+
+  spyOn(CommandDialogModule, "useCommandDialog").mockReturnValue({
+    register: () => () => {},
+    slashes: () => [],
+    keybinds: () => {},
+    suspended: () => false,
+    show: () => {},
+    trigger: () => {},
+  } as any)
+  spyOn(PromptHistoryModule, "usePromptHistory").mockReturnValue({
+    append: () => {},
+    move: () => undefined,
+  } as any)
+  spyOn(FrecencyModule, "useFrecency").mockReturnValue({
+    updateFrecency: () => {},
+    sortByFrecency: <T,>(input: T[]) => input,
+  } as any)
+  spyOn(PromptStashModule, "usePromptStash").mockReturnValue({
+    push: () => {},
+    pop: () => undefined,
+    list: () => [],
+  } as any)
+  spyOn(ExitContext, "useExit").mockReturnValue(
+    Object.assign(async () => {}, {
+      message: {
+        set: () => () => {},
+        clear: () => {},
+        get: () => undefined,
+      },
+    }) as any,
+  )
+  spyOn(KVContext, "useKV").mockReturnValue({
+    get: (_key: string, fallback?: boolean) => fallback,
+    set: () => {},
+    delete: () => {},
+  } as any)
+  spyOn(KeybindContext, "useKeybind").mockReturnValue({
+    leader: false,
+    all: {},
+    parse: (evt: any) => evt,
+    match: () => false,
+    print: (key: string) => key,
+  } as any)
+  spyOn(LocalContext, "useLocal").mockReturnValue({
+    agent: {
+      color: () => "#ffffff",
+      current: () => ({
+        name: "general",
+        model: selectedModel,
+      }),
+      list: () => [{ name: "general", mode: "primary", hidden: false }],
+      move: () => {},
+      set: () => {},
+    },
+    model: {
+      current: () => selectedModel,
+      parsed: () => ({
+        provider: "Agent Swarm",
+      }),
+      set: () => {},
+      cycle: () => {},
+      cycleFavorite: () => {},
+      variant: {
+        current: () => undefined,
+        list: () => [],
+        set: () => {},
+        cycle: () => {},
+      },
+    },
+  } as any)
+  spyOn(RouteContext, "useRoute").mockReturnValue({
+    data: {
+      type: "home",
+    },
+    navigate: () => {},
+  } as any)
+  spyOn(SDKContext, "useSDK").mockReturnValue({
+    event: {
+      on: () => {},
+    },
+    client: {
+      auth: {
+        remove: async () => {},
+      },
+      instance: {
+        dispose: async () => {},
+      },
+      provider: {
+        oauth: {
+          authorize: async () => ({ data: undefined }),
+          callback: async () => ({ data: undefined }),
+        },
+      },
+      session: {
+        create: async () => ({ data: { id: "ses_test" } }),
+        delete: async () => ({ data: undefined }),
+        prompt: async () => ({ data: undefined }),
+        shell: () => {},
+        command: () => {},
+      },
+    },
+  } as any)
+  spyOn(SyncContext, "useSync").mockReturnValue({
+    data: syncData,
+    status: "complete",
+    bootstrap: async () => {},
+    session: {
+      get: () => undefined,
+    },
+  } as any)
+  spyOn(ThemeContext, "useTheme").mockReturnValue({
+    theme: createTheme(),
+    syntax: () => ({
+      getStyleId: () => 1,
+    }),
+  } as any)
+  spyOn(ToastModule, "useToast").mockReturnValue({
+    show: (input: { variant?: string; message?: string }) => {
+      toastMessages.push(input)
+    },
+    error: (error: Error) => {
+      toastMessages.push({
+        variant: "error",
+        message: error.message,
+      })
+    },
+    currentToast: null,
+  } as any)
+
+  let promptRef: PromptRef | undefined
+  let dialogContext!: ReturnType<typeof useDialog>
+
+  const Capture = () => {
+    dialogContext = useDialog()
+    return <Prompt ref={(next) => (promptRef = next)} showPlaceholder={false} />
+  }
+
+  const rendered = await testRender(
+    () => (
+      <TuiConfigProvider config={{}}>
+        <DialogProvider>
+          <Capture />
+        </DialogProvider>
+      </TuiConfigProvider>
+    ),
+    { width: 100, height: 32 },
+  )
+
+  await flushEffects()
+  await rendered.renderOnce()
+
+  return {
+    ...rendered,
+    dialog: dialogContext,
+    promptRef: () => {
+      if (!promptRef) throw new Error("Prompt ref not captured")
+      return promptRef
+    },
+    toastMessages,
+  }
+}
+
+describe("dialog auth modal behavior", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test("blocks prompt input while auth dialog is open", async () => {
+    const app = await renderDialogAuthHarness()
+
+    app.dialog.replace(() => <DialogAuth />)
+    await flushEffects()
+    await app.renderOnce()
+
+    app.promptRef().focus()
+    await flushEffects()
+
+    await app.mockInput.typeText("/exit")
+    await flushEffects()
+    await app.renderOnce()
+
+    expect(app.promptRef().current.input).toBe("")
+  })
+
+  test("closes auth dialog on escape", async () => {
+    const app = await renderDialogAuthHarness()
+
+    app.dialog.replace(() => <DialogAuth />)
+    await flushEffects()
+    await app.renderOnce()
+
+    expect(app.dialog.stack.length).toBe(1)
+
+    expect(closeDialogAuthOnEscape(app.dialog, createEscapeEvent())).toBe(true)
+    await flushEffects()
+    await app.renderOnce()
+
+    expect(app.dialog.stack.length).toBe(0)
+  })
+
+  test("reopens auth dialog on the next send after escape closes it", async () => {
+    const app = await renderDialogAuthHarness()
+
+    app.dialog.replace(() => <DialogAuth />)
+    await flushEffects()
+    await app.renderOnce()
+
+    closeDialogAuthOnEscape(app.dialog, createEscapeEvent())
+    await flushEffects()
+    await app.renderOnce()
+
+    expect(app.dialog.stack.length).toBe(0)
+
+    app.promptRef().focus()
+    await flushEffects()
+    await app.mockInput.typeText("hello")
+    await flushEffects()
+
+    app.promptRef().submit()
+    await flushEffects()
+    await app.renderOnce()
+
+    expect(app.dialog.stack.length).toBe(1)
+    expect(app.toastMessages.at(-1)?.message).toBe("Add a supported provider credential before sending a message")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #102

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes a /auth dialog UX bug where the prompt input was still accepting keystrokes and submits while the auth modal was open, and where Esc did not close the dialog. Now any open dialog in the stack fully blocks prompt submit and keyboard shortcuts, and the auth dialog closes on Esc.

Changes:
- `component/dialog-provider.tsx`: new `closeDialogAuthOnEscape` helper wired into `DialogAuth` so Esc closes the dialog without submitting.
- `component/prompt/index.tsx`: adds `isDialogBlockingPrompt` (dialog.stack.length > 0) guard in `submit()` and blocks all keyboard events except Esc while a dialog is open.
- `test/cli/tui/dialog-auth-modal.test.tsx`: covers Esc close, submit block, and keyboard block behaviors.

### How did you verify your code works?

- `bun typecheck` green in `packages/opencode`.
- `bun test test/cli/tui/dialog-auth-modal.test.tsx` — 3 pass / 0 fail.
- All CI checks green (unit linux+windows, e2e linux+windows, typecheck, nix-eval, pr-standards).

### Screenshots / recordings

Internal TUI dialog behavior; covered by the new automated test file rather than a screenshot.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
