### PR TITLE
fix(tui): label config-backed OpenAI auth

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -94,6 +94,7 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
             if (storedAuthMethod === "oauth") return "(Browser sign-in)"
             if (storedAuthMethod === "api") return "(API key)"
             if (storedAuthMethod === "env") return "(API key from env)"
+            if (storedAuthMethod === "config") return "(API key from config)"
           }
           return {
             opencode: "(Recommended)",

--- a/packages/opencode/test/cli/tui/provider-auth.test.ts
+++ b/packages/opencode/test/cli/tui/provider-auth.test.ts
@@ -184,6 +184,19 @@ test("getStoredProviderAuthMethod returns 'env' for env-backed providers", () =>
   ).toBe("env")
 })
 
+test("getStoredProviderAuthMethod returns 'config' for config-backed providers", () => {
+  expect(
+    getStoredProviderAuthMethod({
+      id: "openai",
+      name: "OpenAI",
+      source: "config",
+      env: [],
+      options: { apiKey: "sk-config" },
+      models: {},
+    }),
+  ).toBe("config")
+})
+
 test("getStoredProviderAuthMethod returns 'oauth' for OAUTH_DUMMY_KEY-marked custom providers", () => {
   expect(
     getStoredProviderAuthMethod({


### PR DESCRIPTION
### Issue for this PR

Closes #152

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When OpenAI credentials come from config-backed provider settings, the `/auth` provider row now shows `(API key from config)` instead of falling back to the generic `(Browser sign-in or API key)` label.

This completes the auth-source display behavior without changing credential storage or provider routing.

### How did you verify your code works?

- `cd packages/opencode && bun test test/cli/tui/provider-auth.test.ts`
- `cd packages/opencode && bun typecheck`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

Not applicable; covered by focused helper test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
