### PR TITLE
fix(agency-swarm): preserve handoff recipient routing

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
@@ -8,6 +8,7 @@ export type AgencyProviderOptions = {
   configToken?: string
   agency?: string
   recipientAgent?: string
+  recipientAgentSelectedAt?: number
   discoveryTimeoutMs: number
   rawOptions: Record<string, unknown>
 }
@@ -29,6 +30,9 @@ export function readAgencyProviderOptions(input: {
   const token = readString(input.connectedProvider?.key) ?? configToken
   const agency = readString(options?.["agency"])
   const recipientAgent = readString(options?.["recipientAgent"]) ?? readString(options?.["recipient_agent"])
+  const recipientAgentSelectedAt =
+    readPositiveNumber(options?.["recipientAgentSelectedAt"]) ??
+    readPositiveNumber(options?.["recipient_agent_selected_at"])
   const discoveryTimeoutMs =
     readPositiveNumber(options?.["discoveryTimeoutMs"]) ??
     readPositiveNumber(options?.["discovery_timeout_ms"]) ??
@@ -40,6 +44,7 @@ export function readAgencyProviderOptions(input: {
     configToken,
     agency,
     recipientAgent,
+    recipientAgentSelectedAt,
     discoveryTimeoutMs,
     rawOptions: (options && typeof options === "object" ? options : {}) as Record<string, unknown>,
   }
@@ -53,7 +58,9 @@ export function resolveAgencyTargetSelection(input: {
   const agency = resolveSelectableAgency(input.agencies, input.configuredAgency)
   if (!agency) return undefined
 
-  const current = input.configuredRecipient ? agency.agents.find((agent) => agent.id === input.configuredRecipient) : undefined
+  const current = input.configuredRecipient
+    ? agency.agents.find((agent) => agent.id === input.configuredRecipient)
+    : undefined
   const recipient = current ?? defaultAgencyRecipient(agency)
   if (!recipient) return undefined
 
@@ -101,7 +108,9 @@ export function buildAgencyTargetOptions(input: {
     discoveryTimeoutMs: input.providerOptions.discoveryTimeoutMs,
     agency: input.agency,
     recipientAgent: input.recipientAgent ?? null,
+    recipientAgentSelectedAt: input.recipientAgent ? Date.now() : null,
     recipient_agent: null,
+    recipient_agent_selected_at: null,
   }
 
   if (input.providerOptions.configToken) {
@@ -120,18 +129,12 @@ export function displayRunOnlyAgentLabel(input: {
   return input.recipientLabel ?? "Run"
 }
 
-export function displayRunOnlyModeLabel(input: {
-  frameworkMode: boolean
-  mode: string
-}) {
+export function displayRunOnlyModeLabel(input: { frameworkMode: boolean; mode: string }) {
   if (input.frameworkMode) return "Run"
   return Locale.titlecase(input.mode)
 }
 
-function resolveSelectableAgency(
-  agencies: AgencySwarmAdapter.AgencyDescriptor[],
-  configuredAgency?: string,
-) {
+function resolveSelectableAgency(agencies: AgencySwarmAdapter.AgencyDescriptor[], configuredAgency?: string) {
   if (configuredAgency) return agencies.find((agency) => agency.id === configuredAgency)
   if (agencies.length === 1) return agencies[0]
   return undefined

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -49,6 +49,7 @@ export namespace SessionAgencySwarm {
     baseURL: string
     agency?: string
     recipientAgent?: string
+    recipientAgentSelectedAt?: number
     additionalInstructions?: string
     userContext?: Record<string, unknown>
     fileIDs?: string[]
@@ -94,6 +95,9 @@ export namespace SessionAgencySwarm {
     const rawAgency = asString(provider?.options?.["agency"])
     const rawRecipientAgent =
       asString(provider?.options?.["recipientAgent"]) ?? asString(provider?.options?.["recipient_agent"])
+    const rawRecipientAgentSelectedAt =
+      asNumber(provider?.options?.["recipientAgentSelectedAt"]) ??
+      asNumber(provider?.options?.["recipient_agent_selected_at"])
     const rawAdditionalInstructions =
       asString(provider?.options?.["additionalInstructions"]) ??
       asString(provider?.options?.["additional_instructions"])
@@ -113,6 +117,7 @@ export namespace SessionAgencySwarm {
       baseURL: AgencySwarmAdapter.normalizeBaseURL(rawBaseURL || AgencySwarmAdapter.DEFAULT_BASE_URL),
       agency: rawAgency || undefined,
       recipientAgent: rawRecipientAgent || undefined,
+      recipientAgentSelectedAt: rawRecipientAgentSelectedAt,
       additionalInstructions: rawAdditionalInstructions || undefined,
       userContext: rawUserContext,
       fileIDs: rawFileIDs.length > 0 ? rawFileIDs : undefined,
@@ -1512,6 +1517,7 @@ export namespace SessionAgencySwarm {
         timeoutMs: input.options.discoveryTimeoutMs,
         mentionedRecipient,
         configuredRecipient: input.options.recipientAgent,
+        configuredRecipientSelectedAt: input.options.recipientAgentSelectedAt,
       })
       const sessionLitellmModel =
         input.sessionModel &&
@@ -1585,7 +1591,9 @@ export namespace SessionAgencySwarm {
           }
           if (kind === "agent_updated_stream_event") {
             const next = asRecord(frame.payload["new_agent"])
-            const maybeName = next ? asString(next["name"]) : undefined
+            const maybeName = next
+              ? (asString(next["id"]) ?? asString(next["name"]) ?? asString(next["label"]))
+              : undefined
             if (maybeName) {
               input.assistantMessage.agent = maybeName
               input.assistantMessage.mode = maybeName
@@ -1894,17 +1902,27 @@ export namespace SessionAgencySwarm {
     timeoutMs: number
     mentionedRecipient?: string
     configuredRecipient?: string
+    configuredRecipientSelectedAt?: number
   }): Promise<string | undefined> {
     const sessionRecipient = await resolveSessionRecipient(input.sessionID)
+    type RecipientCandidate = {
+      value: {
+        agent: string
+        messageAt?: number
+      }
+      source: "message" | "config" | "session"
+    }
     const candidates = [
-      { value: input.mentionedRecipient, source: "message" },
-      { value: input.configuredRecipient, source: "config" },
-      { value: sessionRecipient, source: "session" },
-    ].filter(
-      (candidate, index, array): candidate is { value: string; source: "message" | "config" | "session" } =>
-        !!candidate.value && array.findIndex((item) => item.value === candidate.value) === index,
-    )
-    const candidateValues = candidates.map((candidate) => candidate.value)
+      input.mentionedRecipient ? { value: { agent: input.mentionedRecipient }, source: "message" } : undefined,
+      input.configuredRecipient ? { value: { agent: input.configuredRecipient }, source: "config" } : undefined,
+      sessionRecipient ? { value: sessionRecipient, source: "session" } : undefined,
+    ]
+      .filter((candidate): candidate is RecipientCandidate => !!candidate?.value.agent)
+      .sort((a, b) => candidateRank(a) - candidateRank(b))
+      .filter(
+        (candidate, index, array) => array.findIndex((item) => item.value.agent === candidate.value.agent) === index,
+      )
+    const candidateValues = candidates.map((candidate) => candidate.value.agent)
     if (candidateValues.length === 0) {
       return undefined
     }
@@ -1939,18 +1957,28 @@ export namespace SessionAgencySwarm {
 
     const availableAgents = Array.from(new Set(recipientMap.values()))
     for (const candidate of candidates) {
-      const resolved = recipientMap.get(candidate.value)
+      const resolved = recipientMap.get(candidate.value.agent)
       if (resolved) return resolved
       log.warn("ignoring stale recipient agent candidate", {
         sessionID: input.sessionID,
         agency: input.agency,
-        candidate: candidate.value,
+        candidate: candidate.value.agent,
         source: candidate.source,
         availableAgents,
       })
     }
 
     return undefined
+
+    function candidateRank(candidate: RecipientCandidate) {
+      if (candidate.source === "message") return 0
+      if (candidate.source === "config" && input.configuredRecipientSelectedAt) {
+        const sessionMessageAt = sessionRecipient?.messageAt ?? 0
+        if (input.configuredRecipientSelectedAt > sessionMessageAt) return 1
+      }
+      if (candidate.source === "session") return 2
+      return 3
+    }
   }
 
   async function resolveSessionRecipient(sessionID: SessionID) {
@@ -1964,7 +1992,10 @@ export namespace SessionAgencySwarm {
       })
       if (!last) return
       if (last.info.role !== "assistant") return
-      return last.info.agent
+      return {
+        agent: last.info.agent,
+        messageAt: last.info.time.created,
+      }
     } catch (error) {
       log.warn("unable to load session recipient; skipping recipient override", {
         sessionID,

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -3,30 +3,34 @@ import { buildAgencyTargetOptions } from "../../../src/cli/cmd/tui/util/agency-t
 
 describe("agency target options", () => {
   test("clears stale snake_case recipient state when /agents switches recipients", () => {
-    expect(
-      buildAgencyTargetOptions({
-        providerOptions: {
-          baseURL: "http://127.0.0.1:18080",
-          token: undefined,
-          configToken: undefined,
-          agency: "my-agency",
-          recipientAgent: "ExampleAgent",
-          discoveryTimeoutMs: 5000,
-          rawOptions: {
-            baseURL: "http://127.0.0.1:18080",
-            agency: "my-agency",
-            recipient_agent: "ExampleAgent",
-          },
-        },
+    const options = buildAgencyTargetOptions({
+      providerOptions: {
+        baseURL: "http://127.0.0.1:18080",
+        token: undefined,
+        configToken: undefined,
         agency: "my-agency",
-        recipientAgent: "ExampleAgent2",
-      }),
-    ).toEqual({
+        recipientAgent: "ExampleAgent",
+        discoveryTimeoutMs: 5000,
+        rawOptions: {
+          baseURL: "http://127.0.0.1:18080",
+          agency: "my-agency",
+          recipient_agent: "ExampleAgent",
+          recipient_agent_selected_at: 1,
+        },
+      },
+      agency: "my-agency",
+      recipientAgent: "ExampleAgent2",
+    })
+
+    expect(typeof options.recipientAgentSelectedAt).toBe("number")
+    expect(options).toEqual({
       baseURL: "http://127.0.0.1:18080",
       agency: "my-agency",
       discoveryTimeoutMs: 5000,
       recipientAgent: "ExampleAgent2",
+      recipientAgentSelectedAt: options.recipientAgentSelectedAt,
       recipient_agent: null,
+      recipient_agent_selected_at: null,
     })
   })
 })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -135,6 +135,22 @@ describe("session.agency-swarm", () => {
     expect(options.agency).toBeUndefined()
   })
 
+  test("optionsFromProvider reads manual recipient selection timestamp", () => {
+    const options = SessionAgencySwarm.optionsFromProvider({
+      id: "agency-swarm",
+      name: "agency-swarm",
+      key: undefined,
+      models: {},
+      options: {
+        recipientAgent: "slides_agent",
+        recipientAgentSelectedAt: 123,
+      },
+    } as any)
+
+    expect(options.recipientAgent).toBe("slides_agent")
+    expect(options.recipientAgentSelectedAt).toBe(123)
+  })
+
   test("resolveAgency returns configured agency without discovery", async () => {
     let called = false
     AgencySwarmAdapter.discover = (async () => {
@@ -2707,7 +2723,108 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream prefers configured recipient over persisted handed off recipient", async () => {
+  test("stream routes next message to agent_updated handoff id", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        let sentRecipient: string | undefined
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["orchestrator", "slides_agent"],
+          },
+          nodes: [
+            {
+              id: "slides_agent",
+              type: "agent",
+              data: {
+                label: "Slides Agent",
+              },
+            },
+          ],
+        })) as typeof AgencySwarmAdapter.getMetadata
+        let turn = 0
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          turn++
+          if (turn === 1) {
+            yield {
+              type: "data",
+              payload: {
+                type: "agent_updated_stream_event",
+                new_agent: {
+                  id: "slides_agent",
+                  label: "Slides Agent",
+                },
+              },
+            }
+            yield { type: "end" }
+            return
+          }
+          sentRecipient = args.recipientAgent ?? undefined
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "handoff event recipient" })
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "make slides",
+        })
+        const first = helper()
+        first.input.sessionID = session.id
+        first.input.assistantMessage.sessionID = session.id
+        first.input.assistantMessage.parentID = user.id
+        first.input.assistantMessage.id = MessageID.ascending()
+        first.input.userMessage.info.id = user.id
+
+        const firstStream = await SessionAgencySwarm.stream(first.input)
+        for await (const _ of firstStream.fullStream) {
+        }
+
+        expect(first.input.assistantMessage.agent).toBe("slides_agent")
+
+        const second = helper()
+        second.input.sessionID = session.id
+        second.input.assistantMessage.sessionID = session.id
+        second.input.assistantMessage.id = MessageID.ascending()
+        second.input.userMessage.info.id = MessageID.ascending()
+        second.input.userMessage.parts = [{ type: "text", text: "continue", ignored: false }] as any
+
+        const secondStream = await SessionAgencySwarm.stream(second.input)
+        for await (const _ of secondStream.fullStream) {
+        }
+
+        expect(sentRecipient).toBe("slides_agent")
+      },
+    })
+  })
+
+  test("stream prefers persisted handed off recipient over unmarked configured recipient", async () => {
     await using tmp = await tmpdir({
       git: true,
       config: {
@@ -2742,7 +2859,8 @@ describe("session.agency-swarm", () => {
           yield { type: "end" }
         } as typeof AgencySwarmAdapter.streamRun
 
-        const session = await Session.create({ title: "configured recipient override" })
+        const session = await Session.create({ title: "handoff recipient over default config" })
+        const created = Date.now()
         const user = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "user",
@@ -2753,7 +2871,7 @@ describe("session.agency-swarm", () => {
             modelID: ModelID.make("default"),
           },
           time: {
-            created: Date.now(),
+            created,
           },
         })
         await Session.updatePart({
@@ -2785,8 +2903,8 @@ describe("session.agency-swarm", () => {
             cache: { read: 0, write: 0 },
           },
           time: {
-            created: Date.now(),
-            completed: Date.now(),
+            created: created + 1,
+            completed: created + 2,
           },
         } as any)
 
@@ -2794,6 +2912,106 @@ describe("session.agency-swarm", () => {
         input.sessionID = session.id
         input.assistantMessage.sessionID = session.id
         input.options.recipientAgent = "MathAgent"
+        input.userMessage.info.id = MessageID.ascending()
+        input.userMessage.parts = [{ type: "text", text: "follow up", ignored: false }] as any
+        const stream = await SessionAgencySwarm.stream(input)
+        for await (const _ of stream.fullStream) {
+        }
+
+        expect(sentRecipient).toBe("support_agent")
+      },
+    })
+  })
+
+  test("stream prefers later manual recipient selection over persisted handed off recipient", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        let sentRecipient: string | undefined
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["support_agent", "MathAgent"],
+          },
+          nodes: [
+            {
+              id: "support_agent",
+              type: "agent",
+              data: {
+                label: "UserSupportAgent",
+              },
+            },
+          ],
+        })) as typeof AgencySwarmAdapter.getMetadata
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          sentRecipient = args.recipientAgent ?? undefined
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "manual recipient override" })
+        const created = Date.now()
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created,
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "hello",
+        })
+        await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          sessionID: session.id,
+          parentID: user.id,
+          modelID: "default",
+          providerID: "agency-swarm",
+          mode: "UserSupportAgent",
+          agent: "UserSupportAgent",
+          path: {
+            cwd: "/",
+            root: "/",
+          },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: {
+            created: created + 1,
+            completed: created + 2,
+          },
+        } as any)
+
+        const { input } = helper()
+        input.sessionID = session.id
+        input.assistantMessage.sessionID = session.id
+        input.options.recipientAgent = "MathAgent"
+        ;(input.options as any).recipientAgentSelectedAt = created + 3
         input.userMessage.info.id = MessageID.ascending()
         input.userMessage.parts = [{ type: "text", text: "follow up", ignored: false }] as any
         const stream = await SessionAgencySwarm.stream(input)


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Restores Agency Swarm handoff routing after an orchestrator transfers to another agent. The stream now records agent_updated_stream_event using new_agent.id first, then falls back to name/label, so the assistant message stores the live recipient id. Recipient resolution now lets the last handed-off assistant agent beat stale configured/default recipients, while a later manual /agents recipient selection still wins through a selection timestamp stored in provider options.

### How did you verify your code works?

- bun x prettier --write packages/opencode/src/session/agency-swarm.ts packages/opencode/src/cli/cmd/tui/util/agency-target.ts packages/opencode/test/session/agency-swarm.test.ts packages/opencode/test/cli/tui/agency-target.test.ts
- cd packages/opencode && bun test ./test/session/agency-swarm.test.ts
- cd packages/opencode && bun test ./test/cli/tui/agency-target.test.ts
- bun typecheck

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR