### PR TITLE
chore(release): prepare agentswarm cli 1.4.26

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -348,7 +348,7 @@
     },
     "packages/opencode": {
       "name": "agentswarm-cli",
-      "version": "1.4.6",
+      "version": "1.4.26",
       "bin": {
         "agentswarm": "./bin/agentswarm",
       },

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.4.6",
+  "version": "1.4.26",
   "name": "agentswarm-cli",
   "platformScope": "@vrsen",
   "description": "Agent Swarm CLI for the terminal.",

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -801,7 +801,7 @@ async function installProjectDependencies(
   }
 
   const result = await runCommand(
-    [...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.4"],
+    [...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.5"],
     {
       logFile: options.logFile,
       streamOutputToStderr: true,

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -200,7 +200,7 @@ describe("agency-swarm npx onboarding", () => {
       "pip",
       "install",
       "--upgrade",
-      "agency-swarm[fastapi,litellm]>=1.9.4",
+      "agency-swarm[fastapi,litellm]>=1.9.5",
     ])
   })
 


### PR DESCRIPTION
Summary
- Bump source metadata for `agentswarm-cli` to `1.4.26`.
- Raise fallback Python install floor to `agency-swarm[fastapi,litellm]>=1.9.5` for the launcher path.
- Update the exact launcher test expectation.

Proof
- `bun install --frozen-lockfile`
- `bun test --timeout 30000 test/agency-swarm/npx.test.ts -t "prepareProjectLaunch installs LiteLLM extras when no dependency manifest exists"`
- `bun typecheck`
- `git diff --check`

Release notes
- npm latest checked as `agentswarm-cli@1.4.25`; next release target is `v1.4.26`.
- PyPI checked as `agency-swarm==1.9.5` available.
- Agency Swarm PR #636 is merged; CI for release commit `4d8d6d0f9f7d40314de0cbf5cb5e4c08e17a2aee` was still in progress when checked.