### PR TITLE
fix(tui): cancel queued Run-mode prompts; protect streams on reauth

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -20,6 +20,7 @@ import {
   getVisibleProviderAuthMethods,
   hasStoredProviderCredential,
 } from "@tui/util/provider-auth"
+import { refreshAfterProviderAuth } from "@tui/util/provider-auth-refresh"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { isAgencySwarmFrameworkMode, isSupportedAgencyAuthProvider } from "../session-error"
 import { errorMessage as toErrorMessage } from "@/util/error"
@@ -251,8 +252,11 @@ function DialogRemoveCredential() {
           await sdk.client.auth.remove({
             providerID: provider.id,
           })
-          await sdk.client.instance.dispose()
-          await sync.bootstrap()
+          await refreshAfterProviderAuth({
+            sessionStatus: sync.data.session_status,
+            dispose: () => sdk.client.instance.dispose(),
+            bootstrap: () => sync.bootstrap(),
+          })
           toast.show({
             variant: "success",
             message: `${provider.name} credential removed`,
@@ -576,8 +580,11 @@ export function DialogAgencySwarmConnect() {
       },
       { throwOnError: true },
     )
-    await sdk.client.instance.dispose()
-    await sync.bootstrap()
+    await refreshAfterProviderAuth({
+      sessionStatus: sync.data.session_status,
+      dispose: () => sdk.client.instance.dispose(),
+      bootstrap: () => sync.bootstrap(),
+    })
     dialog.clear()
     toast.show({
       variant: "success",
@@ -623,8 +630,13 @@ export function DialogAgencySwarmConnect() {
               },
             })
             .then(clearConfigToken)
-            .then(() => sdk.client.instance.dispose())
-            .then(() => sync.bootstrap())
+            .then(() =>
+              refreshAfterProviderAuth({
+                sessionStatus: sync.data.session_status,
+                dispose: () => sdk.client.instance.dispose(),
+                bootstrap: () => sync.bootstrap(),
+              }),
+            )
             .then(() => {
               toast.show({
                 variant: "success",
@@ -645,8 +657,13 @@ export function DialogAgencySwarmConnect() {
         providerID: AgencySwarmAdapter.PROVIDER_ID,
       })
       .then(clearConfigToken)
-      .then(() => sdk.client.instance.dispose())
-      .then(() => sync.bootstrap())
+      .then(() =>
+        refreshAfterProviderAuth({
+          sessionStatus: sync.data.session_status,
+          dispose: () => sdk.client.instance.dispose(),
+          bootstrap: () => sync.bootstrap(),
+        }),
+      )
       .then(() => {
         toast.show({
           variant: "success",
@@ -807,8 +824,11 @@ function AutoMethod(props: AutoMethodProps) {
       return
     }
     try {
-      await sdk.client.instance.dispose()
-      await sync.bootstrap()
+      await refreshAfterProviderAuth({
+        sessionStatus: sync.data.session_status,
+        dispose: () => sdk.client.instance.dispose(),
+        bootstrap: () => sync.bootstrap(),
+      })
       if (frameworkMode()) {
         dialog.replace(() => <DialogPostAuthModelChoice providerID={props.providerID} />)
         return
@@ -891,8 +911,11 @@ function CodeMethod(props: CodeMethodProps) {
         })
         if (!error) {
           try {
-            await sdk.client.instance.dispose()
-            await sync.bootstrap()
+            await refreshAfterProviderAuth({
+              sessionStatus: sync.data.session_status,
+              dispose: () => sdk.client.instance.dispose(),
+              bootstrap: () => sync.bootstrap(),
+            })
             if (frameworkMode()) {
               dialog.replace(() => <DialogPostAuthModelChoice providerID={props.providerID} />)
               return
@@ -1023,8 +1046,11 @@ function ApiMethod(props: ApiMethodProps) {
           return
         }
         try {
-          await sdk.client.instance.dispose()
-          await sync.bootstrap()
+          await refreshAfterProviderAuth({
+            sessionStatus: sync.data.session_status,
+            dispose: () => sdk.client.instance.dispose(),
+            bootstrap: () => sync.bootstrap(),
+          })
           if (frameworkMode()) {
             dialog.replace(() => <DialogPostAuthModelChoice providerID={props.providerID} />)
             return

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -71,6 +71,7 @@ import {
   shouldBlockAgencyPromptSubmit,
   shouldOpenAgencyAuthDialog,
 } from "../../session-error"
+import { cancelQueuedRunModeMessages } from "../../util/run-queued-messages"
 import { errorMessage as toErrorMessage } from "@/util/error"
 import {
   buildAgencyTargetOptions,
@@ -475,9 +476,36 @@ export function Prompt(props: PromptProps) {
           }, 5000)
 
           if (store.interrupt >= 2) {
-            void sdk.client.session.abort({
-              sessionID: props.sessionID,
+            const sessionID = props.sessionID
+            void cancelQueuedRunModeMessages({
+              frameworkMode: frameworkMode(),
+              messages: sync.data.message[sessionID] ?? [],
+              parts: sync.data.part,
+              abort: async () => {
+                await sdk.client.session.abort({ sessionID })
+              },
+              deleteMessage: async (messageID) => {
+                await sdk.client.session.deleteMessage({
+                  sessionID,
+                  messageID,
+                })
+              },
             })
+              .then((queued) => {
+                if (queued.length === 0) return
+                toast.show({
+                  message: `Cancelled ${queued.length} queued message${queued.length === 1 ? "" : "s"}`,
+                  variant: "success",
+                  duration: 3000,
+                })
+              })
+              .catch((error) => {
+                toast.show({
+                  message: toErrorMessage(error),
+                  variant: "error",
+                  duration: 5000,
+                })
+              })
             setStore("interrupt", 0)
           }
           dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/util/provider-auth-refresh.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/provider-auth-refresh.ts
@@ -1,0 +1,14 @@
+type SessionStatusMap = Record<string, { type: string } | undefined>
+
+export function hasActiveSession(status: SessionStatusMap) {
+  return Object.values(status).some((item) => item && item.type !== "idle")
+}
+
+export async function refreshAfterProviderAuth(input: {
+  sessionStatus: SessionStatusMap
+  dispose: () => Promise<unknown>
+  bootstrap: () => Promise<unknown>
+}) {
+  if (!hasActiveSession(input.sessionStatus)) await input.dispose()
+  await input.bootstrap()
+}

--- a/packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts
@@ -1,0 +1,56 @@
+import type { AssistantMessage, Part, UserMessage } from "@opencode-ai/sdk/v2"
+import type { PromptInfo } from "../component/prompt/history"
+import { strip } from "../component/prompt/part"
+
+type Message = UserMessage | AssistantMessage
+
+export type QueuedRunModeMessage = {
+  message: UserMessage
+  prompt: PromptInfo
+}
+
+export function collectQueuedRunModeMessages(input: {
+  messages: readonly Message[]
+  parts: Record<string, Part[] | undefined>
+}): QueuedRunModeMessage[] {
+  const activeAssistant = input.messages.findLast(
+    (message): message is AssistantMessage => message.role === "assistant" && !message.time.completed,
+  )
+  if (!activeAssistant) return []
+
+  return input.messages
+    .filter((message): message is UserMessage => message.role === "user" && message.id > activeAssistant.id)
+    .map((message) => ({
+      message,
+      prompt: promptFromMessageParts(input.parts[message.id] ?? []),
+    }))
+}
+
+export async function cancelQueuedRunModeMessages(input: {
+  frameworkMode: boolean
+  messages: readonly Message[]
+  parts: Record<string, Part[] | undefined>
+  abort: () => Promise<void>
+  deleteMessage: (messageID: string) => Promise<void>
+}) {
+  const queued = input.frameworkMode ? collectQueuedRunModeMessages(input) : []
+  await input.abort()
+  for (const item of queued) {
+    await input.deleteMessage(item.message.id)
+  }
+  return queued
+}
+
+function promptFromMessageParts(parts: readonly Part[]): PromptInfo {
+  return parts.reduce(
+    (prompt, part) => {
+      if (part.type === "text") {
+        if (!part.synthetic) prompt.input += part.text
+      } else if (part.type === "file" || part.type === "agent") {
+        prompt.parts.push(strip(part))
+      }
+      return prompt
+    },
+    { input: "", parts: [] } as PromptInfo,
+  )
+}

--- a/packages/opencode/test/cli/tui/provider-auth-refresh.test.ts
+++ b/packages/opencode/test/cli/tui/provider-auth-refresh.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import { hasActiveSession, refreshAfterProviderAuth } from "../../../src/cli/cmd/tui/util/provider-auth-refresh"
+
+describe("provider auth refresh", () => {
+  test("detects active session statuses", () => {
+    expect(hasActiveSession({})).toBe(false)
+    expect(hasActiveSession({ ses_1: { type: "idle" } })).toBe(false)
+    expect(hasActiveSession({ ses_1: { type: "busy" } })).toBe(true)
+  })
+
+  test("defers instance disposal while a session is active", async () => {
+    const calls: string[] = []
+
+    await refreshAfterProviderAuth({
+      sessionStatus: { ses_1: { type: "busy" } },
+      dispose: async () => {
+        calls.push("dispose")
+      },
+      bootstrap: async () => {
+        calls.push("bootstrap")
+      },
+    })
+
+    expect(calls).toEqual(["bootstrap"])
+  })
+
+  test("reloads the instance when all sessions are idle", async () => {
+    const calls: string[] = []
+
+    await refreshAfterProviderAuth({
+      sessionStatus: { ses_1: { type: "idle" } },
+      dispose: async () => {
+        calls.push("dispose")
+      },
+      bootstrap: async () => {
+        calls.push("bootstrap")
+      },
+    })
+
+    expect(calls).toEqual(["dispose", "bootstrap"])
+  })
+})

--- a/packages/opencode/test/cli/tui/run-queued-messages.test.ts
+++ b/packages/opencode/test/cli/tui/run-queued-messages.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test"
+import {
+  cancelQueuedRunModeMessages,
+  collectQueuedRunModeMessages,
+} from "../../../src/cli/cmd/tui/util/run-queued-messages"
+
+describe("run-mode queued messages", () => {
+  test("finds user messages queued after the active assistant turn", () => {
+    const queued = collectQueuedRunModeMessages({
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          sessionID: "ses_1",
+          time: { created: 1 },
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+        },
+        {
+          id: "msg_2",
+          role: "assistant",
+          sessionID: "ses_1",
+          parentID: "msg_1",
+          time: { created: 2 },
+          agent: "build",
+          mode: "build",
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        {
+          id: "msg_3",
+          role: "user",
+          sessionID: "ses_1",
+          time: { created: 3 },
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+        },
+        {
+          id: "msg_4",
+          role: "user",
+          sessionID: "ses_1",
+          time: { created: 4 },
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+        },
+      ],
+      parts: {
+        msg_3: [{ id: "part_1", sessionID: "ses_1", messageID: "msg_3", type: "text", text: "second" }],
+        msg_4: [{ id: "part_2", sessionID: "ses_1", messageID: "msg_4", type: "text", text: "third" }],
+      },
+    })
+
+    expect(queued.map((item) => item.message.id)).toEqual(["msg_3", "msg_4"])
+    expect(queued.map((item) => item.prompt.input)).toEqual(["second", "third"])
+  })
+
+  test("abort removes queued Run-mode user messages after the active turn", async () => {
+    const calls: string[] = []
+
+    const removed = await cancelQueuedRunModeMessages({
+      frameworkMode: true,
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          sessionID: "ses_1",
+          time: { created: 1 },
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+        },
+        {
+          id: "msg_2",
+          role: "assistant",
+          sessionID: "ses_1",
+          parentID: "msg_1",
+          time: { created: 2 },
+          agent: "build",
+          mode: "build",
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        {
+          id: "msg_3",
+          role: "user",
+          sessionID: "ses_1",
+          time: { created: 3 },
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+        },
+      ],
+      parts: {},
+      abort: async () => {
+        calls.push("abort")
+      },
+      deleteMessage: async (messageID) => {
+        calls.push(`delete:${messageID}`)
+      },
+    })
+
+    expect(removed.map((item) => item.message.id)).toEqual(["msg_3"])
+    expect(calls).toEqual(["abort", "delete:msg_3"])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #151

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two follow-ups after PR #148.

1. Pressing Ctrl+C twice in Run mode now drains queued user messages alongside aborting the in-flight assistant turn. New helper `cancelQueuedRunModeMessages` in `util/run-queued-messages.ts` collects queued messages by ID greater than the active assistant ID, then runs `abort()` and `deleteMessage()` per item.

2. Provider auth refresh from inside the TUI no longer disposes the SDK client while a session is non-idle, so the active stream is preserved. New helper `refreshAfterProviderAuth` in `util/provider-auth-refresh.ts` skips dispose when `hasActiveSession` is true; `sync.bootstrap()` still always runs. Wired into the five existing dispose+bootstrap call sites in `dialog-provider.tsx` (remove credential, agency-swarm connect on auth and clear-config, AutoMethod, CodeMethod, ApiMethod).

Both are fork-only paths (Run mode and the agency-swarm provider auth dialog) and gated to those modes.

### How did you verify your code works?

- `bun test test/cli/tui/run-queued-messages.test.ts test/cli/tui/provider-auth-refresh.test.ts` -> 5 pass / 0 fail
- `bun typecheck` -> clean
- `bunx prettier --check` on touched files -> clean

### Screenshots / recordings

Not applicable - behaviors are interaction sequences. Test assertions prove the expected sequence (`abort` then `delete` per item; `dispose` skipped while a session is non-idle).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

Tracks the original multi-bug QA report. Two further behaviors from that report (final response duplicated on macOS; browser-auth handoff failing with stale stored response IDs) lacked deterministic code evidence and are not in this PR; they need runtime reproduction.
