### PR TITLE
Fix agency tool stream completion and framework footer label

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1,5 +1,16 @@
 import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, decodePasteBytes, t, dim, fg } from "@opentui/core"
-import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
+import {
+  createEffect,
+  createMemo,
+  createResource,
+  onMount,
+  createSignal,
+  onCleanup,
+  on,
+  Show,
+  Switch,
+  Match,
+} from "solid-js"
 import "opentui-spinner/solid"
 import path from "path"
 import { fileURLToPath } from "url"
@@ -47,7 +58,11 @@ import {
   shouldOpenAgencyAuthDialog,
 } from "../../session-error"
 import { errorMessage as toErrorMessage } from "@/util/error"
-import { displayRunOnlyAgentLabel, readAgencyProviderOptions } from "../../util/agency-target"
+import {
+  displayRunOnlyAgentLabel,
+  readAgencyProviderOptions,
+  resolveAgencyTargetSelection,
+} from "../../util/agency-target"
 
 export type PromptProps = {
   sessionID?: string
@@ -143,12 +158,50 @@ export function Prompt(props: PromptProps) {
     }),
   )
   const effectiveAgentName = createMemo(() => (frameworkMode() ? "build" : local.agent.current().name))
-  const frameworkRecipientLabel = createMemo(() => {
-    if (!frameworkMode()) return undefined
-    return readAgencyProviderOptions({
+  const agencyProviderOptions = createMemo(() =>
+    readAgencyProviderOptions({
       configuredProvider: sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID],
       connectedProvider: sync.data.provider.find((item) => item.id === AgencySwarmAdapter.PROVIDER_ID),
-    }).recipientAgent
+    }),
+  )
+  const frameworkRecipientDiscoveryInput = createMemo(() => {
+    if (!frameworkMode()) return undefined
+    const options = agencyProviderOptions()
+    if (!options.recipientAgent) return undefined
+    return {
+      baseURL: options.baseURL,
+      token: options.token,
+      timeoutMs: options.discoveryTimeoutMs,
+    }
+  })
+  const [frameworkRecipientDiscovery] = createResource(
+    frameworkRecipientDiscoveryInput,
+    async (input): Promise<AgencySwarmAdapter.AgencyDescriptor[]> => {
+      try {
+        const result = await AgencySwarmAdapter.discover({
+          baseURL: input.baseURL,
+          token: input.token,
+          timeoutMs: input.timeoutMs,
+        })
+        return result.agencies
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") throw error
+        return []
+      }
+    },
+    {
+      initialValue: [],
+    },
+  )
+  const frameworkRecipientLabel = createMemo(() => {
+    if (!frameworkMode()) return undefined
+    const options = agencyProviderOptions()
+    const selection = resolveAgencyTargetSelection({
+      agencies: frameworkRecipientDiscovery(),
+      configuredAgency: options.agency,
+      configuredRecipient: options.recipientAgent,
+    })
+    return selection?.label ?? options.recipientAgent
   })
   const currentProviderLabel = createMemo(() => {
     const current = local.model.current()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -47,7 +47,7 @@ import {
   shouldOpenAgencyAuthDialog,
 } from "../../session-error"
 import { errorMessage as toErrorMessage } from "@/util/error"
-import { displayRunOnlyAgentLabel } from "../../util/agency-target"
+import { displayRunOnlyAgentLabel, readAgencyProviderOptions } from "../../util/agency-target"
 
 export type PromptProps = {
   sessionID?: string
@@ -143,6 +143,13 @@ export function Prompt(props: PromptProps) {
     }),
   )
   const effectiveAgentName = createMemo(() => (frameworkMode() ? "build" : local.agent.current().name))
+  const frameworkRecipientLabel = createMemo(() => {
+    if (!frameworkMode()) return undefined
+    return readAgencyProviderOptions({
+      configuredProvider: sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID],
+      connectedProvider: sync.data.provider.find((item) => item.id === AgencySwarmAdapter.PROVIDER_ID),
+    }).recipientAgent
+  })
   const currentProviderLabel = createMemo(() => {
     const current = local.model.current()
     const provider = local.model.parsed().provider
@@ -1273,6 +1280,7 @@ export function Prompt(props: PromptProps) {
                     ? "Shell"
                     : displayRunOnlyAgentLabel({
                         frameworkMode: frameworkMode(),
+                        recipientLabel: frameworkRecipientLabel(),
                         localAgentName: effectiveAgentName(),
                       })}{" "}
                 </text>

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1348,11 +1348,14 @@ export namespace SessionAgencySwarm {
         ]
       }
 
-      if (name === "tool_output" && itemType.endsWith("_output")) {
-        const callID = asString(rawItem["call_id"])
+      if (name === "tool_output") {
+        const callID = asString(rawItem["call_id"]) || asString(item?.["call_id"])
         if (!callID) return []
         const tool = ensureTool(callID, toolNameFor(callID))
-        return completeTool(callID, tool.tool, stringifyToolOutput(item?.["output"] ?? rawItem["output"]), eventMeta, {
+        const output = item?.["output"] ?? rawItem["output"]
+        if (output === undefined) return []
+        return completeTool(callID, tool.tool, stringifyToolOutput(output), eventMeta, {
+          item_type: itemType || undefined,
           source: "run_item_stream_event",
         })
       }

--- a/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
@@ -18,6 +18,7 @@ import * as TextareaKeybindingsModule from "../../../src/cli/cmd/tui/component/t
 import * as ToastModule from "../../../src/cli/cmd/tui/ui/toast"
 import * as AutocompleteModule from "../../../src/cli/cmd/tui/component/prompt/autocomplete"
 import { DialogProvider } from "../../../src/cli/cmd/tui/ui/dialog"
+import { AgencySwarmAdapter } from "../../../src/agency-swarm/adapter"
 
 function flushEffects() {
   return Promise.resolve().then(() => Promise.resolve())
@@ -28,7 +29,24 @@ describe("prompt framework-mode footer", () => {
     mock.restore()
   })
 
-  test("shows the configured agency recipient instead of the local Agent Builder label", async () => {
+  test("shows the agency recipient display name instead of the configured id or local Agent Builder label", async () => {
+    spyOn(AgencySwarmAdapter, "discover").mockResolvedValue({
+      agencies: [
+        {
+          id: "demo",
+          name: "Demo Agency",
+          agents: [
+            {
+              id: "orchestrator-slug",
+              name: "Orchestrator",
+              isEntryPoint: true,
+            },
+          ],
+          metadata: {},
+        },
+      ],
+      rawOpenAPI: {},
+    })
     spyOn(AutocompleteModule, "Autocomplete").mockImplementation((props: any) => {
       props.ref?.({
         onInput() {},
@@ -114,7 +132,7 @@ describe("prompt framework-mode footer", () => {
             "agency-swarm": {
               options: {
                 agency: "demo",
-                recipientAgent: "Orchestrator",
+                recipientAgent: "orchestrator-slug",
                 baseURL: "http://127.0.0.1:8000",
               },
             },
@@ -201,6 +219,7 @@ describe("prompt framework-mode footer", () => {
 
     const frame = rendered.captureCharFrame()
     expect(frame).toContain("Orchestrator")
+    expect(frame).not.toContain("orchestrator-slug")
     expect(frame).not.toContain("Agent Builder")
   })
 })

--- a/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
@@ -1,0 +1,206 @@
+/** @jsxImportSource @opentui/solid */
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { RGBA } from "@opentui/core"
+import { testRender } from "@opentui/solid"
+import * as AgencySwarmConnectionContext from "../../../src/cli/cmd/tui/context/agency-swarm-connection"
+import * as CommandDialogModule from "../../../src/cli/cmd/tui/component/dialog-command"
+import * as ExitContext from "../../../src/cli/cmd/tui/context/exit"
+import * as KeybindContext from "../../../src/cli/cmd/tui/context/keybind"
+import * as KVContext from "../../../src/cli/cmd/tui/context/kv"
+import * as LocalContext from "../../../src/cli/cmd/tui/context/local"
+import { RouteProvider } from "../../../src/cli/cmd/tui/context/route"
+import * as SDKContext from "../../../src/cli/cmd/tui/context/sdk"
+import * as SyncContext from "../../../src/cli/cmd/tui/context/sync"
+import * as ThemeContext from "../../../src/cli/cmd/tui/context/theme"
+import * as PromptHistoryModule from "../../../src/cli/cmd/tui/component/prompt/history"
+import * as PromptStashModule from "../../../src/cli/cmd/tui/component/prompt/stash"
+import * as TextareaKeybindingsModule from "../../../src/cli/cmd/tui/component/textarea-keybindings"
+import * as ToastModule from "../../../src/cli/cmd/tui/ui/toast"
+import * as AutocompleteModule from "../../../src/cli/cmd/tui/component/prompt/autocomplete"
+import { DialogProvider } from "../../../src/cli/cmd/tui/ui/dialog"
+
+function flushEffects() {
+  return Promise.resolve().then(() => Promise.resolve())
+}
+
+describe("prompt framework-mode footer", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test("shows the configured agency recipient instead of the local Agent Builder label", async () => {
+    spyOn(AutocompleteModule, "Autocomplete").mockImplementation((props: any) => {
+      props.ref?.({
+        onInput() {},
+        onKeyDown() {},
+        visible: false,
+      })
+      return <box />
+    })
+    spyOn(CommandDialogModule, "useCommandDialog").mockReturnValue({
+      register: () => () => {},
+      slashes: () => [],
+      trigger: () => {},
+    } as any)
+    spyOn(ExitContext, "useExit").mockReturnValue(
+      Object.assign(async () => {}, {
+        message: {
+          set: () => () => {},
+          clear: () => {},
+          get: () => undefined,
+        },
+      }) as any,
+    )
+    spyOn(AgencySwarmConnectionContext, "useAgencySwarmConnection").mockReturnValue({
+      requiresReconnect: () => false,
+      openConnectDialog: () => false,
+      status: () => "connected",
+      baseURL: () => undefined,
+      failureCount: () => 0,
+      frameworkMode: () => true,
+    } as any)
+    spyOn(KeybindContext, "useKeybind").mockReturnValue({
+      leader: false,
+      match: () => false,
+      print: (id: string) => (id === "agent_cycle" ? "tab" : ""),
+    } as any)
+    spyOn(KVContext, "useKV").mockReturnValue({
+      get: (_key: string, fallback?: unknown) => fallback,
+    } as any)
+    spyOn(LocalContext, "useLocal").mockReturnValue({
+      agent: {
+        current: () => ({
+          name: "build",
+          model: {
+            providerID: "agency-swarm",
+            modelID: "default",
+          },
+        }),
+        list: () => [{ name: "build" }],
+        set: () => {},
+        color: () => RGBA.fromHex("#38bdf8"),
+      },
+      model: {
+        current: () => ({
+          providerID: "agency-swarm",
+          modelID: "default",
+        }),
+        parsed: () => ({
+          provider: "Agency Swarm",
+          model: "Agency Swarm Default",
+        }),
+        set: () => {},
+        variant: {
+          current: () => undefined,
+          list: () => [],
+          set: () => {},
+        },
+      },
+    } as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({
+      client: {
+        session: {},
+      },
+      event: {
+        on: () => () => {},
+      },
+    } as any)
+    spyOn(SyncContext, "useSync").mockReturnValue({
+      data: {
+        command: [],
+        config: {
+          model: "agency-swarm/default",
+          provider: {
+            "agency-swarm": {
+              options: {
+                agency: "demo",
+                recipientAgent: "Orchestrator",
+                baseURL: "http://127.0.0.1:8000",
+              },
+            },
+          },
+          experimental: {},
+        },
+        console_state: {
+          activeOrgName: "",
+          consoleManagedProviders: [],
+          switchableOrgCount: 0,
+        },
+        message: {},
+        provider: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+        ],
+        provider_auth: {},
+        provider_next: {
+          all: [],
+          connected: [],
+          default: {},
+        },
+        session_status: {},
+      },
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {
+        _hasSelectedListItemText: false,
+        accent: RGBA.fromHex("#14b8a6"),
+        background: RGBA.fromHex("#020617"),
+        backgroundElement: RGBA.fromHex("#111827"),
+        backgroundPanel: RGBA.fromHex("#0f172a"),
+        border: RGBA.fromHex("#334155"),
+        error: RGBA.fromHex("#ef4444"),
+        primary: RGBA.fromHex("#38bdf8"),
+        selectedListItemText: RGBA.fromHex("#f8fafc"),
+        success: RGBA.fromHex("#22c55e"),
+        text: RGBA.fromHex("#f8fafc"),
+        textMuted: RGBA.fromHex("#94a3b8"),
+        warning: RGBA.fromHex("#f59e0b"),
+      },
+      syntax: () => ({
+        getStyleId: () => 1,
+      }),
+    } as any)
+    spyOn(PromptHistoryModule, "usePromptHistory").mockReturnValue({
+      move: () => undefined,
+      append: () => {},
+    } as any)
+    spyOn(PromptStashModule, "usePromptStash").mockReturnValue({
+      list: () => [],
+      push: () => {},
+      pop: () => undefined,
+      remove: () => {},
+    } as any)
+    spyOn(TextareaKeybindingsModule, "useTextareaKeybindings").mockReturnValue(() => [] as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: () => {},
+      error: () => {},
+      currentToast: null,
+    } as any)
+
+    const { Prompt } = await import("../../../src/cli/cmd/tui/component/prompt")
+
+    const rendered = await testRender(
+      () => (
+        <RouteProvider>
+          <DialogProvider>
+            <Prompt showPlaceholder={false} />
+          </DialogProvider>
+        </RouteProvider>
+      ),
+      { width: 100, height: 20 },
+    )
+
+    await flushEffects()
+    await rendered.renderOnce()
+
+    const frame = rendered.captureCharFrame()
+    expect(frame).toContain("Orchestrator")
+    expect(frame).not.toContain("Agent Builder")
+  })
+})

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3193,6 +3193,82 @@ describe("session.agency-swarm", () => {
     expect(calls).toHaveLength(1)
   })
 
+  test("stream accepts tool_output events even when raw_item.type is not an _output item", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: {
+              type: "function_call",
+              id: "call_item_tool_output",
+              call_id: "call_tool_output",
+              name: "greet",
+              arguments: '{"name":"hello"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "tool_called",
+          item: {
+            raw_item: {
+              type: "function_call",
+              id: "call_item_tool_output",
+              call_id: "call_tool_output",
+              name: "greet",
+              arguments: '{"name":"hello"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "tool_output",
+          item: {
+            raw_item: {
+              type: "function_call",
+              id: "call_item_tool_output",
+              call_id: "call_tool_output",
+              output: "hi there",
+            },
+            output: "hi there",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: any[] = []
+    for await (const event of stream.fullStream) {
+      events.push(event)
+    }
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "start-step",
+      "tool-input-start",
+      "tool-input-delta",
+      "tool-call",
+      "tool-result",
+      "finish-step",
+      "finish",
+    ])
+    expect(events.some((event) => event.type === "error")).toBeFalse()
+    expect(events.find((event) => event.type === "tool-result")?.output?.output).toBe("hi there")
+  })
+
   test("stream closes prior text part before switching content_index", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {


### PR DESCRIPTION
### Issue for this PR

Covers the agency tool-stream completion error and the framework-mode footer label leak.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes two post-1.4.21 regressions.

For the agency tool-stream completion error, the agency-swarm session stream was treating a completed tool call as dangling when the bridge sent `run_item_stream_event` `tool_output` data but left `raw_item.type` as `function_call`. That dropped the tool result, closed the stream, and surfaced `Tool stream ended before output was received`. The fix accepts the `tool_output` event by name, reads `call_id` and `output` from the event payload, and closes the tool with the same `tool-result` contract the non-agency path expects.

For the framework-mode footer label leak, the framework-mode footer still rendered the local Agent Builder label in the bottom mode-switcher row. The fix keeps the footer close to the existing upstream-style helper and only threads the configured agency recipient label into that helper so framework mode shows the agency recipient instead of `Agent Builder`.

Both bugs now have focused regression tests.

### How did you verify your code works?

- Added a failing stream regression test in `packages/opencode/test/session/agency-swarm.test.ts` for the happy path where `tool_output` arrives with `raw_item.type: "function_call"`, then fixed the stream handling until it passed.
- Added a failing TUI render regression test in `packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx` for the framework-mode footer label, then fixed the footer rendering until it passed.
- Ran `cd packages/opencode && bun test ./test/session/agency-swarm.test.ts ./test/cli/tui/prompt-framework-mode.test.tsx`
- Ran `bun typecheck`
- Ran `cd packages/opencode && bun test`
  - This full package suite is currently red far outside this diff in the current checkout. The failures are in unrelated areas such as config, plugin loading, MCP, provider/model fixtures, skill discovery, tool registry, and LSP installation. The targeted regressions in this PR pass.

### Screenshots / recordings

Not attached. The UI change is covered by the new TUI render regression test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

