### PR TITLE
fix(tui): keep active run when clearing queue

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts
@@ -34,7 +34,10 @@ export async function cancelQueuedRunModeMessages(input: {
   deleteMessage: (messageID: string) => Promise<void>
 }) {
   const queued = input.frameworkMode ? collectQueuedRunModeMessages(input) : []
-  await input.abort()
+  if (queued.length === 0) {
+    await input.abort()
+    return queued
+  }
   for (const item of queued) {
     await input.deleteMessage(item.message.id)
   }

--- a/packages/opencode/test/cli/tui/run-queued-messages.test.ts
+++ b/packages/opencode/test/cli/tui/run-queued-messages.test.ts
@@ -57,7 +57,7 @@ describe("run-mode queued messages", () => {
     expect(queued.map((item) => item.prompt.input)).toEqual(["second", "third"])
   })
 
-  test("abort removes queued Run-mode user messages after the active turn", async () => {
+  test("queued cancel removes queued Run-mode user messages without aborting the active turn", async () => {
     const calls: string[] = []
 
     const removed = await cancelQueuedRunModeMessages({
@@ -104,6 +104,48 @@ describe("run-mode queued messages", () => {
     })
 
     expect(removed.map((item) => item.message.id)).toEqual(["msg_3"])
-    expect(calls).toEqual(["abort", "delete:msg_3"])
+    expect(calls).toEqual(["delete:msg_3"])
+  })
+
+  test("queued cancel aborts the active turn when there are no queued messages", async () => {
+    const calls: string[] = []
+
+    const removed = await cancelQueuedRunModeMessages({
+      frameworkMode: true,
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          sessionID: "ses_1",
+          time: { created: 1 },
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+        },
+        {
+          id: "msg_2",
+          role: "assistant",
+          sessionID: "ses_1",
+          parentID: "msg_1",
+          time: { created: 2 },
+          agent: "build",
+          mode: "build",
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+      ],
+      parts: {},
+      abort: async () => {
+        calls.push("abort")
+      },
+      deleteMessage: async (messageID) => {
+        calls.push(`delete:${messageID}`)
+      },
+    })
+
+    expect(removed).toEqual([])
+    expect(calls).toEqual(["abort"])
   })
 })


### PR DESCRIPTION
Closes #161

## Summary
- delete queued Run-mode user messages without calling session abort when a queue drain target exists
- keep active abort behavior when there are no queued messages
- update direct queued-message tests to lock both paths

## Validation
- bun test test/cli/tui/run-queued-messages.test.ts
- bun typecheck
- bun turbo typecheck