### PR TITLE
fix(tui): harden run mode after upstream alignment

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -216,7 +216,7 @@ export function DialogAgent() {
 
   return (
     <DialogSelect
-      title={agencySwarmEnabled() ? "Select agency-swarm target" : "Select agent"}
+      title={agencySwarmEnabled() ? "Select swarm" : "Select agent"}
       current={current()}
       options={options()}
       onSelect={(option) => {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -143,14 +143,14 @@ export function DialogAgent() {
 
     const agencies = discovered?.agencies ?? []
     for (const agency of agencies) {
-      const category = `Agency: ${agency.id}`
+      const category = `Agency: ${agency.name}`
       result.push({
         value: {
           kind: "agency",
           agency: agency.id,
         },
-        title: agency.id,
-        description: agency.description || `Use ${agency.name}`,
+        title: agency.name,
+        description: agency.description,
         category,
       })
       for (const recipient of agency.agents) {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -15,7 +15,11 @@ import { useKeyboard } from "@opentui/solid"
 import * as Clipboard from "@tui/util/clipboard"
 import { useToast } from "../ui/toast"
 import { CONSOLE_MANAGED_ICON, isConsoleManagedProvider } from "@tui/util/provider-origin"
-import { getVisibleProviderAuthMethods, hasStoredProviderCredential } from "@tui/util/provider-auth"
+import {
+  getStoredProviderAuthMethod,
+  getVisibleProviderAuthMethods,
+  hasStoredProviderCredential,
+} from "@tui/util/provider-auth"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { isAgencySwarmFrameworkMode, isSupportedAgencyAuthProvider } from "../session-error"
 import { errorMessage as toErrorMessage } from "@/util/error"
@@ -83,15 +87,24 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
         const consoleManaged = isConsoleManagedProvider(sync.data.console_state.consoleManagedProviders, provider.id)
         const connected = sync.data.provider_next.connected.includes(provider.id)
 
-        return {
-          title: provider.name,
-          value: provider.id,
-          description: {
+        const storedAuthMethod = connected ? getStoredProviderAuthMethod(provider) : undefined
+        const description = ((): string | undefined => {
+          if (provider.id === "openai" && storedAuthMethod) {
+            if (storedAuthMethod === "oauth") return "(Browser sign-in)"
+            if (storedAuthMethod === "api") return "(API key)"
+            if (storedAuthMethod === "env") return "(API key from env)"
+          }
+          return {
             opencode: "(Recommended)",
             anthropic: "(API key)",
             openai: "(Browser sign-in or API key)",
             "opencode-go": "Low cost subscription for everyone",
-          }[provider.id],
+          }[provider.id]
+        })()
+        return {
+          title: provider.name,
+          value: provider.id,
+          description,
           footer: consoleManaged ? sync.data.console_state.activeOrgName : undefined,
           category: provider.id in PROVIDER_PRIORITY ? "Popular" : "Other",
           gutter: consoleManaged ? (

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -224,7 +224,6 @@ export function Prompt(props: PromptProps) {
           agency: options.agency,
           currentRecipient: options.recipientAgent,
           assistantAgent: info.agent,
-          completed: !!info.time.completed,
         })
       ) {
         return

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -1,11 +1,13 @@
 import { createMemo } from "solid-js"
 import { useSync } from "@tui/context/sync"
-import { DialogSelect } from "@tui/ui/dialog-select"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
 import { useSDK } from "@tui/context/sdk"
+import { useLocal } from "@tui/context/local"
 import { useRoute } from "@tui/context/route"
 import * as Clipboard from "@tui/util/clipboard"
 import type { PromptInfo } from "@tui/component/prompt/history"
 import { strip } from "@tui/component/prompt/part"
+import { isAgencySwarmFrameworkMode } from "../../session-error"
 
 export function DialogMessage(props: {
   messageID: string
@@ -14,44 +16,52 @@ export function DialogMessage(props: {
 }) {
   const sync = useSync()
   const sdk = useSDK()
+  const local = useLocal()
   const message = createMemo(() => sync.data.message[props.sessionID]?.find((x) => x.id === props.messageID))
   const route = useRoute()
+  const frameworkMode = isAgencySwarmFrameworkMode({
+    currentProviderID: local.model.current()?.providerID,
+    configuredModel: sync.data.config.model,
+    agentModel: local.agent.current()?.model,
+  })
+
+  const revertOption: DialogSelectOption<string> = {
+    title: "Revert",
+    value: "session.revert",
+    description: "undo messages and file changes",
+    onSelect: (dialog) => {
+      const msg = message()
+      if (!msg) return
+
+      void sdk.client.session.revert({
+        sessionID: props.sessionID,
+        messageID: msg.id,
+      })
+
+      if (props.setPrompt) {
+        const parts = sync.data.part[msg.id]
+        const promptInfo = parts.reduce(
+          (agg, part) => {
+            if (part.type === "text") {
+              if (!part.synthetic) agg.input += part.text
+            }
+            if (part.type === "file") agg.parts.push(strip(part))
+            return agg
+          },
+          { input: "", parts: [] as PromptInfo["parts"] },
+        )
+        props.setPrompt(promptInfo)
+      }
+
+      dialog.clear()
+    },
+  }
 
   return (
     <DialogSelect
       title="Message Actions"
       options={[
-        {
-          title: "Revert",
-          value: "session.revert",
-          description: "undo messages and file changes",
-          onSelect: (dialog) => {
-            const msg = message()
-            if (!msg) return
-
-            void sdk.client.session.revert({
-              sessionID: props.sessionID,
-              messageID: msg.id,
-            })
-
-            if (props.setPrompt) {
-              const parts = sync.data.part[msg.id]
-              const promptInfo = parts.reduce(
-                (agg, part) => {
-                  if (part.type === "text") {
-                    if (!part.synthetic) agg.input += part.text
-                  }
-                  if (part.type === "file") agg.parts.push(strip(part))
-                  return agg
-                },
-                { input: "", parts: [] as PromptInfo["parts"] },
-              )
-              props.setPrompt(promptInfo)
-            }
-
-            dialog.clear()
-          },
-        },
+        ...(frameworkMode ? [] : [revertOption]),
         {
           title: "Copy",
           value: "message.copy",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -527,6 +527,8 @@ export function Session() {
       value: "session.undo",
       keybind: "messages_undo",
       category: "Session",
+      enabled: !frameworkMode(),
+      hidden: frameworkMode(),
       slash: {
         name: "undo",
       },
@@ -565,7 +567,8 @@ export function Session() {
       value: "session.redo",
       keybind: "messages_redo",
       category: "Session",
-      enabled: !!session()?.revert?.messageID,
+      enabled: !!session()?.revert?.messageID && !frameworkMode(),
+      hidden: frameworkMode(),
       slash: {
         name: "redo",
       },

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -109,9 +109,10 @@ export function isSupportedAgencyAuthProvider(
 }
 
 function isAgencyProviderCredentialFailure(message: string) {
-  return /missing provider credentials|client_config|invalid api key|api key rejected|authentication failed|auth failed|access token/i.test(
-    message,
-  )
+  if (/missing provider credentials|client_config|authentication failed|auth failed|access token/i.test(message)) {
+    return true
+  }
+  return describeStreamAuthError(message) !== null
 }
 
 function hasSupportedAgencyCredential(
@@ -286,7 +287,7 @@ export function describeStreamAuthError(message: string): string | null {
     hasEnvVarHint ||
     (/\bAuthenticationError\b/i.test(message) && /\bMissing\b/i.test(message) && Boolean(provider))
   const isRejected =
-    /incorrect_api_key|invalid_api_key|Invalid API key for\s+\w[\w-]+|api key rejected/i.test(message) && !isMissing
+    /incorrect_api_key|invalid_api_key|Invalid API key|incorrect api key|api key rejected/i.test(message) && !isMissing
 
   if (isMissing) {
     return provider ? `${provider} API key required. Run /auth to add it.` : "Missing API key. Run /auth to add it."

--- a/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
@@ -125,10 +125,8 @@ export function shouldAdoptAgencyHandoffRecipient(input: {
   agency?: string
   currentRecipient?: string
   assistantAgent?: string
-  completed?: boolean
 }) {
   if (!input.frameworkMode) return false
-  if (!input.completed) return false
   if (!input.agency) return false
   if (!input.assistantAgent) return false
   if (input.assistantAgent === "build") return false

--- a/packages/opencode/src/cli/cmd/tui/util/provider-auth.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/provider-auth.ts
@@ -1,5 +1,9 @@
 import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
 
+export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
+
+export type StoredProviderAuthMethod = "oauth" | "api" | "env" | "config"
+
 export function hasStoredProviderCredential(
   providers: Provider[],
   _methods: Record<string, ProviderAuthMethod[]>,
@@ -24,4 +28,17 @@ export function getVisibleProviderAuthMethods(
     return methods.filter((item) => !(item.type === "oauth" && /headless/i.test(item.label)))
   }
   return methods.filter((item) => item.type === "api")
+}
+
+export function getStoredProviderAuthMethod(provider: Provider): StoredProviderAuthMethod | undefined {
+  if (provider.source === "api") return "api"
+  if (provider.source === "env" && (provider.env?.length ?? 0) > 0) return "env"
+  if (provider.source === "config") return "config"
+  if (provider.source === "custom") {
+    const options = provider.options ?? {}
+    if (provider.id === "opencode" && options["apiKey"] === "public") return undefined
+    if (options["apiKey"] === OAUTH_DUMMY_KEY) return "oauth"
+    if (Object.keys(options).length > 0) return "oauth"
+  }
+  return undefined
 }

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1503,7 +1503,18 @@ export namespace SessionAgencySwarm {
 
       const history = await AgencySwarmHistory.load(scope)
       const chatHistory = await Session.messages({ sessionID: input.sessionID })
-        .then((msgs) => compactHistory({ msgs, currentID: input.userMessage.info.id }) ?? history.chat_history)
+        .then((msgs) => {
+          const compacted = compactHistory({ msgs, currentID: input.userMessage.info.id })
+          if (compacted) return compacted
+          // Forked sessions clone local messages but get a fresh AgencySwarmHistory key, so the bridge
+          // would otherwise start with no context. Rebuild from the cloned messages when stored history
+          // is empty and prior messages are all agency-swarm.
+          if (history.chat_history.length === 0) {
+            const rebuilt = buildAgencyHistoryFromMessages({ msgs, currentID: input.userMessage.info.id })
+            if (rebuilt && rebuilt.length > 0) return rebuilt
+          }
+          return history.chat_history
+        })
         .catch((error) => {
           log.warn("unable to rebuild compacted agency history; falling back to stored history", {
             sessionID: input.sessionID,
@@ -2025,42 +2036,56 @@ export namespace SessionAgencySwarm {
     const slice = input.msgs.slice(start < 0 ? 0 : start)
     if (slice.some((msg) => msg.info.id !== input.currentID && !isAgencySwarmMessage(msg))) return
 
-    return slice.flatMap((msg) => {
-      if (msg.info.id === input.currentID) return []
+    return slice.flatMap((msg) => messageToHistoryItem(msg, input.currentID))
+  }
 
-      if (msg.info.role === "user") {
-        const text = buildOutgoingMessage(msg)
-        if (!text) return []
-        return [
-          {
-            type: "message",
-            role: "user",
-            content: [{ type: "input_text", text }],
-            agent: msg.info.agent,
-            callerAgent: null,
-            timestamp: msg.info.time.created,
-          },
-        ]
-      }
+  /**
+   * Rebuild bridge chat_history from local session messages. Used as a fallback when
+   * `AgencySwarmHistory` has no entry for the session (e.g. a forked session whose new sessionID
+   * never streamed before). Returns undefined when the prior messages are not all agency-swarm,
+   * to avoid sending mismatched-shape items into the bridge.
+   */
+  export function buildAgencyHistoryFromMessages(input: { msgs: MessageV2.WithParts[]; currentID: string }) {
+    if (input.msgs.length <= 1) return undefined
+    if (input.msgs.some((msg) => msg.info.id !== input.currentID && !isAgencySwarmMessage(msg))) return undefined
+    return input.msgs.flatMap((msg) => messageToHistoryItem(msg, input.currentID))
+  }
 
-      const text = msg.parts
-        .filter((part): part is MessageV2.TextPart => part.type === "text")
-        .filter((part) => !part.ignored)
-        .map((part) => part.text.trim())
-        .filter(Boolean)
-        .join("\n\n")
+  function messageToHistoryItem(msg: MessageV2.WithParts, currentID: string) {
+    if (msg.info.id === currentID) return []
+
+    if (msg.info.role === "user") {
+      const text = buildOutgoingMessage(msg)
       if (!text) return []
       return [
         {
           type: "message",
-          role: "assistant",
-          content: [{ type: "output_text", text }],
+          role: "user",
+          content: [{ type: "input_text", text }],
           agent: msg.info.agent,
-          callerAgent: extractCallerAgent(msg),
+          callerAgent: null,
           timestamp: msg.info.time.created,
         },
       ]
-    })
+    }
+
+    const text = msg.parts
+      .filter((part): part is MessageV2.TextPart => part.type === "text")
+      .filter((part) => !part.ignored)
+      .map((part) => part.text.trim())
+      .filter(Boolean)
+      .join("\n\n")
+    if (!text) return []
+    return [
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text }],
+        agent: msg.info.agent,
+        callerAgent: extractCallerAgent(msg),
+        timestamp: msg.info.time.created,
+      },
+    ]
   }
 
   function extractCallerAgent(msg: MessageV2.WithParts): string | null {

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -37,36 +37,44 @@ describe("agency target options", () => {
     })
   })
 
-  test("adopts completed handoff agent as selected run target", () => {
+  test("adopts handoff agent as soon as the assistant message reports a new agent", () => {
     expect(
       shouldAdoptAgencyHandoffRecipient({
         frameworkMode: true,
         agency: "my-agency",
         currentRecipient: "ExampleAgent",
         assistantAgent: "ExampleAgent2",
-        completed: true,
       }),
     ).toBe(true)
   })
 
-  test("does not adopt incomplete or unchanged handoff agent", () => {
-    expect(
-      shouldAdoptAgencyHandoffRecipient({
-        frameworkMode: true,
-        agency: "my-agency",
-        currentRecipient: "ExampleAgent",
-        assistantAgent: "ExampleAgent2",
-        completed: false,
-      }),
-    ).toBe(false)
+  test("does not re-adopt when agent is unchanged or matches build", () => {
     expect(
       shouldAdoptAgencyHandoffRecipient({
         frameworkMode: true,
         agency: "my-agency",
         currentRecipient: "ExampleAgent",
         assistantAgent: "ExampleAgent",
-        completed: true,
       }),
     ).toBe(false)
+    expect(
+      shouldAdoptAgencyHandoffRecipient({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "ExampleAgent",
+        assistantAgent: "build",
+      }),
+    ).toBe(false)
+  })
+
+  test("requires framework mode, agency context, and an assistant agent", () => {
+    const base = {
+      agency: "my-agency",
+      currentRecipient: "ExampleAgent",
+      assistantAgent: "ExampleAgent2",
+    }
+    expect(shouldAdoptAgencyHandoffRecipient({ frameworkMode: false, ...base })).toBe(false)
+    expect(shouldAdoptAgencyHandoffRecipient({ frameworkMode: true, ...base, agency: undefined })).toBe(false)
+    expect(shouldAdoptAgencyHandoffRecipient({ frameworkMode: true, ...base, assistantAgent: undefined })).toBe(false)
   })
 })

--- a/packages/opencode/test/cli/tui/provider-auth.test.ts
+++ b/packages/opencode/test/cli/tui/provider-auth.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "bun:test"
-import { getVisibleProviderAuthMethods, hasStoredProviderCredential } from "../../../src/cli/cmd/tui/util/provider-auth"
+import {
+  getStoredProviderAuthMethod,
+  getVisibleProviderAuthMethods,
+  hasStoredProviderCredential,
+  OAUTH_DUMMY_KEY,
+} from "../../../src/cli/cmd/tui/util/provider-auth"
 
 test("detects stored api credentials", () => {
   expect(
@@ -151,4 +156,69 @@ test("keeps only API auth methods for non-openai providers in agency-swarm frame
       { frameworkMode: true },
     ),
   ).toEqual([{ type: "api", label: "API key" }])
+})
+
+test("getStoredProviderAuthMethod returns 'api' for stored API key", () => {
+  expect(
+    getStoredProviderAuthMethod({
+      id: "openai",
+      name: "OpenAI",
+      source: "api",
+      env: [],
+      options: {},
+      models: {},
+    }),
+  ).toBe("api")
+})
+
+test("getStoredProviderAuthMethod returns 'env' for env-backed providers", () => {
+  expect(
+    getStoredProviderAuthMethod({
+      id: "openai",
+      name: "OpenAI",
+      source: "env",
+      env: ["OPENAI_API_KEY"],
+      options: {},
+      models: {},
+    }),
+  ).toBe("env")
+})
+
+test("getStoredProviderAuthMethod returns 'oauth' for OAUTH_DUMMY_KEY-marked custom providers", () => {
+  expect(
+    getStoredProviderAuthMethod({
+      id: "openai",
+      name: "OpenAI",
+      source: "custom",
+      env: [],
+      options: { apiKey: OAUTH_DUMMY_KEY },
+      models: {},
+    }),
+  ).toBe("oauth")
+})
+
+test("getStoredProviderAuthMethod returns undefined for opencode public mode", () => {
+  expect(
+    getStoredProviderAuthMethod({
+      id: "opencode",
+      name: "OpenCode",
+      source: "custom",
+      env: [],
+      options: { apiKey: "public" },
+      models: {},
+    }),
+  ).toBeUndefined()
+})
+
+test("getStoredProviderAuthMethod returns undefined for empty custom options", () => {
+  expect(
+    getStoredProviderAuthMethod({
+      id: "openai",
+      name: "OpenAI",
+      source: "custom",
+      env: [],
+      options: {},
+      models: {},
+    }),
+  ).toBeUndefined()
 })

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -963,6 +963,31 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
+  test("routes spaced 'Incorrect API key' upstream errors to auth", () => {
+    const message = "Streaming request failed (401): Incorrect API key provided: sk-***"
+    expect(shouldOpenAgencyConnectDialog({ providerID: "agency-swarm", message })).toBe(false)
+    expect(shouldOpenAgencyAuthDialog({ providerID: "agency-swarm", message })).toBe(true)
+  })
+
+  test("routes invalid_api_key error code upstream errors to auth", () => {
+    const message = 'Streaming request failed (401): {"error":{"code":"invalid_api_key","message":"Incorrect API key"}}'
+    expect(shouldOpenAgencyConnectDialog({ providerID: "agency-swarm", message })).toBe(false)
+    expect(shouldOpenAgencyAuthDialog({ providerID: "agency-swarm", message })).toBe(true)
+  })
+
+  test("routes litellm AuthenticationError upstream errors to auth", () => {
+    const message =
+      "Streaming request failed (500): litellm.AuthenticationError: AuthenticationError: OpenAIException - Incorrect API key provided"
+    expect(shouldOpenAgencyConnectDialog({ providerID: "agency-swarm", message })).toBe(false)
+    expect(shouldOpenAgencyAuthDialog({ providerID: "agency-swarm", message })).toBe(true)
+  })
+
+  test("routes Missing API key env-var hints to auth", () => {
+    const message = "Streaming request failed (401): Please set OPENAI_API_KEY before retrying."
+    expect(shouldOpenAgencyConnectDialog({ providerID: "agency-swarm", message })).toBe(false)
+    expect(shouldOpenAgencyAuthDialog({ providerID: "agency-swarm", message })).toBe(true)
+  })
+
   test("describes missing agency provider credentials with /auth add guidance", () => {
     expect(
       describeAgencyAuthFailure("Streaming request failed (401): Missing provider credentials in client_config"),
@@ -1053,6 +1078,16 @@ describe("describeStreamAuthError", () => {
     expect(describeStreamAuthError(msg)).toBe("API key rejected. Run /auth to update it.")
   })
 
+  test("detects rejected key via spaced 'Incorrect API key' phrasing", () => {
+    expect(describeStreamAuthError("Streaming request failed (401): Incorrect API key provided: sk-***")).toBe(
+      "API key rejected. Run /auth to update it.",
+    )
+  })
+
+  test("detects rejected key via bare 'Invalid API key' without provider", () => {
+    expect(describeStreamAuthError("Error: Invalid API key")).toBe("API key rejected. Run /auth to update it.")
+  })
+
   test("detects rejected key via LiteLLM AuthenticationError marker", () => {
     const msg = "litellm.AuthenticationError: API key rejected by upstream"
     expect(describeStreamAuthError(msg)).toBe("API key rejected. Run /auth to update it.")
@@ -1069,8 +1104,7 @@ describe("describeStreamAuthError", () => {
   })
 
   test("prioritizes missing over rejected when both patterns appear", () => {
-    const msg =
-      'litellm.AuthenticationError: Missing Anthropic API Key {"error":{"code":"invalid_api_key"}}'
+    const msg = 'litellm.AuthenticationError: Missing Anthropic API Key {"error":{"code":"invalid_api_key"}}'
     expect(describeStreamAuthError(msg)).toBe("anthropic API key required. Run /auth to add it.")
   })
 })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -2447,6 +2447,111 @@ describe("session.agency-swarm", () => {
     expect(SessionAgencySwarm.compactHistory({ msgs, currentID: "current" })).toBeUndefined()
   })
 
+  test("buildAgencyHistoryFromMessages rebuilds bridge history from cloned messages", () => {
+    const msgs = [
+      {
+        info: {
+          id: "user_1",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 1 },
+        },
+        parts: [{ type: "text", text: "first question", ignored: false }],
+      },
+      {
+        info: {
+          id: "assistant_1",
+          role: "assistant",
+          parentID: "user_1",
+          providerID: "agency-swarm",
+          modelID: "default",
+          mode: "Default",
+          agent: "Reviewer",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: 2 },
+          sessionID: "session_1",
+        },
+        parts: [{ type: "text", text: "first answer" }],
+      },
+      {
+        info: {
+          id: "current",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 3 },
+        },
+        parts: [{ type: "text", text: "follow up", ignored: false }],
+      },
+    ] as any
+
+    expect(SessionAgencySwarm.buildAgencyHistoryFromMessages({ msgs, currentID: "current" })).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "first question" }],
+        agent: "build",
+        callerAgent: null,
+        timestamp: 1,
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "first answer" }],
+        agent: "Reviewer",
+        callerAgent: null,
+        timestamp: 2,
+      },
+    ])
+  })
+
+  test("buildAgencyHistoryFromMessages returns undefined when only the current user message exists", () => {
+    const msgs = [
+      {
+        info: {
+          id: "current",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 1 },
+        },
+        parts: [{ type: "text", text: "first prompt", ignored: false }],
+      },
+    ] as any
+
+    expect(SessionAgencySwarm.buildAgencyHistoryFromMessages({ msgs, currentID: "current" })).toBeUndefined()
+  })
+
+  test("buildAgencyHistoryFromMessages bails out when prior messages are not all agency-swarm", () => {
+    const msgs = [
+      {
+        info: {
+          id: "user_1",
+          role: "user",
+          agent: "build",
+          model: { providerID: "openai", modelID: "gpt-5" },
+          time: { created: 1 },
+        },
+        parts: [{ type: "text", text: "openai prompt", ignored: false }],
+      },
+      {
+        info: {
+          id: "current",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 2 },
+        },
+        parts: [{ type: "text", text: "follow up", ignored: false }],
+      },
+    ] as any
+
+    expect(SessionAgencySwarm.buildAgencyHistoryFromMessages({ msgs, currentID: "current" })).toBeUndefined()
+  })
+
   test("stream resolves configured recipient alias to live agent id from metadata", async () => {
     mockHistory()
     let sentRecipient: string | undefined
@@ -2619,6 +2724,98 @@ describe("session.agency-swarm", () => {
     }
 
     expect(sentHistory).toEqual(storedHistory)
+  })
+
+  test("stream rebuilds chat history from cloned messages when bridge history is empty", async () => {
+    const clonedAgencyMessages = [
+      {
+        info: {
+          id: "user_clone_1",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 1 },
+        },
+        parts: [{ type: "text", text: "before fork", ignored: false }],
+      },
+      {
+        info: {
+          id: "assistant_clone_1",
+          role: "assistant",
+          parentID: "user_clone_1",
+          providerID: "agency-swarm",
+          modelID: "default",
+          mode: "Default",
+          agent: "Reviewer",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: 2 },
+          sessionID: "session_1",
+        },
+        parts: [{ type: "text", text: "answer before fork" }],
+      },
+      {
+        info: {
+          id: "message_user_1",
+          role: "user",
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+          time: { created: 3 },
+        },
+        parts: [{ type: "text", text: "follow up after fork", ignored: false }],
+      },
+    ] as any
+
+    let sentHistory: unknown
+    AgencySwarmHistory.load = (async () => ({
+      scope: "http://127.0.0.1:8000|builder|session_1",
+      chat_history: [],
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.load
+    AgencySwarmHistory.appendMessages = (async () => ({
+      scope: "scope",
+      chat_history: [],
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.appendMessages
+    AgencySwarmHistory.setLastRunID = (async () => ({
+      scope: "scope",
+      chat_history: [],
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.setLastRunID
+    AgencySwarmAdapter.streamRun = async function* (args) {
+      sentHistory = args.chatHistory
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const messagesSpy = spyOn(Session, "messages").mockResolvedValue(clonedAgencyMessages)
+    try {
+      const { input } = helper()
+      const stream = await SessionAgencySwarm.stream(input)
+      for await (const _ of stream.fullStream) {
+      }
+    } finally {
+      messagesSpy.mockRestore()
+    }
+
+    expect(sentHistory).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "before fork" }],
+        agent: "build",
+        callerAgent: null,
+        timestamp: 1,
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "answer before fork" }],
+        agent: "Reviewer",
+        callerAgent: null,
+        timestamp: 2,
+      },
+    ])
   })
 
   test("stream persists handed off recipient from session history", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #149

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the post-upstream Run-mode TUI behaviors that are already reproduced or evidence-backed in this branch:

- Shows agency display names in the run-target picker and shortens the dialog title to `Select swarm`.
- Rebuilds Agency Swarm bridge history for forked sessions when local messages were cloned but bridge history is empty.
- Updates the selected recipient as soon as an Agency Swarm handoff/delegation changes the active assistant agent.
- Sends OpenAI/LiteLLM credential failures to `/auth` instead of `/connect`.
- Shows the active OpenAI auth method in `/auth`.
- Hides/disables Revert, undo, and redo in Run mode.

Not fixed here:

- Duplicated final responses are still unreproduced.
- Queued-message cancellation needs a separate product decision because it is not restored upstream behavior.
- Reauth during active chat is still unreproduced and needs a UX decision before changing behavior.
- Browser-auth handoff `rs_...` errors need a separate root-cause pass. The previous `previous_response_id` explanation is not treated as proven and is not part of this PR.

### How did you verify your code works?

- `cd packages/opencode && bun typecheck`
- `cd packages/opencode && bun test test/cli/tui test/session/agency-swarm.test.ts`
- `bun turbo test:ci`
- Codex GPT-5.5 medium independent review found no valid branch regressions.
- Claude Opus max review returned no findings, but high-risk unresolved claims are not relying on Claude alone.

### Screenshots / recordings

Manual TUI QA is still requested from the team on this PR.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
