### PR TITLE
fix: align installer binary and update source detection

### DIFF
--- a/install
+++ b/install
@@ -2,7 +2,7 @@
 set -euo pipefail
 APP=agentswarm-cli
 CMD=agentswarm
-BIN=agency
+BIN="$CMD"
 REPO=VRSEN/agentswarm-cli
 INSTALL_URL="https://raw.githubusercontent.com/${REPO}/dev/install"
 RELEASES_URL="https://github.com/${REPO}/releases"
@@ -28,7 +28,7 @@ Options:
 Examples:
     curl -fsSL ${INSTALL_URL} | bash
     curl -fsSL ${INSTALL_URL} | bash -s -- --version 1.0.180
-    ./install --binary /path/to/agency
+    ./install --binary /path/to/agentswarm
 EOF
 }
 

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -10,12 +10,14 @@ import { BusEvent } from "@/bus/bus-event"
 import { Flag } from "../flag/flag"
 import { Log } from "../util/log"
 import { CHANNEL as channel, VERSION as version } from "./meta"
-import { AgencyBrand } from "@/agency-swarm/brand"
 
 import semver from "semver"
 
 export namespace Installation {
   const log = Log.create({ service: "installation" })
+  const packageName = "agentswarm-cli"
+  const releaseRepo = "VRSEN/agentswarm-cli"
+  const curlInstallDir = ".opencode"
 
   export type Method = "curl" | "npm" | "yarn" | "pnpm" | "bun" | "brew" | "scoop" | "choco" | "unknown"
 
@@ -59,7 +61,7 @@ export namespace Installation {
 
   export const VERSION = version
   export const CHANNEL = channel
-  export const USER_AGENT = `agentswarm-cli/${CHANNEL}/${VERSION}/${Flag.OPENCODE_CLIENT}`
+  export const USER_AGENT = `${packageName}/${CHANNEL}/${VERSION}/${Flag.OPENCODE_CLIENT}`
 
   export function isPreview() {
     return CHANNEL !== "latest"
@@ -134,8 +136,7 @@ export namespace Installation {
           Effect.catch(() => Effect.succeed({ code: ChildProcessSpawner.ExitCode(1), stdout: "", stderr: "" })),
         )
 
-        const repo = "VRSEN/agentswarm-cli"
-        const install = `https://raw.githubusercontent.com/${repo}/dev/install`
+        const install = `https://raw.githubusercontent.com/${releaseRepo}/dev/install`
 
         const upgradeCurl = Effect.fnUntraced(
           function* (target: string) {
@@ -160,10 +161,9 @@ export namespace Installation {
         )
 
         const methodImpl = Effect.fn("Installation.method")(function* () {
-          if (process.execPath.includes(path.join(AgencyBrand.workspace, "bin"))) return "curl" as Method
+          if (process.execPath.includes(path.join(curlInstallDir, "bin"))) return "curl" as Method
           if (process.execPath.includes(path.join(".local", "bin"))) return "curl" as Method
           const exec = process.execPath.toLowerCase()
-          const pkg = "agentswarm-cli"
 
           const checks: Array<{ name: Method; command: () => Effect.Effect<string> }> = [
             { name: "npm", command: () => text(["npm", "list", "-g", "--depth=0"]) },
@@ -182,7 +182,7 @@ export namespace Installation {
 
           for (const check of checks) {
             const output = yield* check.command()
-            const installedName = pkg
+            const installedName = packageName
             if (output.includes(installedName)) {
               return check.name
             }
@@ -200,13 +200,18 @@ export namespace Installation {
             })
           }
 
-          if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm" || detectedMethod === "yarn") {
+          if (
+            detectedMethod === "npm" ||
+            detectedMethod === "bun" ||
+            detectedMethod === "pnpm" ||
+            detectedMethod === "yarn"
+          ) {
             const r = (yield* text(["npm", "config", "get", "registry"])).trim()
             const reg = r || "https://registry.npmjs.org"
             const registry = reg.endsWith("/") ? reg.slice(0, -1) : reg
             const channel = CHANNEL
             const response = yield* httpOk.execute(
-              HttpClientRequest.get(`${registry}/agentswarm-cli/${channel}`).pipe(HttpClientRequest.acceptJson),
+              HttpClientRequest.get(`${registry}/${packageName}/${channel}`).pipe(HttpClientRequest.acceptJson),
             )
             const data = yield* HttpClientResponse.schemaBodyJson(NpmPackage)(response)
             return data.version
@@ -229,7 +234,7 @@ export namespace Installation {
           }
 
           const response = yield* httpOk.execute(
-            HttpClientRequest.get(`https://api.github.com/repos/${repo}/releases/latest`).pipe(
+            HttpClientRequest.get(`https://api.github.com/repos/${releaseRepo}/releases/latest`).pipe(
               HttpClientRequest.acceptJson,
             ),
           )
@@ -244,16 +249,16 @@ export namespace Installation {
               result = yield* upgradeCurl(target)
               break
             case "npm":
-              result = yield* run(["npm", "install", "-g", `agentswarm-cli@${target}`])
+              result = yield* run(["npm", "install", "-g", `${packageName}@${target}`])
               break
             case "yarn":
-              result = yield* run(["yarn", "global", "add", `agentswarm-cli@${target}`])
+              result = yield* run(["yarn", "global", "add", `${packageName}@${target}`])
               break
             case "pnpm":
-              result = yield* run(["pnpm", "install", "-g", `agentswarm-cli@${target}`])
+              result = yield* run(["pnpm", "install", "-g", `${packageName}@${target}`])
               break
             case "bun":
-              result = yield* run(["bun", "install", "-g", `agentswarm-cli@${target}`])
+              result = yield* run(["bun", "install", "-g", `${packageName}@${target}`])
               break
             case "brew": {
               return yield* new UpgradeFailedError({

--- a/packages/opencode/test/installation/install-script.test.ts
+++ b/packages/opencode/test/installation/install-script.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(testDir, "../../../..")
+const installScript = fs.readFileSync(path.join(repoRoot, "install"), "utf8")
+const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "packages/opencode/package.json"), "utf8")) as {
+  name: string
+  bin: Record<string, string>
+  repository: { url: string }
+}
+
+function readInstallVar(name: string) {
+  const match = installScript.match(new RegExp(`^${name}=(.+)$`, "m"))
+  expect(match?.[1]).toBeDefined()
+  return match![1].replace(/^"/, "").replace(/"$/, "")
+}
+
+test("install script expects the release archive binary name", () => {
+  const binName = Object.keys(packageJson.bin)[0]
+  expect(readInstallVar("CMD")).toBe(binName)
+  expect(readInstallVar("BIN")).toBe("$CMD")
+})
+
+test("install script and installation package source point at the fork package and repo", () => {
+  expect(readInstallVar("APP")).toBe(packageJson.name)
+  expect(readInstallVar("REPO")).toBe("VRSEN/agentswarm-cli")
+  expect(packageJson.repository.url).toContain("VRSEN/agentswarm-cli.git")
+})

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -48,14 +48,42 @@ function testLayer(
 }
 
 describe("installation", () => {
+  describe("method", () => {
+    test("detects curl installs from the installer directory", async () => {
+      const originalExecPath = process.execPath
+      Object.defineProperty(process, "execPath", {
+        value: "/Users/test/.opencode/bin/agentswarm",
+        configurable: true,
+      })
+
+      try {
+        const layer = testLayer(() => jsonResponse({}))
+        const result = await Effect.runPromise(
+          Installation.Service.use((svc) => svc.method()).pipe(Effect.provide(layer)),
+        )
+        expect(result).toBe("curl")
+      } finally {
+        Object.defineProperty(process, "execPath", {
+          value: originalExecPath,
+          configurable: true,
+        })
+      }
+    })
+  })
+
   describe("latest", () => {
     test("reads release version from GitHub releases", async () => {
-      const layer = testLayer(() => jsonResponse({ tag_name: "v1.2.3" }))
+      let requestURL = ""
+      const layer = testLayer((request) => {
+        requestURL = request.url
+        return jsonResponse({ tag_name: "v1.2.3" })
+      })
 
       const result = await Effect.runPromise(
         Installation.Service.use((svc) => svc.latest("unknown")).pipe(Effect.provide(layer)),
       )
       expect(result).toBe("1.2.3")
+      expect(requestURL).toBe("https://api.github.com/repos/VRSEN/agentswarm-cli/releases/latest")
     })
 
     test("strips v prefix from GitHub release tag", async () => {
@@ -68,8 +96,12 @@ describe("installation", () => {
     })
 
     test("reads npm registry versions", async () => {
+      let requestURL = ""
       const layer = testLayer(
-        () => jsonResponse({ version: "1.5.0" }),
+        (request) => {
+          requestURL = request.url
+          return jsonResponse({ version: "1.5.0" })
+        },
         (cmd, args) => {
           if (cmd === "npm" && args.includes("registry")) return "https://registry.npmjs.org\n"
           return ""
@@ -80,6 +112,7 @@ describe("installation", () => {
         Installation.Service.use((svc) => svc.latest("npm")).pipe(Effect.provide(layer)),
       )
       expect(result).toBe("1.5.0")
+      expect(requestURL).toBe(`https://registry.npmjs.org/agentswarm-cli/${Installation.CHANNEL}`)
     })
 
     test("reads npm registry versions for bun method", async () => {


### PR DESCRIPTION
## Summary
- align the shell installer with the actual release archive binary name
- detect curl installs from the real installer directory so update checks use the GitHub release source
- add deterministic installation tests for the installer contract and update source paths

## Validation
- cd packages/opencode && bun test test/installation/installation.test.ts test/installation/install-script.test.ts
- cd packages/opencode && bun run typecheck