### PR TITLE
fix(tui): Run-only mode — hide Agent Builder + Plan, cycle agency recipients with Tab

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -68,6 +68,7 @@ import {
   shouldOpenAgencyConnectDialog,
   shouldOpenStartupAuthDialog,
 } from "./session-error"
+import { buildAgencyTargetOptions, cycleAgencyTargetSelection, readAgencyProviderOptions } from "./util/agency-target"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -478,6 +479,85 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       agentModel: local.agent.current()?.model,
     }),
   )
+  const agencyProviderOptions = createMemo(() =>
+    readAgencyProviderOptions({
+      configuredProvider: sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID],
+      connectedProvider: sync.data.provider.find((item) => item.id === AgencySwarmAdapter.PROVIDER_ID),
+    }),
+  )
+
+  createEffect(() => {
+    if (!frameworkMode()) return
+    if (local.agent.current().name === "build") return
+    local.agent.set("build")
+  })
+
+  async function setAgencyRunTarget(input: {
+    agency: string
+    recipientAgent?: string | null
+    label: string
+  }) {
+    const nextOptions = buildAgencyTargetOptions({
+      providerOptions: agencyProviderOptions(),
+      agency: input.agency,
+      recipientAgent: input.recipientAgent ?? null,
+    })
+
+    await sdk.client.global.config.update(
+      {
+        config: {
+          model: `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`,
+          provider: {
+            [AgencySwarmAdapter.PROVIDER_ID]: {
+              name: "agency-swarm",
+              options: nextOptions,
+            },
+          },
+        },
+      },
+      {
+        throwOnError: true,
+      },
+    )
+
+    await sdk.client.instance.dispose()
+    await sync.bootstrap()
+    toast.show({
+      variant: "info",
+      message: `Run target: ${input.label}`,
+      duration: 2000,
+    })
+  }
+
+  async function cycleAgencyRunTarget(direction: 1 | -1) {
+    const providerOptions = agencyProviderOptions()
+    const discovered = await AgencySwarmAdapter.discover({
+      baseURL: providerOptions.baseURL,
+      token: providerOptions.token,
+      timeoutMs: providerOptions.discoveryTimeoutMs,
+    })
+    const next = cycleAgencyTargetSelection({
+      agencies: discovered.agencies,
+      configuredAgency: providerOptions.agency,
+      configuredRecipient: providerOptions.recipientAgent,
+      direction,
+    })
+
+    if (!next) {
+      toast.show({
+        variant: "warning",
+        message:
+          !providerOptions.agency && discovered.agencies.length > 1
+            ? "Select an agency first with /agents"
+            : "No recipient agents are available to cycle",
+        duration: 3000,
+      })
+      return
+    }
+
+    await setAgencyRunTarget(next)
+  }
+
   command.register(() => [
     {
       title: "Switch session",
@@ -587,7 +667,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
     },
     {
-      title: "Switch agent",
+      title: frameworkMode() ? "Switch run target" : "Switch agent",
       value: "agent.list",
       keybind: "agent_list",
       category: "Agent",
@@ -610,12 +690,22 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
     },
     {
-      title: "Agent cycle",
+      title: frameworkMode() ? "Run target cycle" : "Agent cycle",
       value: "agent.cycle",
       keybind: "agent_cycle",
       category: "Agent",
       hidden: true,
       onSelect: () => {
+        if (frameworkMode()) {
+          void cycleAgencyRunTarget(1).catch((error) => {
+            toast.show({
+              variant: "error",
+              message: error instanceof Error ? error.message : String(error),
+              duration: 4000,
+            })
+          })
+          return
+        }
         local.agent.move(1)
       },
     },
@@ -645,12 +735,22 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
     },
     {
-      title: "Agent cycle reverse",
+      title: frameworkMode() ? "Run target cycle reverse" : "Agent cycle reverse",
       value: "agent.cycle.reverse",
       keybind: "agent_cycle_reverse",
       category: "Agent",
       hidden: true,
       onSelect: () => {
+        if (frameworkMode()) {
+          void cycleAgencyRunTarget(-1).catch((error) => {
+            toast.show({
+              variant: "error",
+              message: error instanceof Error ? error.message : String(error),
+              duration: 4000,
+            })
+          })
+          return
+        }
         local.agent.move(-1)
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@tui/ui/toast"
 import { createMemo, createResource } from "solid-js"
 import { DialogAgencySwarmConnect } from "./dialog-provider"
 import { isAgencySwarmFrameworkMode } from "../session-error"
+import { buildAgencyTargetOptions, readAgencyProviderOptions, resolveAgencyTargetSelection } from "../util/agency-target"
 
 type AgentOptionValue =
   | {
@@ -45,29 +46,10 @@ export function DialogAgent() {
   )
 
   const providerOptions = createMemo(() => {
-    const provider = sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID]
-    const connected = sync.data.provider.find((item) => item.id === AgencySwarmAdapter.PROVIDER_ID)
-    const options = provider?.options
-    const baseURL =
-      readString(options?.["baseURL"]) ?? readString(options?.["base_url"]) ?? AgencySwarmAdapter.DEFAULT_BASE_URL
-    const configToken = readString(options?.["token"])
-    const token = readString(connected?.key) ?? configToken
-    const agency = readString(options?.["agency"])
-    const recipientAgent = readString(options?.["recipientAgent"]) ?? readString(options?.["recipient_agent"])
-    const discoveryTimeoutMs =
-      readPositiveNumber(options?.["discoveryTimeoutMs"]) ??
-      readPositiveNumber(options?.["discovery_timeout_ms"]) ??
-      AgencySwarmAdapter.DEFAULT_DISCOVERY_TIMEOUT_MS
-
-    return {
-      baseURL: AgencySwarmAdapter.normalizeBaseURL(baseURL),
-      token,
-      configToken,
-      agency,
-      recipientAgent,
-      discoveryTimeoutMs,
-      rawOptions: (options && typeof options === "object" ? options : {}) as Record<string, unknown>,
-    }
+    return readAgencyProviderOptions({
+      configuredProvider: sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID],
+      connectedProvider: sync.data.provider.find((item) => item.id === AgencySwarmAdapter.PROVIDER_ID),
+    })
   })
 
   const discoveryInput = createMemo(() => {
@@ -205,21 +187,23 @@ export function DialogAgent() {
       }
     }
 
-    const configuredAgency = providerOptions().agency
-    const configuredRecipient = providerOptions().recipientAgent
-
-    if (configuredAgency && configuredRecipient) {
+    const selected = resolveAgencyTargetSelection({
+      agencies: discovery()?.agencies ?? [],
+      configuredAgency: providerOptions().agency,
+      configuredRecipient: providerOptions().recipientAgent,
+    })
+    if (selected) {
       return {
         kind: "recipient",
-        agency: configuredAgency,
-        recipientAgent: configuredRecipient,
+        agency: selected.agency,
+        recipientAgent: selected.recipientAgent,
       }
     }
 
-    if (configuredAgency) {
+    if (providerOptions().agency) {
       return {
         kind: "agency",
-        agency: configuredAgency,
+        agency: providerOptions().agency!,
       }
     }
 
@@ -256,16 +240,11 @@ export function DialogAgent() {
 
   async function setAgencySwarmTarget(value: Extract<AgentOptionValue, { kind: "agency" | "recipient" }>) {
     const options = providerOptions()
-    const nextOptions: Record<string, unknown> = {
-      ...options.rawOptions,
-      baseURL: options.baseURL,
-      discoveryTimeoutMs: options.discoveryTimeoutMs,
+    const nextOptions = buildAgencyTargetOptions({
+      providerOptions: options,
       agency: value.agency,
       recipientAgent: value.kind === "recipient" ? value.recipientAgent : null,
-    }
-    if (options.configToken) {
-      nextOptions["token"] = options.configToken
-    }
+    })
 
     await sdk.client.global.config.update(
       {
@@ -298,17 +277,4 @@ export function DialogAgent() {
       duration: 3000,
     })
   }
-}
-
-function readString(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined
-  const trimmed = value.trim()
-  return trimmed ? trimmed : undefined
-}
-
-function readPositiveNumber(value: unknown): number | undefined {
-  if (typeof value !== "number") return undefined
-  if (!Number.isFinite(value)) return undefined
-  if (value <= 0) return undefined
-  return value
 }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -12,7 +12,6 @@ import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { MessageID, PartID } from "@/session/schema"
-import { displayAgentName } from "@/agent/display"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
 import { usePromptHistory, type PromptInfo } from "./history"
@@ -48,6 +47,7 @@ import {
   shouldOpenAgencyAuthDialog,
 } from "../../session-error"
 import { errorMessage as toErrorMessage } from "@/util/error"
+import { displayRunOnlyAgentLabel } from "../../util/agency-target"
 
 export type PromptProps = {
   sessionID?: string
@@ -135,6 +135,14 @@ export function Prompt(props: PromptProps) {
   const [auto, setAuto] = createSignal<AutocompleteRef>()
   const activeOrgName = createMemo(() => sync.data.console_state.activeOrgName)
   const canSwitchOrgs = createMemo(() => sync.data.console_state.switchableOrgCount > 1)
+  const frameworkMode = createMemo(() =>
+    isAgencySwarmFrameworkMode({
+      currentProviderID: local.model.current()?.providerID,
+      configuredModel: sync.data.config.model,
+      agentModel: local.agent.current()?.model,
+    }),
+  )
+  const effectiveAgentName = createMemo(() => (frameworkMode() ? "build" : local.agent.current().name))
   const currentProviderLabel = createMemo(() => {
     const current = local.model.current()
     const provider = local.model.parsed().provider
@@ -338,16 +346,8 @@ export function Prompt(props: PromptProps) {
         slash: {
           name: "editor",
         },
-        enabled: !isAgencySwarmFrameworkMode({
-          currentProviderID: local.model.current()?.providerID,
-          configuredModel: sync.data.config.model,
-          agentModel: local.agent.current()?.model,
-        }),
-        hidden: isAgencySwarmFrameworkMode({
-          currentProviderID: local.model.current()?.providerID,
-          configuredModel: sync.data.config.model,
-          agentModel: local.agent.current()?.model,
-        }),
+        enabled: !frameworkMode(),
+        hidden: frameworkMode(),
         onSelect: async (dialog) => {
           dialog.clear()
 
@@ -784,7 +784,7 @@ export function Prompt(props: PromptProps) {
     if (store.mode === "shell") {
       sdk.client.session.shell({
         sessionID,
-        agent: local.agent.current().name,
+        agent: effectiveAgentName(),
         model: {
           providerID: selectedModel.providerID,
           modelID: selectedModel.modelID,
@@ -802,7 +802,7 @@ export function Prompt(props: PromptProps) {
         sessionID,
         command: command.slice(1),
         arguments: args,
-        agent: local.agent.current().name,
+        agent: effectiveAgentName(),
         model: `${selectedModel.providerID}/${selectedModel.modelID}`,
         messageID,
         variant,
@@ -820,7 +820,7 @@ export function Prompt(props: PromptProps) {
           sessionID,
           ...selectedModel,
           messageID,
-          agent: local.agent.current().name,
+          agent: effectiveAgentName(),
           model: selectedModel,
           variant,
           parts: [
@@ -1269,7 +1269,12 @@ export function Prompt(props: PromptProps) {
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1} justifyContent="space-between">
               <box flexDirection="row" gap={1}>
                 <text fg={highlight()}>
-                  {store.mode === "shell" ? "Shell" : displayAgentName(local.agent.current().name)}{" "}
+                  {store.mode === "shell"
+                    ? "Shell"
+                    : displayRunOnlyAgentLabel({
+                        frameworkMode: frameworkMode(),
+                        localAgentName: effectiveAgentName(),
+                      })}{" "}
                 </text>
                 <Show when={store.mode === "normal"}>
                   <box flexDirection="row" gap={1}>
@@ -1432,7 +1437,8 @@ export function Prompt(props: PromptProps) {
                     </Match>
                     <Match when={true}>
                       <text fg={theme.text}>
-                        {keybind.print("agent_cycle")} <span style={{ fg: theme.textMuted }}>agents</span>
+                        {keybind.print("agent_cycle")}{" "}
+                        <span style={{ fg: theme.textMuted }}>{frameworkMode() ? "recipients" : "agents"}</span>
                       </text>
                     </Match>
                   </Switch>

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -49,7 +49,7 @@ export function Tips() {
 const TIPS = AgencyProduct.tips([
   "Type {highlight}@{/highlight} followed by a filename to fuzzy search and attach files",
   "Start a message with {highlight}!{/highlight} to run shell commands directly (e.g., {highlight}!ls -la{/highlight})",
-  "Press {highlight}Tab{/highlight} to cycle between Agent Builder and Plan agents",
+  "Press {highlight}Tab{/highlight} to cycle between recipient agents in Run mode",
   "Use {highlight}/undo{/highlight} to revert the last message and file changes",
   "Use {highlight}/redo{/highlight} to restore previously undone messages and file changes",
   "Run {highlight}/share{/highlight} to create a public link to your conversation at opencode.ai",
@@ -75,7 +75,7 @@ const TIPS = AgencyProduct.tips([
   "Press {highlight}Shift+Enter{/highlight} or {highlight}Ctrl+J{/highlight} to add newlines in your prompt",
   "Press {highlight}Ctrl+C{/highlight} when typing to clear the input field",
   "Press {highlight}Escape{/highlight} to stop the AI mid-response",
-  "Switch to {highlight}Plan{/highlight} agent to get suggestions without making actual changes",
+  "Use {highlight}/agents{/highlight} to choose the active Run target before sending a message",
   "Use {highlight}@agent-name{/highlight} in prompts to invoke specialized subagents",
   "Press {highlight}Ctrl+X Right/Left{/highlight} to cycle through parent and child sessions",
   "Create {highlight}agentswarm.json{/highlight} for server settings and {highlight}tui.json{/highlight} for TUI settings",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -84,7 +84,8 @@ import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
 import { getScrollAcceleration } from "../../util/scroll"
 import { TuiPluginRuntime } from "../../plugin"
-import { describeStreamAuthError } from "../../session-error"
+import { describeStreamAuthError, isAgencySwarmFrameworkMode } from "../../session-error"
+import { displayRunOnlyModeLabel } from "../../util/agency-target"
 
 addDefaultParsers(parsers.parsers)
 
@@ -97,6 +98,7 @@ const context = createContext<{
   showDetails: () => boolean
   showGenericToolOutput: () => boolean
   diffWrapMode: () => "word" | "none"
+  frameworkMode: () => boolean
   providers: () => ReadonlyMap<string, Provider>
   sync: ReturnType<typeof useSync>
   tui: ReturnType<typeof useTuiConfig>
@@ -202,7 +204,7 @@ export function Session() {
       local.agent.set("build")
       lastSwitch = part.id
     } else if (part.tool === "plan_enter") {
-      local.agent.set("plan")
+      local.agent.set(frameworkMode() ? "build" : "plan")
       lastSwitch = part.id
     }
   })
@@ -300,6 +302,13 @@ export function Session() {
   }
 
   const local = useLocal()
+  const frameworkMode = createMemo(() =>
+    isAgencySwarmFrameworkMode({
+      currentProviderID: local.model.current()?.providerID,
+      configuredModel: sync.data.config.model,
+      agentModel: local.agent.current()?.model,
+    }),
+  )
 
   function moveFirstChild() {
     if (children().length === 1) return
@@ -1019,6 +1028,7 @@ export function Session() {
         showDetails,
         showGenericToolOutput,
         diffWrapMode,
+        frameworkMode,
         providers,
         sync,
         tui: tuiConfig,
@@ -1390,7 +1400,12 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               >
                 ▣{" "}
               </span>{" "}
-              <span style={{ fg: theme.text }}>{Locale.titlecase(props.message.mode)}</span>
+              <span style={{ fg: theme.text }}>
+                {displayRunOnlyModeLabel({
+                  frameworkMode: ctx.frameworkMode(),
+                  mode: props.message.mode,
+                })}
+              </span>
               <span style={{ fg: theme.textMuted }}> · {model()}</span>
               <Show when={duration()}>
                 <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>

--- a/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
@@ -1,0 +1,154 @@
+import { displayAgentName } from "@/agent/display"
+import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { Locale } from "@/util/locale"
+
+export type AgencyProviderOptions = {
+  baseURL: string
+  token?: string
+  configToken?: string
+  agency?: string
+  recipientAgent?: string
+  discoveryTimeoutMs: number
+  rawOptions: Record<string, unknown>
+}
+
+export type AgencyTargetSelection = {
+  agency: string
+  recipientAgent: string
+  label: string
+}
+
+export function readAgencyProviderOptions(input: {
+  configuredProvider?: { options?: Record<string, unknown> }
+  connectedProvider?: { key?: string }
+}): AgencyProviderOptions {
+  const options = input.configuredProvider?.options
+  const baseURL =
+    readString(options?.["baseURL"]) ?? readString(options?.["base_url"]) ?? AgencySwarmAdapter.DEFAULT_BASE_URL
+  const configToken = readString(options?.["token"])
+  const token = readString(input.connectedProvider?.key) ?? configToken
+  const agency = readString(options?.["agency"])
+  const recipientAgent = readString(options?.["recipientAgent"]) ?? readString(options?.["recipient_agent"])
+  const discoveryTimeoutMs =
+    readPositiveNumber(options?.["discoveryTimeoutMs"]) ??
+    readPositiveNumber(options?.["discovery_timeout_ms"]) ??
+    AgencySwarmAdapter.DEFAULT_DISCOVERY_TIMEOUT_MS
+
+  return {
+    baseURL: AgencySwarmAdapter.normalizeBaseURL(baseURL),
+    token,
+    configToken,
+    agency,
+    recipientAgent,
+    discoveryTimeoutMs,
+    rawOptions: (options && typeof options === "object" ? options : {}) as Record<string, unknown>,
+  }
+}
+
+export function resolveAgencyTargetSelection(input: {
+  agencies: AgencySwarmAdapter.AgencyDescriptor[]
+  configuredAgency?: string
+  configuredRecipient?: string
+}): AgencyTargetSelection | undefined {
+  const agency = resolveSelectableAgency(input.agencies, input.configuredAgency)
+  if (!agency) return undefined
+
+  const current = input.configuredRecipient ? agency.agents.find((agent) => agent.id === input.configuredRecipient) : undefined
+  const recipient = current ?? defaultAgencyRecipient(agency)
+  if (!recipient) return undefined
+
+  return {
+    agency: agency.id,
+    recipientAgent: recipient.id,
+    label: recipient.name,
+  }
+}
+
+export function cycleAgencyTargetSelection(input: {
+  agencies: AgencySwarmAdapter.AgencyDescriptor[]
+  configuredAgency?: string
+  configuredRecipient?: string
+  direction: 1 | -1
+}): AgencyTargetSelection | undefined {
+  const agency = resolveSelectableAgency(input.agencies, input.configuredAgency)
+  if (!agency || agency.agents.length === 0) return undefined
+
+  const fallback = defaultAgencyRecipient(agency)
+  if (!fallback) return undefined
+
+  const currentID = agency.agents.some((agent) => agent.id === input.configuredRecipient)
+    ? input.configuredRecipient!
+    : fallback.id
+  const index = agency.agents.findIndex((agent) => agent.id === currentID)
+  const next = agency.agents[(index + input.direction + agency.agents.length) % agency.agents.length]
+  if (!next) return undefined
+
+  return {
+    agency: agency.id,
+    recipientAgent: next.id,
+    label: next.name,
+  }
+}
+
+export function buildAgencyTargetOptions(input: {
+  providerOptions: AgencyProviderOptions
+  agency: string
+  recipientAgent?: string | null
+}) {
+  const nextOptions: Record<string, unknown> = {
+    ...input.providerOptions.rawOptions,
+    baseURL: input.providerOptions.baseURL,
+    discoveryTimeoutMs: input.providerOptions.discoveryTimeoutMs,
+    agency: input.agency,
+    recipientAgent: input.recipientAgent ?? null,
+  }
+
+  if (input.providerOptions.configToken) {
+    nextOptions["token"] = input.providerOptions.configToken
+  }
+
+  return nextOptions
+}
+
+export function displayRunOnlyAgentLabel(input: {
+  frameworkMode: boolean
+  recipientLabel?: string
+  localAgentName: string
+}) {
+  if (!input.frameworkMode) return displayAgentName(input.localAgentName)
+  return input.recipientLabel ?? "Run"
+}
+
+export function displayRunOnlyModeLabel(input: {
+  frameworkMode: boolean
+  mode: string
+}) {
+  if (input.frameworkMode) return "Run"
+  return Locale.titlecase(input.mode)
+}
+
+function resolveSelectableAgency(
+  agencies: AgencySwarmAdapter.AgencyDescriptor[],
+  configuredAgency?: string,
+) {
+  if (configuredAgency) return agencies.find((agency) => agency.id === configuredAgency)
+  if (agencies.length === 1) return agencies[0]
+  return undefined
+}
+
+function defaultAgencyRecipient(agency: AgencySwarmAdapter.AgencyDescriptor) {
+  return agency.agents.find((agent) => agent.isEntryPoint) ?? agency.agents[0]
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function readPositiveNumber(value: unknown): number | undefined {
+  if (typeof value !== "number") return undefined
+  if (!Number.isFinite(value)) return undefined
+  if (value <= 0) return undefined
+  return value
+}


### PR DESCRIPTION
### Issue for this PR

Closes #103

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement

### What does this PR do?

Enforces the Run-only TUI surface for `agentswarm` framework mode by hiding the Agent Builder and Plan mode switches, and enables Tab cycling through agency recipient agents while in Run mode.

Changes:
- `component/dialog-agent.tsx`: refactored to consume the new shared helpers instead of inline logic.
- `util/agency-target.ts`: new utility with `readAgencyProviderOptions`, `resolveAgencyTargetSelection`, `cycleAgencyTargetSelection`, and `buildAgencyTargetOptions`.
- `cli/cmd/tui/app.tsx`, `routes/session/index.tsx`, `feature-plugins/home/tips-view.tsx`: gate Agent Builder + Plan UI behind non-framework mode only, and wire Tab-cycling through agency recipients.
- `component/prompt/index.tsx`: honors the Tab-cycling helper when in Run mode.

### How did you verify your code works?

- `bun typecheck` green in `packages/opencode`.
- All CI checks green (unit linux+windows, e2e linux+windows, typecheck, nix-eval, pr-standards).

### Screenshots / recordings

TUI behavior change; will be validated in the post-release 1.4.21 end-to-end smoke per release gate.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
