### PR TITLE
fix(opencode): resolve correlated tool_output events

### DIFF
--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -744,7 +744,10 @@ export namespace SessionAgencySwarm {
       }
 
       if (item) {
-        const fromItem = asString(item["call_id"]) || asString(item["id"])
+        const fromItemID = asString(item["id"])
+        if (fromItemID && callByItem.has(fromItemID)) return callByItem.get(fromItemID)
+        if (fromItemID && tools.has(fromItemID)) return fromItemID
+        const fromItem = asString(item["call_id"]) || fromItemID
         if (fromItem) return fromItem
       }
 
@@ -1349,7 +1352,7 @@ export namespace SessionAgencySwarm {
       }
 
       if (name === "tool_output") {
-        const callID = asString(rawItem["call_id"]) || asString(item?.["call_id"])
+        const callID = findCallID(rawItem, rawItem) || findCallID(item ?? {}, rawItem)
         if (!callID) return []
         const tool = ensureTool(callID, toolNameFor(callID))
         const output = item?.["output"] ?? rawItem["output"]

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1352,7 +1352,7 @@ export namespace SessionAgencySwarm {
       }
 
       if (name === "tool_output") {
-        const callID = findCallID(rawItem, rawItem) || findCallID(item ?? {}, rawItem)
+        const callID = asString(item?.["call_id"]) || asString(rawItem["call_id"]) || findCallID(item ?? {}, rawItem)
         if (!callID) return []
         const tool = ensureTool(callID, toolNameFor(callID))
         const output = item?.["output"] ?? rawItem["output"]

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3269,6 +3269,98 @@ describe("session.agency-swarm", () => {
     expect(events.find((event) => event.type === "tool-result")?.output?.output).toBe("hi there")
   })
 
+  test("stream resolves tool_output events from prior tool item ids when call_id is omitted", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: {
+              type: "function_call",
+              id: "call_item_litellm_tool_output",
+              call_id: "call_litellm_tool_output",
+              name: "ExampleTool",
+              arguments: '{"name":"hi","greeting_type":"Hello"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: {
+              type: "function_call",
+              id: "call_item_litellm_tool_output",
+              call_id: "call_litellm_tool_output",
+              name: "ExampleTool",
+              arguments: '{"name":"hi","greeting_type":"Hello"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "tool_called",
+          item: {
+            raw_item: {
+              type: "function_call",
+              id: "call_item_litellm_tool_output",
+              call_id: "call_litellm_tool_output",
+              name: "ExampleTool",
+              arguments: '{"name":"hi","greeting_type":"Hello"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "tool_output",
+          item: {
+            raw_item: {
+              type: "function_call_output",
+              id: "call_item_litellm_tool_output",
+              output: "Hello, hi!",
+            },
+            output: "Hello, hi!",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: any[] = []
+    for await (const event of stream.fullStream) {
+      events.push(event)
+    }
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "start-step",
+      "tool-input-start",
+      "tool-input-delta",
+      "tool-call",
+      "tool-result",
+      "finish-step",
+      "finish",
+    ])
+    expect(events.some((event) => event.type === "error")).toBeFalse()
+    expect(events.find((event) => event.type === "tool-result")?.output?.output).toBe("Hello, hi!")
+  })
+
   test("stream closes prior text part before switching content_index", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3361,6 +3361,63 @@ describe("session.agency-swarm", () => {
     expect(events.find((event) => event.type === "tool-result")?.output?.output).toBe("Hello, hi!")
   })
 
+  test("stream prefers wrapper call_id before raw_item.id for tool_output after argument deltas", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.function_call_arguments.delta",
+            call_id: "call_wrapper_preferred",
+            name: "ExampleTool",
+            delta: '{"name":"hi","greeting_type":"Hello"}',
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "tool_output",
+          item: {
+            call_id: "call_wrapper_preferred",
+            raw_item: {
+              type: "function_call_output",
+              id: "call_item_wrapper_preferred",
+              output: "Hello, hi!",
+            },
+            output: "Hello, hi!",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: any[] = []
+    for await (const event of stream.fullStream) {
+      events.push(event)
+    }
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "start-step",
+      "tool-input-start",
+      "tool-input-delta",
+      "tool-call",
+      "tool-result",
+      "finish-step",
+      "finish",
+    ])
+    expect(events.some((event) => event.type === "tool-error")).toBeFalse()
+    expect(events.find((event) => event.type === "tool-call")?.toolCallId).toBe("call_wrapper_preferred")
+    expect(events.find((event) => event.type === "tool-result")?.toolCallId).toBe("call_wrapper_preferred")
+    expect(events.find((event) => event.type === "tool-result")?.output?.output).toBe("Hello, hi!")
+  })
+
   test("stream closes prior text part before switching content_index", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {


### PR DESCRIPTION
### Issue for this PR

Covers the correlated `tool_output` event regression.

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes "Tool stream ended before output was received" that reproduced across OpenAI and Anthropic LiteLLM in framework mode (team-verified cross-provider).

- Routes `run_item_stream_event` with `tool_output` through the existing tool-call correlation in `packages/opencode/src/session/agency-swarm.ts`.
- Prefers wrapper `item.call_id` before `raw_item.call_id` and `raw_item.id` so a snapshot with only `raw_item.id` does not split one tool across two IDs (addresses Codex-bot P2 r3117288244).
- Adds focused regression coverage in `packages/opencode/test/session/agency-swarm.test.ts`.

### How did you verify your code works?

- `bun typecheck` green in `packages/opencode`.
- `bun test test/session/agency-swarm.test.ts` → 66/66 pass.
- Real-frame capture against live LiteLLM + Anthropic drove the fix (`/tmp/cx/tool_stream_frames*.ndjson`).
- Independent Codex xhigh review of HEAD `a52afd5a7`: clean (0 P1 / 0 P2). P2 from bot addressed in follow-up commit on same branch.

### Screenshots / recordings

tmux QA pending (venv rebuild in flight) — release will be gated on green QA.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

