### PR TITLE
refactor(installation): centralize distribution metadata

### DIFF
--- a/packages/opencode/src/agency-swarm/distribution.ts
+++ b/packages/opencode/src/agency-swarm/distribution.ts
@@ -1,0 +1,10 @@
+import { AgencyProduct } from "./product"
+
+export namespace AgencyDistribution {
+  export const packageName = "agentswarm-cli"
+  export const releaseRepo = "VRSEN/agentswarm-cli"
+  export const installDir = ".opencode"
+  export const installURL = `https://raw.githubusercontent.com/${releaseRepo}/dev/install`
+  export const releasesURL = `https://github.com/${releaseRepo}/releases`
+  export const docsURL = AgencyProduct.docs
+}

--- a/packages/opencode/src/installation/distribution.ts
+++ b/packages/opencode/src/installation/distribution.ts
@@ -1,10 +1,8 @@
-import { AgencyProduct } from "./product"
-
-export namespace AgencyDistribution {
+export namespace InstallationDistribution {
   export const packageName = "agentswarm-cli"
   export const releaseRepo = "VRSEN/agentswarm-cli"
   export const installDir = ".opencode"
   export const installURL = `https://raw.githubusercontent.com/${releaseRepo}/dev/install`
   export const releasesURL = `https://github.com/${releaseRepo}/releases`
-  export const docsURL = AgencyProduct.docs
+  export const docsURL = "https://agency-swarm.ai/core-framework/agencies/agent-swarm-cli"
 }

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -10,7 +10,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { Flag } from "../flag/flag"
 import { Log } from "../util/log"
 import { CHANNEL as channel, VERSION as version } from "./meta"
-import { AgencyDistribution } from "../agency-swarm/distribution"
+import { InstallationDistribution } from "./distribution"
 
 import semver from "semver"
 
@@ -59,7 +59,7 @@ export namespace Installation {
 
   export const VERSION = version
   export const CHANNEL = channel
-  export const USER_AGENT = `${AgencyDistribution.packageName}/${CHANNEL}/${VERSION}/${Flag.OPENCODE_CLIENT}`
+  export const USER_AGENT = `${InstallationDistribution.packageName}/${CHANNEL}/${VERSION}/${Flag.OPENCODE_CLIENT}`
 
   export function isPreview() {
     return CHANNEL !== "latest"
@@ -136,7 +136,7 @@ export namespace Installation {
 
         const upgradeCurl = Effect.fnUntraced(
           function* (target: string) {
-            const response = yield* httpOk.execute(HttpClientRequest.get(AgencyDistribution.installURL))
+            const response = yield* httpOk.execute(HttpClientRequest.get(InstallationDistribution.installURL))
             const body = yield* response.text
             const bodyBytes = new TextEncoder().encode(body)
             const proc = ChildProcess.make("bash", [], {
@@ -157,7 +157,7 @@ export namespace Installation {
         )
 
         const methodImpl = Effect.fn("Installation.method")(function* () {
-          if (process.execPath.includes(path.join(AgencyDistribution.installDir, "bin"))) return "curl" as Method
+          if (process.execPath.includes(path.join(InstallationDistribution.installDir, "bin"))) return "curl" as Method
           if (process.execPath.includes(path.join(".local", "bin"))) return "curl" as Method
           const exec = process.execPath.toLowerCase()
 
@@ -178,7 +178,7 @@ export namespace Installation {
 
           for (const check of checks) {
             const output = yield* check.command()
-            const installedName = AgencyDistribution.packageName
+            const installedName = InstallationDistribution.packageName
             if (output.includes(installedName)) {
               return check.name
             }
@@ -207,7 +207,7 @@ export namespace Installation {
             const registry = reg.endsWith("/") ? reg.slice(0, -1) : reg
             const channel = CHANNEL
             const response = yield* httpOk.execute(
-              HttpClientRequest.get(`${registry}/${AgencyDistribution.packageName}/${channel}`).pipe(
+              HttpClientRequest.get(`${registry}/${InstallationDistribution.packageName}/${channel}`).pipe(
                 HttpClientRequest.acceptJson,
               ),
             )
@@ -233,7 +233,7 @@ export namespace Installation {
 
           const response = yield* httpOk.execute(
             HttpClientRequest.get(
-              `https://api.github.com/repos/${AgencyDistribution.releaseRepo}/releases/latest`,
+              `https://api.github.com/repos/${InstallationDistribution.releaseRepo}/releases/latest`,
             ).pipe(HttpClientRequest.acceptJson),
           )
           const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
@@ -247,16 +247,16 @@ export namespace Installation {
               result = yield* upgradeCurl(target)
               break
             case "npm":
-              result = yield* run(["npm", "install", "-g", `${AgencyDistribution.packageName}@${target}`])
+              result = yield* run(["npm", "install", "-g", `${InstallationDistribution.packageName}@${target}`])
               break
             case "yarn":
-              result = yield* run(["yarn", "global", "add", `${AgencyDistribution.packageName}@${target}`])
+              result = yield* run(["yarn", "global", "add", `${InstallationDistribution.packageName}@${target}`])
               break
             case "pnpm":
-              result = yield* run(["pnpm", "install", "-g", `${AgencyDistribution.packageName}@${target}`])
+              result = yield* run(["pnpm", "install", "-g", `${InstallationDistribution.packageName}@${target}`])
               break
             case "bun":
-              result = yield* run(["bun", "install", "-g", `${AgencyDistribution.packageName}@${target}`])
+              result = yield* run(["bun", "install", "-g", `${InstallationDistribution.packageName}@${target}`])
               break
             case "brew": {
               return yield* new UpgradeFailedError({

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -10,14 +10,12 @@ import { BusEvent } from "@/bus/bus-event"
 import { Flag } from "../flag/flag"
 import { Log } from "../util/log"
 import { CHANNEL as channel, VERSION as version } from "./meta"
+import { AgencyDistribution } from "../agency-swarm/distribution"
 
 import semver from "semver"
 
 export namespace Installation {
   const log = Log.create({ service: "installation" })
-  const packageName = "agentswarm-cli"
-  const releaseRepo = "VRSEN/agentswarm-cli"
-  const curlInstallDir = ".opencode"
 
   export type Method = "curl" | "npm" | "yarn" | "pnpm" | "bun" | "brew" | "scoop" | "choco" | "unknown"
 
@@ -61,7 +59,7 @@ export namespace Installation {
 
   export const VERSION = version
   export const CHANNEL = channel
-  export const USER_AGENT = `${packageName}/${CHANNEL}/${VERSION}/${Flag.OPENCODE_CLIENT}`
+  export const USER_AGENT = `${AgencyDistribution.packageName}/${CHANNEL}/${VERSION}/${Flag.OPENCODE_CLIENT}`
 
   export function isPreview() {
     return CHANNEL !== "latest"
@@ -136,11 +134,9 @@ export namespace Installation {
           Effect.catch(() => Effect.succeed({ code: ChildProcessSpawner.ExitCode(1), stdout: "", stderr: "" })),
         )
 
-        const install = `https://raw.githubusercontent.com/${releaseRepo}/dev/install`
-
         const upgradeCurl = Effect.fnUntraced(
           function* (target: string) {
-            const response = yield* httpOk.execute(HttpClientRequest.get(install))
+            const response = yield* httpOk.execute(HttpClientRequest.get(AgencyDistribution.installURL))
             const body = yield* response.text
             const bodyBytes = new TextEncoder().encode(body)
             const proc = ChildProcess.make("bash", [], {
@@ -161,7 +157,7 @@ export namespace Installation {
         )
 
         const methodImpl = Effect.fn("Installation.method")(function* () {
-          if (process.execPath.includes(path.join(curlInstallDir, "bin"))) return "curl" as Method
+          if (process.execPath.includes(path.join(AgencyDistribution.installDir, "bin"))) return "curl" as Method
           if (process.execPath.includes(path.join(".local", "bin"))) return "curl" as Method
           const exec = process.execPath.toLowerCase()
 
@@ -182,7 +178,7 @@ export namespace Installation {
 
           for (const check of checks) {
             const output = yield* check.command()
-            const installedName = packageName
+            const installedName = AgencyDistribution.packageName
             if (output.includes(installedName)) {
               return check.name
             }
@@ -211,7 +207,9 @@ export namespace Installation {
             const registry = reg.endsWith("/") ? reg.slice(0, -1) : reg
             const channel = CHANNEL
             const response = yield* httpOk.execute(
-              HttpClientRequest.get(`${registry}/${packageName}/${channel}`).pipe(HttpClientRequest.acceptJson),
+              HttpClientRequest.get(`${registry}/${AgencyDistribution.packageName}/${channel}`).pipe(
+                HttpClientRequest.acceptJson,
+              ),
             )
             const data = yield* HttpClientResponse.schemaBodyJson(NpmPackage)(response)
             return data.version
@@ -234,9 +232,9 @@ export namespace Installation {
           }
 
           const response = yield* httpOk.execute(
-            HttpClientRequest.get(`https://api.github.com/repos/${releaseRepo}/releases/latest`).pipe(
-              HttpClientRequest.acceptJson,
-            ),
+            HttpClientRequest.get(
+              `https://api.github.com/repos/${AgencyDistribution.releaseRepo}/releases/latest`,
+            ).pipe(HttpClientRequest.acceptJson),
           )
           const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
           return data.tag_name.replace(/^v/, "")
@@ -249,16 +247,16 @@ export namespace Installation {
               result = yield* upgradeCurl(target)
               break
             case "npm":
-              result = yield* run(["npm", "install", "-g", `${packageName}@${target}`])
+              result = yield* run(["npm", "install", "-g", `${AgencyDistribution.packageName}@${target}`])
               break
             case "yarn":
-              result = yield* run(["yarn", "global", "add", `${packageName}@${target}`])
+              result = yield* run(["yarn", "global", "add", `${AgencyDistribution.packageName}@${target}`])
               break
             case "pnpm":
-              result = yield* run(["pnpm", "install", "-g", `${packageName}@${target}`])
+              result = yield* run(["pnpm", "install", "-g", `${AgencyDistribution.packageName}@${target}`])
               break
             case "bun":
-              result = yield* run(["bun", "install", "-g", `${packageName}@${target}`])
+              result = yield* run(["bun", "install", "-g", `${AgencyDistribution.packageName}@${target}`])
               break
             case "brew": {
               return yield* new UpgradeFailedError({

--- a/packages/opencode/test/installation/install-script.test.ts
+++ b/packages/opencode/test/installation/install-script.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from "bun:test"
 import fs from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import { AgencyDistribution } from "../../src/agency-swarm/distribution"
 
 const testDir = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(testDir, "../../../..")
@@ -23,6 +22,12 @@ function readResolvedInstallVar(name: string) {
   return readInstallVar(name).replaceAll("${REPO}", readInstallVar("REPO")).replaceAll("$CMD", readInstallVar("CMD"))
 }
 
+const expectedPackageName = "agentswarm-cli"
+const expectedReleaseRepo = "VRSEN/agentswarm-cli"
+const expectedInstallURL = "https://raw.githubusercontent.com/VRSEN/agentswarm-cli/dev/install"
+const expectedReleasesURL = "https://github.com/VRSEN/agentswarm-cli/releases"
+const expectedDocsURL = "https://agency-swarm.ai/core-framework/agencies/agent-swarm-cli"
+
 test("install script expects the release archive binary name", () => {
   const binName = Object.keys(packageJson.bin)[0]
   expect(readInstallVar("CMD")).toBe(binName)
@@ -30,11 +35,11 @@ test("install script expects the release archive binary name", () => {
 })
 
 test("install script and installation package source point at the fork package and repo", () => {
-  expect(readInstallVar("APP")).toBe(AgencyDistribution.packageName)
-  expect(packageJson.name).toBe(AgencyDistribution.packageName)
-  expect(readInstallVar("REPO")).toBe(AgencyDistribution.releaseRepo)
-  expect(readResolvedInstallVar("INSTALL_URL")).toBe(AgencyDistribution.installURL)
-  expect(readResolvedInstallVar("RELEASES_URL")).toBe(AgencyDistribution.releasesURL)
-  expect(readResolvedInstallVar("DOCS_URL")).toBe(AgencyDistribution.docsURL)
-  expect(packageJson.repository.url).toContain(`${AgencyDistribution.releaseRepo}.git`)
+  expect(packageJson.name).toBe(expectedPackageName)
+  expect(readInstallVar("APP")).toBe(expectedPackageName)
+  expect(readInstallVar("REPO")).toBe(expectedReleaseRepo)
+  expect(readResolvedInstallVar("INSTALL_URL")).toBe(expectedInstallURL)
+  expect(readResolvedInstallVar("RELEASES_URL")).toBe(expectedReleasesURL)
+  expect(readResolvedInstallVar("DOCS_URL")).toBe(expectedDocsURL)
+  expect(packageJson.repository.url).toContain(`${expectedReleaseRepo}.git`)
 })

--- a/packages/opencode/test/installation/install-script.test.ts
+++ b/packages/opencode/test/installation/install-script.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test"
 import fs from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { AgencyDistribution } from "../../src/agency-swarm/distribution"
 
 const testDir = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(testDir, "../../../..")
@@ -18,6 +19,10 @@ function readInstallVar(name: string) {
   return match![1].replace(/^"/, "").replace(/"$/, "")
 }
 
+function readResolvedInstallVar(name: string) {
+  return readInstallVar(name).replaceAll("${REPO}", readInstallVar("REPO")).replaceAll("$CMD", readInstallVar("CMD"))
+}
+
 test("install script expects the release archive binary name", () => {
   const binName = Object.keys(packageJson.bin)[0]
   expect(readInstallVar("CMD")).toBe(binName)
@@ -25,7 +30,11 @@ test("install script expects the release archive binary name", () => {
 })
 
 test("install script and installation package source point at the fork package and repo", () => {
-  expect(readInstallVar("APP")).toBe(packageJson.name)
-  expect(readInstallVar("REPO")).toBe("VRSEN/agentswarm-cli")
-  expect(packageJson.repository.url).toContain("VRSEN/agentswarm-cli.git")
+  expect(readInstallVar("APP")).toBe(AgencyDistribution.packageName)
+  expect(packageJson.name).toBe(AgencyDistribution.packageName)
+  expect(readInstallVar("REPO")).toBe(AgencyDistribution.releaseRepo)
+  expect(readResolvedInstallVar("INSTALL_URL")).toBe(AgencyDistribution.installURL)
+  expect(readResolvedInstallVar("RELEASES_URL")).toBe(AgencyDistribution.releasesURL)
+  expect(readResolvedInstallVar("DOCS_URL")).toBe(AgencyDistribution.docsURL)
+  expect(packageJson.repository.url).toContain(`${AgencyDistribution.releaseRepo}.git`)
 })

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Effect, Layer, Stream } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { AgencyDistribution } from "../../src/agency-swarm/distribution"
 import { Installation } from "../../src/installation"
 
 const encoder = new TextEncoder()
@@ -52,7 +53,7 @@ describe("installation", () => {
     test("detects curl installs from the installer directory", async () => {
       const originalExecPath = process.execPath
       Object.defineProperty(process, "execPath", {
-        value: "/Users/test/.opencode/bin/agentswarm",
+        value: `/Users/test/${AgencyDistribution.installDir}/bin/agentswarm`,
         configurable: true,
       })
 
@@ -83,7 +84,7 @@ describe("installation", () => {
         Installation.Service.use((svc) => svc.latest("unknown")).pipe(Effect.provide(layer)),
       )
       expect(result).toBe("1.2.3")
-      expect(requestURL).toBe("https://api.github.com/repos/VRSEN/agentswarm-cli/releases/latest")
+      expect(requestURL).toBe(`https://api.github.com/repos/${AgencyDistribution.releaseRepo}/releases/latest`)
     })
 
     test("strips v prefix from GitHub release tag", async () => {
@@ -112,7 +113,7 @@ describe("installation", () => {
         Installation.Service.use((svc) => svc.latest("npm")).pipe(Effect.provide(layer)),
       )
       expect(result).toBe("1.5.0")
-      expect(requestURL).toBe(`https://registry.npmjs.org/agentswarm-cli/${Installation.CHANNEL}`)
+      expect(requestURL).toBe(`https://registry.npmjs.org/${AgencyDistribution.packageName}/${Installation.CHANNEL}`)
     })
 
     test("reads npm registry versions for bun method", async () => {

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test"
 import { Effect, Layer, Stream } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
-import { AgencyDistribution } from "../../src/agency-swarm/distribution"
 import { Installation } from "../../src/installation"
 
 const encoder = new TextEncoder()
+const expectedPackageName = "agentswarm-cli"
+const expectedReleaseRepo = "VRSEN/agentswarm-cli"
+const expectedInstallDir = ".opencode"
 
 function mockHttpClient(handler: (request: HttpClientRequest.HttpClientRequest) => Response) {
   const client = HttpClient.make((request) => Effect.succeed(HttpClientResponse.fromWeb(request, handler(request))))
@@ -53,7 +55,7 @@ describe("installation", () => {
     test("detects curl installs from the installer directory", async () => {
       const originalExecPath = process.execPath
       Object.defineProperty(process, "execPath", {
-        value: `/Users/test/${AgencyDistribution.installDir}/bin/agentswarm`,
+        value: `/Users/test/${expectedInstallDir}/bin/agentswarm`,
         configurable: true,
       })
 
@@ -84,7 +86,7 @@ describe("installation", () => {
         Installation.Service.use((svc) => svc.latest("unknown")).pipe(Effect.provide(layer)),
       )
       expect(result).toBe("1.2.3")
-      expect(requestURL).toBe(`https://api.github.com/repos/${AgencyDistribution.releaseRepo}/releases/latest`)
+      expect(requestURL).toBe(`https://api.github.com/repos/${expectedReleaseRepo}/releases/latest`)
     })
 
     test("strips v prefix from GitHub release tag", async () => {
@@ -113,7 +115,7 @@ describe("installation", () => {
         Installation.Service.use((svc) => svc.latest("npm")).pipe(Effect.provide(layer)),
       )
       expect(result).toBe("1.5.0")
-      expect(requestURL).toBe(`https://registry.npmjs.org/${AgencyDistribution.packageName}/${Installation.CHANNEL}`)
+      expect(requestURL).toBe(`https://registry.npmjs.org/${expectedPackageName}/${Installation.CHANNEL}`)
     })
 
     test("reads npm registry versions for bun method", async () => {


### PR DESCRIPTION
Covers the stage 1 upstream-shape cleanup.

## Summary
- add a shared installation distribution metadata module for fork package/repo/install constants
- route installation source detection and upgrade URLs/package names through that shared metadata
- keep public contract assertions independent in the PR #135 installation regression tests

## Validation
- bun x prettier --write src/installation/index.ts src/installation/distribution.ts test/installation/install-script.test.ts test/installation/installation.test.ts
- bun test test/installation/install-script.test.ts test/installation/installation.test.ts
- bun typecheck
- git diff --check

