### PR TITLE
fix(tui): /agents dialog now changes the active recipient mid-session

### DIFF
--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1885,10 +1885,16 @@ export namespace SessionAgencySwarm {
     configuredRecipient?: string
   }): Promise<string | undefined> {
     const sessionRecipient = await resolveSessionRecipient(input.sessionID)
-    const candidates = [input.mentionedRecipient, sessionRecipient, input.configuredRecipient].filter(
-      (value, index, array): value is string => !!value && array.indexOf(value) === index,
+    const candidates = [
+      { value: input.mentionedRecipient, source: "message" },
+      { value: input.configuredRecipient, source: "config" },
+      { value: sessionRecipient, source: "session" },
+    ].filter(
+      (candidate, index, array): candidate is { value: string; source: "message" | "config" | "session" } =>
+        !!candidate.value && array.findIndex((item) => item.value === candidate.value) === index,
     )
-    if (candidates.length === 0) {
+    const candidateValues = candidates.map((candidate) => candidate.value)
+    if (candidateValues.length === 0) {
       return undefined
     }
 
@@ -1904,7 +1910,7 @@ export namespace SessionAgencySwarm {
       log.warn("unable to refresh agency metadata; skipping recipient override", {
         sessionID: input.sessionID,
         agency: input.agency,
-        candidates,
+        candidates: candidateValues,
         error: error instanceof Error ? error.message : String(error),
       })
       return undefined
@@ -1915,22 +1921,20 @@ export namespace SessionAgencySwarm {
       log.warn("agency metadata has no recipient agents; skipping recipient override", {
         sessionID: input.sessionID,
         agency: input.agency,
-        candidates,
+        candidates: candidateValues,
       })
       return undefined
     }
 
     const availableAgents = Array.from(new Set(recipientMap.values()))
     for (const candidate of candidates) {
-      const resolved = recipientMap.get(candidate)
+      const resolved = recipientMap.get(candidate.value)
       if (resolved) return resolved
-      const source =
-        candidate === input.mentionedRecipient ? "message" : candidate === sessionRecipient ? "session" : "config"
       log.warn("ignoring stale recipient agent candidate", {
         sessionID: input.sessionID,
         agency: input.agency,
-        candidate,
-        source,
+        candidate: candidate.value,
+        source: candidate.source,
         availableAgents,
       })
     }

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -2531,6 +2531,104 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream prefers configured recipient over persisted handed off recipient", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        let sentRecipient: string | undefined
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["support_agent", "MathAgent"],
+          },
+          nodes: [
+            {
+              id: "support_agent",
+              type: "agent",
+              data: {
+                label: "UserSupportAgent",
+              },
+            },
+          ],
+        })) as typeof AgencySwarmAdapter.getMetadata
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          sentRecipient = args.recipientAgent ?? undefined
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "configured recipient override" })
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "hello",
+        })
+        await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          sessionID: session.id,
+          parentID: user.id,
+          modelID: "default",
+          providerID: "agency-swarm",
+          mode: "UserSupportAgent",
+          agent: "UserSupportAgent",
+          path: {
+            cwd: "/",
+            root: "/",
+          },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: {
+            created: Date.now(),
+            completed: Date.now(),
+          },
+        } as any)
+
+        const { input } = helper()
+        input.sessionID = session.id
+        input.assistantMessage.sessionID = session.id
+        input.options.recipientAgent = "MathAgent"
+        input.userMessage.info.id = MessageID.ascending()
+        input.userMessage.parts = [{ type: "text", text: "follow up", ignored: false }] as any
+        const stream = await SessionAgencySwarm.stream(input)
+        for await (const _ of stream.fullStream) {
+        }
+
+        expect(sentRecipient).toBe("MathAgent")
+      },
+    })
+  })
+
   test("stream prefers explicit mention over persisted handed off recipient", async () => {
     await using tmp = await tmpdir({
       git: true,


### PR DESCRIPTION
### Issue for this PR

Closes #128

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a P0 bug where picking a new recipient via `/agents` silently did nothing once a session had any prior assistant reply.

**Root cause:** `resolveRecipientAgent` in `packages/opencode/src/session/agency-swarm.ts` used priority `[mention, sessionRecipient, configuredRecipient]`. After any assistant reply, `sessionRecipient` (last-assistant agent from message history) won over `configuredRecipient` (the `/agents` pick), so the dialog became a no-op.

**Fix:** reorder priority to `mention > /agents config > session handoff memory`. Explicit user intent now beats passive history inference. The in-session handoff memory stays as a fallback when no explicit recipient is configured, so agent-to-agent handoff still works when the user has not manually selected.

Also updated the stale-recipient log source tag so the `config`/`session`/`message` attribution stays accurate under the new ordering.

### How did you verify your code works?

- Added regression test in `packages/opencode/test/session/agency-swarm.test.ts`: assistant reply from agent A, `/agents` switches config to agent B, next user message, assert it routes to B.
- Ran focused suite: `cd packages/opencode && bun test session/agency-swarm` → **73 pass, 0 fail, 137 expect() calls**.
- All existing recipient-routing tests still pass (including the agent-to-agent handoff persistence test, which now relies on handoff memory as a fallback when no config is set — which is its actual scenario).

### Screenshots / recordings

N/A — the fix is observable via the existing `/agents` flow. Manual QA to be done by the user on the 1.4.24 release build.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR