### PR TITLE
fix(agency-swarm): require explicit handoff evidence

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -77,6 +77,7 @@ import { errorMessage as toErrorMessage } from "@/util/error"
 import {
   buildAgencyTargetOptions,
   displayRunOnlyAgentLabel,
+  hasAgencyHandoffEvidence,
   readAgencyProviderOptions,
   resolveAgencyTargetSelection,
   shouldAdoptAgencyHandoffRecipient,
@@ -212,58 +213,72 @@ export function Prompt(props: PromptProps) {
     return selection?.label ?? options.recipientAgent
   })
   const adoptedAgencyRecipients = new Set<string>()
-  onCleanup(
-    event.on("message.updated", (evt) => {
-      const info = evt.properties.info
-      if (info.sessionID !== props.sessionID) return
-      if (info.role !== "assistant") return
-      if (info.providerID !== AgencySwarmAdapter.PROVIDER_ID) return
+  function adoptAgencyHandoffRecipient(info: AssistantMessage, handoffEvidence: boolean) {
+    if (info.sessionID !== props.sessionID) return
+    if (info.providerID !== AgencySwarmAdapter.PROVIDER_ID) return
 
-      const options = agencyProviderOptions()
-      if (
-        !shouldAdoptAgencyHandoffRecipient({
-          frameworkMode: frameworkMode(),
-          agency: options.agency,
-          currentRecipient: options.recipientAgent,
-          assistantAgent: info.agent,
-        })
-      ) {
-        return
-      }
+    const options = agencyProviderOptions()
+    if (
+      !shouldAdoptAgencyHandoffRecipient({
+        frameworkMode: frameworkMode(),
+        agency: options.agency,
+        currentRecipient: options.recipientAgent,
+        assistantAgent: info.agent,
+        handoffEvidence,
+      })
+    ) {
+      return
+    }
 
-      const key = `${info.sessionID}:${info.id}:${info.agent}`
-      if (adoptedAgencyRecipients.has(key)) return
-      adoptedAgencyRecipients.add(key)
+    const key = `${info.sessionID}:${info.id}:${info.agent}`
+    if (adoptedAgencyRecipients.has(key)) return
+    adoptedAgencyRecipients.add(key)
 
-      void sdk.client.global.config
-        .update(
-          {
-            config: {
-              model: `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`,
-              provider: {
-                [AgencySwarmAdapter.PROVIDER_ID]: {
-                  name: "agency-swarm",
-                  options: buildAgencyTargetOptions({
-                    providerOptions: options,
-                    agency: options.agency!,
-                    recipientAgent: info.agent,
-                  }),
-                },
+    void sdk.client.global.config
+      .update(
+        {
+          config: {
+            model: `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`,
+            provider: {
+              [AgencySwarmAdapter.PROVIDER_ID]: {
+                name: "agency-swarm",
+                options: buildAgencyTargetOptions({
+                  providerOptions: options,
+                  agency: options.agency!,
+                  recipientAgent: info.agent,
+                }),
               },
             },
           },
-          {
-            throwOnError: true,
-          },
-        )
-        .then(() => sync.bootstrap())
-        .catch((error) => {
-          toast.show({
-            variant: "error",
-            message: error instanceof Error ? error.message : String(error),
-            duration: 4000,
-          })
+        },
+        {
+          throwOnError: true,
+        },
+      )
+      .then(() => sync.bootstrap())
+      .catch((error) => {
+        toast.show({
+          variant: "error",
+          message: error instanceof Error ? error.message : String(error),
+          duration: 4000,
         })
+      })
+  }
+  onCleanup(
+    event.on("message.updated", (evt) => {
+      const info = evt.properties.info
+      if (info.role !== "assistant") return
+      adoptAgencyHandoffRecipient(info, hasAgencyHandoffEvidence(sync.data.part[info.id]))
+    }),
+  )
+  onCleanup(
+    event.on("message.part.updated", (evt) => {
+      if (!hasAgencyHandoffEvidence([evt.properties.part])) return
+      const info = sync.data.message[evt.properties.sessionID]?.find(
+        (item) => item.id === evt.properties.part.messageID,
+      )
+      if (!info || info.role !== "assistant") return
+      adoptAgencyHandoffRecipient(info, true)
     }),
   )
   const editorPath = createMemo(() => editor.selection()?.filePath)

--- a/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
@@ -1,5 +1,6 @@
 import { displayAgentName } from "@/agent/display"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { hasAgencyHandoffEvidence } from "@/session/agency-swarm-utils"
 import * as Locale from "@/util/locale"
 
 export type AgencyProviderOptions = {
@@ -167,13 +168,17 @@ export function shouldAdoptAgencyHandoffRecipient(input: {
   agency?: string
   currentRecipient?: string
   assistantAgent?: string
+  handoffEvidence: boolean
 }) {
   if (!input.frameworkMode) return false
   if (!input.agency) return false
   if (!input.assistantAgent) return false
+  if (!input.handoffEvidence) return false
   if (input.assistantAgent === "build") return false
   return input.assistantAgent !== input.currentRecipient
 }
+
+export { hasAgencyHandoffEvidence }
 
 export function displayRunOnlyAgentLabel(input: {
   frameworkMode: boolean

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -52,6 +52,23 @@ export function isAgencyToolOutputType(value: string | undefined) {
   return value === "function_call_output" || value === "tool_call_output_item" || value === "handoff_output_item"
 }
 
+export function hasAgencyHandoffEvidence(parts: readonly unknown[] | undefined) {
+  if (!parts) return false
+  return parts.some((part) => {
+    const record = asRecord(part)
+    if (!record || asString(record["type"]) !== "tool") return false
+    if (isAgencyHandoffToolName(asString(record["tool"]))) return true
+
+    const state = asRecord(record["state"])
+    const metadata = asRecord(record["metadata"]) ?? asRecord(state?.["metadata"])
+    return asString(metadata?.["type"]) === "handoff_output_item"
+  })
+}
+
+export function isAgencyHandoffToolName(value: string | undefined) {
+  return !!value?.startsWith("transfer_to_")
+}
+
 export function parseToolInput(raw: unknown): Record<string, unknown> {
   const rawRecord = asRecord(raw)
   if (rawRecord) return rawRecord

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -33,6 +33,7 @@ import {
   extractEventMeta,
   extractFunctionCallOutputs as extractFunctionCallOutputsFromMessages,
   findRecipientAgent,
+  hasAgencyHandoffEvidence,
   isAgencyToolOutputType,
   normalizeCallerAgent as normalizeCallerAgentValue,
   parseToolInput,
@@ -1538,6 +1539,7 @@ export namespace SessionAgencySwarm {
         mentionedRecipient,
         configuredRecipient: input.options.recipientAgent,
         configuredRecipientSelectedAt: input.options.recipientAgentSelectedAt,
+        chatHistory: history.chat_history,
       })
       const sessionLitellmModel =
         input.sessionModel &&
@@ -1927,8 +1929,9 @@ export namespace SessionAgencySwarm {
     mentionedRecipient?: string
     configuredRecipient?: string
     configuredRecipientSelectedAt?: number
+    chatHistory?: Array<Record<string, unknown>>
   }): Promise<string | undefined> {
-    const sessionRecipient = await resolveSessionRecipient(input.sessionID)
+    const sessionRecipient = await resolveSessionRecipient(input.sessionID, input.chatHistory)
     if (
       !input.configuredRecipient &&
       input.configuredRecipientSelectedAt &&
@@ -2012,28 +2015,66 @@ export namespace SessionAgencySwarm {
     }
   }
 
-  async function resolveSessionRecipient(sessionID: SessionID) {
+  async function resolveSessionRecipient(sessionID: SessionID, chatHistory?: Array<Record<string, unknown>>) {
+    const historyRecipient = resolveHistoryHandoffRecipient(chatHistory)
     try {
       const messages = await Session.messages({ sessionID })
       const last = messages.findLast((item) => {
         if (item.info.role !== "assistant") return false
         if (item.info.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
         if (item.info.summary) return false
+        if (!hasAgencyHandoffEvidence(item.parts)) return false
         return !!item.info.agent
       })
-      if (!last) return
+      if (!last) return historyRecipient ? { agent: historyRecipient } : undefined
       if (last.info.role !== "assistant") return
       return {
         agent: last.info.agent,
         messageAt: last.info.time.completed ?? last.info.time.created,
       }
     } catch (error) {
-      log.warn("unable to load session recipient; skipping recipient override", {
+      log.warn("unable to load session recipient; using stored handoff history if available", {
         sessionID,
         error: error instanceof Error ? error.message : String(error),
       })
-      return undefined
+      return historyRecipient ? { agent: historyRecipient } : undefined
     }
+  }
+
+  function resolveHistoryHandoffRecipient(chatHistory?: Array<Record<string, unknown>>) {
+    if (!chatHistory) return undefined
+
+    for (let index = chatHistory.length - 1; index >= 0; index--) {
+      const item = asRecord(chatHistory[index])
+      if (!item || asString(item["type"]) !== "handoff_output_item") continue
+
+      const outputRecipient = resolveHandoffOutputRecipient(item["output"])
+      if (outputRecipient) return outputRecipient
+
+      for (let nextIndex = index + 1; nextIndex < chatHistory.length; nextIndex++) {
+        const message = asRecord(chatHistory[nextIndex])
+        if (!message || asString(message["type"]) !== "message") continue
+        if (asString(message["role"]) !== "assistant") continue
+        const agent = asString(message["agent"])
+        if (agent) return agent
+      }
+    }
+
+    return undefined
+  }
+
+  function resolveHandoffOutputRecipient(output: unknown) {
+    if (typeof output === "string") {
+      try {
+        return resolveHandoffOutputRecipient(JSON.parse(output))
+      } catch {
+        return undefined
+      }
+    }
+
+    const record = asRecord(output)
+    if (!record) return undefined
+    return asString(record["assistant"]) ?? asString(record["agent"])
   }
 
   export function compactHistory(input: { msgs: MessageV2.WithParts[]; currentID: string }) {

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   buildAgencyTargetOptions,
+  hasAgencyHandoffEvidence,
   resolveAgencyTargetFromPicker,
   shouldAdoptAgencyHandoffRecipient,
 } from "../../../src/cli/cmd/tui/util/agency-target"
@@ -45,7 +46,57 @@ describe("agency target options", () => {
         agency: "my-agency",
         currentRecipient: "ExampleAgent",
         assistantAgent: "ExampleAgent2",
+        handoffEvidence: true,
       }),
+    ).toBe(true)
+  })
+
+  test("does not adopt a normal swarm/default assistant response as a handoff", () => {
+    expect(
+      shouldAdoptAgencyHandoffRecipient({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: undefined,
+        assistantAgent: "ExampleAgent",
+        handoffEvidence: false,
+      }),
+    ).toBe(false)
+    expect(
+      shouldAdoptAgencyHandoffRecipient({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "ExampleAgent",
+        assistantAgent: "ExampleAgent2",
+        handoffEvidence: false,
+      }),
+    ).toBe(false)
+  })
+
+  test("handoff evidence requires transfer tool or handoff output", () => {
+    expect(
+      hasAgencyHandoffEvidence([
+        {
+          type: "tool",
+          tool: "file_search",
+          state: {
+            status: "completed",
+            metadata: { type: "function_call_output" },
+          },
+        },
+      ]),
+    ).toBe(false)
+    expect(hasAgencyHandoffEvidence([{ type: "tool", tool: "transfer_to_support_agent" }])).toBe(true)
+    expect(
+      hasAgencyHandoffEvidence([
+        {
+          type: "tool",
+          tool: "tool",
+          state: {
+            status: "completed",
+            metadata: { type: "handoff_output_item" },
+          },
+        },
+      ]),
     ).toBe(true)
   })
 
@@ -109,6 +160,7 @@ describe("agency target options", () => {
         agency: "my-agency",
         currentRecipient: "ExampleAgent",
         assistantAgent: "ExampleAgent",
+        handoffEvidence: true,
       }),
     ).toBe(false)
     expect(
@@ -117,6 +169,7 @@ describe("agency target options", () => {
         agency: "my-agency",
         currentRecipient: "ExampleAgent",
         assistantAgent: "build",
+        handoffEvidence: true,
       }),
     ).toBe(false)
   })
@@ -126,6 +179,7 @@ describe("agency target options", () => {
       agency: "my-agency",
       currentRecipient: "ExampleAgent",
       assistantAgent: "ExampleAgent2",
+      handoffEvidence: true,
     }
     expect(shouldAdoptAgencyHandoffRecipient({ frameworkMode: false, ...base })).toBe(false)
     expect(shouldAdoptAgencyHandoffRecipient({ frameworkMode: true, ...base, agency: undefined })).toBe(false)

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -122,6 +122,36 @@ describe("session.agency-swarm", () => {
     return { appended, runs }
   }
 
+  const addCompletedTransferPart = async (input: {
+    sessionID: string
+    messageID: string
+    tool: string
+    callID?: string
+    output?: string
+    start?: number
+    end?: number
+  }) => {
+    await Session.updatePart({
+      id: PartID.ascending(),
+      messageID: input.messageID as any,
+      sessionID: input.sessionID as any,
+      type: "tool",
+      tool: input.tool,
+      callID: input.callID ?? "call_handoff",
+      state: {
+        status: "completed",
+        input: {},
+        output: input.output ?? "{}",
+        title: "",
+        metadata: {},
+        time: {
+          start: input.start ?? Date.now(),
+          end: input.end ?? Date.now(),
+        },
+      },
+    })
+  }
+
   test("optionsFromProvider applies defaults", () => {
     const options = SessionAgencySwarm.optionsFromProvider(undefined)
 
@@ -2198,6 +2228,96 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream does not treat a normal prior assistant agent as a handoff recipient", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        let sentRecipient: string | undefined
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["ExampleAgent", "ExampleAgent2"],
+          },
+        })) as typeof AgencySwarmAdapter.getMetadata
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          sentRecipient = args.recipientAgent ?? undefined
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "normal assistant is not handoff" })
+        const created = Date.now()
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created,
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "hello",
+        })
+        await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          sessionID: session.id,
+          parentID: user.id,
+          modelID: "default",
+          providerID: "agency-swarm",
+          mode: "ExampleAgent",
+          agent: "ExampleAgent",
+          path: {
+            cwd: "/",
+            root: "/",
+          },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: {
+            created: created + 1,
+            completed: created + 2,
+          },
+        } as any)
+
+        const followup = helper()
+        followup.input.sessionID = session.id
+        followup.input.assistantMessage.sessionID = session.id
+        followup.input.userMessage.info.id = MessageID.ascending()
+        followup.input.userMessage.parts = [{ type: "text", text: "follow up", ignored: false }] as any
+
+        const stream = await SessionAgencySwarm.stream(followup.input)
+        for await (const _ of stream.fullStream) {
+        }
+
+        expect(sentRecipient).toBeUndefined()
+      },
+    })
+  })
+
   test("compactHistory rebuilds request history from the compacted session slice", () => {
     const msgs = [
       {
@@ -2984,7 +3104,7 @@ describe("session.agency-swarm", () => {
           type: "text",
           text: "hello",
         })
-        await Session.updateMessage({
+        const assistant = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "assistant",
           sessionID: session.id,
@@ -3010,6 +3130,11 @@ describe("session.agency-swarm", () => {
             completed: Date.now(),
           },
         } as any)
+        await addCompletedTransferPart({
+          sessionID: session.id,
+          messageID: assistant.id,
+          tool: "transfer_to_support_agent",
+        })
 
         const { input } = helper()
         input.sessionID = session.id
@@ -3131,6 +3256,13 @@ describe("session.agency-swarm", () => {
         const firstStream = await SessionAgencySwarm.stream(first.input)
         for await (const _ of firstStream.fullStream) {
         }
+        await addCompletedTransferPart({
+          sessionID: session.id,
+          messageID: first.input.assistantMessage.id,
+          tool: "transfer_to_support_agent",
+          callID: "call_handoff",
+          output: '{"assistant":"support_agent"}',
+        })
 
         const second = helper()
         second.input.sessionID = session.id
@@ -3149,7 +3281,63 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream routes next message to agent_updated handoff id", async () => {
+  test("stream routes next message from stored handoff output history", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        AgencySwarmHistory.load = (async () => ({
+          scope: "http://127.0.0.1:8000|builder|session_1",
+          chat_history: [
+            {
+              type: "handoff_output_item",
+              call_id: "call_transfer_math",
+              output: '{"assistant":"MathAgent"}',
+            },
+            {
+              id: "msg_math_1",
+              type: "message",
+              role: "assistant",
+              agent: "MathAgent",
+              content: [{ type: "output_text", text: "Math agent now has control." }],
+            },
+          ],
+          updated_at: Date.now(),
+        })) as typeof AgencySwarmHistory.load
+        let sentRecipient: string | undefined
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["UserSupportAgent", "MathAgent"],
+          },
+        })) as typeof AgencySwarmAdapter.getMetadata
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          sentRecipient = args.recipientAgent ?? undefined
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const { input } = helper()
+        input.options.recipientAgent = "UserSupportAgent"
+
+        const stream = await SessionAgencySwarm.stream(input)
+        for await (const _ of stream.fullStream) {
+        }
+
+        expect(sentRecipient).toBe("MathAgent")
+      },
+    })
+  })
+
+  test("stream does not route next message from agent_updated without transfer handoff", async () => {
     await using tmp = await tmpdir({
       git: true,
       config: {
@@ -3200,7 +3388,7 @@ describe("session.agency-swarm", () => {
           yield { type: "end" }
         } as typeof AgencySwarmAdapter.streamRun
 
-        const session = await Session.create({ title: "handoff event recipient" })
+        const session = await Session.create({ title: "agent updated without handoff" })
         const user = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "user",
@@ -3245,7 +3433,7 @@ describe("session.agency-swarm", () => {
         for await (const _ of secondStream.fullStream) {
         }
 
-        expect(sentRecipient).toBe("slides_agent")
+        expect(sentRecipient).toBeUndefined()
       },
     })
   })
@@ -3307,7 +3495,7 @@ describe("session.agency-swarm", () => {
           type: "text",
           text: "hello",
         })
-        await Session.updateMessage({
+        const assistant = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "assistant",
           sessionID: session.id,
@@ -3333,6 +3521,13 @@ describe("session.agency-swarm", () => {
             completed: created + 2,
           },
         } as any)
+        await addCompletedTransferPart({
+          sessionID: session.id,
+          messageID: assistant.id,
+          tool: "transfer_to_support_agent",
+          start: created + 1,
+          end: created + 2,
+        })
 
         const { input } = helper()
         input.sessionID = session.id
@@ -3406,7 +3601,7 @@ describe("session.agency-swarm", () => {
           type: "text",
           text: "hello",
         })
-        await Session.updateMessage({
+        const assistant = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "assistant",
           sessionID: session.id,
@@ -3432,6 +3627,13 @@ describe("session.agency-swarm", () => {
             completed: created + 2,
           },
         } as any)
+        await addCompletedTransferPart({
+          sessionID: session.id,
+          messageID: assistant.id,
+          tool: "transfer_to_support_agent",
+          start: created + 1,
+          end: created + 2,
+        })
 
         const { input } = helper()
         input.sessionID = session.id
@@ -3507,7 +3709,7 @@ describe("session.agency-swarm", () => {
           type: "text",
           text: "hello",
         })
-        await Session.updateMessage({
+        const assistant = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "assistant",
           sessionID: session.id,
@@ -3533,6 +3735,13 @@ describe("session.agency-swarm", () => {
             completed: handoffCompletedAt,
           },
         } as any)
+        await addCompletedTransferPart({
+          sessionID: session.id,
+          messageID: assistant.id,
+          tool: "transfer_to_support_agent",
+          start: handoffStartedAt,
+          end: handoffCompletedAt,
+        })
 
         const { input } = helper()
         input.sessionID = session.id
@@ -3607,7 +3816,7 @@ describe("session.agency-swarm", () => {
           type: "text",
           text: "hello",
         })
-        await Session.updateMessage({
+        const assistant = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "assistant",
           sessionID: session.id,
@@ -3633,6 +3842,11 @@ describe("session.agency-swarm", () => {
             completed: Date.now(),
           },
         } as any)
+        await addCompletedTransferPart({
+          sessionID: session.id,
+          messageID: assistant.id,
+          tool: "transfer_to_support_agent",
+        })
 
         const { input } = helper()
         input.sessionID = session.id


### PR DESCRIPTION
### Issue for this PR

Closes #162
Closes #163

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes the post-1.4.26 Run-mode regressions where normal Agency Swarm assistant responses could be mistaken for handoffs.

The TUI now adopts a new active recipient only when the assistant message has explicit handoff evidence: a `transfer_to_*` tool or handoff output. Session routing now applies the same rule, and it can recover the handoff target from stored Agency Swarm `handoff_output_item` history when the local message parts are not enough.

Selecting the swarm row still clears explicit recipient config and does not let a normal prior assistant response become stale handoff state.

### How did you verify your code works?

- `cd packages/opencode && bun test test/cli/tui/agency-target.test.ts test/cli/tui/prompt-framework-mode.test.tsx`
- `cd packages/opencode && bun test test/session/agency-swarm.test.ts`
- `cd packages/opencode && bun run test:agentswarm:e2e`
- `bun typecheck`
- `bun turbo test:ci`

### Notes

Open PR #160 overlaps the same handoff/routing area. This PR stays on `vrsen/dev` and keeps the fix limited to explicit handoff evidence, so #160 should be reviewed for integration with the stricter handoff gate before merging both.