### PR TITLE
docs(fork): clarify history-compaction wording

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -33,7 +33,7 @@ This file records the intentional, maintainable fork delta carried on `vrsen/dev
   Upstream-merge impact: `high` because upstream core has no equivalent Agency Swarm abstraction, so these files carry fork-only concepts.
 
 - `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/session/agency-swarm-utils.ts`, `packages/opencode/src/session/prompt.ts`, `packages/opencode/src/session/processor.ts`, `packages/opencode/src/provider/provider.ts`
-  Motivation: route prompt execution, structured output, cancellation, history compaction, and session resume through Agency Swarm runs instead of only upstream provider flows.
+  Motivation: route prompt execution, structured output, cancellation, and session resume through Agency Swarm runs instead of only upstream provider flows. History compaction stays client-side: the fork summarizes in `compactHistory()` and sends the already-compacted `chat_history` to Agency Swarm (the backend does not expose a compaction endpoint). End-to-end `/compact` behavior in framework mode is tracked for verification (ledger).
   Upstream-merge impact: `high` because these are hot core paths with frequent upstream edits and non-trivial behavioral divergence.
 
 - `packages/opencode/src/session/agency-swarm.ts` (`resolveClientConfig`) + `packages/opencode/src/agency-swarm/litellm-provider.ts` (`isOpenAIBasedLitellmModel`)


### PR DESCRIPTION
### Issue for this PR

Covers the compact framework-mode QA follow-up.

### Type of change

- [x] Documentation

### What does this PR do?

Clarifies one `FORK_CHANGELOG.md` line that implied Agency Swarm itself owned history compaction. It doesn't. The fork summarizes history client-side in `compactHistory()` (`packages/opencode/src/session/agency-swarm.ts:1959`) and forwards the already-compacted `chat_history` to Agency Swarm. Notes the `/compact` end-to-end verification is tracked separately.

### How did you verify your code works?

Docs-only edit; no runtime change. Line reads correctly against the actual code path at `packages/opencode/src/session/agency-swarm.ts:1485`.

### Screenshots / recordings

N/A.

### Checklist

- [x] Tested locally
- [x] No unrelated changes

