### PR TITLE
fix(tui): loud fallback + restore agency-swarm wiring after /auth

### DIFF
--- a/packages/opencode/src/agency-swarm/adapter.ts
+++ b/packages/opencode/src/agency-swarm/adapter.ts
@@ -240,6 +240,10 @@ export namespace AgencySwarmAdapter {
       )
     } catch (error) {
       if (isAbortError(error)) throw error
+      log.error("agency-swarm stream request failed before the backend responded", {
+        url,
+        error: toErrorMessage(error),
+      })
       yield {
         type: "error",
         error: toErrorMessage(error),
@@ -250,6 +254,11 @@ export namespace AgencySwarmAdapter {
 
     if (!response.ok) {
       const body = await response.text().catch(() => "")
+      log.error("agency-swarm stream request failed", {
+        url,
+        status: response.status,
+        body: body || "No response body",
+      })
       yield {
         type: "error",
         error: `Streaming request failed (${response.status}): ${body || "No response body"}`,
@@ -273,6 +282,10 @@ export namespace AgencySwarmAdapter {
         if (event.event === "messages") {
           const payload = parseJSON(event.data)
           if (!payload) {
+            log.error("received malformed messages payload from agency-swarm stream", {
+              url,
+              data: event.data,
+            })
             yield {
               type: "error",
               error: "Received malformed messages payload from agency-swarm stream",
@@ -291,6 +304,10 @@ export namespace AgencySwarmAdapter {
 
         const payload = parseJSON(event.data)
         if (!payload) {
+          log.error("received malformed stream payload from agency-swarm", {
+            url,
+            data: event.data,
+          })
           yield {
             type: "error",
             error: "Received malformed stream payload from agency-swarm",
@@ -321,6 +338,10 @@ export namespace AgencySwarmAdapter {
       }
     } catch (error) {
       if (isAbortError(error)) throw error
+      log.error("agency-swarm stream parser failed", {
+        url,
+        error: toErrorMessage(error),
+      })
       yield {
         type: "error",
         error: toErrorMessage(error),

--- a/packages/opencode/src/agency-swarm/history.ts
+++ b/packages/opencode/src/agency-swarm/history.ts
@@ -1,9 +1,11 @@
 import { Storage } from "@/storage/storage"
 import { Global } from "@/global"
+import { Log } from "@/util/log"
 import path from "path"
 import { AgencySwarmAdapter } from "./adapter"
 
 export namespace AgencySwarmHistory {
+  const log = Log.create({ service: "agency-swarm.history" })
   export type Scope = {
     baseURL: string
     agency: string
@@ -102,7 +104,13 @@ export namespace AgencySwarmHistory {
     const file = legacyFile(scope)
     const existing = await Bun.file(file)
       .json()
-      .catch(() => undefined)
+      .catch((error) => {
+        log.error("failed to load legacy agency-swarm history; continuing without it", {
+          file,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return undefined
+      })
     return existing as Entry | undefined
   }
 
@@ -113,7 +121,12 @@ export namespace AgencySwarmHistory {
   async function loadRecoveredLoopback(scope: Scope): Promise<Entry | undefined> {
     if (!isLoopbackBaseURL(scope.baseURL)) return
 
-    const keys = await Storage.list(["agency_swarm_history"]).catch(() => [] as string[][])
+    const keys = await Storage.list(["agency_swarm_history"]).catch((error) => {
+      log.error("failed to list agency-swarm history while recovering loopback state; continuing without recovery", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return [] as string[][]
+    })
     let newest: Entry | undefined
 
     for (const key of keys) {
@@ -163,7 +176,11 @@ export namespace AgencySwarmHistory {
         parsed.hostname === "localhost" ||
         parsed.hostname === "::1"
       )
-    } catch {
+    } catch (error) {
+      log.error("failed to parse agency-swarm history base URL while checking loopback recovery", {
+        baseURL,
+        error: error instanceof Error ? error.message : String(error),
+      })
       return false
     }
   }

--- a/packages/opencode/src/agency-swarm/run-session.ts
+++ b/packages/opencode/src/agency-swarm/run-session.ts
@@ -1,8 +1,10 @@
 import path from "node:path"
 import { Global } from "@/global"
+import { Log } from "@/util/log"
 import { Filesystem } from "@/util/filesystem"
 
 export namespace AgencySwarmRunSession {
+  const log = Log.create({ service: "agency-swarm.run-session" })
   export const LOCAL_PROJECT_ENV = "AGENTSWARM_RUN_PROJECT"
   const PROVIDER_ID = "agency-swarm"
 
@@ -42,7 +44,13 @@ export namespace AgencySwarmRunSession {
   }
 
   async function read(): Promise<Record<string, Info>> {
-    const data = await Filesystem.readJson<Record<string, Info>>(file).catch((): Record<string, Info> => ({}))
+    const data = await Filesystem.readJson<Record<string, Info>>(file).catch((error): Record<string, Info> => {
+      log.error("failed to read agency-swarm run-session state; continuing with empty state", {
+        file,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return {}
+    })
     return data && typeof data === "object" && !Array.isArray(data) ? data : {}
   }
 

--- a/packages/opencode/src/agency-swarm/tui.ts
+++ b/packages/opencode/src/agency-swarm/tui.ts
@@ -1,3 +1,7 @@
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "agency-swarm.tui" })
+
 function read(input: Record<string, unknown>, keys: string[]) {
   for (const key of keys) {
     const value = input[key]
@@ -10,7 +14,10 @@ function read(input: Record<string, unknown>, keys: string[]) {
 function parse(raw: string) {
   try {
     return JSON.parse(raw) as unknown
-  } catch {
+  } catch (error) {
+    log.error("failed to parse agency-swarm TUI payload; ignoring malformed value", {
+      error: error instanceof Error ? error.message : String(error),
+    })
     return
   }
 }

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -19,6 +19,7 @@ import { getVisibleProviderAuthMethods, hasStoredProviderCredential } from "@tui
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { isAgencySwarmFrameworkMode, isSupportedAgencyAuthProvider } from "../session-error"
 import { errorMessage as toErrorMessage } from "@/util/error"
+import { Log } from "@/util/log"
 import open from "open"
 import type { Provider } from "@opencode-ai/sdk/v2"
 
@@ -30,6 +31,8 @@ const PROVIDER_PRIORITY: Record<string, number> = {
   "opencode-go": 4,
   opencode: 100,
 }
+
+const log = Log.create({ service: "tui.dialog-provider" })
 
 export function createDialogProviderOptions() {
   return createDialogProviderOptionsWithFilter()
@@ -154,6 +157,12 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
                 inputs,
               })
               if (result.error) {
+                log.error("provider oauth authorize failed", {
+                  providerID: provider.id,
+                  method: method.label,
+                  frameworkMode: frameworkMode(),
+                  error: toErrorMessage(result.error),
+                })
                 toast.show({
                   variant: "error",
                   message: toErrorMessage(result.error),
@@ -750,6 +759,11 @@ function AutoMethod(props: AutoMethodProps) {
   onMount(async () => {
     if (frameworkMode()) {
       void watchBrowserOpen(props.authorization.url, (message) => {
+        log.error("failed to open browser for provider oauth", {
+          providerID: props.providerID,
+          frameworkMode: frameworkMode(),
+          message,
+        })
         setError(message)
         toast.show({
           variant: "warning",
@@ -764,6 +778,11 @@ function AutoMethod(props: AutoMethodProps) {
     })
     if (result.error) {
       const message = toErrorMessage(result.error)
+      log.error("provider oauth callback failed", {
+        providerID: props.providerID,
+        frameworkMode: frameworkMode(),
+        message,
+      })
       setError(message)
       toast.show({
         variant: "error",
@@ -782,6 +801,11 @@ function AutoMethod(props: AutoMethodProps) {
       dialog.replace(() => <DialogModel providerID={props.providerID} />)
     } catch (error) {
       const message = toErrorMessage(error)
+      log.error("provider oauth post-callback bootstrap failed", {
+        providerID: props.providerID,
+        frameworkMode: frameworkMode(),
+        message,
+      })
       setError(message)
       toast.show({
         variant: "error",
@@ -861,6 +885,11 @@ function CodeMethod(props: CodeMethodProps) {
             dialog.replace(() => <DialogModel providerID={props.providerID} />)
           } catch (error) {
             const message = toErrorMessage(error)
+            log.error("provider oauth code-flow bootstrap failed", {
+              providerID: props.providerID,
+              frameworkMode: frameworkMode(),
+              message,
+            })
             setError(message)
             toast.show({
               variant: "error",
@@ -871,6 +900,11 @@ function CodeMethod(props: CodeMethodProps) {
           return
         }
         const message = toErrorMessage(error)
+        log.error("provider oauth code callback failed", {
+          providerID: props.providerID,
+          frameworkMode: frameworkMode(),
+          message,
+        })
         setError(message)
         toast.show({
           variant: "error",
@@ -960,6 +994,11 @@ function ApiMethod(props: ApiMethodProps) {
         })
         if (result.error) {
           const message = toErrorMessage(result.error)
+          log.error("provider api credential save failed", {
+            providerID: props.providerID,
+            frameworkMode: frameworkMode(),
+            message,
+          })
           setError(message)
           toast.show({
             variant: "error",
@@ -978,6 +1017,11 @@ function ApiMethod(props: ApiMethodProps) {
           dialog.replace(() => <DialogModel providerID={props.providerID} />)
         } catch (error) {
           const message = toErrorMessage(error)
+          log.error("provider api auth bootstrap failed", {
+            providerID: props.providerID,
+            frameworkMode: frameworkMode(),
+            message,
+          })
           setError(message)
           toast.show({
             variant: "error",

--- a/packages/opencode/src/cli/cmd/tui/context/agency-swarm-connection.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/agency-swarm-connection.tsx
@@ -1,6 +1,7 @@
 import { createMemo, createEffect, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { Log } from "@/util/log"
 import { createSimpleContext } from "./helper"
 import { useLocal } from "./local"
 import { useSync } from "./sync"
@@ -11,6 +12,8 @@ import { isAgencySwarmFrameworkMode } from "../session-error"
 export const AGENCY_SWARM_HEALTH_FAILURE_THRESHOLD = 2
 export const AGENCY_SWARM_HEALTH_IDLE_INTERVAL_MS = 5_000
 export const AGENCY_SWARM_HEALTH_RECOVERED_INTERVAL_MS = 15_000
+
+const log = Log.create({ service: "tui.agency-swarm-connection" })
 
 type AgencySwarmConfig = {
   baseURL: string
@@ -100,7 +103,14 @@ export function createAgencySwarmConnectionMonitor(input: {
   }
 
   const openConnectDialog = () => {
-    if (!input.openConnectDialog()) return
+    if (!input.openConnectDialog()) {
+      log.error("agency-swarm reconnect dialog could not open while the bridge was unhealthy", {
+        baseURL: store.baseURL,
+        failureCount: store.failureCount,
+        lastError: store.lastError,
+      })
+      return
+    }
     const baseURL = store.baseURL
     if (baseURL) dialogShownForBaseURL = baseURL
   }
@@ -114,6 +124,11 @@ export function createAgencySwarmConnectionMonitor(input: {
     clearTimer()
 
     if (!enabled || !config) {
+      if (enabled && !config) {
+        log.error("agency-swarm framework mode is active but no bridge config is available", {
+          baseURL: store.baseURL,
+        })
+      }
       dialogShownForBaseURL = undefined
       setStore({
         active: false,
@@ -189,6 +204,11 @@ export function createAgencySwarmConnectionMonitor(input: {
         })
 
         if (disconnected && dialogShownForBaseURL !== config.baseURL) {
+          log.error("agency-swarm bridge marked disconnected after repeated health-check failures", {
+            baseURL: config.baseURL,
+            failureCount,
+            lastError,
+          })
           openConnectDialog()
         }
       } finally {

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,10 +1,12 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { hasClientConfigCredential } from "@/agency-swarm/client-config"
 import { Flag } from "@/flag/flag"
+import { Log } from "@/util/log"
 import { hasStoredProviderCredential } from "@tui/util/provider-auth"
 import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
 
 export const AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS = ["openai", "anthropic"] as const
+const log = Log.create({ service: "tui.session-error" })
 
 /**
  * True when a provider id is usable in Agent Swarm framework mode: either the
@@ -69,7 +71,11 @@ function isLoopbackBaseURL(baseURL: string) {
       parsed.hostname === "::1" ||
       parsed.hostname === "[::1]"
     )
-  } catch {
+  } catch (error) {
+    log.error("failed to parse agency-swarm base URL while checking local-provider auth policy", {
+      baseURL,
+      error: error instanceof Error ? error.message : String(error),
+    })
     return false
   }
 }
@@ -230,15 +236,32 @@ export function shouldBlockAgencyPromptSubmit(input: {
 
 export function shouldOpenAgencyConnectDialog(input: { providerID?: string; message: string }) {
   if (input.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
-  if (/cannot reach agency-swarm backend/i.test(input.message)) return true
+  if (/cannot reach agency-swarm backend/i.test(input.message)) {
+    log.error("agency-swarm bridge failure requires reconnect dialog", {
+      message: input.message,
+    })
+    return true
+  }
   if (isAgencyProviderCredentialFailure(input.message)) return false
-  return /unauthori[sz]ed|forbidden|\b401\b|\b403\b/i.test(input.message)
+  const shouldOpen = /unauthori[sz]ed|forbidden|\b401\b|\b403\b/i.test(input.message)
+  if (shouldOpen) {
+    log.error("agency-swarm bridge authz failure requires reconnect dialog", {
+      message: input.message,
+    })
+  }
+  return shouldOpen
 }
 
 export function shouldOpenAgencyAuthDialog(input: { providerID?: string; message: string }) {
   if (input.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
   if (shouldOpenAgencyConnectDialog(input)) return false
-  return isAgencyProviderCredentialFailure(input.message)
+  const shouldOpen = isAgencyProviderCredentialFailure(input.message)
+  if (shouldOpen) {
+    log.error("agency-swarm upstream credential failure requires auth dialog", {
+      message: input.message,
+    })
+  }
+  return shouldOpen
 }
 
 export function describeAgencyAuthFailure(message: string) {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -152,12 +152,17 @@ export namespace SessionAgencySwarm {
 
   async function resolveClientConfig(
     baseURL: string,
+    agency: string,
+    token: string | undefined,
+    timeoutMs: number,
     config: Record<string, unknown> | undefined,
     forwardUpstreamCredentials?: boolean,
     sessionLitellmModel?: string,
   ): Promise<Record<string, unknown> | undefined> {
     const explicit = asRecord(config)
     const explicitUpstreamBaseURL = readConfiguredBaseURL(explicit)
+    const explicitModel = explicit && asString(explicit["model"])
+    const requestedModel = explicitModel ? normalizeExplicitClientConfigModel(explicitModel) : sessionLitellmModel
     const forwardGenerated =
       isLocalAgencyUpstreamURL(baseURL) ||
       Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS ||
@@ -171,7 +176,24 @@ export namespace SessionAgencySwarm {
         })
       : undefined
     const generated =
-      !explicitUpstreamBaseURL && shouldStripCodexOAuth(sessionLitellmModel, rawGenerated, explicit)
+      !explicitUpstreamBaseURL &&
+      (await shouldStripCodexOAuth(requestedModel, rawGenerated, explicit, async () => {
+        try {
+          return await AgencySwarmAdapter.getMetadata({
+            baseURL,
+            agency,
+            token,
+            timeoutMs,
+          })
+        } catch (error) {
+          log.error("unable to load agency metadata while deciding Codex OAuth routing", {
+            baseURL,
+            agency,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          return undefined
+        }
+      }))
         ? stripCodexOAuthForNonOpenAI(rawGenerated)
         : rawGenerated
     if (!config) {
@@ -357,14 +379,54 @@ export namespace SessionAgencySwarm {
    * A session model that is explicitly OpenAI-based keeps the OAuth triplet so the
    * forced OpenAI override still authenticates.
    */
-  function shouldStripCodexOAuth(
+  async function shouldStripCodexOAuth(
     sessionLitellmModel: string | undefined,
     generated: Record<string, unknown> | undefined,
     explicit: Record<string, unknown> | undefined,
-  ): boolean {
+    loadAgencyMetadata: () => Promise<AgencySwarmAdapter.AgencyMetadata | undefined>,
+  ): Promise<boolean> {
     if (!isOpenAIBasedLitellmModel(sessionLitellmModel)) return true
     if (sessionLitellmModel) return false
-    return hasNonOpenAILitellmKey(generated) || hasNonOpenAILitellmKey(explicit)
+    if (!hasNonOpenAILitellmKey(generated) && !hasNonOpenAILitellmKey(explicit)) return false
+
+    const metadata = await loadAgencyMetadata()
+    if (!metadata) {
+      log.error("agency metadata unavailable while deciding Codex OAuth routing; stripping OpenAI OAuth conservatively")
+      return true
+    }
+
+    const agencyModels = extractAgencyModels(metadata)
+    if (agencyModels.length === 0) {
+      log.error(
+        "agency metadata exposed no agent models while deciding Codex OAuth routing; stripping OpenAI OAuth conservatively",
+        {
+          metadataKeys: Object.keys(metadata),
+        },
+      )
+      return true
+    }
+
+    const nonOpenAIModels = agencyModels.filter(
+      (model) => !isOpenAIBasedLitellmModel(normalizeExplicitClientConfigModel(model)),
+    )
+    if (nonOpenAIModels.length === 0) {
+      log.info(
+        "keeping Codex OAuth for agency-swarm request because agency metadata only exposes OpenAI-based models",
+        {
+          agencyModels,
+        },
+      )
+      return false
+    }
+
+    log.warn(
+      "stripping Codex OAuth because agency metadata exposes non-OpenAI models and upstream applies base_url globally",
+      {
+        agencyModels,
+        nonOpenAIModels,
+      },
+    )
+    return true
   }
 
   // TODO(agency-swarm#629): remove after upstream scopes config.base_url per-provider.
@@ -416,7 +478,13 @@ export namespace SessionAgencySwarm {
   async function listProvidersForEnvCheck(): Promise<Record<string, Provider.Info> | undefined> {
     try {
       return await Provider.list()
-    } catch {
+    } catch (error) {
+      log.error(
+        "failed to list providers while building agency-swarm client_config; continuing without provider env inspection",
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      )
       return undefined
     }
   }
@@ -424,7 +492,10 @@ export namespace SessionAgencySwarm {
   function getEnvForClientConfig(): Record<string, string | undefined> {
     try {
       return Env.all()
-    } catch {
+    } catch (error) {
+      log.error("failed to read Env service while building agency-swarm client_config; falling back to process.env", {
+        error: error instanceof Error ? error.message : String(error),
+      })
       return { ...process.env }
     }
   }
@@ -1430,6 +1501,9 @@ export namespace SessionAgencySwarm {
         buildLitellmModelForClientConfig(input.sessionModel.providerID, input.sessionModel.modelID)
       const clientConfig = await resolveClientConfig(
         input.options.baseURL,
+        agency,
+        input.options.token,
+        input.options.discoveryTimeoutMs,
         input.options.clientConfig,
         input.options.forwardUpstreamCredentials,
         sessionLitellmModel,
@@ -1977,6 +2051,20 @@ export namespace SessionAgencySwarm {
     }
 
     return result
+  }
+
+  function extractAgencyModels(metadata: AgencySwarmAdapter.AgencyMetadata): string[] {
+    const models = new Set<string>()
+    const nodes = Array.isArray(metadata["nodes"]) ? metadata["nodes"] : []
+    for (const rawNode of nodes) {
+      const node = asRecord(rawNode)
+      if (!node) continue
+      if (asString(node["type"]) !== "agent") continue
+      const data = asRecord(node["data"])
+      const model = asString(data?.["model"])
+      if (model) models.add(model)
+    }
+    return [...models]
   }
 
   function asStringArray(value: unknown): string[] {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -72,6 +72,18 @@ const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested struc
 export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
 
+  export function shouldUseAgencySwarmBridge(input: {
+    resolvedProviderID: string
+    agentProviderID?: string
+    lastAssistantProviderID?: string
+  }) {
+    return (
+      input.resolvedProviderID === SessionAgencySwarm.PROVIDER_ID ||
+      input.agentProviderID === SessionAgencySwarm.PROVIDER_ID ||
+      input.lastAssistantProviderID === SessionAgencySwarm.PROVIDER_ID
+    )
+  }
+
   export interface Interface {
     readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void, Session.BusyError>
     readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
@@ -1400,25 +1412,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }).pipe(Effect.ignore, Effect.forkIn(scope))
 
             const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
-            // Use the Agency Swarm HTTP bridge when:
-            // - the resolved turn model is agency-swarm, or
-            // - the last assistant was from the bridge (continuation of an ongoing agency-swarm session).
-            // Explicit non-agency-swarm overrides (agent/stored/CLI) must run direct — do not coerce based on
-            // config.model alone, since the resolved model already reflects selectCurrentModel's decision.
-            const useAgencySwarmBridge =
-              model.providerID === SessionAgencySwarm.PROVIDER_ID ||
-              (lastAssistant?.providerID === SessionAgencySwarm.PROVIDER_ID &&
-                model.providerID !== SessionAgencySwarm.PROVIDER_ID)
-            // Persist assistant rows as agency-swarm when using the HTTP bridge. Otherwise the message would
-            // carry the UI/credential model (e.g. opencode/anthropic) and the next turn would not match
-            // `lastAssistant?.providerID === agency-swarm`, so the bridge would stop after one reply.
-            const processorModel = useAgencySwarmBridge
-              ? yield* getModel(
-                  ProviderID.make(SessionAgencySwarm.PROVIDER_ID),
-                  ModelID.make(AgencySwarmAdapter.DEFAULT_MODEL_ID),
-                  sessionID,
-                )
-              : model
             const task = tasks.pop()
 
             if (task?.type === "subtask") {
@@ -1455,6 +1448,21 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               yield* bus.publish(Session.Event.Error, { sessionID, error: error.toObject() })
               throw error
             }
+            const useAgencySwarmBridge = shouldUseAgencySwarmBridge({
+              resolvedProviderID: model.providerID,
+              agentProviderID: agent.model?.providerID,
+              lastAssistantProviderID: lastAssistant?.providerID,
+            })
+            // Persist assistant rows as agency-swarm when using the HTTP bridge. Otherwise the message would
+            // carry the UI/credential model (e.g. opencode/anthropic) and the next turn would not match
+            // `lastAssistant?.providerID === agency-swarm`, so the bridge would stop after one reply.
+            const processorModel = useAgencySwarmBridge
+              ? yield* getModel(
+                  ProviderID.make(SessionAgencySwarm.PROVIDER_ID),
+                  ModelID.make(AgencySwarmAdapter.DEFAULT_MODEL_ID),
+                  sessionID,
+                )
+              : model
             const maxSteps = agent.steps ?? Infinity
             const isLastStep = step >= maxSteps
             msgs = yield* insertReminders({ messages: msgs, agent, session })

--- a/packages/opencode/test/cli/tui/dialog-provider-browser.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-provider-browser.test.tsx
@@ -89,6 +89,9 @@ describe("dialog provider browser auth", () => {
       model: {
         current: () => ({ providerID: "agency-swarm", modelID: "default" }),
       },
+      agent: {
+        current: () => undefined,
+      },
     } as any)
     spyOn(ThemeContext, "useTheme").mockReturnValue({
       theme: {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -796,6 +796,120 @@ describe("session.agency-swarm", () => {
     }
   })
 
+  test("stream keeps Codex OAuth triplet in framework mode when agency metadata only exposes OpenAI models", async () => {
+    mockHistory()
+    await Auth.set("openai", {
+      type: "oauth",
+      access: "oauth-access",
+      refresh: "oauth-refresh",
+      expires: Date.now() + 60_000,
+      accountId: "acct_123",
+    } as any)
+    Env.all = (() => ({
+      ANTHROPIC_API_KEY: "env-anthropic",
+    })) as typeof Env.all
+    Provider.list = (async () => ({
+      openai: {
+        id: "openai",
+        name: "OpenAI",
+        source: "oauth",
+        env: ["OPENAI_API_KEY"],
+        options: {},
+        models: {},
+      },
+      anthropic: {
+        id: "anthropic",
+        name: "Anthropic",
+        source: "api",
+        env: ["ANTHROPIC_API_KEY"],
+        options: {},
+        models: {},
+      },
+    })) as typeof Provider.list
+
+    let body: Record<string, unknown> | undefined
+    const metadata = {
+      nodes: [
+        {
+          id: "ExampleAgent",
+          type: "agent",
+          data: {
+            label: "ExampleAgent",
+            model: "gpt-5.4-mini",
+          },
+        },
+        {
+          id: "ExampleAgent2",
+          type: "agent",
+          data: {
+            label: "ExampleAgent2",
+            model: "gpt-5.4-mini",
+          },
+        },
+      ],
+      metadata: {
+        agents: ["ExampleAgent", "ExampleAgent2"],
+      },
+    }
+    const server = createServer(async (request, response) => {
+      if (request.url === "/builder/get_metadata") {
+        response.writeHead(200, { "Content-Type": "application/json" })
+        response.end(JSON.stringify(metadata))
+        return
+      }
+      if (request.url !== "/builder/get_response_stream") {
+        response.writeHead(404)
+        response.end("not found")
+        return
+      }
+      const chunks: Buffer[] = []
+      for await (const chunk of request) {
+        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+        else chunks.push(Buffer.from(chunk))
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+      response.writeHead(200, { "Content-Type": "text/event-stream" })
+      response.end(
+        [
+          'data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"ok"}}}\n\n',
+          "event: end\ndata: [DONE]\n\n",
+        ].join(""),
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      server.close()
+      throw new Error("Expected local test server address")
+    }
+
+    try {
+      const { input } = helper()
+      input.options.baseURL = `http://127.0.0.1:${(address as AddressInfo).port}`
+      const stream = await SessionAgencySwarm.stream(input)
+      for await (const _ of stream.fullStream) {
+        /* drain */
+      }
+
+      expect(body?.["client_config"]).toEqual({
+        api_key: "oauth-access",
+        base_url: "https://chatgpt.com/backend-api/codex",
+        default_headers: { "ChatGPT-Account-Id": "acct_123" },
+        litellm_keys: { anthropic: "env-anthropic" },
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+      await Auth.remove("openai")
+    }
+  })
+
   test("stream keeps stored OpenAI auth working when an Anthropic env key exists", async () => {
     mockHistory()
     Auth.all = (async () => ({

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -230,6 +230,33 @@ describe("session.prompt special characters", () => {
 })
 
 describe("session.prompt regression", () => {
+  test("uses the agency-swarm bridge on the first send after auth when the agent stays in framework mode", () => {
+    expect(
+      SessionPrompt.shouldUseAgencySwarmBridge({
+        resolvedProviderID: "openai",
+        agentProviderID: "agency-swarm",
+      }),
+    ).toBe(true)
+  })
+
+  test("keeps the agency-swarm bridge active for follow-up turns after an agency response", () => {
+    expect(
+      SessionPrompt.shouldUseAgencySwarmBridge({
+        resolvedProviderID: "openai",
+        lastAssistantProviderID: "agency-swarm",
+      }),
+    ).toBe(true)
+  })
+
+  test("does not use the agency-swarm bridge outside framework mode", () => {
+    expect(
+      SessionPrompt.shouldUseAgencySwarmBridge({
+        resolvedProviderID: "openai",
+        agentProviderID: "openai",
+      }),
+    ).toBe(false)
+  })
+
   test("skips fallback title generation for agency-swarm sessions", async () => {
     const originalStreamRun = AgencySwarmAdapter.streamRun
     const originalLLMStream = LLM.stream


### PR DESCRIPTION
### Issue for this PR

Covers the post-`/auth` fallback and Agency Swarm wiring regressions reported during QA.

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes two P0 regressions found in pre-release QA:

- **REQ-004 — Codex OAuth vs bare-OpenAI agencies:** sessions keep Codex OAuth attached for bare-OpenAI agencies by inspecting agency metadata before stripping OAuth when unrelated LiteLLM keys are present. Before this fix, any stored LiteLLM key caused the OAuth credential to be stripped, and bare OpenAI agencies failed with `api_key client option must be set`.
- **REQ-005 — First send after `/auth` silently fell back to Agent Builder:** bridge selection now uses three signals (resolved provider, agent provider, last-assistant provider) so framework mode stays on the agency-swarm bridge even when `/auth` stored a direct per-agent override. `local.tsx` prefers the configured `agency-swarm/default` over stale stored overrides until the user explicitly stores one.
- **Loud errors instead of silent fallback:** every agency-swarm branch that previously degraded quietly now logs explicitly and surfaces a user-visible toast. No upstream log statements were removed or weakened.

### How did you verify your code works?

- `bun typecheck` green.
- Focused package tests green: `test/session/agency-swarm`, `test/session/prompt`, `test/agency-swarm/*`, `test/cli/tui/dialog-provider*`, `test/cli/tui/agency-swarm-connection`, `test/cli/tui/session-error`, `test/agency-swarm/client-config`.
- Hosted CI: all required checks green.
- Independent Codex xhigh review: 0 P1 / 0 P2 findings.
- User manual QA on the linked local build: both bugs confirmed fixed.

### Screenshots / recordings

Not applicable — fix is in wiring/log paths; behavior is covered by the new regression tests and manual user QA.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

