### PR TITLE
fix(tui): clear prompt immediately on submit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -810,11 +810,13 @@ export function Prompt(props: PromptProps) {
       return
     }
     const submittedPrompt = structuredClone(unwrap(store.prompt))
+    const savedPrompt = { input: store.prompt.input, parts: [...store.prompt.parts] }
     let sessionID = props.sessionID
     let createdSessionID: string | undefined
     let navigatedToCreatedSession = false
     let navigateTimer: ReturnType<typeof setTimeout> | undefined
     let promptProgress: ReturnType<typeof waitForSessionPromptProgress> | undefined
+    let promptTask: ReturnType<typeof sdk.client.session.prompt> | undefined
     if (sessionID == null) {
       const res = await sdk.client.session.create({
         workspaceID: props.workspaceID,
@@ -874,90 +876,93 @@ export function Prompt(props: PromptProps) {
           })),
       })
     } else {
-      const savedPrompt = { input: store.prompt.input, parts: [...store.prompt.parts] }
-      try {
-        const promptTask = sdk.client.session.prompt({
-          sessionID,
-          ...selectedModel,
-          messageID,
-          agent: effectiveAgentName(),
-          model: selectedModel,
-          variant,
-          parts: [
-            {
-              id: PartID.ascending(),
-              type: "text",
-              text: inputText,
-            },
-            ...nonTextParts.map(assign),
-          ],
-        })
+      promptTask = sdk.client.session.prompt({
+        sessionID,
+        ...selectedModel,
+        messageID,
+        agent: effectiveAgentName(),
+        model: selectedModel,
+        variant,
+        parts: [
+          {
+            id: PartID.ascending(),
+            type: "text",
+            text: inputText,
+          },
+          ...nonTextParts.map(assign),
+        ],
+      })
+    }
 
-        clearSubmittedPrompt(currentMode)
+    clearSubmittedPrompt(currentMode)
 
-        if (createdSessionID) {
-          const newSessionID = createdSessionID
-          await Promise.race([promptTask, promptProgress!.promise])
-
-          // temporary hack to make sure the message is sent
-          navigateTimer = setTimeout(() => {
-            navigateTimer = undefined
-            navigatedToCreatedSession = true
-            route.navigate({
-              type: "session",
-              sessionID: newSessionID,
-            })
-          }, 50)
+    try {
+      if (createdSessionID) {
+        const newSessionID = createdSessionID
+        if (promptTask && promptProgress) {
+          await Promise.race([promptTask, promptProgress.promise])
         }
 
-        await promptTask
-      } catch (error) {
-        // Fork-only: surface auth errors via the connect/auth dialog and restore the
-        // composer state so the user can retry. Rebuilding extmarks from the saved parts
-        // keeps file/agent/paste markers in sync — without this, syncExtmarksWithPromptParts
-        // would drop them on the next keystroke.
-        setStore("prompt", savedPrompt)
-        input.setText(savedPrompt.input)
-        restoreExtmarksFromParts(savedPrompt.parts)
-        const message = toErrorMessage(error)
-        const shouldReopenAuth = shouldOpenAgencyAuthDialog({
-          providerID: selectedModel.providerID,
-          message,
-        })
-        if (navigateTimer) {
-          clearTimeout(navigateTimer)
+        // temporary hack to make sure the message is sent
+        navigateTimer = setTimeout(() => {
           navigateTimer = undefined
-        }
-        if (createdSessionID && shouldReopenAuth) {
-          if (navigatedToCreatedSession) {
-            route.navigate({
-              type: "home",
-              workspaceID: props.workspaceID,
-              initialPrompt: submittedPrompt,
-            })
-          }
-          void sdk.client.session.delete({
-            sessionID: createdSessionID,
+          navigatedToCreatedSession = true
+          route.navigate({
+            type: "session",
+            sessionID: newSessionID,
+          })
+        }, 50)
+      }
+
+      if (!promptTask) return
+
+      await promptTask
+    } catch (error) {
+      // Fork-only: surface auth errors via the connect/auth dialog and restore the
+      // composer state so the user can retry. Rebuilding extmarks from the saved parts
+      // keeps file/agent/paste markers in sync — without this, syncExtmarksWithPromptParts
+      // would drop them on the next keystroke.
+      setStore("prompt", savedPrompt)
+      input.setText(savedPrompt.input)
+      restoreExtmarksFromParts(savedPrompt.parts)
+      const message = toErrorMessage(error)
+      const shouldReopenAuth = shouldOpenAgencyAuthDialog({
+        providerID: selectedModel.providerID,
+        message,
+      })
+      if (navigateTimer) {
+        clearTimeout(navigateTimer)
+        navigateTimer = undefined
+      }
+      if (createdSessionID && shouldReopenAuth) {
+        if (navigatedToCreatedSession) {
+          route.navigate({
+            type: "home",
+            workspaceID: props.workspaceID,
+            initialPrompt: submittedPrompt,
           })
         }
-        if (shouldReopenAuth) {
-          toast.show({
-            variant: "error",
-            message: describeAgencyAuthFailure(message),
-            duration: 5000,
-          })
-          dialog.replace(() => <DialogAuth />)
-          return
-        }
+        void sdk.client.session.delete({
+          sessionID: createdSessionID,
+        })
+      }
+      if (shouldReopenAuth) {
         toast.show({
           variant: "error",
-          message,
+          message: describeAgencyAuthFailure(message),
           duration: 5000,
         })
+        dialog.replace(() => <DialogAuth />)
         return
-      } finally {
-        promptProgress?.cleanup()
       }
+      toast.show({
+        variant: "error",
+        message,
+        duration: 5000,
+      })
+      return
+    } finally {
+      promptProgress?.cleanup()
     }
   }
   const exit = useExit()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -893,6 +893,8 @@ export function Prompt(props: PromptProps) {
           ],
         })
 
+        clearSubmittedPrompt(currentMode)
+
         if (createdSessionID) {
           const newSessionID = createdSessionID
           await Promise.race([promptTask, promptProgress!.promise])
@@ -957,7 +959,6 @@ export function Prompt(props: PromptProps) {
         promptProgress?.cleanup()
       }
     }
-    clearSubmittedPrompt(currentMode)
   }
   const exit = useExit()
 

--- a/packages/opencode/test/cli/tui/prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt.test.tsx
@@ -281,6 +281,228 @@ describe("prompt auth rejection handling", () => {
     await flushEffects()
   })
 
+  test("clears the draft after dispatching a server slash command", async () => {
+    process.env.OPENAI_API_KEY = "sk-test"
+
+    const events = createEventBus()
+    const commandSession = spyOn(
+      {
+        command: () => undefined,
+      },
+      "command",
+    )
+    const promptSession = spyOn(
+      {
+        prompt: () => Promise.resolve(),
+      },
+      "prompt",
+    )
+
+    spyOn(AgencySwarmRunSession, "sync").mockResolvedValue(undefined)
+    spyOn(AutocompleteModule, "Autocomplete").mockImplementation((props: any) => {
+      props.ref?.({
+        onInput() {},
+        onKeyDown() {},
+        visible: false,
+      })
+      return <box />
+    })
+    spyOn(CommandDialogModule, "useCommandDialog").mockReturnValue({
+      register: () => () => {},
+      slashes: () => [],
+      trigger: () => {},
+    } as any)
+    spyOn(ExitContext, "useExit").mockReturnValue(
+      Object.assign(async () => {}, {
+        message: {
+          set: () => () => {},
+          clear: () => {},
+          get: () => undefined,
+        },
+      }) as any,
+    )
+    spyOn(AgencySwarmConnectionContext, "useAgencySwarmConnection").mockReturnValue({
+      requiresReconnect: () => false,
+      openConnectDialog: () => false,
+      status: () => "connected",
+      baseURL: () => undefined,
+      failureCount: () => 0,
+      frameworkMode: () => true,
+    } as any)
+    spyOn(KeybindContext, "useKeybind").mockReturnValue({
+      leader: false,
+      match: () => false,
+      print: () => "",
+    } as any)
+    spyOn(KVContext, "useKV").mockReturnValue({
+      get: (_key: string, fallback?: unknown) => fallback,
+    } as any)
+    spyOn(LocalContext, "useLocal").mockReturnValue({
+      agent: {
+        current: () => ({
+          name: "builder",
+          model: {
+            providerID: "agency-swarm",
+            modelID: "default",
+          },
+        }),
+        list: () => [{ name: "builder" }],
+        set: () => {},
+        color: () => RGBA.fromHex("#38bdf8"),
+      },
+      model: {
+        current: () => ({
+          providerID: "agency-swarm",
+          modelID: "default",
+        }),
+        parsed: () => ({
+          provider: "Agency Swarm",
+          model: "default",
+        }),
+        set: () => {},
+        variant: {
+          current: () => undefined,
+          list: () => [],
+          set: () => {},
+        },
+      },
+    } as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({
+      client: {
+        session: {
+          command: commandSession,
+          prompt: promptSession,
+        },
+      },
+      event: events,
+    } as any)
+    spyOn(SyncContext, "useSync").mockReturnValue({
+      data: {
+        command: [{ name: "auth" }],
+        config: {
+          model: "agency-swarm/default",
+          experimental: {},
+        },
+        console_state: {
+          activeOrgName: "",
+          consoleManagedProviders: [],
+          switchableOrgCount: 0,
+        },
+        message: {},
+        provider: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+        provider_auth: {
+          openai: [{ type: "api", label: "API key" }],
+        },
+        provider_next: {
+          all: [{ id: "openai", name: "OpenAI" }],
+          connected: [],
+          default: {},
+        },
+        session_status: {},
+      },
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {
+        _hasSelectedListItemText: false,
+        accent: RGBA.fromHex("#14b8a6"),
+        background: RGBA.fromHex("#020617"),
+        backgroundElement: RGBA.fromHex("#111827"),
+        backgroundPanel: RGBA.fromHex("#0f172a"),
+        border: RGBA.fromHex("#334155"),
+        error: RGBA.fromHex("#ef4444"),
+        primary: RGBA.fromHex("#38bdf8"),
+        selectedListItemText: RGBA.fromHex("#f8fafc"),
+        success: RGBA.fromHex("#22c55e"),
+        text: RGBA.fromHex("#f8fafc"),
+        textMuted: RGBA.fromHex("#94a3b8"),
+        warning: RGBA.fromHex("#f59e0b"),
+      },
+      syntax: () => ({
+        getStyleId: () => 1,
+      }),
+    } as any)
+    spyOn(TuiConfigContext, "useTuiConfig").mockReturnValue({} as any)
+    const appendHistory = spyOn(
+      {
+        append: () => {},
+      },
+      "append",
+    )
+    spyOn(PromptHistoryModule, "usePromptHistory").mockReturnValue({
+      move: () => undefined,
+      append: appendHistory,
+    } as any)
+    spyOn(PromptStashModule, "usePromptStash").mockReturnValue({
+      list: () => [],
+      push: () => {},
+      pop: () => undefined,
+      remove: () => {},
+    } as any)
+    spyOn(TextareaKeybindingsModule, "useTextareaKeybindings").mockReturnValue(() => [] as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: () => {},
+      error: () => {},
+      currentToast: null,
+    } as any)
+
+    const { Prompt } = await import("../../../src/cli/cmd/tui/component/prompt")
+
+    let promptRef: PromptRef | undefined
+
+    await testRender(() => (
+      <RouteProvider>
+        <DialogProvider>
+          <Prompt
+            ref={(value) => (promptRef = value)}
+            sessionID="session_server_command"
+            workspaceID="workspace_server_command"
+            placeholders={{ normal: [] }}
+          />
+        </DialogProvider>
+      </RouteProvider>
+    ))
+
+    expect(promptRef).toBeDefined()
+
+    promptRef!.set({
+      input: "/auth refresh\nsecond line",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef!.submit()
+    await flushEffects()
+
+    expect(commandSession).toHaveBeenCalledTimes(1)
+    expect(promptSession).not.toHaveBeenCalled()
+    expect(appendHistory).toHaveBeenCalledWith({
+      input: "/auth refresh\nsecond line",
+      parts: [],
+      mode: "normal",
+    })
+    expect(promptRef!.current).toEqual({
+      input: "",
+      parts: [],
+    })
+  })
+
   test("keeps the first draft on home when a slow auth rejection lands before streaming starts", async () => {
     process.env.OPENAI_API_KEY = "sk-test"
 

--- a/packages/opencode/test/cli/tui/prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt.test.tsx
@@ -59,6 +59,228 @@ describe("prompt auth rejection handling", () => {
     delete process.env.OPENAI_API_KEY
   })
 
+  test("clears the draft as soon as the prompt request starts", async () => {
+    process.env.OPENAI_API_KEY = "sk-test"
+
+    const events = createEventBus()
+    let resolvePrompt!: () => void
+    const promptFinished = new Promise<void>((resolve) => {
+      resolvePrompt = resolve
+    })
+    const promptSession = spyOn(
+      {
+        prompt: () => promptFinished,
+      },
+      "prompt",
+    )
+
+    spyOn(AgencySwarmRunSession, "sync").mockResolvedValue(undefined)
+    spyOn(AutocompleteModule, "Autocomplete").mockImplementation((props: any) => {
+      props.ref?.({
+        onInput() {},
+        onKeyDown() {},
+        visible: false,
+      })
+      return <box />
+    })
+    spyOn(CommandDialogModule, "useCommandDialog").mockReturnValue({
+      register: () => () => {},
+      slashes: () => [],
+      trigger: () => {},
+    } as any)
+    spyOn(ExitContext, "useExit").mockReturnValue(
+      Object.assign(async () => {}, {
+        message: {
+          set: () => () => {},
+          clear: () => {},
+          get: () => undefined,
+        },
+      }) as any,
+    )
+    spyOn(AgencySwarmConnectionContext, "useAgencySwarmConnection").mockReturnValue({
+      requiresReconnect: () => false,
+      openConnectDialog: () => false,
+      status: () => "connected",
+      baseURL: () => undefined,
+      failureCount: () => 0,
+      frameworkMode: () => true,
+    } as any)
+    spyOn(KeybindContext, "useKeybind").mockReturnValue({
+      leader: false,
+      match: () => false,
+      print: () => "",
+    } as any)
+    spyOn(KVContext, "useKV").mockReturnValue({
+      get: (_key: string, fallback?: unknown) => fallback,
+    } as any)
+    spyOn(LocalContext, "useLocal").mockReturnValue({
+      agent: {
+        current: () => ({
+          name: "builder",
+          model: {
+            providerID: "agency-swarm",
+            modelID: "default",
+          },
+        }),
+        list: () => [{ name: "builder" }],
+        set: () => {},
+        color: () => RGBA.fromHex("#38bdf8"),
+      },
+      model: {
+        current: () => ({
+          providerID: "agency-swarm",
+          modelID: "default",
+        }),
+        parsed: () => ({
+          provider: "Agency Swarm",
+          model: "default",
+        }),
+        set: () => {},
+        variant: {
+          current: () => undefined,
+          list: () => [],
+          set: () => {},
+        },
+      },
+    } as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({
+      client: {
+        session: {
+          prompt: promptSession,
+        },
+      },
+      event: events,
+    } as any)
+    spyOn(SyncContext, "useSync").mockReturnValue({
+      data: {
+        command: [],
+        config: {
+          model: "agency-swarm/default",
+          experimental: {},
+        },
+        console_state: {
+          activeOrgName: "",
+          consoleManagedProviders: [],
+          switchableOrgCount: 0,
+        },
+        message: {},
+        provider: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+        provider_auth: {
+          openai: [{ type: "api", label: "API key" }],
+        },
+        provider_next: {
+          all: [{ id: "openai", name: "OpenAI" }],
+          connected: [],
+          default: {},
+        },
+        session_status: {},
+      },
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {
+        _hasSelectedListItemText: false,
+        accent: RGBA.fromHex("#14b8a6"),
+        background: RGBA.fromHex("#020617"),
+        backgroundElement: RGBA.fromHex("#111827"),
+        backgroundPanel: RGBA.fromHex("#0f172a"),
+        border: RGBA.fromHex("#334155"),
+        error: RGBA.fromHex("#ef4444"),
+        primary: RGBA.fromHex("#38bdf8"),
+        selectedListItemText: RGBA.fromHex("#f8fafc"),
+        success: RGBA.fromHex("#22c55e"),
+        text: RGBA.fromHex("#f8fafc"),
+        textMuted: RGBA.fromHex("#94a3b8"),
+        warning: RGBA.fromHex("#f59e0b"),
+      },
+      syntax: () => ({
+        getStyleId: () => 1,
+      }),
+    } as any)
+    spyOn(TuiConfigContext, "useTuiConfig").mockReturnValue({} as any)
+    const appendHistory = spyOn(
+      {
+        append: () => {},
+      },
+      "append",
+    )
+    spyOn(PromptHistoryModule, "usePromptHistory").mockReturnValue({
+      move: () => undefined,
+      append: appendHistory,
+    } as any)
+    spyOn(PromptStashModule, "usePromptStash").mockReturnValue({
+      list: () => [],
+      push: () => {},
+      pop: () => undefined,
+      remove: () => {},
+    } as any)
+    spyOn(TextareaKeybindingsModule, "useTextareaKeybindings").mockReturnValue(() => [] as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: () => {},
+      error: () => {},
+      currentToast: null,
+    } as any)
+
+    const { Prompt } = await import("../../../src/cli/cmd/tui/component/prompt")
+
+    let promptRef: PromptRef | undefined
+
+    await testRender(() => (
+      <RouteProvider>
+        <DialogProvider>
+          <Prompt
+            ref={(value) => (promptRef = value)}
+            sessionID="session_immediate_clear"
+            workspaceID="workspace_immediate_clear"
+            placeholders={{ normal: [] }}
+          />
+        </DialogProvider>
+      </RouteProvider>
+    ))
+
+    expect(promptRef).toBeDefined()
+
+    promptRef!.set({
+      input: "clear right away",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef!.submit()
+    await flushEffects()
+
+    expect(promptSession).toHaveBeenCalledTimes(1)
+    expect(appendHistory).toHaveBeenCalledWith({
+      input: "clear right away",
+      parts: [],
+      mode: "normal",
+    })
+    expect(promptRef!.current).toEqual({
+      input: "",
+      parts: [],
+    })
+
+    resolvePrompt()
+    await promptFinished
+    await flushEffects()
+  })
+
   test("keeps the first draft on home when a slow auth rejection lands before streaming starts", async () => {
     process.env.OPENAI_API_KEY = "sk-test"
 
@@ -283,7 +505,11 @@ describe("prompt auth rejection handling", () => {
       <RouteProvider>
         <DialogProvider>
           <Capture />
-          <Prompt ref={(value) => (promptRef = value)} workspaceID="workspace_auth_race" placeholders={{ normal: [] }} />
+          <Prompt
+            ref={(value) => (promptRef = value)}
+            workspaceID="workspace_auth_race"
+            placeholders={{ normal: [] }}
+          />
         </DialogProvider>
       </RouteProvider>
     ))
@@ -321,7 +547,7 @@ describe("prompt auth rejection handling", () => {
     expect(dialogDepth.at(-1)).toBe(1)
     expect(toasts.at(-1)).toEqual({
       variant: "error",
-      message: "The current provider credential was rejected. Reconnect OpenAI or Anthropic and try again.",
+      message: "The current provider credential was rejected. Run /auth to update it.",
       duration: 5000,
     })
   })


### PR DESCRIPTION
## Summary
- clear the normal prompt composer immediately after the prompt request is launched
- keep the fork-only restore-on-pre-stream/auth-failure path intact
- add a focused TUI prompt test for immediate clear and align the existing auth-failure toast expectation

## Validation
- bun x prettier --write packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx packages/opencode/test/cli/tui/prompt.test.tsx
- cd packages/opencode && bun test --config ./bunfig.toml test/cli/tui/prompt.test.tsx
- bun typecheck