### PR TITLE
fix(tui): restore moved config subpaths

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/config/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui.ts
@@ -1,5 +1,3 @@
-export * as TuiConfig from "./tui"
-
 import { existsSync } from "fs"
 import z from "zod"
 import { mergeDeep, unique } from "remeda"
@@ -14,133 +12,135 @@ import { isRecord } from "@/util/record"
 import { Global } from "@/global"
 import { AgencyBrand } from "@/agency-swarm/brand"
 
-const log = Log.create({ service: "tui.config" })
+export namespace TuiConfig {
+  const log = Log.create({ service: "tui.config" })
 
-export const Info = TuiInfo
+  export const Info = TuiInfo
 
-type Acc = { result: Info }
+  type Acc = { result: Info }
 
-export type Info = z.output<typeof Info> & {
-  // Internal resolved plugin list used by runtime loading.
-  plugin_origins?: Config.PluginOrigin[]
-}
-
-function normalize(raw: Record<string, unknown>) {
-  let data = { ...raw }
-  if (isRecord(data.tui)) {
-    data = { ...data.tui, ...data }
-  }
-  delete data.tui
-  delete data.theme
-  if (isRecord(data.keybinds)) {
-    const keybinds = { ...data.keybinds }
-    delete keybinds.theme_list
-    data.keybinds = keybinds
-  }
-  return data
-}
-
-async function load(text: string, configFilepath: string): Promise<Info> {
-  const raw = await ConfigPaths.parseText(text, configFilepath, "empty")
-  if (!isRecord(raw)) return {}
-
-  const parsed = Info.safeParse(normalize(raw))
-  if (!parsed.success) {
-    log.warn("invalid tui config", { path: configFilepath, issues: parsed.error.issues })
-    return {}
+  export type Info = z.output<typeof Info> & {
+    // Internal resolved plugin list used by runtime loading.
+    plugin_origins?: Config.PluginOrigin[]
   }
 
-  const data = parsed.data
-  if (data.plugin) {
-    for (let i = 0; i < data.plugin.length; i++) {
-      data.plugin[i] = await Config.resolvePluginSpec(data.plugin[i], configFilepath)
+  function normalize(raw: Record<string, unknown>) {
+    let data = { ...raw }
+    if (isRecord(data.tui)) {
+      data = { ...data.tui, ...data }
     }
-  }
-  return data
-}
-
-async function loadFile(filepath: string): Promise<Info> {
-  const text = await ConfigPaths.readFile(filepath)
-  if (!text) return {}
-  return load(text, filepath).catch((error) => {
-    log.warn("failed to load tui config", { path: filepath, error })
-    return {}
-  })
-}
-
-async function mergeFile(acc: Acc, file: string) {
-  const data = await loadFile(file)
-  acc.result = mergeDeep(acc.result, data)
-  if (!data.plugin?.length) return
-
-  const scope: Config.PluginScope = Instance.containsPath(file) ? "local" : "global"
-  const origins = Config.deduplicatePluginOrigins([
-    ...(acc.result.plugin_origins ?? []),
-    ...data.plugin.map((spec) => ({ spec, scope, source: file })),
-  ])
-  acc.result.plugin = origins.map((item) => item.spec)
-  acc.result.plugin_origins = origins
-}
-
-function shouldLoadConfigDir(dir: string) {
-  return dir.endsWith(AgencyBrand.workspace) || dir === Flag.OPENCODE_CONFIG_DIR
-}
-
-const state = Instance.state(async () => {
-  let projectFiles = Flag.OPENCODE_DISABLE_PROJECT_CONFIG
-    ? []
-    : await ConfigPaths.projectFiles("tui", Instance.directory, Instance.worktree)
-  const directories = await ConfigPaths.directories(Instance.directory, Instance.worktree)
-  const managed = Config.managedConfigDir()
-
-  await migrateTuiConfig({
-    directories,
-    custom: Flag.OPENCODE_TUI_CONFIG,
-    managed,
-  })
-
-  projectFiles = Flag.OPENCODE_DISABLE_PROJECT_CONFIG
-    ? []
-    : await ConfigPaths.projectFiles("tui", Instance.directory, Instance.worktree)
-
-  const acc: Acc = { result: {} }
-  const files = [
-    ...ConfigPaths.fileInDirectory(Global.Path.config, "tui"),
-    ...(Flag.OPENCODE_TUI_CONFIG ? [Flag.OPENCODE_TUI_CONFIG] : []),
-    ...projectFiles,
-    ...unique(directories)
-      .filter(shouldLoadConfigDir)
-      .flatMap((dir) => ConfigPaths.fileInDirectory(dir, "tui")),
-    ...(existsSync(managed) ? ConfigPaths.fileInDirectory(managed, "tui") : []),
-  ]
-
-  for (const file of files) {
-    await mergeFile(acc, file)
-    if (file === Flag.OPENCODE_TUI_CONFIG) log.debug("loaded custom tui config", { path: file })
+    delete data.tui
+    delete data.theme
+    if (isRecord(data.keybinds)) {
+      const keybinds = { ...data.keybinds }
+      delete keybinds.theme_list
+      data.keybinds = keybinds
+    }
+    return data
   }
 
-  const keybinds = { ...(acc.result.keybinds ?? {}) }
-  if (process.platform === "win32") {
-    keybinds.terminal_suspend = "none"
-    keybinds.input_undo ??= unique(["ctrl+z", ...Config.Keybinds.shape.input_undo.parse(undefined).split(",")]).join(
-      ",",
-    )
-  }
-  acc.result.keybinds = Config.Keybinds.parse(keybinds)
+  async function load(text: string, configFilepath: string): Promise<Info> {
+    const raw = await ConfigPaths.parseText(text, configFilepath, "empty")
+    if (!isRecord(raw)) return {}
 
-  const deps = acc.result.plugin?.length
-    ? unique(directories)
+    const parsed = Info.safeParse(normalize(raw))
+    if (!parsed.success) {
+      log.warn("invalid tui config", { path: configFilepath, issues: parsed.error.issues })
+      return {}
+    }
+
+    const data = parsed.data
+    if (data.plugin) {
+      for (let i = 0; i < data.plugin.length; i++) {
+        data.plugin[i] = await Config.resolvePluginSpec(data.plugin[i], configFilepath)
+      }
+    }
+    return data
+  }
+
+  async function loadFile(filepath: string): Promise<Info> {
+    const text = await ConfigPaths.readFile(filepath)
+    if (!text) return {}
+    return load(text, filepath).catch((error) => {
+      log.warn("failed to load tui config", { path: filepath, error })
+      return {}
+    })
+  }
+
+  async function mergeFile(acc: Acc, file: string) {
+    const data = await loadFile(file)
+    acc.result = mergeDeep(acc.result, data)
+    if (!data.plugin?.length) return
+
+    const scope: Config.PluginScope = Instance.containsPath(file) ? "local" : "global"
+    const origins = Config.deduplicatePluginOrigins([
+      ...(acc.result.plugin_origins ?? []),
+      ...data.plugin.map((spec) => ({ spec, scope, source: file })),
+    ])
+    acc.result.plugin = origins.map((item) => item.spec)
+    acc.result.plugin_origins = origins
+  }
+
+  function shouldLoadConfigDir(dir: string) {
+    return dir.endsWith(AgencyBrand.workspace) || dir === Flag.OPENCODE_CONFIG_DIR
+  }
+
+  const state = Instance.state(async () => {
+    let projectFiles = Flag.OPENCODE_DISABLE_PROJECT_CONFIG
+      ? []
+      : await ConfigPaths.projectFiles("tui", Instance.directory, Instance.worktree)
+    const directories = await ConfigPaths.directories(Instance.directory, Instance.worktree)
+    const managed = Config.managedConfigDir()
+
+    await migrateTuiConfig({
+      directories,
+      custom: Flag.OPENCODE_TUI_CONFIG,
+      managed,
+    })
+
+    projectFiles = Flag.OPENCODE_DISABLE_PROJECT_CONFIG
+      ? []
+      : await ConfigPaths.projectFiles("tui", Instance.directory, Instance.worktree)
+
+    const acc: Acc = { result: {} }
+    const files = [
+      ...ConfigPaths.fileInDirectory(Global.Path.config, "tui"),
+      ...(Flag.OPENCODE_TUI_CONFIG ? [Flag.OPENCODE_TUI_CONFIG] : []),
+      ...projectFiles,
+      ...unique(directories)
         .filter(shouldLoadConfigDir)
-        .map((dir) => Config.installDependencies(dir))
-    : []
+        .flatMap((dir) => ConfigPaths.fileInDirectory(dir, "tui")),
+      ...(existsSync(managed) ? ConfigPaths.fileInDirectory(managed, "tui") : []),
+    ]
 
-  return { config: acc.result, deps }
-})
+    for (const file of files) {
+      await mergeFile(acc, file)
+      if (file === Flag.OPENCODE_TUI_CONFIG) log.debug("loaded custom tui config", { path: file })
+    }
 
-export async function get() {
-  return state().then((x) => x.config)
-}
+    const keybinds = { ...(acc.result.keybinds ?? {}) }
+    if (process.platform === "win32") {
+      keybinds.terminal_suspend = "none"
+      keybinds.input_undo ??= unique(["ctrl+z", ...Config.Keybinds.shape.input_undo.parse(undefined).split(",")]).join(
+        ",",
+      )
+    }
+    acc.result.keybinds = Config.Keybinds.parse(keybinds)
 
-export async function waitForDependencies() {
-  await Promise.all(await state().then((x) => x.deps))
+    const deps = acc.result.plugin?.length
+      ? unique(directories)
+          .filter(shouldLoadConfigDir)
+          .map((dir) => Config.installDependencies(dir))
+      : []
+
+    return { config: acc.result, deps }
+  })
+
+  export async function get() {
+    return state().then((x) => x.config)
+  }
+
+  export async function waitForDependencies() {
+    await Promise.all(await state().then((x) => x.deps))
+  }
 }

--- a/packages/opencode/src/cli/cmd/tui/config/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui.ts
@@ -1,3 +1,5 @@
+export * as TuiConfig from "./tui"
+
 import { existsSync } from "fs"
 import z from "zod"
 import { mergeDeep, unique } from "remeda"
@@ -12,135 +14,133 @@ import { isRecord } from "@/util/record"
 import { Global } from "@/global"
 import { AgencyBrand } from "@/agency-swarm/brand"
 
-export namespace TuiConfig {
-  const log = Log.create({ service: "tui.config" })
+const log = Log.create({ service: "tui.config" })
 
-  export const Info = TuiInfo
+export const Info = TuiInfo
 
-  type Acc = { result: Info }
+type Acc = { result: Info }
 
-  export type Info = z.output<typeof Info> & {
-    // Internal resolved plugin list used by runtime loading.
-    plugin_origins?: Config.PluginOrigin[]
+export type Info = z.output<typeof Info> & {
+  // Internal resolved plugin list used by runtime loading.
+  plugin_origins?: Config.PluginOrigin[]
+}
+
+function normalize(raw: Record<string, unknown>) {
+  let data = { ...raw }
+  if (isRecord(data.tui)) {
+    data = { ...data.tui, ...data }
+  }
+  delete data.tui
+  delete data.theme
+  if (isRecord(data.keybinds)) {
+    const keybinds = { ...data.keybinds }
+    delete keybinds.theme_list
+    data.keybinds = keybinds
+  }
+  return data
+}
+
+async function load(text: string, configFilepath: string): Promise<Info> {
+  const raw = await ConfigPaths.parseText(text, configFilepath, "empty")
+  if (!isRecord(raw)) return {}
+
+  const parsed = Info.safeParse(normalize(raw))
+  if (!parsed.success) {
+    log.warn("invalid tui config", { path: configFilepath, issues: parsed.error.issues })
+    return {}
   }
 
-  function normalize(raw: Record<string, unknown>) {
-    let data = { ...raw }
-    if (isRecord(data.tui)) {
-      data = { ...data.tui, ...data }
+  const data = parsed.data
+  if (data.plugin) {
+    for (let i = 0; i < data.plugin.length; i++) {
+      data.plugin[i] = await Config.resolvePluginSpec(data.plugin[i], configFilepath)
     }
-    delete data.tui
-    delete data.theme
-    if (isRecord(data.keybinds)) {
-      const keybinds = { ...data.keybinds }
-      delete keybinds.theme_list
-      data.keybinds = keybinds
-    }
-    return data
   }
+  return data
+}
 
-  async function load(text: string, configFilepath: string): Promise<Info> {
-    const raw = await ConfigPaths.parseText(text, configFilepath, "empty")
-    if (!isRecord(raw)) return {}
+async function loadFile(filepath: string): Promise<Info> {
+  const text = await ConfigPaths.readFile(filepath)
+  if (!text) return {}
+  return load(text, filepath).catch((error) => {
+    log.warn("failed to load tui config", { path: filepath, error })
+    return {}
+  })
+}
 
-    const parsed = Info.safeParse(normalize(raw))
-    if (!parsed.success) {
-      log.warn("invalid tui config", { path: configFilepath, issues: parsed.error.issues })
-      return {}
-    }
+async function mergeFile(acc: Acc, file: string) {
+  const data = await loadFile(file)
+  acc.result = mergeDeep(acc.result, data)
+  if (!data.plugin?.length) return
 
-    const data = parsed.data
-    if (data.plugin) {
-      for (let i = 0; i < data.plugin.length; i++) {
-        data.plugin[i] = await Config.resolvePluginSpec(data.plugin[i], configFilepath)
-      }
-    }
-    return data
-  }
+  const scope: Config.PluginScope = Instance.containsPath(file) ? "local" : "global"
+  const origins = Config.deduplicatePluginOrigins([
+    ...(acc.result.plugin_origins ?? []),
+    ...data.plugin.map((spec) => ({ spec, scope, source: file })),
+  ])
+  acc.result.plugin = origins.map((item) => item.spec)
+  acc.result.plugin_origins = origins
+}
 
-  async function loadFile(filepath: string): Promise<Info> {
-    const text = await ConfigPaths.readFile(filepath)
-    if (!text) return {}
-    return load(text, filepath).catch((error) => {
-      log.warn("failed to load tui config", { path: filepath, error })
-      return {}
-    })
-  }
+function shouldLoadConfigDir(dir: string) {
+  return dir.endsWith(AgencyBrand.workspace) || dir === Flag.OPENCODE_CONFIG_DIR
+}
 
-  async function mergeFile(acc: Acc, file: string) {
-    const data = await loadFile(file)
-    acc.result = mergeDeep(acc.result, data)
-    if (!data.plugin?.length) return
+const state = Instance.state(async () => {
+  let projectFiles = Flag.OPENCODE_DISABLE_PROJECT_CONFIG
+    ? []
+    : await ConfigPaths.projectFiles("tui", Instance.directory, Instance.worktree)
+  const directories = await ConfigPaths.directories(Instance.directory, Instance.worktree)
+  const managed = Config.managedConfigDir()
 
-    const scope: Config.PluginScope = Instance.containsPath(file) ? "local" : "global"
-    const origins = Config.deduplicatePluginOrigins([
-      ...(acc.result.plugin_origins ?? []),
-      ...data.plugin.map((spec) => ({ spec, scope, source: file })),
-    ])
-    acc.result.plugin = origins.map((item) => item.spec)
-    acc.result.plugin_origins = origins
-  }
-
-  function shouldLoadConfigDir(dir: string) {
-    return dir.endsWith(AgencyBrand.workspace) || dir === Flag.OPENCODE_CONFIG_DIR
-  }
-
-  const state = Instance.state(async () => {
-    let projectFiles = Flag.OPENCODE_DISABLE_PROJECT_CONFIG
-      ? []
-      : await ConfigPaths.projectFiles("tui", Instance.directory, Instance.worktree)
-    const directories = await ConfigPaths.directories(Instance.directory, Instance.worktree)
-    const managed = Config.managedConfigDir()
-
-    await migrateTuiConfig({
-      directories,
-      custom: Flag.OPENCODE_TUI_CONFIG,
-      managed,
-    })
-
-    projectFiles = Flag.OPENCODE_DISABLE_PROJECT_CONFIG
-      ? []
-      : await ConfigPaths.projectFiles("tui", Instance.directory, Instance.worktree)
-
-    const acc: Acc = { result: {} }
-    const files = [
-      ...ConfigPaths.fileInDirectory(Global.Path.config, "tui"),
-      ...(Flag.OPENCODE_TUI_CONFIG ? [Flag.OPENCODE_TUI_CONFIG] : []),
-      ...projectFiles,
-      ...unique(directories)
-        .filter(shouldLoadConfigDir)
-        .flatMap((dir) => ConfigPaths.fileInDirectory(dir, "tui")),
-      ...(existsSync(managed) ? ConfigPaths.fileInDirectory(managed, "tui") : []),
-    ]
-
-    for (const file of files) {
-      await mergeFile(acc, file)
-      if (file === Flag.OPENCODE_TUI_CONFIG) log.debug("loaded custom tui config", { path: file })
-    }
-
-    const keybinds = { ...(acc.result.keybinds ?? {}) }
-    if (process.platform === "win32") {
-      keybinds.terminal_suspend = "none"
-      keybinds.input_undo ??= unique(["ctrl+z", ...Config.Keybinds.shape.input_undo.parse(undefined).split(",")]).join(
-        ",",
-      )
-    }
-    acc.result.keybinds = Config.Keybinds.parse(keybinds)
-
-    const deps = acc.result.plugin?.length
-      ? unique(directories)
-          .filter(shouldLoadConfigDir)
-          .map((dir) => Config.installDependencies(dir))
-      : []
-
-    return { config: acc.result, deps }
+  await migrateTuiConfig({
+    directories,
+    custom: Flag.OPENCODE_TUI_CONFIG,
+    managed,
   })
 
-  export async function get() {
-    return state().then((x) => x.config)
+  projectFiles = Flag.OPENCODE_DISABLE_PROJECT_CONFIG
+    ? []
+    : await ConfigPaths.projectFiles("tui", Instance.directory, Instance.worktree)
+
+  const acc: Acc = { result: {} }
+  const files = [
+    ...ConfigPaths.fileInDirectory(Global.Path.config, "tui"),
+    ...(Flag.OPENCODE_TUI_CONFIG ? [Flag.OPENCODE_TUI_CONFIG] : []),
+    ...projectFiles,
+    ...unique(directories)
+      .filter(shouldLoadConfigDir)
+      .flatMap((dir) => ConfigPaths.fileInDirectory(dir, "tui")),
+    ...(existsSync(managed) ? ConfigPaths.fileInDirectory(managed, "tui") : []),
+  ]
+
+  for (const file of files) {
+    await mergeFile(acc, file)
+    if (file === Flag.OPENCODE_TUI_CONFIG) log.debug("loaded custom tui config", { path: file })
   }
 
-  export async function waitForDependencies() {
-    await Promise.all(await state().then((x) => x.deps))
+  const keybinds = { ...(acc.result.keybinds ?? {}) }
+  if (process.platform === "win32") {
+    keybinds.terminal_suspend = "none"
+    keybinds.input_undo ??= unique(["ctrl+z", ...Config.Keybinds.shape.input_undo.parse(undefined).split(",")]).join(
+      ",",
+    )
   }
+  acc.result.keybinds = Config.Keybinds.parse(keybinds)
+
+  const deps = acc.result.plugin?.length
+    ? unique(directories)
+        .filter(shouldLoadConfigDir)
+        .map((dir) => Config.installDependencies(dir))
+    : []
+
+  return { config: acc.result, deps }
+})
+
+export async function get() {
+  return state().then((x) => x.config)
+}
+
+export async function waitForDependencies() {
+  await Promise.all(await state().then((x) => x.deps))
 }

--- a/packages/opencode/src/config/tui-migrate.ts
+++ b/packages/opencode/src/config/tui-migrate.ts
@@ -1,0 +1,1 @@
+export * from "../cli/cmd/tui/config/tui-migrate"

--- a/packages/opencode/src/config/tui-schema.ts
+++ b/packages/opencode/src/config/tui-schema.ts
@@ -1,0 +1,1 @@
+export * from "../cli/cmd/tui/config/tui-schema"

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -1,0 +1,1 @@
+export * from "../cli/cmd/tui/config/tui"

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test } from "bun:test"
+import { afterEach, beforeEach, expect, spyOn, test } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
 import { tmpdir } from "../fixture/fixture"
@@ -124,6 +124,35 @@ test("loads tui config with the same precedence order as server config paths", a
       expect(config.diff_style).toBe("stacked")
     },
   })
+})
+
+test("keeps TuiConfig mutable for spies from the refactored import path", async () => {
+  const get = spyOn(TuiConfig, "get").mockResolvedValue({ scroll_speed: 9 })
+  const wait = spyOn(TuiConfig, "waitForDependencies").mockResolvedValue()
+
+  try {
+    await expect(TuiConfig.get()).resolves.toEqual({ scroll_speed: 9 })
+    await expect(TuiConfig.waitForDependencies()).resolves.toBeUndefined()
+  } finally {
+    get.mockRestore()
+    wait.mockRestore()
+  }
+})
+
+test("preserves config/tui* deep import shims", async () => {
+  const current = await import("../../src/cli/cmd/tui/config/tui")
+  const legacy = await import("../../src/config/tui")
+  const currentSchema = await import("../../src/cli/cmd/tui/config/tui-schema")
+  const legacySchema = await import("../../src/config/tui-schema")
+  const currentMigrate = await import("../../src/cli/cmd/tui/config/tui-migrate")
+  const legacyMigrate = await import("../../src/config/tui-migrate")
+
+  expect(legacy.TuiConfig.get).toBe(current.TuiConfig.get)
+  expect(legacy.TuiConfig.waitForDependencies).toBe(current.TuiConfig.waitForDependencies)
+  expect(legacy.TuiConfig.Info).toBe(current.TuiConfig.Info)
+  expect(legacySchema.TuiInfo).toBe(currentSchema.TuiInfo)
+  expect(legacySchema.TuiOptions).toBe(currentSchema.TuiOptions)
+  expect(legacyMigrate.migrateTuiConfig).toBe(currentMigrate.migrateTuiConfig)
 })
 
 test("migrates tui-specific keys from opencode.json when tui.json does not exist", async () => {

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, spyOn, test } from "bun:test"
+import { afterEach, beforeEach, expect, test } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
 import { tmpdir } from "../fixture/fixture"
@@ -126,30 +126,16 @@ test("loads tui config with the same precedence order as server config paths", a
   })
 })
 
-test("keeps TuiConfig mutable for spies from the refactored import path", async () => {
-  const get = spyOn(TuiConfig, "get").mockResolvedValue({ scroll_speed: 9 })
-  const wait = spyOn(TuiConfig, "waitForDependencies").mockResolvedValue()
-
-  try {
-    await expect(TuiConfig.get()).resolves.toEqual({ scroll_speed: 9 })
-    await expect(TuiConfig.waitForDependencies()).resolves.toBeUndefined()
-  } finally {
-    get.mockRestore()
-    wait.mockRestore()
-  }
-})
-
-test("preserves config/tui* deep import shims", async () => {
+test("preserves public config/tui* package subpaths after the config move", async () => {
   const current = await import("../../src/cli/cmd/tui/config/tui")
-  const legacy = await import("../../src/config/tui")
+  const legacy = await import("agentswarm-cli/config/tui")
   const currentSchema = await import("../../src/cli/cmd/tui/config/tui-schema")
-  const legacySchema = await import("../../src/config/tui-schema")
+  const legacySchema = await import("agentswarm-cli/config/tui-schema")
   const currentMigrate = await import("../../src/cli/cmd/tui/config/tui-migrate")
-  const legacyMigrate = await import("../../src/config/tui-migrate")
+  const legacyMigrate = await import("agentswarm-cli/config/tui-migrate")
 
   expect(legacy.TuiConfig.get).toBe(current.TuiConfig.get)
   expect(legacy.TuiConfig.waitForDependencies).toBe(current.TuiConfig.waitForDependencies)
-  expect(legacy.TuiConfig.Info).toBe(current.TuiConfig.Info)
   expect(legacySchema.TuiInfo).toBe(currentSchema.TuiInfo)
   expect(legacySchema.TuiOptions).toBe(currentSchema.TuiOptions)
   expect(legacyMigrate.migrateTuiConfig).toBe(currentMigrate.migrateTuiConfig)


### PR DESCRIPTION
### Issue for this PR

Closes #123

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PR #138 moved TUI config implementation files from `src/config/tui*` to `src/cli/cmd/tui/config/tui*` to match upstream layout. The package export map still exposes `./*` as `./src/*.ts`, so the old public package subpaths `agentswarm-cli/config/tui`, `agentswarm-cli/config/tui-schema`, and `agentswarm-cli/config/tui-migrate` stopped resolving.

This PR keeps the upstream-shaped TUI config implementation and adds only three one-line compatibility shims at the old paths. It also adds a focused test proving the public package subpaths re-export the moved modules.

### How did you verify your code works?

- `cd packages/opencode && bun run test test/config/tui.test.ts`
- `cd packages/opencode && bun typecheck`
- `git diff --check`

### Screenshots / recordings

N/A. This is import-path compatibility only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR