### PR TITLE
Fix/agency handoff recipient override

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -59,9 +59,11 @@ import {
 } from "../../session-error"
 import { errorMessage as toErrorMessage } from "@/util/error"
 import {
+  buildAgencyTargetOptions,
   displayRunOnlyAgentLabel,
   readAgencyProviderOptions,
   resolveAgencyTargetSelection,
+  shouldAdoptAgencyHandoffRecipient,
 } from "../../util/agency-target"
 
 export type PromptProps = {
@@ -203,6 +205,62 @@ export function Prompt(props: PromptProps) {
     })
     return selection?.label ?? options.recipientAgent
   })
+  const adoptedAgencyRecipients = new Set<string>()
+  onCleanup(
+    sdk.event.on("message.updated", (evt) => {
+      const info = evt.properties.info
+      if (info.sessionID !== props.sessionID) return
+      if (info.role !== "assistant") return
+      if (info.providerID !== AgencySwarmAdapter.PROVIDER_ID) return
+
+      const options = agencyProviderOptions()
+      if (
+        !shouldAdoptAgencyHandoffRecipient({
+          frameworkMode: frameworkMode(),
+          agency: options.agency,
+          currentRecipient: options.recipientAgent,
+          assistantAgent: info.agent,
+          completed: !!info.time.completed,
+        })
+      ) {
+        return
+      }
+
+      const key = `${info.sessionID}:${info.id}:${info.agent}`
+      if (adoptedAgencyRecipients.has(key)) return
+      adoptedAgencyRecipients.add(key)
+
+      void sdk.client.global.config
+        .update(
+          {
+            config: {
+              model: `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`,
+              provider: {
+                [AgencySwarmAdapter.PROVIDER_ID]: {
+                  name: "agency-swarm",
+                  options: buildAgencyTargetOptions({
+                    providerOptions: options,
+                    agency: options.agency!,
+                    recipientAgent: info.agent,
+                  }),
+                },
+              },
+            },
+          },
+          {
+            throwOnError: true,
+          },
+        )
+        .then(() => sync.bootstrap())
+        .catch((error) => {
+          toast.show({
+            variant: "error",
+            message: error instanceof Error ? error.message : String(error),
+            duration: 4000,
+          })
+        })
+    }),
+  )
   const currentProviderLabel = createMemo(() => {
     const current = local.model.current()
     const provider = local.model.parsed().provider

--- a/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
@@ -120,6 +120,21 @@ export function buildAgencyTargetOptions(input: {
   return nextOptions
 }
 
+export function shouldAdoptAgencyHandoffRecipient(input: {
+  frameworkMode: boolean
+  agency?: string
+  currentRecipient?: string
+  assistantAgent?: string
+  completed?: boolean
+}) {
+  if (!input.frameworkMode) return false
+  if (!input.completed) return false
+  if (!input.agency) return false
+  if (!input.assistantAgent) return false
+  if (input.assistantAgent === "build") return false
+  return input.assistantAgent !== input.currentRecipient
+}
+
 export function displayRunOnlyAgentLabel(input: {
   frameworkMode: boolean
   recipientLabel?: string

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1197,12 +1197,14 @@ export namespace SessionAgencySwarm {
       for (const raw of newMessages) {
         const message = asRecord(raw)
         if (!message || asString(message["type"]) !== "message") continue
+        const messageMeta = extractEventMeta(message)
+        if (asString(message["role"]) === "assistant") await applyAssistantLabel(input.assistantMessage, messageMeta)
         const itemID = asString(message["id"])
         if (!itemID) continue
         const text = extractMessageText(message)
         if (!text) continue
         if (shouldSkipDuplicateAssistantText(itemID, 0, text)) continue
-        yield* finishText(itemID, 0, text, {}, { source: "messages" })
+        yield* finishText(itemID, 0, text, messageMeta, { source: "messages" })
       }
     }
 
@@ -1914,8 +1916,8 @@ export namespace SessionAgencySwarm {
     }
     const candidates = [
       input.mentionedRecipient ? { value: { agent: input.mentionedRecipient }, source: "message" } : undefined,
-      input.configuredRecipient ? { value: { agent: input.configuredRecipient }, source: "config" } : undefined,
       sessionRecipient ? { value: sessionRecipient, source: "session" } : undefined,
+      input.configuredRecipient ? { value: { agent: input.configuredRecipient }, source: "config" } : undefined,
     ]
       .filter((candidate): candidate is RecipientCandidate => !!candidate?.value.agent)
       .sort((a, b) => candidateRank(a) - candidateRank(b))
@@ -1994,7 +1996,7 @@ export namespace SessionAgencySwarm {
       if (last.info.role !== "assistant") return
       return {
         agent: last.info.agent,
-        messageAt: last.info.time.created,
+        messageAt: last.info.time.completed ?? last.info.time.created,
       }
     } catch (error) {
       log.warn("unable to load session recipient; skipping recipient override", {

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { buildAgencyTargetOptions } from "../../../src/cli/cmd/tui/util/agency-target"
+import {
+  buildAgencyTargetOptions,
+  shouldAdoptAgencyHandoffRecipient,
+} from "../../../src/cli/cmd/tui/util/agency-target"
 
 describe("agency target options", () => {
   test("clears stale snake_case recipient state when /agents switches recipients", () => {
@@ -32,5 +35,38 @@ describe("agency target options", () => {
       recipient_agent: null,
       recipient_agent_selected_at: null,
     })
+  })
+
+  test("adopts completed handoff agent as selected run target", () => {
+    expect(
+      shouldAdoptAgencyHandoffRecipient({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "ExampleAgent",
+        assistantAgent: "ExampleAgent2",
+        completed: true,
+      }),
+    ).toBe(true)
+  })
+
+  test("does not adopt incomplete or unchanged handoff agent", () => {
+    expect(
+      shouldAdoptAgencyHandoffRecipient({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "ExampleAgent",
+        assistantAgent: "ExampleAgent2",
+        completed: false,
+      }),
+    ).toBe(false)
+    expect(
+      shouldAdoptAgencyHandoffRecipient({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "ExampleAgent",
+        assistantAgent: "ExampleAgent",
+        completed: true,
+      }),
+    ).toBe(false)
   })
 })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -2723,6 +2723,101 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream persists handed off recipient from final messages payload", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        let turn = 0
+        let sentRecipient: string | undefined
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["support_agent", "MathAgent"],
+          },
+        })) as typeof AgencySwarmAdapter.getMetadata
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          turn++
+          sentRecipient = args.recipientAgent ?? undefined
+          if (turn === 1) {
+            yield {
+              type: "messages",
+              payload: {
+                new_messages: [
+                  {
+                    id: "agency_message_1",
+                    type: "message",
+                    role: "assistant",
+                    agent: "support_agent",
+                    content: [{ type: "output_text", text: "Transferred." }],
+                  },
+                ],
+              },
+            }
+          }
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "messages handoff recipient" })
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "hello",
+        })
+
+        const first = helper()
+        first.input.sessionID = session.id
+        first.input.assistantMessage.sessionID = session.id
+        first.input.assistantMessage.id = MessageID.ascending()
+        first.input.assistantMessage.parentID = user.id
+        first.input.userMessage.info.id = user.id
+        first.input.options.recipientAgent = "MathAgent"
+
+        const firstStream = await SessionAgencySwarm.stream(first.input)
+        for await (const _ of firstStream.fullStream) {
+        }
+
+        const second = helper()
+        second.input.sessionID = session.id
+        second.input.assistantMessage.sessionID = session.id
+        second.input.assistantMessage.id = MessageID.ascending()
+        second.input.userMessage.info.id = MessageID.ascending()
+        second.input.userMessage.parts = [{ type: "text", text: "follow up", ignored: false }] as any
+        second.input.options.recipientAgent = "MathAgent"
+
+        const secondStream = await SessionAgencySwarm.stream(second.input)
+        for await (const _ of secondStream.fullStream) {
+        }
+
+        expect(sentRecipient).toBe("support_agent")
+      },
+    })
+  })
+
   test("stream routes next message to agent_updated handoff id", async () => {
     await using tmp = await tmpdir({
       git: true,
@@ -3019,6 +3114,108 @@ describe("session.agency-swarm", () => {
         }
 
         expect(sentRecipient).toBe("MathAgent")
+      },
+    })
+  })
+
+  test("stream prefers completed handoff over recipient selected during that response", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        let sentRecipient: string | undefined
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["support_agent", "MathAgent"],
+          },
+          nodes: [
+            {
+              id: "support_agent",
+              type: "agent",
+              data: {
+                label: "UserSupportAgent",
+              },
+            },
+          ],
+        })) as typeof AgencySwarmAdapter.getMetadata
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          sentRecipient = args.recipientAgent ?? undefined
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "completed handoff override" })
+        const handoffStartedAt = Date.now()
+        const handoffCompletedAt = handoffStartedAt + 10
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created: handoffStartedAt - 1,
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "hello",
+        })
+        await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          sessionID: session.id,
+          parentID: user.id,
+          modelID: "default",
+          providerID: "agency-swarm",
+          mode: "UserSupportAgent",
+          agent: "UserSupportAgent",
+          path: {
+            cwd: "/",
+            root: "/",
+          },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: {
+            created: handoffStartedAt,
+            completed: handoffCompletedAt,
+          },
+        } as any)
+
+        const { input } = helper()
+        input.sessionID = session.id
+        input.assistantMessage.sessionID = session.id
+        input.options.recipientAgent = "MathAgent"
+        ;(input.options as any).recipientAgentSelectedAt = handoffStartedAt + 1
+        input.userMessage.info.id = MessageID.ascending()
+        input.userMessage.parts = [{ type: "text", text: "follow up", ignored: false }] as any
+
+        const stream = await SessionAgencySwarm.stream(input)
+        for await (const _ of stream.fullStream) {
+        }
+
+        expect(sentRecipient).toBe("support_agent")
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #131

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes Agency Swarm handoff routing in the TUI.

Before this change, a backend handoff could update the assistant message, but the next user message could still be sent to the old configured recipient. The TUI also kept showing the old selected run target, which made the state confusing and could keep sending follow-ups to the wrong agent.

This PR makes the handoff recipient persist in the session flow and updates the TUI selected run target after a completed Agency Swarm assistant message changes agent. Manual recipient selection still wins after that: using `/agents` or Tab records a new selected recipient timestamp, so an intentional user switch overrides an older handoff.

It also handles handoff agent metadata from final `messages` payloads and from `agent_updated_stream_event.new_agent.id`, not only `new_agent.name`.

### How did you verify your code works?

Ran locally:

- `bun test ./test/cli/tui/agency-target.test.ts`
- `bun test ./test/session/agency-swarm.test.ts -t "recipient"`
- `bun run --cwd packages/opencode typecheck`
- `bun turbo typecheck`
- `git diff --check`

### Screenshots / recordings

No screenshot included. This is a terminal routing/state fix; behavior is covered by focused tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR