### PR TITLE
fix(npx): surface launcher dependency install progress

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -2,8 +2,8 @@ import * as prompts from "@clack/prompts"
 import net from "node:net"
 import os from "node:os"
 import path from "node:path"
-import { existsSync, statSync } from "node:fs"
-import { mkdtemp, rm } from "node:fs/promises"
+import { createWriteStream, existsSync, statSync } from "node:fs"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
 import { AgencySwarmRunSession } from "./run-session"
 import { SERVER_LAUNCHER_SCRIPT } from "./server-launcher"
@@ -36,6 +36,8 @@ interface CommandResult {
   code: number
   stdout: string
   stderr: string
+  timedOut?: boolean
+  logFile?: string
 }
 
 interface PythonInfo {
@@ -52,6 +54,17 @@ interface VenvCanaryResult {
 interface DependencyInstallResult extends CommandResult {
   hadManifests: boolean
 }
+
+interface RunCommandOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  logFile?: string
+  streamOutputToStderr?: boolean
+  timeoutMs?: number
+}
+
+const VENV_CANARY_SCRIPT = ["import agency_swarm", "import agency_swarm.integrations.fastapi"].join("\n")
+const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
 
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
@@ -712,26 +725,43 @@ async function ensureProjectPython(directory: string) {
   }
 
   spinner.stop("`.venv` created")
-  spinner.start("Installing project dependencies")
-  const install = await installProjectDependencies(directory, [venvPython])
+  const installLogFile = await createProjectCommandLogFile(directory, "launcher-rebuild")
+  prompts.log.info(`Installing project dependencies. Streaming output to stderr. Full log: ${installLogFile}`)
+  const install = await installProjectDependencies(directory, [venvPython], {
+    logFile: installLogFile,
+    timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+  })
+  if (install.timedOut) {
+    throw new Error(
+      `Dependency install timed out after ${formatInstallDuration(REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${installLogFile}.`,
+    )
+  }
   if (install.code !== 0) {
-    spinner.stop("Dependency install failed")
-    throw new Error(install.stderr.trim() || install.stdout.trim() || "Dependency install failed")
+    throw new Error(formatCommandFailure(install, "Dependency install failed"))
   }
   const canary = await venvCanaryPasses([venvPython], { cwd: directory, includeStderr: true })
   if (!canary.healthy) {
-    spinner.stop("Python environment unhealthy")
     throw new Error(await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr))
   }
-  spinner.stop("Python environment ready")
+  prompts.log.success("Python environment ready")
   return [venvPython]
 }
 
-async function installProjectDependencies(directory: string, python: string[]): Promise<DependencyInstallResult> {
+async function installProjectDependencies(
+  directory: string,
+  python: string[],
+  options: {
+    logFile: string
+    timeoutMs: number
+  },
+): Promise<DependencyInstallResult> {
   const requirements = path.join(directory, "requirements.txt")
   if (await Filesystem.exists(requirements)) {
     const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "-r", "requirements.txt"], {
       cwd: directory,
+      logFile: options.logFile,
+      streamOutputToStderr: true,
+      timeoutMs: options.timeoutMs,
     })
     return { ...result, hadManifests: true }
   }
@@ -740,11 +770,21 @@ async function installProjectDependencies(directory: string, python: string[]): 
   if (await Filesystem.exists(pyproject)) {
     const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "-e", "."], {
       cwd: directory,
+      logFile: options.logFile,
+      streamOutputToStderr: true,
+      timeoutMs: options.timeoutMs,
     })
     return { ...result, hadManifests: true }
   }
 
-  const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.1"])
+  const result = await runCommand(
+    [...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.1"],
+    {
+      logFile: options.logFile,
+      streamOutputToStderr: true,
+      timeoutMs: options.timeoutMs,
+    },
+  )
   return { ...result, hadManifests: false }
 }
 
@@ -786,14 +826,17 @@ async function findProjectShadowingFiles(directory: string) {
 }
 
 async function venvCanaryPasses(python: string[], options?: { cwd?: string }): Promise<boolean>
-async function venvCanaryPasses(python: string[], options: { cwd?: string; includeStderr: true }): Promise<VenvCanaryResult>
+async function venvCanaryPasses(
+  python: string[],
+  options: { cwd?: string; includeStderr: true },
+): Promise<VenvCanaryResult>
 async function venvCanaryPasses(python: string[], options?: { cwd?: string; includeStderr?: boolean }) {
   // No cwd by default: the canary must not pick up project-local modules (e.g. `fastapi.py`
   // sitting next to `agency.py`) that shadow installed packages and falsely flag a healthy
   // .venv as broken. Callers that need the server-launch cwd (post-install verification)
   // pass it explicitly.
   const result = await runCommand(
-    [...python, "-c", "from agency_swarm.integrations.fastapi import run_fastapi"],
+    [...python, "-c", VENV_CANARY_SCRIPT],
     options?.cwd ? { cwd: options.cwd } : undefined,
   )
   if (options?.includeStderr) {
@@ -807,13 +850,15 @@ async function venvCanaryPasses(python: string[], options?: { cwd?: string; incl
 
 async function ensureLatestAgencySwarm(directory: string, python: string[]) {
   try {
-    const result = await runCommand(
-      [...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]"],
-      { cwd: directory },
-    )
+    const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]"], {
+      cwd: directory,
+    })
     if (result.code !== 0) {
+      const summary = summarizeCommandOutput(result)
       prompts.log.warn(
-        "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
+        summary
+          ? `Could not refresh agency-swarm to the latest version. Installer output: ${summary}. The current venv package will be used as-is.`
+          : "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
       )
     }
   } catch {
@@ -821,6 +866,35 @@ async function ensureLatestAgencySwarm(directory: string, python: string[]) {
       "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
     )
   }
+}
+
+async function createProjectCommandLogFile(directory: string, stem: string) {
+  const logDirectory = path.join(directory, "activity-logs")
+  await mkdir(logDirectory, { recursive: true })
+  return path.join(logDirectory, `${new Date().toISOString().replaceAll(":", "").replaceAll(".", "")}-${stem}.log`)
+}
+
+function summarizeCommandOutput(result: Pick<CommandResult, "stdout" | "stderr">) {
+  return summarizeBridgeStderr(result.stderr) || summarizeBridgeStderr(result.stdout)
+}
+
+function formatCommandFailure(result: CommandResult, fallback: string) {
+  const summary = summarizeCommandOutput(result)
+  const logHint = result.logFile ? ` Check the log file at ${result.logFile}.` : ""
+  if (summary) return `${fallback}: ${summary}.${logHint}`
+  return `${fallback}.${logHint}`.trim()
+}
+
+function formatInstallDuration(ms: number) {
+  if (ms % 60000 === 0) {
+    const minutes = ms / 60000
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`
+  }
+  if (ms % 1000 === 0) {
+    const seconds = ms / 1000
+    return `${seconds} second${seconds === 1 ? "" : "s"}`
+  }
+  return `${ms}ms`
 }
 
 async function startProjectServer(directory: string, python: string[]) {
@@ -1028,10 +1102,13 @@ async function getFreePort() {
   })
 }
 
-async function runCommand(
-  cmd: string[],
-  options?: { cwd?: string; env?: NodeJS.ProcessEnv },
-): Promise<CommandResult> {
+async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<CommandResult> {
+  const logStream = options?.logFile ? createWriteStream(options.logFile, { flags: "a" }) : undefined
+  const writeChunk = (chunk: string) => {
+    if (options?.streamOutputToStderr) process.stderr.write(chunk)
+    logStream?.write(chunk)
+  }
+
   try {
     const proc = Bun.spawn({
       cmd,
@@ -1040,19 +1117,70 @@ async function runCommand(
       stderr: "pipe",
       env: options?.env ?? process.env,
     })
+    let timedOut = false
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    if (options?.timeoutMs) {
+      timeout = setTimeout(() => {
+        timedOut = true
+        proc.kill()
+      }, options.timeoutMs)
+    }
     const [code, stdout, stderr] = await Promise.all([
       proc.exited,
-      proc.stdout ? new Response(proc.stdout).text() : Promise.resolve(""),
-      proc.stderr ? new Response(proc.stderr).text() : Promise.resolve(""),
+      readCommandOutput(proc.stdout, writeChunk),
+      readCommandOutput(proc.stderr, writeChunk),
     ])
-    return { code, stdout, stderr }
+    if (timeout) clearTimeout(timeout)
+    await closeCommandLog(logStream)
+    return { code: timedOut ? -1 : code, stdout, stderr, timedOut, logFile: options?.logFile }
   } catch (error) {
+    await closeCommandLog(logStream)
     return {
       code: -1,
       stdout: "",
       stderr: error instanceof Error ? error.message : String(error),
+      logFile: options?.logFile,
     }
   }
+}
+
+async function closeCommandLog(stream?: ReturnType<typeof createWriteStream>) {
+  if (!stream) return
+  await new Promise<void>((resolve, reject) => {
+    stream.end((error?: Error | null) => {
+      if (error) reject(error)
+      else resolve()
+    })
+  }).catch(() => undefined)
+}
+
+async function readCommandOutput(
+  output: string | ReadableStream<Uint8Array> | null | undefined,
+  writer?: (chunk: string) => void,
+) {
+  if (typeof output === "string") {
+    if (output && writer) writer(output)
+    return output
+  }
+  if (!output) return ""
+
+  const reader = output.getReader()
+  const decoder = new TextDecoder()
+  let text = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (!value || value.length === 0) continue
+    const chunk = decoder.decode(value, { stream: true })
+    if (writer) writer(chunk)
+    text += chunk
+  }
+  const tail = decoder.decode()
+  if (tail) {
+    if (writer) writer(tail)
+    text += tail
+  }
+  return text
 }
 
 function sleep(ms: number) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1155,10 +1155,10 @@ async function getFreePort() {
 }
 
 async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<CommandResult> {
-  const logStream = options?.logFile ? createWriteStream(options.logFile, { flags: "a" }) : undefined
+  const commandLog = openCommandLog(options?.logFile)
   const writeChunk = (chunk: string) => {
     if (options?.streamOutputToStderr) process.stderr.write(chunk)
-    logStream?.write(chunk)
+    commandLog.write(chunk)
   }
 
   try {
@@ -1169,46 +1169,101 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
       stderr: "pipe",
       env: options?.env ?? process.env,
     })
+    const outputAbort = new AbortController()
     let timedOut = false
     let timeout: ReturnType<typeof setTimeout> | undefined
-    if (options?.timeoutMs) {
-      timeout = setTimeout(() => {
-        timedOut = true
-        proc.kill()
-      }, options.timeoutMs)
-    }
-    const [code, stdout, stderr] = await Promise.all([
-      proc.exited,
-      readCommandOutput(proc.stdout, writeChunk),
-      readCommandOutput(proc.stderr, writeChunk),
+    const exitResult = proc.exited.then((code) => ({ code, timedOut: false as const }))
+    const timeoutResult =
+      options?.timeoutMs === undefined
+        ? undefined
+        : new Promise<{ code: number; timedOut: true }>((resolve) => {
+            timeout = setTimeout(() => {
+              timedOut = true
+              outputAbort.abort()
+              try {
+                proc.kill()
+              } catch {}
+              resolve({ code: -1, timedOut: true })
+            }, options.timeoutMs)
+          })
+    const [result, stdout, stderr] = await Promise.all([
+      timeoutResult ? Promise.race([exitResult, timeoutResult]) : exitResult,
+      readCommandOutput(proc.stdout, writeChunk, outputAbort.signal),
+      readCommandOutput(proc.stderr, writeChunk, outputAbort.signal),
     ])
     if (timeout) clearTimeout(timeout)
-    await closeCommandLog(logStream)
-    return { code: timedOut ? -1 : code, stdout, stderr, timedOut, logFile: options?.logFile }
+    const logFile = await closeCommandLog(commandLog)
+    return { code: result.code, stdout, stderr, timedOut: timedOut || result.timedOut, logFile }
   } catch (error) {
-    await closeCommandLog(logStream)
+    const logFile = await closeCommandLog(commandLog)
     return {
       code: -1,
       stdout: "",
       stderr: error instanceof Error ? error.message : String(error),
-      logFile: options?.logFile,
+      logFile,
     }
   }
 }
 
-async function closeCommandLog(stream?: ReturnType<typeof createWriteStream>) {
-  if (!stream) return
-  await new Promise<void>((resolve, reject) => {
-    stream.end((error?: Error | null) => {
-      if (error) reject(error)
-      else resolve()
+function openCommandLog(logFile?: string) {
+  if (!logFile) {
+    return {
+      getLogFile: () => undefined,
+      write(_chunk: string) {},
+      async close() {},
+    }
+  }
+
+  let activeLogFile: string | undefined = logFile
+  let stream: ReturnType<typeof createWriteStream> | undefined
+  const disable = () => {
+    activeLogFile = undefined
+    if (!stream) return
+    stream.destroy()
+    stream = undefined
+  }
+
+  try {
+    stream = createWriteStream(logFile, { flags: "a" })
+    stream.on("error", () => {
+      disable()
     })
-  }).catch(() => undefined)
+  } catch {
+    disable()
+  }
+
+  return {
+    getLogFile: () => activeLogFile,
+    write(chunk: string) {
+      if (!stream) return
+      try {
+        stream.write(chunk)
+      } catch {
+        disable()
+      }
+    },
+    async close() {
+      if (!stream) return
+      await new Promise<void>((resolve, reject) => {
+        stream?.end((error?: Error | null) => {
+          if (error) reject(error)
+          else resolve()
+        })
+      }).catch(() => undefined)
+      stream = undefined
+    },
+  }
+}
+
+async function closeCommandLog(log: ReturnType<typeof openCommandLog>) {
+  await log.close()
+  return log.getLogFile()
 }
 
 async function readCommandOutput(
   output: string | ReadableStream<Uint8Array> | null | undefined,
   writer?: (chunk: string) => void,
+  signal?: AbortSignal,
 ) {
   if (typeof output === "string") {
     if (output && writer) writer(output)
@@ -1219,20 +1274,32 @@ async function readCommandOutput(
   const reader = output.getReader()
   const decoder = new TextDecoder()
   let text = ""
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    if (!value || value.length === 0) continue
-    const chunk = decoder.decode(value, { stream: true })
-    if (writer) writer(chunk)
-    text += chunk
+  const abortRead = () => {
+    void reader.cancel().catch(() => undefined)
   }
-  const tail = decoder.decode()
-  if (tail) {
-    if (writer) writer(tail)
-    text += tail
+  signal?.addEventListener("abort", abortRead, { once: true })
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done || signal?.aborted) break
+      if (!value || value.length === 0) continue
+      const chunk = decoder.decode(value, { stream: true })
+      if (writer) writer(chunk)
+      text += chunk
+    }
+    const tail = decoder.decode()
+    if (tail) {
+      if (writer) writer(tail)
+      text += tail
+    }
+    return text
+  } catch (error) {
+    if (signal?.aborted) return text
+    throw error
+  } finally {
+    signal?.removeEventListener("abort", abortRead)
   }
-  return text
 }
 
 function sleep(ms: number) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1171,7 +1171,6 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
       env: options?.env ?? process.env,
     })
     const outputAbort = new AbortController()
-    let timedOut = false
     let timeout: ReturnType<typeof setTimeout> | undefined
     const exitPromise = proc.exited.finally(() => {
       if (timeout) clearTimeout(timeout)
@@ -1181,19 +1180,21 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
       options?.timeoutMs === undefined
         ? undefined
         : new Promise<{ code: number; timedOut: true }>((resolve) => {
-            timeout = setTimeout(async () => {
-              timedOut = true
-              try {
-                proc.kill()
-              } catch {}
-              const forceKill = setTimeout(() => {
-                try {
-                  proc.kill("SIGKILL")
-                } catch {}
-              }, PROCESS_KILL_GRACE_MS)
-              await exitPromise.catch(() => undefined)
-              clearTimeout(forceKill)
+            timeout = setTimeout(() => {
               resolve({ code: -1, timedOut: true })
+              void (async () => {
+                try {
+                  proc.kill()
+                } catch {}
+                const forceKill = setTimeout(() => {
+                  try {
+                    proc.kill("SIGKILL")
+                  } catch {}
+                }, PROCESS_KILL_GRACE_MS)
+                await exitPromise.catch(() => undefined)
+                clearTimeout(forceKill)
+                outputAbort.abort()
+              })()
             }, options.timeoutMs)
           })
     const [result, stdout, stderr] = await Promise.all([
@@ -1202,7 +1203,7 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
       readCommandOutput(proc.stderr, writeChunk, outputAbort.signal),
     ])
     const logFile = await closeCommandLog(commandLog)
-    return { code: result.code, stdout, stderr, timedOut: timedOut || result.timedOut, logFile }
+    return { code: result.code, stdout, stderr, timedOut: result.timedOut, logFile }
   } catch (error) {
     const logFile = await closeCommandLog(commandLog)
     return {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1173,7 +1173,10 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
     const outputAbort = new AbortController()
     let timedOut = false
     let timeout: ReturnType<typeof setTimeout> | undefined
-    const exitResult = proc.exited.then((code) => ({ code, timedOut: false as const }))
+    const exitPromise = proc.exited.finally(() => {
+      if (timeout) clearTimeout(timeout)
+    })
+    const exitResult = exitPromise.then((code) => ({ code, timedOut: false as const }))
     const timeoutResult =
       options?.timeoutMs === undefined
         ? undefined
@@ -1188,7 +1191,7 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
                   proc.kill("SIGKILL")
                 } catch {}
               }, PROCESS_KILL_GRACE_MS)
-              await proc.exited.catch(() => undefined)
+              await exitPromise.catch(() => undefined)
               clearTimeout(forceKill)
               resolve({ code: -1, timedOut: true })
             }, options.timeoutMs)
@@ -1198,7 +1201,6 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
       readCommandOutput(proc.stdout, writeChunk, outputAbort.signal),
       readCommandOutput(proc.stderr, writeChunk, outputAbort.signal),
     ])
-    if (timeout) clearTimeout(timeout)
     const logFile = await closeCommandLog(commandLog)
     return { code: result.code, stdout, stderr, timedOut: timedOut || result.timedOut, logFile }
   } catch (error) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -63,7 +63,9 @@ interface RunCommandOptions {
   timeoutMs?: number
 }
 
-const VENV_CANARY_SCRIPT = ["import agency_swarm", "import agency_swarm.integrations.fastapi"].join("\n")
+const VENV_CANARY_SCRIPT = ["import agency_swarm", "from agency_swarm.integrations.fastapi import run_fastapi"].join(
+  "\n",
+)
 const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
 
 export function shouldRunNpxOnboarding(input: {
@@ -655,8 +657,12 @@ async function ensureProjectPython(directory: string) {
       corruptedVenv = true
     } else {
       prompts.log.info(`Using project Python: ${formatPython(info, [venvPython])}`)
-      const refreshLogFile = await createProjectCommandLogFile(directory, "launcher-refresh")
-      prompts.log.info(`Refreshing project dependencies. Streaming output to stderr. Full log: ${refreshLogFile}`)
+      const refreshLogFile = await tryCreateProjectCommandLogFile(directory, "launcher-refresh", "launcher refresh")
+      prompts.log.info(
+        refreshLogFile
+          ? `Refreshing project dependencies. Streaming output to stderr. Full log: ${refreshLogFile}`
+          : "Refreshing project dependencies. Streaming output to stderr.",
+      )
       try {
         await ensureLatestAgencySwarm(directory, [venvPython], {
           logFile: refreshLogFile,
@@ -730,15 +736,21 @@ async function ensureProjectPython(directory: string) {
   }
 
   spinner.stop("`.venv` created")
-  const installLogFile = await createProjectCommandLogFile(directory, "launcher-rebuild")
-  prompts.log.info(`Installing project dependencies. Streaming output to stderr. Full log: ${installLogFile}`)
+  const installLogFile = await tryCreateProjectCommandLogFile(directory, "launcher-rebuild", "launcher rebuild")
+  prompts.log.info(
+    installLogFile
+      ? `Installing project dependencies. Streaming output to stderr. Full log: ${installLogFile}`
+      : "Installing project dependencies. Streaming output to stderr.",
+  )
   const install = await installProjectDependencies(directory, [venvPython], {
     logFile: installLogFile,
     timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
   })
   if (install.timedOut) {
     throw new Error(
-      `Dependency install timed out after ${formatInstallDuration(REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${installLogFile}.`,
+      installLogFile
+        ? `Dependency install timed out after ${formatInstallDuration(REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${installLogFile}.`
+        : `Dependency install timed out after ${formatInstallDuration(REBUILD_INSTALL_TIMEOUT_MS)}.`,
     )
   }
   if (install.code !== 0) {
@@ -756,7 +768,7 @@ async function installProjectDependencies(
   directory: string,
   python: string[],
   options: {
-    logFile: string
+    logFile?: string
     timeoutMs: number
   },
 ): Promise<DependencyInstallResult> {
@@ -870,7 +882,9 @@ async function ensureLatestAgencySwarm(
     })
     if (result.timedOut) {
       prompts.log.warn(
-        `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${options?.logFile}.`,
+        options?.logFile
+          ? `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${options.logFile}.`
+          : `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}.`,
       )
       return
     }
@@ -892,9 +906,20 @@ async function ensureLatestAgencySwarm(
 }
 
 async function createProjectCommandLogFile(directory: string, stem: string) {
-  const logDirectory = path.join(directory, "activity-logs")
+  const projectID = `${path.basename(path.resolve(directory)) || "project"}-${Bun.hash(path.resolve(directory)).toString(16)}`
+  const logDirectory = path.join(os.tmpdir(), "agentswarm-cli-logs", projectID)
   await mkdir(logDirectory, { recursive: true })
   return path.join(logDirectory, `${new Date().toISOString().replaceAll(":", "").replaceAll(".", "")}-${stem}.log`)
+}
+
+async function tryCreateProjectCommandLogFile(directory: string, stem: string, label: string) {
+  try {
+    return await createProjectCommandLogFile(directory, stem)
+  } catch (error) {
+    prompts.log.warn(
+      `Could not create ${label} log file. Continuing without a saved log: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
 }
 
 function summarizeCommandOutput(result: Pick<CommandResult, "stdout" | "stderr">) {
@@ -902,8 +927,12 @@ function summarizeCommandOutput(result: Pick<CommandResult, "stdout" | "stderr">
 }
 
 function formatCommandFailure(result: CommandResult, fallback: string) {
+  if (!result.logFile) {
+    const detail = result.stderr.trim() || result.stdout.trim()
+    return detail ? `${fallback}: ${detail}` : fallback
+  }
   const summary = summarizeCommandOutput(result)
-  const logHint = result.logFile ? ` Check the log file at ${result.logFile}.` : ""
+  const logHint = ` Check the log file at ${result.logFile}.`
   if (summary) return `${fallback}: ${summary}.${logHint}`
   return `${fallback}.${logHint}`.trim()
 }

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -67,6 +67,7 @@ const VENV_CANARY_SCRIPT = ["import agency_swarm", "from agency_swarm.integratio
   "\n",
 )
 const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
+const PROCESS_KILL_GRACE_MS = 5000
 
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
@@ -1177,12 +1178,19 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
       options?.timeoutMs === undefined
         ? undefined
         : new Promise<{ code: number; timedOut: true }>((resolve) => {
-            timeout = setTimeout(() => {
+            timeout = setTimeout(async () => {
               timedOut = true
               outputAbort.abort()
               try {
                 proc.kill()
               } catch {}
+              const forceKill = setTimeout(() => {
+                try {
+                  proc.kill("SIGKILL")
+                } catch {}
+              }, PROCESS_KILL_GRACE_MS)
+              await proc.exited.catch(() => undefined)
+              clearTimeout(forceKill)
               resolve({ code: -1, timedOut: true })
             }, options.timeoutMs)
           })

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -655,8 +655,13 @@ async function ensureProjectPython(directory: string) {
       corruptedVenv = true
     } else {
       prompts.log.info(`Using project Python: ${formatPython(info, [venvPython])}`)
+      const refreshLogFile = await createProjectCommandLogFile(directory, "launcher-refresh")
+      prompts.log.info(`Refreshing project dependencies. Streaming output to stderr. Full log: ${refreshLogFile}`)
       try {
-        await ensureLatestAgencySwarm(directory, [venvPython])
+        await ensureLatestAgencySwarm(directory, [venvPython], {
+          logFile: refreshLogFile,
+          timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+        })
       } catch {
         corruptedVenv = true
       }
@@ -848,16 +853,34 @@ async function venvCanaryPasses(python: string[], options?: { cwd?: string; incl
   return result.code === 0
 }
 
-async function ensureLatestAgencySwarm(directory: string, python: string[]) {
+async function ensureLatestAgencySwarm(
+  directory: string,
+  python: string[],
+  options?: {
+    logFile?: string
+    timeoutMs?: number
+  },
+) {
   try {
     const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]"], {
       cwd: directory,
+      logFile: options?.logFile,
+      streamOutputToStderr: true,
+      timeoutMs: options?.timeoutMs,
     })
+    if (result.timedOut) {
+      prompts.log.warn(
+        `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${options?.logFile}.`,
+      )
+      return
+    }
     if (result.code !== 0) {
       const summary = summarizeCommandOutput(result)
       prompts.log.warn(
         summary
-          ? `Could not refresh agency-swarm to the latest version. Installer output: ${summary}. The current venv package will be used as-is.`
+          ? `Could not refresh agency-swarm to the latest version. Installer output: ${summary}.${
+              result.logFile ? ` Check the log file at ${result.logFile}.` : ""
+            } The current venv package will be used as-is.`
           : "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
       )
     }

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -2,13 +2,14 @@ import * as prompts from "@clack/prompts"
 import net from "node:net"
 import os from "node:os"
 import path from "node:path"
-import { existsSync, statSync } from "node:fs"
-import { mkdtemp, rm } from "node:fs/promises"
+import { createWriteStream, existsSync, statSync } from "node:fs"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
 import { AgencySwarmRunSession } from "./run-session"
 import { SERVER_LAUNCHER_SCRIPT } from "./server-launcher"
 import { Storage } from "@/storage/storage"
 import { Filesystem } from "@/util/filesystem"
+import * as Which from "@/util/which"
 import type { Session } from "@/session"
 import { SessionID } from "@/session/schema"
 
@@ -36,6 +37,8 @@ interface CommandResult {
   code: number
   stdout: string
   stderr: string
+  timedOut?: boolean
+  logFile?: string
 }
 
 interface PythonInfo {
@@ -52,6 +55,25 @@ interface VenvCanaryResult {
 interface DependencyInstallResult extends CommandResult {
   hadManifests: boolean
 }
+
+const VENV_CANARY_SCRIPT = ["import agency_swarm", "import agency_swarm.integrations.fastapi"].join("\n")
+const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
+
+interface PythonPackageInstaller {
+  tool: "uv" | "pip"
+  cmd: string[]
+  env: NodeJS.ProcessEnv
+}
+
+interface RunCommandOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  logFile?: string
+  streamOutputToStderr?: boolean
+  timeoutMs?: number
+}
+
+const UV_INSTALLER_URL = "https://astral.sh/uv/install.sh"
 
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
@@ -712,39 +734,67 @@ async function ensureProjectPython(directory: string) {
   }
 
   spinner.stop("`.venv` created")
-  spinner.start("Installing project dependencies")
-  const install = await installProjectDependencies(directory, [venvPython])
+  const installLogFile = await createProjectCommandLogFile(directory, "launcher-rebuild")
+  prompts.log.info(`Installing project dependencies. Streaming output to stderr. Full log: ${installLogFile}`)
+  const install = await installProjectDependencies(directory, [venvPython], {
+    logFile: installLogFile,
+    timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+  })
+  if (install.timedOut) {
+    throw new Error(
+      `Dependency install timed out after ${formatDuration(REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${installLogFile}.`,
+    )
+  }
   if (install.code !== 0) {
-    spinner.stop("Dependency install failed")
-    throw new Error(install.stderr.trim() || install.stdout.trim() || "Dependency install failed")
+    throw new Error(formatCommandFailure(install, "Dependency install failed"))
   }
   const canary = await venvCanaryPasses([venvPython], { cwd: directory, includeStderr: true })
   if (!canary.healthy) {
-    spinner.stop("Python environment unhealthy")
     throw new Error(await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr))
   }
-  spinner.stop("Python environment ready")
+  prompts.log.success("Python environment ready")
   return [venvPython]
 }
 
-async function installProjectDependencies(directory: string, python: string[]): Promise<DependencyInstallResult> {
+async function installProjectDependencies(
+  directory: string,
+  python: string[],
+  options: {
+    logFile: string
+    timeoutMs: number
+  },
+): Promise<DependencyInstallResult> {
+  const installer = await resolvePythonPackageInstaller(python)
   const requirements = path.join(directory, "requirements.txt")
   if (await Filesystem.exists(requirements)) {
-    const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "-r", "requirements.txt"], {
+    const result = await runCommand([...installer.cmd, "--upgrade", "-r", "requirements.txt"], {
       cwd: directory,
+      env: installer.env,
+      logFile: options.logFile,
+      streamOutputToStderr: true,
+      timeoutMs: options.timeoutMs,
     })
     return { ...result, hadManifests: true }
   }
 
   const pyproject = path.join(directory, "pyproject.toml")
   if (await Filesystem.exists(pyproject)) {
-    const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "-e", "."], {
+    const result = await runCommand([...installer.cmd, "--upgrade", "-e", "."], {
       cwd: directory,
+      env: installer.env,
+      logFile: options.logFile,
+      streamOutputToStderr: true,
+      timeoutMs: options.timeoutMs,
     })
     return { ...result, hadManifests: true }
   }
 
-  const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.1"])
+  const result = await runCommand([...installer.cmd, "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.1"], {
+    env: installer.env,
+    logFile: options.logFile,
+    streamOutputToStderr: true,
+    timeoutMs: options.timeoutMs,
+  })
   return { ...result, hadManifests: false }
 }
 
@@ -785,15 +835,18 @@ async function findProjectShadowingFiles(directory: string) {
   return shadowingFiles.flatMap((file) => (file ? [file] : []))
 }
 
-async function venvCanaryPasses(python: string[], options?: { cwd?: string }): Promise<boolean>
-async function venvCanaryPasses(python: string[], options: { cwd?: string; includeStderr: true }): Promise<VenvCanaryResult>
-async function venvCanaryPasses(python: string[], options?: { cwd?: string; includeStderr?: boolean }) {
+export async function venvCanaryPasses(python: string[], options?: { cwd?: string }): Promise<boolean>
+export async function venvCanaryPasses(
+  python: string[],
+  options: { cwd?: string; includeStderr: true },
+): Promise<VenvCanaryResult>
+export async function venvCanaryPasses(python: string[], options?: { cwd?: string; includeStderr?: boolean }) {
   // No cwd by default: the canary must not pick up project-local modules (e.g. `fastapi.py`
   // sitting next to `agency.py`) that shadow installed packages and falsely flag a healthy
   // .venv as broken. Callers that need the server-launch cwd (post-install verification)
   // pass it explicitly.
   const result = await runCommand(
-    [...python, "-c", "from agency_swarm.integrations.fastapi import run_fastapi"],
+    [...python, "-c", VENV_CANARY_SCRIPT],
     options?.cwd ? { cwd: options.cwd } : undefined,
   )
   if (options?.includeStderr) {
@@ -807,20 +860,128 @@ async function venvCanaryPasses(python: string[], options?: { cwd?: string; incl
 
 async function ensureLatestAgencySwarm(directory: string, python: string[]) {
   try {
-    const result = await runCommand(
-      [...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]"],
-      { cwd: directory },
-    )
+    const installer = await resolvePythonPackageInstaller(python)
+    const result = await runCommand([...installer.cmd, "--upgrade", "agency-swarm[fastapi,litellm]"], {
+      cwd: directory,
+      env: installer.env,
+    })
     if (result.code !== 0) {
+      const summary = summarizeCommandOutput(result)
       prompts.log.warn(
-        "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
+        summary
+          ? `Could not refresh agency-swarm to the latest version. Installer output: ${summary}. The current venv package will be used as-is.`
+          : "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
       )
     }
-  } catch {
+  } catch (error) {
     prompts.log.warn(
-      "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
+      `Could not refresh agency-swarm to the latest version. ${
+        error instanceof Error ? error.message : String(error)
+      }. The current venv package will be used as-is.`,
     )
   }
+}
+
+async function resolvePythonPackageInstaller(python: string[]): Promise<PythonPackageInstaller> {
+  const uvEnv = withUserLocalBinPath(process.env)
+  const uv = findUvExecutable(uvEnv)
+  if (uv) {
+    return {
+      tool: "uv",
+      cmd: [uv, "pip", "install", "--python", getPythonExecutable(python)],
+      env: uvEnv,
+    }
+  }
+
+  const sh = process.platform === "win32" ? null : Which.which("sh", uvEnv)
+  const curl = process.platform === "win32" ? null : Which.which("curl", uvEnv)
+  if (sh && curl) {
+    prompts.log.info("uv not found. Installing uv for faster Python dependency setup...")
+    const result = await runCommand([sh, "-c", `curl -LsSf ${UV_INSTALLER_URL} | sh`], {
+      env: uvEnv,
+      streamOutputToStderr: true,
+    })
+    const installedUv = findUvExecutable(uvEnv)
+    if (installedUv) {
+      return {
+        tool: "uv",
+        cmd: [installedUv, "pip", "install", "--python", getPythonExecutable(python)],
+        env: uvEnv,
+      }
+    }
+    if (result.code !== 0) {
+      prompts.log.warn("uv install failed. Falling back to pip for Python dependency setup.")
+    } else {
+      prompts.log.warn("uv install completed without a usable binary. Falling back to pip for Python dependency setup.")
+    }
+  } else {
+    prompts.log.warn(
+      "uv not found and the shell installer is unavailable. Falling back to pip for Python dependency setup.",
+    )
+  }
+
+  return {
+    tool: "pip",
+    cmd: [...python, "-m", "pip", "install"],
+    env: process.env,
+  }
+}
+
+function getPythonExecutable(python: string[]) {
+  const executable = python[0]
+  if (!executable) {
+    throw new Error("Python executable path is required for uv installs.")
+  }
+  return executable
+}
+
+function findUvExecutable(env: NodeJS.ProcessEnv) {
+  return Which.which("uv", env)
+}
+
+function withUserLocalBinPath(env: NodeJS.ProcessEnv) {
+  const current = env.PATH ?? env.Path ?? process.env.PATH ?? process.env.Path ?? ""
+  const entries = [
+    path.join(os.homedir(), ".local", "bin"),
+    path.join(os.homedir(), ".cargo", "bin"),
+    ...current.split(path.delimiter).filter(Boolean),
+  ]
+  const merged = entries.filter((entry, index) => entries.indexOf(entry) === index).join(path.delimiter)
+  const next: NodeJS.ProcessEnv & { PATH: string; Path?: string } = {
+    ...env,
+    PATH: merged,
+  }
+  if (env.Path !== undefined || process.env.Path !== undefined) next.Path = merged
+  return next
+}
+
+async function createProjectCommandLogFile(directory: string, stem: string) {
+  const logDirectory = path.join(directory, "activity-logs")
+  await mkdir(logDirectory, { recursive: true })
+  return path.join(logDirectory, `${new Date().toISOString().replaceAll(":", "").replaceAll(".", "")}-${stem}.log`)
+}
+
+function summarizeCommandOutput(result: Pick<CommandResult, "stdout" | "stderr">) {
+  return summarizeBridgeStderr(result.stderr) || summarizeBridgeStderr(result.stdout)
+}
+
+function formatCommandFailure(result: CommandResult, fallback: string) {
+  const summary = summarizeCommandOutput(result)
+  const logHint = result.logFile ? ` Check the log file at ${result.logFile}.` : ""
+  if (summary) return `${fallback}: ${summary}.${logHint}`
+  return `${fallback}.${logHint}`.trim()
+}
+
+function formatDuration(ms: number) {
+  if (ms % 60000 === 0) {
+    const minutes = ms / 60000
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`
+  }
+  if (ms % 1000 === 0) {
+    const seconds = ms / 1000
+    return `${seconds} second${seconds === 1 ? "" : "s"}`
+  }
+  return `${ms}ms`
 }
 
 async function startProjectServer(directory: string, python: string[]) {
@@ -1028,10 +1189,13 @@ async function getFreePort() {
   })
 }
 
-async function runCommand(
-  cmd: string[],
-  options?: { cwd?: string; env?: NodeJS.ProcessEnv },
-): Promise<CommandResult> {
+async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<CommandResult> {
+  const logStream = options?.logFile ? createWriteStream(options.logFile, { flags: "a" }) : undefined
+  const writeChunk = (chunk: string) => {
+    if (options?.streamOutputToStderr) process.stderr.write(chunk)
+    logStream?.write(chunk)
+  }
+
   try {
     const proc = Bun.spawn({
       cmd,
@@ -1040,19 +1204,70 @@ async function runCommand(
       stderr: "pipe",
       env: options?.env ?? process.env,
     })
+    let timedOut = false
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    if (options?.timeoutMs) {
+      timeout = setTimeout(() => {
+        timedOut = true
+        proc.kill()
+      }, options.timeoutMs)
+    }
     const [code, stdout, stderr] = await Promise.all([
       proc.exited,
-      proc.stdout ? new Response(proc.stdout).text() : Promise.resolve(""),
-      proc.stderr ? new Response(proc.stderr).text() : Promise.resolve(""),
+      readCommandOutput(proc.stdout, writeChunk),
+      readCommandOutput(proc.stderr, writeChunk),
     ])
-    return { code, stdout, stderr }
+    if (timeout) clearTimeout(timeout)
+    await closeCommandLog(logStream)
+    return { code: timedOut ? -1 : code, stdout, stderr, timedOut, logFile: options?.logFile }
   } catch (error) {
+    await closeCommandLog(logStream)
     return {
       code: -1,
       stdout: "",
       stderr: error instanceof Error ? error.message : String(error),
+      logFile: options?.logFile,
     }
   }
+}
+
+async function closeCommandLog(stream?: ReturnType<typeof createWriteStream>) {
+  if (!stream) return
+  await new Promise<void>((resolve, reject) => {
+    stream.end((error?: Error | null) => {
+      if (error) reject(error)
+      else resolve()
+    })
+  }).catch(() => undefined)
+}
+
+async function readCommandOutput(
+  output: string | ReadableStream<Uint8Array> | null | undefined,
+  writer?: (chunk: string) => void,
+) {
+  if (typeof output === "string") {
+    if (output && writer) writer(output)
+    return output
+  }
+  if (!output) return ""
+
+  const reader = output.getReader()
+  const decoder = new TextDecoder()
+  let text = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (!value || value.length === 0) continue
+    const chunk = decoder.decode(value, { stream: true })
+    if (writer) writer(chunk)
+    text += chunk
+  }
+  const tail = decoder.decode()
+  if (tail) {
+    if (writer) writer(tail)
+    text += tail
+  }
+  return text
 }
 
 function sleep(ms: number) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1180,7 +1180,6 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
         : new Promise<{ code: number; timedOut: true }>((resolve) => {
             timeout = setTimeout(async () => {
               timedOut = true
-              outputAbort.abort()
               try {
                 proc.kill()
               } catch {}

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -749,8 +749,8 @@ async function ensureProjectPython(directory: string) {
   })
   if (install.timedOut) {
     throw new Error(
-      installLogFile
-        ? `Dependency install timed out after ${formatInstallDuration(REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${installLogFile}.`
+      install.logFile
+        ? `Dependency install timed out after ${formatInstallDuration(REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${install.logFile}.`
         : `Dependency install timed out after ${formatInstallDuration(REBUILD_INSTALL_TIMEOUT_MS)}.`,
     )
   }
@@ -883,8 +883,8 @@ async function ensureLatestAgencySwarm(
     })
     if (result.timedOut) {
       prompts.log.warn(
-        options?.logFile
-          ? `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${options.logFile}.`
+        result.logFile
+          ? `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${result.logFile}.`
           : `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}.`,
       )
       return
@@ -1158,7 +1158,11 @@ async function getFreePort() {
 async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<CommandResult> {
   const commandLog = openCommandLog(options?.logFile)
   const writeChunk = (chunk: string) => {
-    if (options?.streamOutputToStderr) process.stderr.write(chunk)
+    if (options?.streamOutputToStderr) {
+      try {
+        process.stderr.write(chunk)
+      } catch {}
+    }
     commandLog.write(chunk)
   }
 

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -252,7 +252,7 @@ describe("agency-swarm npx onboarding", () => {
           } as never
         }
       }
-      if (cmd.includes("from agency_swarm.integrations.fastapi import run_fastapi")) {
+      if (isCanaryCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
           stdout: "",
@@ -288,14 +288,200 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(error).toBeInstanceOf(Error)
     if (!error) throw new Error("Expected prepareProjectLaunch to fail")
-    expect(error.message).toContain("Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.")
+    expect(error.message).toContain(
+      "Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.",
+    )
     expect(error.message).not.toContain("Canary import failed on fallback install.")
     expect(error.message).toContain("LoadFileAttachment")
 
-    const canaryCommands = commands.filter((cmd) =>
-      cmd.includes("from agency_swarm.integrations.fastapi import run_fastapi"),
-    )
+    const canaryCommands = commands.filter(isCanaryCommand)
     expect(canaryCommands).toHaveLength(2)
+  })
+
+  test("prepareProjectLaunch streams rebuild output to stderr", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+    const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true as never)
+
+    let resolveInstall!: (code: number) => void
+    const installExited = new Promise<number>((resolve) => {
+      resolveInstall = resolve
+    })
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: installExited,
+          stdout: "Resolving packages...\n",
+          stderr: "Downloading wheels...\n",
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    resolveInstall(1)
+    await expect(launch).rejects.toThrow("Dependency install failed: Downloading wheels....")
+    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Resolving packages...\n")
+    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Downloading wheels...\n")
+  })
+
+  test("prepareProjectLaunch times out dependency rebuilds with a clear log path", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
+      if (typeof fn === "function") fn()
+      return 1 as never
+    }) as unknown as typeof setTimeout)
+    spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stdout: "",
+          stderr: "still working...\n",
+          kill() {
+            resolveExit(1)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow(/Dependency install timed out after 10 minutes\..*activity-logs.*launcher-rebuild\.log/)
+  })
+
+  test("prepareProjectLaunch surfaces refresh stderr when agency-swarm upgrade fails", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "ERROR: No matching distribution found for agency-swarm[fastapi,litellm]",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    expect(prompts.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Installer output: ERROR: No matching distribution found"),
+    )
+
+    await launch?.cleanup?.()
   })
 
   test("prepareProjectLaunch avoids manifest remediation after fallback install canary failures", async () => {
@@ -350,9 +536,7 @@ describe("agency-swarm npx onboarding", () => {
         directory: dir.path,
         agencyFile: path.join(dir.path, "agency.py"),
       }),
-    ).rejects.toThrow(
-      "Detected project-local fastapi.py, agency_swarm.py that may shadow installed packages.",
-    )
+    ).rejects.toThrow("Detected project-local fastapi.py, agency_swarm.py that may shadow installed packages.")
   })
 
   test("detectAgencyProject requires agency.py with create_agency", async () => {
@@ -1009,7 +1193,7 @@ function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
         } as never
       }
     }
-    if (cmd.includes("from agency_swarm.integrations.fastapi import run_fastapi")) {
+    if (isCanaryCommand(cmd)) {
       return {
         exited: Promise.resolve(1),
         stdout: "",
@@ -1032,4 +1216,15 @@ function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
     }
     throw new Error(`Unexpected command: ${cmd.join(" ")}`)
   })
+}
+
+function isPipInstallCommand(cmd: string[]) {
+  return cmd[1] === "-m" && cmd[2] === "pip" && cmd[3] === "install"
+}
+
+function isCanaryCommand(cmd: string[]) {
+  const script = cmd.at(-1) ?? ""
+  return (
+    cmd.includes("-c") && script.includes("import agency_swarm") && script.includes("agency_swarm.integrations.fastapi")
+  )
 }

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -428,7 +428,9 @@ describe("agency-swarm npx onboarding", () => {
       "",
     )
 
-    spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true as never)
     spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
 
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
@@ -445,7 +447,7 @@ describe("agency-swarm npx onboarding", () => {
       if (isPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
-          stdout: "",
+          stdout: "Collecting agency-swarm...\n",
           stderr: "ERROR: No matching distribution found for agency-swarm[fastapi,litellm]",
         } as never
       }
@@ -477,7 +479,14 @@ describe("agency-swarm npx onboarding", () => {
       agencyFile: path.join(dir.path, "agency.py"),
     })
 
-    expect(prompts.log.warn).toHaveBeenCalledWith(
+    expect(info).toHaveBeenCalledWith(
+      expect.stringContaining("Refreshing project dependencies. Streaming output to stderr."),
+    )
+    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Collecting agency-swarm...\n")
+    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain(
+      "ERROR: No matching distribution found for agency-swarm[fastapi,litellm]",
+    )
+    expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("Installer output: ERROR: No matching distribution found"),
     )
 

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -494,6 +494,71 @@ describe("agency-swarm npx onboarding", () => {
     expect(outcome.message).toContain("Dependency install timed out after 10 minutes")
   })
 
+  test("prepareProjectLaunch preserves shutdown stderr emitted during timeout", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true as never)
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
+      if (typeof fn === "function") fn()
+      return 1 as never
+    }) as unknown as typeof setTimeout)
+    spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        let resolveExit!: (code: number) => void
+        const stderr = createTextOutputStream("still working...\n")
+        return {
+          exited: new Promise<number>((resolve) => {
+            resolveExit = resolve
+          }),
+          stdout: "",
+          stderr: stderr.stream,
+          kill() {
+            stderr.push("term tail\n")
+            stderr.close()
+            resolveExit(1)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow("Dependency install timed out after 10 minutes")
+
+    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("still working...\n")
+    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("term tail\n")
+  })
+
   test("prepareProjectLaunch surfaces refresh stderr when agency-swarm upgrade fails", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -1589,6 +1654,27 @@ function launcherLogDirectory(directory: string) {
 
 function launcherLogFilePath(directory: string, stem: string, iso: string) {
   return path.join(launcherLogDirectory(directory), `${iso.replaceAll(":", "").replaceAll(".", "")}-${stem}.log`)
+}
+
+function createTextOutputStream(initial?: string) {
+  let controller!: ReadableStreamDefaultController<Uint8Array>
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream<Uint8Array>({
+    start(next) {
+      controller = next
+      if (initial) controller.enqueue(encoder.encode(initial))
+    },
+  })
+
+  return {
+    stream,
+    push(text: string) {
+      controller.enqueue(encoder.encode(text))
+    },
+    close() {
+      controller.close()
+    },
+  }
 }
 
 function isPipInstallCommand(cmd: string[]) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { mkdir } from "node:fs/promises"
+import os from "node:os"
 import path from "node:path"
 import * as prompts from "@clack/prompts"
 import {
@@ -404,12 +405,20 @@ describe("agency-swarm npx onboarding", () => {
       throw new Error(`Unexpected command: ${cmd.join(" ")}`)
     })
 
-    await expect(
-      prepareProjectLaunch({
+    let error: Error | undefined
+    try {
+      await prepareProjectLaunch({
         directory: dir.path,
         agencyFile: path.join(dir.path, "agency.py"),
-      }),
-    ).rejects.toThrow(/Dependency install timed out after 10 minutes\..*activity-logs.*launcher-rebuild\.log/)
+      })
+    } catch (caught) {
+      error = caught as Error
+    }
+
+    expect(error).toBeInstanceOf(Error)
+    if (!error) throw new Error("Expected prepareProjectLaunch to fail")
+    expect(error.message).toMatch(/Dependency install timed out after 10 minutes\..*launcher-rebuild\.log/)
+    expect(error.message).not.toContain(dir.path)
   })
 
   test("prepareProjectLaunch surfaces refresh stderr when agency-swarm upgrade fails", async () => {
@@ -491,6 +500,190 @@ describe("agency-swarm npx onboarding", () => {
     )
 
     await launch?.cleanup?.()
+  })
+
+  test("prepareProjectLaunch checks the FastAPI launcher symbol in the canary", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    const commands: string[][] = []
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    const canaryScripts = commands.filter(isCanaryCommand).map((cmd) => cmd.at(-1) ?? "")
+    expect(canaryScripts.length).toBeGreaterThan(0)
+    expect(
+      canaryScripts.every((script) => script.includes("from agency_swarm.integrations.fastapi import run_fastapi")),
+    ).toBe(true)
+
+    await launch?.cleanup?.()
+  })
+
+  test("prepareProjectLaunch does not fail healthy `.venv` launches when refresh logging cannot be created", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    const blockedLogDir = launcherLogDirectory(dir.path)
+    await mkdir(path.dirname(blockedLogDir), { recursive: true })
+    await Bun.write(blockedLogDir, "occupied\n")
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Could not create launcher refresh log file"))
+
+    await launch?.cleanup?.()
+  })
+
+  test("prepareProjectLaunch preserves full install stderr when log creation falls back", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    const blockedLogDir = launcherLogDirectory(dir.path)
+    await mkdir(path.dirname(blockedLogDir), { recursive: true })
+    await Bun.write(blockedLogDir, "occupied\n")
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+
+    const installStderr = Array.from({ length: 8 }, (_, i) => `resolver detail ${i}`).join("\n")
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: installStderr,
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow(`Dependency install failed: ${installStderr}`)
   })
 
   test("prepareProjectLaunch avoids manifest remediation after fallback install canary failures", async () => {
@@ -1225,6 +1418,14 @@ function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
     }
     throw new Error(`Unexpected command: ${cmd.join(" ")}`)
   })
+}
+
+function launcherLogDirectory(directory: string) {
+  return path.join(
+    os.tmpdir(),
+    "agentswarm-cli-logs",
+    `${path.basename(path.resolve(directory)) || "project"}-${Bun.hash(path.resolve(directory)).toString(16)}`,
+  )
 }
 
 function isPipInstallCommand(cmd: string[]) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -459,12 +459,13 @@ describe("agency-swarm npx onboarding", () => {
       }
       if (isPipInstallCommand(cmd)) {
         let resolveExit!: (code: number) => void
+        const stderr = createTextOutputStream("still working...\n")
         return {
           exited: new Promise<number>((resolve) => {
             resolveExit = resolve
           }),
           stdout: "",
-          stderr: "still working...\n",
+          stderr: stderr.stream,
           kill(signal?: string) {
             killSignals.push(signal)
             if (signal === "SIGKILL") resolveExit(1)
@@ -642,6 +643,9 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(timers).not.toHaveLength(0)
     expect(timers[0]?.cleared).toBe(true)
+    const installTimeout = timers[0]
+    if (typeof installTimeout?.fn !== "function") throw new Error("Expected install timeout callback")
+    await installTimeout.fn()
 
     setTimeoutSpy.mockRestore()
     clearTimeoutSpy.mockRestore()
@@ -1763,7 +1767,13 @@ function createTextOutputStream(initial?: string) {
       controller.enqueue(encoder.encode(text))
     },
     close() {
-      controller.close()
+      try {
+        controller.close()
+      } catch (error) {
+        if (!(error instanceof TypeError) || !String(error.message).includes("Controller is already closed")) {
+          throw error
+        }
+      }
     },
   }
 }

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -421,6 +421,71 @@ describe("agency-swarm npx onboarding", () => {
     expect(error.message).not.toContain(dir.path)
   })
 
+  test("prepareProjectLaunch times out even when the install process ignores kill", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const realSetTimeout = globalThis.setTimeout
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
+      if (typeof fn === "function") fn()
+      return 1 as never
+    }) as unknown as typeof setTimeout)
+    spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: new Promise<number>(() => {}),
+          stdout: "",
+          stderr: "still working...\n",
+          kill() {},
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+    const pending = Symbol("pending")
+    const outcome = await Promise.race([
+      launch.then(
+        () => "resolved",
+        (error) => error,
+      ),
+      new Promise((resolve) => realSetTimeout(() => resolve(pending), 20)),
+    ])
+
+    expect(outcome).not.toBe(pending)
+    expect(outcome).toBeInstanceOf(Error)
+    if (!(outcome instanceof Error)) throw new Error("Expected prepareProjectLaunch to fail")
+    expect(outcome.message).toContain("Dependency install timed out after 10 minutes")
+  })
+
   test("prepareProjectLaunch surfaces refresh stderr when agency-swarm upgrade fails", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -440,6 +505,99 @@ describe("agency-swarm npx onboarding", () => {
     const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
     const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "Collecting agency-swarm...\n",
+          stderr: "ERROR: No matching distribution found for agency-swarm[fastapi,litellm]",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    expect(info).toHaveBeenCalledWith(
+      expect.stringContaining("Refreshing project dependencies. Streaming output to stderr."),
+    )
+    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Collecting agency-swarm...\n")
+    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain(
+      "ERROR: No matching distribution found for agency-swarm[fastapi,litellm]",
+    )
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Installer output: ERROR: No matching distribution found"),
+    )
+
+    await launch?.cleanup?.()
+  })
+
+  test("prepareProjectLaunch survives refresh log stream failures", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    const iso = "2026-04-22T23:45:00.000Z"
+    const refreshLogFile = launcherLogFilePath(dir.path, "launcher-refresh", iso)
+    await mkdir(path.dirname(refreshLogFile), { recursive: true })
+    await mkdir(refreshLogFile, { recursive: true })
+
+    const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(Date.prototype, "toISOString").mockReturnValue(iso)
     spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
 
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
@@ -488,13 +646,6 @@ describe("agency-swarm npx onboarding", () => {
       agencyFile: path.join(dir.path, "agency.py"),
     })
 
-    expect(info).toHaveBeenCalledWith(
-      expect.stringContaining("Refreshing project dependencies. Streaming output to stderr."),
-    )
-    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Collecting agency-swarm...\n")
-    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain(
-      "ERROR: No matching distribution found for agency-swarm[fastapi,litellm]",
-    )
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("Installer output: ERROR: No matching distribution found"),
     )
@@ -1426,6 +1577,10 @@ function launcherLogDirectory(directory: string) {
     "agentswarm-cli-logs",
     `${path.basename(path.resolve(directory)) || "project"}-${Bun.hash(path.resolve(directory)).toString(16)}`,
   )
+}
+
+function launcherLogFilePath(directory: string, stem: string, iso: string) {
+  return path.join(launcherLogDirectory(directory), `${iso.replaceAll(":", "").replaceAll(".", "")}-${stem}.log`)
 }
 
 function isPipInstallCommand(cmd: string[]) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -559,6 +559,97 @@ describe("agency-swarm npx onboarding", () => {
     expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("term tail\n")
   })
 
+  test("prepareProjectLaunch clears the install timeout as soon as the child exits", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const realSetTimeout = globalThis.setTimeout
+    const timers: Array<{ fn: TimerHandler; cleared: boolean }> = []
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
+      const timer = { fn, cleared: false }
+      timers.push(timer)
+      return timer as never
+    }) as unknown as typeof setTimeout)
+    const clearTimeoutSpy = spyOn(globalThis, "clearTimeout").mockImplementation(((timer: { cleared?: boolean }) => {
+      timer.cleared = true
+    }) as unknown as typeof clearTimeout)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    const installStderr = createTextOutputStream("install finished\n")
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: installStderr.stream,
+          kill() {},
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launchPromise = prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    await new Promise((resolve) => realSetTimeout(resolve, 20))
+
+    expect(timers).not.toHaveLength(0)
+    expect(timers[0]?.cleared).toBe(true)
+
+    setTimeoutSpy.mockRestore()
+    clearTimeoutSpy.mockRestore()
+    installStderr.close()
+    const launch = await launchPromise
+    await launch?.cleanup?.()
+  })
+
   test("prepareProjectLaunch surfaces refresh stderr when agency-swarm upgrade fails", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import * as prompts from "@clack/prompts"
+import * as Which from "../../src/util/which"
 import {
   buildAgencyConfig,
   buildPythonEnv,
@@ -13,6 +14,7 @@ import {
   shouldRunNpxOnboarding,
   summarizeBridgeStderr,
   validateStarterName,
+  venvCanaryPasses,
 } from "../../src/agency-swarm/npx"
 import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
 import { Instance } from "../../src/project/instance"
@@ -141,10 +143,57 @@ describe("agency-swarm npx onboarding", () => {
     expect(env.PYTHONPATH).toBe(`/tmp/project${path.delimiter}/existing/path`)
   })
 
+  test("healthy venv canary only imports agency_swarm and the fastapi integration module", async () => {
+    const commands: string[][] = []
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(venvCanaryPasses(["python"])).resolves.toBe(true)
+    expect(commands).toHaveLength(1)
+    expect(commands[0]?.at(-1)).toContain("import agency_swarm.integrations.fastapi")
+    expect(commands[0]?.at(-1)).not.toContain("run_fastapi")
+  })
+
+  test("corrupted venv canary surfaces import failure stderr", async () => {
+    const canaryStderr = "ModuleNotFoundError: No module named 'agency_swarm.integrations.fastapi'"
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: canaryStderr,
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(venvCanaryPasses(["python"])).resolves.toBe(false)
+    await expect(venvCanaryPasses(["python"], { includeStderr: true })).resolves.toEqual({
+      healthy: false,
+      stderr: canaryStderr,
+    })
+  })
+
   test("prepareProjectLaunch installs LiteLLM extras when no dependency manifest exists", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
 
+    spyOn(Which, "which").mockImplementation((cmd) => (cmd === "uv" ? "/tmp/test-bin/uv" : null))
     spyOn(prompts, "confirm").mockResolvedValue(true as never)
     spyOn(prompts, "spinner").mockReturnValue({
       start() {},
@@ -169,7 +218,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("pip")) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
           stdout: "",
@@ -186,7 +235,73 @@ describe("agency-swarm npx onboarding", () => {
       }),
     ).rejects.toThrow("fallback install failed")
 
-    const installCommand = commands.find((cmd) => cmd.includes("pip"))
+    const installCommand = commands.find(isUvPipInstallCommand)
+
+    expect(installCommand).toEqual([
+      "/tmp/test-bin/uv",
+      "pip",
+      "install",
+      "--python",
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "--upgrade",
+      "agency-swarm[fastapi,litellm]>=1.9.1",
+    ])
+  })
+
+  test("prepareProjectLaunch falls back to pip when uv cannot be used", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(Which, "which").mockImplementation(() => null)
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+
+    const commands: string[][] = []
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+      if (cmd.includes("-c")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "fallback install failed",
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow("fallback install failed")
+
+    const installCommand = commands.find(isPipInstallCommand)
 
     expect(installCommand).toEqual([
       path.join(
@@ -201,6 +316,195 @@ describe("agency-swarm npx onboarding", () => {
       "--upgrade",
       "agency-swarm[fastapi,litellm]>=1.9.1",
     ])
+    expect(warn).toHaveBeenCalledWith(
+      "uv not found and the shell installer is unavailable. Falling back to pip for Python dependency setup.",
+    )
+  })
+
+  test("prepareProjectLaunch streams rebuild output to stderr while uv is running", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(Which, "which").mockImplementation((cmd) => (cmd === "uv" ? "/tmp/test-bin/uv" : null))
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true as never)
+
+    let resolveInstall!: (code: number) => void
+    const installExited = new Promise<number>((resolve) => {
+      resolveInstall = resolve
+    })
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isUvPipInstallCommand(cmd)) {
+        return {
+          exited: installExited,
+          stdout: "Resolving packages...\n",
+          stderr: "Downloading wheels...\n",
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    resolveInstall(1)
+    await expect(launch).rejects.toThrow("Downloading wheels...")
+    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Resolving packages...\n")
+    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Downloading wheels...\n")
+  })
+
+  test("prepareProjectLaunch times out dependency rebuilds with a clear log path", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    spyOn(Which, "which").mockImplementation(() => null)
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
+      if (typeof fn === "function") fn()
+      return 1 as never
+    }) as unknown as typeof setTimeout)
+    spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stdout: "",
+          stderr: "still working...\n",
+          kill() {
+            resolveExit(1)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow(/Dependency install timed out after 10 minutes\..*activity-logs.*launcher-rebuild\.log/)
+  })
+
+  test("prepareProjectLaunch surfaces refresh stderr when agency-swarm upgrade fails", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    spyOn(Which, "which").mockImplementation(() => null)
+    spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "ERROR: No matching distribution found for agency-swarm[fastapi,litellm]",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    expect(prompts.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Installer output: ERROR: No matching distribution found"),
+    )
+
+    await launch?.cleanup?.()
   })
 
   test("prepareProjectLaunch reruns the canary after rebuilding `.venv` and surfaces manifest import mismatches", async () => {
@@ -220,6 +524,7 @@ describe("agency-swarm npx onboarding", () => {
       "",
     )
 
+    spyOn(Which, "which").mockImplementation((cmd) => (cmd === "uv" ? "/tmp/test-bin/uv" : null))
     spyOn(prompts, "spinner").mockReturnValue({
       start() {},
       stop() {},
@@ -252,7 +557,7 @@ describe("agency-swarm npx onboarding", () => {
           } as never
         }
       }
-      if (cmd.includes("from agency_swarm.integrations.fastapi import run_fastapi")) {
+      if (isCanaryCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
           stdout: "",
@@ -266,7 +571,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("pip")) {
+      if (isPythonPackageInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -288,13 +593,13 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(error).toBeInstanceOf(Error)
     if (!error) throw new Error("Expected prepareProjectLaunch to fail")
-    expect(error.message).toContain("Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.")
+    expect(error.message).toContain(
+      "Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.",
+    )
     expect(error.message).not.toContain("Canary import failed on fallback install.")
     expect(error.message).toContain("LoadFileAttachment")
 
-    const canaryCommands = commands.filter((cmd) =>
-      cmd.includes("from agency_swarm.integrations.fastapi import run_fastapi"),
-    )
+    const canaryCommands = commands.filter(isCanaryCommand)
     expect(canaryCommands).toHaveLength(2)
   })
 
@@ -350,9 +655,7 @@ describe("agency-swarm npx onboarding", () => {
         directory: dir.path,
         agencyFile: path.join(dir.path, "agency.py"),
       }),
-    ).rejects.toThrow(
-      "Detected project-local fastapi.py, agency_swarm.py that may shadow installed packages.",
-    )
+    ).rejects.toThrow("Detected project-local fastapi.py, agency_swarm.py that may shadow installed packages.")
   })
 
   test("detectAgencyProject requires agency.py with create_agency", async () => {
@@ -989,6 +1292,7 @@ async function writeAgency(dir: string) {
 }
 
 function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
+  spyOn(Which, "which").mockImplementation((cmd) => (cmd === "uv" ? "/tmp/test-bin/uv" : null))
   spyOn(Bun, "spawn").mockImplementation((options: any) => {
     const cmd = options?.cmd as string[] | undefined
     if (!cmd) throw new Error("Missing command")
@@ -1009,7 +1313,7 @@ function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
         } as never
       }
     }
-    if (cmd.includes("from agency_swarm.integrations.fastapi import run_fastapi")) {
+    if (isCanaryCommand(cmd)) {
       return {
         exited: Promise.resolve(1),
         stdout: "",
@@ -1023,7 +1327,7 @@ function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
         stderr: "",
       } as never
     }
-    if (cmd.includes("pip")) {
+    if (isPythonPackageInstallCommand(cmd)) {
       return {
         exited: Promise.resolve(0),
         stdout: "",
@@ -1032,4 +1336,24 @@ function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
     }
     throw new Error(`Unexpected command: ${cmd.join(" ")}`)
   })
+}
+
+function isUvPipInstallCommand(cmd: string[]) {
+  const executable = path.basename(cmd[0] ?? "").toLowerCase()
+  return (executable === "uv" || executable === "uv.exe") && cmd[1] === "pip" && cmd[2] === "install"
+}
+
+function isPipInstallCommand(cmd: string[]) {
+  return cmd[1] === "-m" && cmd[2] === "pip" && cmd[3] === "install"
+}
+
+function isPythonPackageInstallCommand(cmd: string[]) {
+  return isUvPipInstallCommand(cmd) || isPipInstallCommand(cmd)
+}
+
+function isCanaryCommand(cmd: string[]) {
+  const script = cmd.at(-1) ?? ""
+  return (
+    cmd.includes("-c") && script.includes("import agency_swarm") && script.includes("agency_swarm.integrations.fastapi")
+  )
 }

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -956,6 +956,80 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
+  test("prepareProjectLaunch ignores mirrored stderr pipe failures during rebuild installs", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const stderrPipeError = Object.assign(new Error("write EPIPE"), { code: "EPIPE" })
+    const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => {
+      throw stderrPipeError
+    })
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "Collecting agency-swarm...\n",
+          stderr: "",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    expect(stderrWrite).toHaveBeenCalled()
+
+    await launch?.cleanup?.()
+  })
+
   test("prepareProjectLaunch preserves full install stderr when log creation falls back", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -1003,6 +1077,77 @@ describe("agency-swarm npx onboarding", () => {
         agencyFile: path.join(dir.path, "agency.py"),
       }),
     ).rejects.toThrow(`Dependency install failed: ${installStderr}`)
+  })
+
+  test("prepareProjectLaunch omits rebuild log hints when timeout logging never opens", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+
+    const iso = "2026-04-23T02:30:00.000Z"
+    const installLogFile = launcherLogFilePath(dir.path, "launcher-rebuild", iso)
+    await mkdir(path.dirname(installLogFile), { recursive: true })
+    await mkdir(installLogFile, { recursive: true })
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(Date.prototype, "toISOString").mockReturnValue(iso)
+    spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
+      if (typeof fn === "function") fn()
+      return 1 as never
+    }) as unknown as typeof setTimeout)
+    spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined as never)
+
+    let error: Error | undefined
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stdout: "",
+          stderr: "still working...\n",
+          kill() {
+            resolveExit(1)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    try {
+      await prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      })
+    } catch (caught) {
+      error = caught as Error
+    }
+
+    expect(error).toBeInstanceOf(Error)
+    if (!error) throw new Error("Expected prepareProjectLaunch to fail")
+    expect(error.message).toBe("Dependency install timed out after 10 minutes.")
   })
 
   test("prepareProjectLaunch avoids manifest remediation after fallback install canary failures", async () => {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -426,6 +426,7 @@ describe("agency-swarm npx onboarding", () => {
     await writeAgency(dir.path)
 
     const realSetTimeout = globalThis.setTimeout
+    const killSignals: Array<string | undefined> = []
 
     spyOn(prompts, "confirm").mockResolvedValue(true as never)
     spyOn(prompts, "spinner").mockReturnValue({
@@ -457,11 +458,17 @@ describe("agency-swarm npx onboarding", () => {
         } as never
       }
       if (isPipInstallCommand(cmd)) {
+        let resolveExit!: (code: number) => void
         return {
-          exited: new Promise<number>(() => {}),
+          exited: new Promise<number>((resolve) => {
+            resolveExit = resolve
+          }),
           stdout: "",
           stderr: "still working...\n",
-          kill() {},
+          kill(signal?: string) {
+            killSignals.push(signal)
+            if (signal === "SIGKILL") resolveExit(1)
+          },
         } as never
       }
       throw new Error(`Unexpected command: ${cmd.join(" ")}`)
@@ -483,6 +490,7 @@ describe("agency-swarm npx onboarding", () => {
     expect(outcome).not.toBe(pending)
     expect(outcome).toBeInstanceOf(Error)
     if (!(outcome instanceof Error)) throw new Error("Expected prepareProjectLaunch to fail")
+    expect(killSignals).toEqual([undefined, "SIGKILL"])
     expect(outcome.message).toContain("Dependency install timed out after 10 minutes")
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #130

Related follow-up: launcher dependency refresh diagnostics.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fix the launcher path that can look hung while it refreshes or rebuilds Agency Swarm project dependencies.

- announce the pre-launch `agency-swarm` refresh and stream installer stdout and stderr to stderr with a project log file
- narrow the post-rebuild canary to import-only checks for the modules the launcher actually needs
- stream rebuild installer output to stderr while teeing it to a project log file
- time out rebuild installs after 10 minutes with a clear log-file path
- include installer stderr when the refresh fails so the warning is actionable

### Why did this happen?

The launcher runs `pip install --upgrade agency-swarm[fastapi,litellm]` before start when it reuses a project `.venv`, but that refresh path was silent, so startup could look hung for several seconds. The rebuild path also used an overly broad canary and weak diagnostics, which could misclassify a healthy install or hide the real failure.

### How did you verify your code works?

- `bun run typecheck`
- `bun test test/agency-swarm/npx.test.ts`
- local published-path verification with `agency.tui()` and `npx @vrsen/agentswarm@1.4.24 --prompt hey`

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

