### PR TITLE
fix(tui): stabilize run-mode cancellation targets

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -167,6 +167,7 @@ export function Prompt(props: PromptProps) {
       }
     | undefined
   >()
+  const observedAssistantAgentsByMessage = new Map<string, string>()
   const activeOrgName = createMemo(() => sync.data.console_state.activeOrgName)
   const canSwitchOrgs = createMemo(() => sync.data.console_state.switchableOrgCount > 1)
   const frameworkMode = createMemo(() =>
@@ -251,7 +252,10 @@ export function Prompt(props: PromptProps) {
   createEffect(
     on(
       () => props.sessionID,
-      () => setHandoffRecipient(undefined),
+      () => {
+        setHandoffRecipient(undefined)
+        observedAssistantAgentsByMessage.clear()
+      },
     ),
   )
 
@@ -275,13 +279,22 @@ export function Prompt(props: PromptProps) {
       const parts = sync.data.part?.[info.id] ?? []
       const handoffAgent = resolveAgencyHandoffRecipientFromParts(parts) ?? info.agent
       const explicitHandoffEvidence = hasAgencyHandoffEvidence(parts)
+      const previousAssistantAgent = observedAssistantAgentsByMessage.get(info.id)
+      const liveAgentUpdatedEvidence =
+        !explicitHandoffEvidence &&
+        status().type !== "idle" &&
+        !!previousAssistantAgent &&
+        previousAssistantAgent !== handoffAgent
+      if (handoffAgent) {
+        observedAssistantAgentsByMessage.set(info.id, handoffAgent)
+      }
       if (
         !shouldAdoptAgencyHandoffRecipient({
           frameworkMode: frameworkMode(),
           agency: options.agency,
           currentRecipient: options.recipientAgent,
           assistantAgent: handoffAgent,
-          handoffEvidence: explicitHandoffEvidence || status().type !== "idle",
+          handoffEvidence: explicitHandoffEvidence || liveAgentUpdatedEvidence,
         })
       ) {
         return
@@ -291,7 +304,7 @@ export function Prompt(props: PromptProps) {
         sessionID: info.sessionID,
         messageID: info.id,
         agent: handoffAgent,
-        selectedAt: explicitHandoffEvidence ? options.recipientAgentSelectedAt : undefined,
+        selectedAt: options.recipientAgentSelectedAt,
       })
     }),
   )

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -274,13 +274,14 @@ export function Prompt(props: PromptProps) {
       const options = agencyProviderOptions()
       const parts = sync.data.part?.[info.id] ?? []
       const handoffAgent = resolveAgencyHandoffRecipientFromParts(parts) ?? info.agent
+      const explicitHandoffEvidence = hasAgencyHandoffEvidence(parts)
       if (
         !shouldAdoptAgencyHandoffRecipient({
           frameworkMode: frameworkMode(),
           agency: options.agency,
           currentRecipient: options.recipientAgent,
           assistantAgent: handoffAgent,
-          handoffEvidence: hasAgencyHandoffEvidence(parts),
+          handoffEvidence: explicitHandoffEvidence || status().type !== "idle",
         })
       ) {
         return
@@ -290,7 +291,7 @@ export function Prompt(props: PromptProps) {
         sessionID: info.sessionID,
         messageID: info.id,
         agent: handoffAgent,
-        selectedAt: options.recipientAgentSelectedAt,
+        selectedAt: explicitHandoffEvidence ? options.recipientAgentSelectedAt : undefined,
       })
     }),
   )

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -77,10 +77,12 @@ import { errorMessage as toErrorMessage } from "@/util/error"
 import {
   displayRunOnlyAgentLabel,
   readAgencyProviderOptions,
+  resolveAgencyHandoffRecipientFromParts,
   resolveAgencyHandoffRecipientFromMessages,
   resolveAgencyTargetSelection,
   shouldAdoptAgencyHandoffRecipient,
 } from "../../util/agency-target"
+import { hasAgencyHandoffEvidence } from "@/session/agency-swarm-utils"
 import { DialogWorkspaceCreate, restoreWorkspaceSession } from "../dialog-workspace-create"
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { useArgs } from "@tui/context/args"
@@ -270,12 +272,15 @@ export function Prompt(props: PromptProps) {
       if (info.providerID !== AgencySwarmAdapter.PROVIDER_ID) return
 
       const options = agencyProviderOptions()
+      const parts = sync.data.part?.[info.id] ?? []
+      const handoffAgent = resolveAgencyHandoffRecipientFromParts(parts) ?? info.agent
       if (
         !shouldAdoptAgencyHandoffRecipient({
           frameworkMode: frameworkMode(),
           agency: options.agency,
           currentRecipient: options.recipientAgent,
-          assistantAgent: info.agent,
+          assistantAgent: handoffAgent,
+          handoffEvidence: hasAgencyHandoffEvidence(parts),
         })
       ) {
         return
@@ -284,7 +289,7 @@ export function Prompt(props: PromptProps) {
       setHandoffRecipient({
         sessionID: info.sessionID,
         messageID: info.id,
-        agent: info.agent,
+        agent: handoffAgent,
         selectedAt: options.recipientAgentSelectedAt,
       })
     }),

--- a/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
@@ -1,5 +1,6 @@
 import { displayAgentName } from "@/agent/display"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { hasAgencyHandoffEvidence } from "@/session/agency-swarm-utils"
 import * as Locale from "@/util/locale"
 
 export type AgencyHandoffMessage = {
@@ -188,10 +189,12 @@ export function shouldAdoptAgencyHandoffRecipient(input: {
   agency?: string
   currentRecipient?: string
   assistantAgent?: string
+  handoffEvidence: boolean
 }) {
   if (!input.frameworkMode) return false
   if (!input.agency) return false
   if (!input.assistantAgent) return false
+  if (!input.handoffEvidence) return false
   if (input.assistantAgent === "build") return false
   return input.assistantAgent !== input.currentRecipient
 }
@@ -208,11 +211,14 @@ export function resolveAgencyHandoffRecipientFromMessages(input: {
   const assistant = input.messages.findLast((item) => {
     if (item.role !== "assistant") return false
     if (item.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
-    const handoffAgent = resolveAgencyHandoffRecipientFromParts(input.partsByMessage?.[item.id] ?? [])
+    const parts = input.partsByMessage?.[item.id] ?? []
+    if (!hasAgencyHandoffEvidence(parts)) return false
+    const handoffAgent = resolveAgencyHandoffRecipientFromParts(parts)
     return !!(handoffAgent ?? item.agent)
   })
   if (!assistant) return undefined
-  const agent = resolveAgencyHandoffRecipientFromParts(input.partsByMessage?.[assistant.id] ?? []) ?? assistant.agent
+  const parts = input.partsByMessage?.[assistant.id] ?? []
+  const agent = resolveAgencyHandoffRecipientFromParts(parts) ?? assistant.agent
   if (
     input.currentRecipientSelectedAt &&
     assistant.time.completed &&
@@ -226,6 +232,7 @@ export function resolveAgencyHandoffRecipientFromMessages(input: {
       agency: input.agency,
       currentRecipient: input.currentRecipient,
       assistantAgent: agent,
+      handoffEvidence: hasAgencyHandoffEvidence(parts),
     })
   ) {
     return undefined

--- a/packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts
@@ -34,7 +34,10 @@ export async function cancelQueuedRunModeMessages(input: {
   deleteMessage: (messageID: string) => Promise<void>
 }) {
   const queued = input.frameworkMode ? collectQueuedRunModeMessages(input) : []
-  await input.abort()
+  if (queued.length === 0) {
+    await input.abort()
+    return queued
+  }
   for (const item of queued) {
     await input.deleteMessage(item.message.id)
   }

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -61,8 +61,15 @@ export function hasAgencyHandoffEvidence(parts: readonly unknown[] | undefined) 
 
     const state = asRecord(record["state"])
     const metadata = asRecord(record["metadata"]) ?? asRecord(state?.["metadata"])
-    return asString(metadata?.["type"]) === "handoff_output_item"
+    return isAgencyHandoffOutputMetadata(metadata)
   })
+}
+
+function isAgencyHandoffOutputMetadata(metadata: Record<string, unknown> | undefined) {
+  return (
+    asString(metadata?.["type"]) === "handoff_output_item" ||
+    asString(metadata?.["item_type"]) === "handoff_output_item"
+  )
 }
 
 export function isAgencyHandoffToolName(value: string | undefined) {

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -52,6 +52,23 @@ export function isAgencyToolOutputType(value: string | undefined) {
   return value === "function_call_output" || value === "tool_call_output_item" || value === "handoff_output_item"
 }
 
+export function hasAgencyHandoffEvidence(parts: readonly unknown[] | undefined) {
+  if (!parts) return false
+  return parts.some((part) => {
+    const record = asRecord(part)
+    if (!record || asString(record["type"]) !== "tool") return false
+    if (isAgencyHandoffToolName(asString(record["tool"]))) return true
+
+    const state = asRecord(record["state"])
+    const metadata = asRecord(record["metadata"]) ?? asRecord(state?.["metadata"])
+    return asString(metadata?.["type"]) === "handoff_output_item"
+  })
+}
+
+export function isAgencyHandoffToolName(value: string | undefined) {
+  return !!value?.startsWith("transfer_to_")
+}
+
 export function parseToolInput(raw: unknown): Record<string, unknown> {
   const rawRecord = asRecord(raw)
   if (rawRecord) return rawRecord

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -33,6 +33,7 @@ import {
   extractEventMeta,
   extractFunctionCallOutputs as extractFunctionCallOutputsFromMessages,
   findRecipientAgent,
+  hasAgencyHandoffEvidence,
   isAgencyToolOutputType,
   normalizeCallerAgent as normalizeCallerAgentValue,
   parseToolInput,
@@ -1625,6 +1626,19 @@ export namespace SessionAgencySwarm {
               input.assistantMessage.agent = maybeName
               input.assistantMessage.mode = maybeName
               await Session.updateMessage(input.assistantMessage)
+              await AgencySwarmHistory.appendMessages(scope, [
+                {
+                  type: "handoff_output_item",
+                  output: {
+                    assistant: maybeName,
+                  },
+                },
+                {
+                  type: "message",
+                  role: "assistant",
+                  agent: maybeName,
+                },
+              ])
             }
             continue
           }
@@ -2028,6 +2042,7 @@ export namespace SessionAgencySwarm {
         if (item.info.role !== "assistant") return false
         if (item.info.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
         if (item.info.summary) return false
+        if (!hasAgencyHandoffEvidence(item.parts)) return false
         return !!(resolveHandoffRecipientFromParts(item.parts) ?? item.info.agent)
       })
       if (!last) return
@@ -2064,8 +2079,13 @@ export namespace SessionAgencySwarm {
     return match?.[1]
   }
 
-  function readHandoffOutputAgent(output: string | undefined) {
+  function readHandoffOutputAgent(output: unknown) {
     if (!output) return undefined
+    if (typeof output !== "string") {
+      const parsed = asRecord(output)
+      if (!parsed) return undefined
+      return asString(parsed["assistant"] ?? parsed["agent"] ?? parsed["recipientAgent"] ?? parsed["recipient_agent"])
+    }
     try {
       const parsed = JSON.parse(output)
       if (!parsed || typeof parsed !== "object") return undefined
@@ -2088,15 +2108,20 @@ export namespace SessionAgencySwarm {
   }
 
   function resolveHandoffRecipientFromHistory(history: Array<Record<string, unknown>>) {
-    for (const item of history.toReversed()) {
+    for (let index = history.length - 1; index >= 0; index--) {
+      const item = history[index]
       const type = asString(item["type"])
       if (type === "handoff_output_item") {
-        const outputAgent = readHandoffOutputAgent(asString(item["output"]))
+        const outputAgent = readHandoffOutputAgent(item["output"])
         if (outputAgent) return outputAgent
-      }
-      if (type === "message" && asString(item["role"]) === "assistant") {
-        const agent = asString(item["agent"])
-        if (agent) return agent
+
+        for (let nextIndex = index + 1; nextIndex < history.length; nextIndex++) {
+          const message = history[nextIndex]
+          if (asString(message["type"]) !== "message") continue
+          if (asString(message["role"]) !== "assistant") continue
+          const agent = asString(message["agent"])
+          if (agent) return agent
+        }
       }
     }
     return undefined

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -46,6 +46,7 @@ describe("agency target options", () => {
         agency: "my-agency",
         currentRecipient: "ExampleAgent",
         assistantAgent: "ExampleAgent2",
+        handoffEvidence: true,
       }),
     ).toBe(true)
   })
@@ -69,6 +70,17 @@ describe("agency target options", () => {
             },
           },
         ],
+        partsByMessage: {
+          message_1: [
+            {
+              type: "tool",
+              tool: "transfer_to_Agent2",
+              state: {
+                status: "completed",
+              },
+            },
+          ],
+        },
       }),
     ).toEqual({
       sessionID: "session_1",
@@ -76,6 +88,36 @@ describe("agency target options", () => {
       agent: "Agent2",
       selectedAt: 1,
     })
+  })
+
+  test("does not restore a normal assistant response as a handoff", () => {
+    expect(
+      resolveAgencyHandoffRecipientFromMessages({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: undefined,
+        currentRecipientSelectedAt: undefined,
+        sessionID: "session_1",
+        messages: [
+          {
+            id: "message_1",
+            role: "assistant",
+            providerID: "agency-swarm",
+            agent: "Agent1",
+            time: {
+              completed: 2,
+            },
+          },
+        ],
+        partsByMessage: {
+          message_1: [
+            {
+              type: "text",
+            },
+          ],
+        },
+      }),
+    ).toBeUndefined()
   })
 
   test("keeps later manual recipient selection over restored handoff", () => {
@@ -201,6 +243,7 @@ describe("agency target options", () => {
         agency: "my-agency",
         currentRecipient: "ExampleAgent",
         assistantAgent: "ExampleAgent",
+        handoffEvidence: true,
       }),
     ).toBe(false)
     expect(
@@ -209,6 +252,7 @@ describe("agency target options", () => {
         agency: "my-agency",
         currentRecipient: "ExampleAgent",
         assistantAgent: "build",
+        handoffEvidence: true,
       }),
     ).toBe(false)
   })
@@ -218,6 +262,7 @@ describe("agency target options", () => {
       agency: "my-agency",
       currentRecipient: "ExampleAgent",
       assistantAgent: "ExampleAgent2",
+      handoffEvidence: true,
     }
     expect(shouldAdoptAgencyHandoffRecipient({ frameworkMode: false, ...base })).toBe(false)
     expect(shouldAdoptAgencyHandoffRecipient({ frameworkMode: true, ...base, agency: undefined })).toBe(false)

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -102,6 +102,49 @@ describe("agency target options", () => {
     })
   })
 
+  test("restores handed off recipient from handoff output item metadata", () => {
+    expect(
+      resolveAgencyHandoffRecipientFromMessages({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "Agent1",
+        currentRecipientSelectedAt: 1,
+        sessionID: "session_1",
+        messages: [
+          {
+            id: "message_1",
+            role: "assistant",
+            providerID: "agency-swarm",
+            agent: "Agent2",
+            time: {
+              completed: 2,
+            },
+          },
+        ],
+        partsByMessage: {
+          message_1: [
+            {
+              type: "tool",
+              tool: "tool",
+              state: {
+                status: "completed",
+                metadata: {
+                  item_type: "handoff_output_item",
+                  assistant: "Agent2",
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      sessionID: "session_1",
+      messageID: "message_1",
+      agent: "Agent2",
+      selectedAt: 1,
+    })
+  })
+
   test("does not restore a normal assistant response as a handoff", () => {
     expect(
       resolveAgencyHandoffRecipientFromMessages({

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -51,6 +51,18 @@ describe("agency target options", () => {
     ).toBe(true)
   })
 
+  test("does not adopt a new assistant agent without handoff evidence", () => {
+    expect(
+      shouldAdoptAgencyHandoffRecipient({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: undefined,
+        assistantAgent: "ExampleAgent2",
+        handoffEvidence: false,
+      }),
+    ).toBe(false)
+  })
+
   test("restores handed off recipient from synced session messages", () => {
     expect(
       resolveAgencyHandoffRecipientFromMessages({

--- a/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
@@ -183,6 +183,17 @@ describe("prompt framework-mode footer", () => {
           switchableOrgCount: 0,
         },
         message: {},
+        part: {
+          message_assistant_1: [
+            {
+              type: "tool",
+              tool: "transfer_to_slides_agent",
+              state: {
+                status: "completed",
+              },
+            },
+          ],
+        },
         provider: [
           {
             id: "agency-swarm",

--- a/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
@@ -222,7 +222,9 @@ describe("prompt framework-mode footer", () => {
           connected: [],
           default: {},
         },
-        session_status: {},
+        session_status: {
+          session_1: { type: "busy" },
+        },
       },
       session: {
         get: () => undefined,
@@ -300,6 +302,27 @@ describe("prompt framework-mode footer", () => {
     eventHandlers["message.updated"]?.({
       properties: {
         info: {
+          id: "message_assistant_normal",
+          sessionID: "session_1",
+          role: "assistant",
+          providerID: "agency-swarm",
+          agent: "slides_agent",
+        },
+      },
+    })
+    await flushEffects()
+
+    promptRef!.set({ input: "normal follow-up", parts: [] })
+    await promptRef!.submit()
+    await flushEffects()
+
+    expect(prompt).toHaveBeenCalledTimes(1)
+    const calls = prompt.mock.calls as unknown as Array<[{ parts: unknown[]; $body_agencyRecipientAgent?: string }]>
+    expect(calls[0][0].$body_agencyRecipientAgent).toBeUndefined()
+
+    eventHandlers["message.updated"]?.({
+      properties: {
+        info: {
           id: "message_assistant_1",
           sessionID: "session_1",
           role: "assistant",
@@ -319,9 +342,8 @@ describe("prompt framework-mode footer", () => {
     await promptRef!.submit()
     await flushEffects()
 
-    expect(prompt).toHaveBeenCalledTimes(1)
-    const calls = prompt.mock.calls as unknown as Array<[{ parts: unknown[]; $body_agencyRecipientAgent?: string }]>
-    const payload = calls[0][0]
+    expect(prompt).toHaveBeenCalledTimes(2)
+    const payload = calls[1][0]
     expect(payload.parts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -332,6 +354,37 @@ describe("prompt framework-mode footer", () => {
     )
     expect(payload.parts).not.toContainEqual(expect.objectContaining({ type: "agent" }))
     expect(payload.$body_agencyRecipientAgent).toBe("slides_agent")
+
+    eventHandlers["message.updated"]?.({
+      properties: {
+        info: {
+          id: "message_assistant_live_update",
+          sessionID: "session_1",
+          role: "assistant",
+          providerID: "agency-swarm",
+          agent: "slides_agent",
+        },
+      },
+    })
+    eventHandlers["message.updated"]?.({
+      properties: {
+        info: {
+          id: "message_assistant_live_update",
+          sessionID: "session_1",
+          role: "assistant",
+          providerID: "agency-swarm",
+          agent: "support_agent",
+        },
+      },
+    })
+    await flushEffects()
+
+    promptRef!.set({ input: "after live handoff", parts: [] })
+    await promptRef!.submit()
+    await flushEffects()
+
+    expect(prompt).toHaveBeenCalledTimes(3)
+    expect(calls[2][0].$body_agencyRecipientAgent).toBe("support_agent")
   })
 
   test("sends agency handoff recipient through the generated sdk prompt body", async () => {

--- a/packages/opencode/test/cli/tui/run-queued-messages.test.ts
+++ b/packages/opencode/test/cli/tui/run-queued-messages.test.ts
@@ -57,7 +57,7 @@ describe("run-mode queued messages", () => {
     expect(queued.map((item) => item.prompt.input)).toEqual(["second", "third"])
   })
 
-  test("abort removes queued Run-mode user messages after the active turn", async () => {
+  test("queued cancel removes queued Run-mode user messages without aborting the active turn", async () => {
     const calls: string[] = []
 
     const removed = await cancelQueuedRunModeMessages({
@@ -104,6 +104,48 @@ describe("run-mode queued messages", () => {
     })
 
     expect(removed.map((item) => item.message.id)).toEqual(["msg_3"])
-    expect(calls).toEqual(["abort", "delete:msg_3"])
+    expect(calls).toEqual(["delete:msg_3"])
+  })
+
+  test("queued cancel aborts the active turn when there are no queued messages", async () => {
+    const calls: string[] = []
+
+    const removed = await cancelQueuedRunModeMessages({
+      frameworkMode: true,
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          sessionID: "ses_1",
+          time: { created: 1 },
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+        },
+        {
+          id: "msg_2",
+          role: "assistant",
+          sessionID: "ses_1",
+          parentID: "msg_1",
+          time: { created: 2 },
+          agent: "build",
+          mode: "build",
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+      ],
+      parts: {},
+      abort: async () => {
+        calls.push("abort")
+      },
+      deleteMessage: async (messageID) => {
+        calls.push(`delete:${messageID}`)
+      },
+    })
+
+    expect(removed).toEqual([])
+    expect(calls).toEqual(["abort"])
   })
 })

--- a/packages/opencode/test/session/agency-swarm-utils.test.ts
+++ b/packages/opencode/test/session/agency-swarm-utils.test.ts
@@ -10,6 +10,7 @@ import {
   compactMetadata,
   extractEventMeta,
   findRecipientAgent,
+  hasAgencyHandoffEvidence,
   parseToolInput,
 } from "../../src/session/agency-swarm-utils"
 
@@ -171,5 +172,64 @@ describe("session.agency-swarm-utils", () => {
         ]),
       ),
     ).toBe("Reviewer")
+  })
+
+  test("hasAgencyHandoffEvidence accepts handoff output item metadata", () => {
+    expect(
+      hasAgencyHandoffEvidence([
+        {
+          type: "tool",
+          tool: "tool",
+          state: {
+            status: "completed",
+            metadata: {
+              item_type: "handoff_output_item",
+            },
+          },
+        },
+      ]),
+    ).toBeTrue()
+    expect(
+      hasAgencyHandoffEvidence([
+        {
+          type: "tool",
+          tool: "tool",
+          metadata: {
+            type: "handoff_output_item",
+          },
+        },
+      ]),
+    ).toBeTrue()
+  })
+
+  test("hasAgencyHandoffEvidence rejects non-handoff metadata", () => {
+    expect(
+      hasAgencyHandoffEvidence([
+        {
+          type: "tool",
+          tool: "tool",
+          state: {
+            status: "completed",
+            metadata: {
+              item_type: "function_call_output",
+            },
+          },
+        },
+        {
+          type: "tool",
+          tool: "tool",
+          metadata: {
+            item_type: "tool_call_output_item",
+          },
+        },
+        {
+          type: "text",
+          text: "assistant response",
+          metadata: {
+            item_type: "handoff_output_item",
+          },
+        },
+      ]),
+    ).toBeFalse()
   })
 })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -96,17 +96,20 @@ describe("session.agency-swarm", () => {
   const mockHistory = (lastRunID?: string) => {
     const appended: unknown[][] = []
     const runs: (string | undefined)[] = []
+    const chatHistory: unknown[] = []
     AgencySwarmHistory.load = (async () => ({
       scope: "http://127.0.0.1:8000|builder|session_1",
-      chat_history: [],
+      chat_history: chatHistory,
       last_run_id: lastRunID,
       updated_at: Date.now(),
     })) as typeof AgencySwarmHistory.load
     AgencySwarmHistory.appendMessages = (async (_scope, newMessages) => {
-      appended.push(Array.isArray(newMessages) ? newMessages : [])
+      const messages = Array.isArray(newMessages) ? newMessages : []
+      appended.push(messages)
+      chatHistory.push(...messages)
       return {
         scope: "scope",
-        chat_history: [],
+        chat_history: chatHistory,
         updated_at: Date.now(),
       }
     }) as typeof AgencySwarmHistory.appendMessages
@@ -120,6 +123,35 @@ describe("session.agency-swarm", () => {
       }
     }) as typeof AgencySwarmHistory.setLastRunID
     return { appended, runs }
+  }
+
+  const addCompletedTransferPart = async (input: {
+    sessionID: string
+    messageID: string
+    tool: string
+    output?: string
+    start?: number
+    end?: number
+  }) => {
+    await Session.updatePart({
+      id: PartID.ascending(),
+      messageID: input.messageID as any,
+      sessionID: input.sessionID as any,
+      type: "tool",
+      callID: "call_handoff",
+      tool: input.tool,
+      state: {
+        status: "completed",
+        input: {},
+        output: input.output ?? "{}",
+        title: "",
+        metadata: {},
+        time: {
+          start: input.start ?? Date.now(),
+          end: input.end ?? Date.now(),
+        },
+      },
+    })
   }
 
   test("optionsFromProvider applies defaults", () => {
@@ -2198,6 +2230,99 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream does not route to a normal prior assistant agent after local cache reset", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        let sentRecipient: string | undefined
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["ExampleAgent", "ExampleAgent2"],
+          },
+        })) as typeof AgencySwarmAdapter.getMetadata
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          sentRecipient = args.recipientAgent ?? undefined
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "normal assistant after cache reset" })
+        const created = Date.now()
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created,
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "hello",
+        })
+        await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          sessionID: session.id,
+          parentID: user.id,
+          modelID: "default",
+          providerID: "agency-swarm",
+          mode: "ExampleAgent",
+          agent: "ExampleAgent",
+          path: {
+            cwd: "/",
+            root: "/",
+          },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: {
+            created: created + 1,
+            completed: created + 2,
+          },
+        } as any)
+
+        const followUp = helper()
+        followUp.input.sessionID = session.id
+        followUp.input.assistantMessage.sessionID = session.id
+        followUp.input.options.recipientAgent = undefined
+        followUp.input.userMessage.info.id = MessageID.ascending()
+        followUp.input.userMessage.parts = [
+          { type: "text", text: "first prompt after cache reset", ignored: false },
+        ] as any
+
+        const stream = await SessionAgencySwarm.stream(followUp.input)
+        for await (const _ of stream.fullStream) {
+        }
+
+        expect(sentRecipient).toBeUndefined()
+      },
+    })
+  })
+
   test("compactHistory rebuilds request history from the compacted session slice", () => {
     const msgs = [
       {
@@ -2984,7 +3109,7 @@ describe("session.agency-swarm", () => {
           type: "text",
           text: "hello",
         })
-        await Session.updateMessage({
+        const assistant = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "assistant",
           sessionID: session.id,
@@ -3010,6 +3135,12 @@ describe("session.agency-swarm", () => {
             completed: Date.now(),
           },
         } as any)
+        await addCompletedTransferPart({
+          sessionID: session.id,
+          messageID: assistant.id,
+          tool: "transfer_to_support_agent",
+          output: '{"assistant":"support_agent"}',
+        })
 
         const { input } = helper()
         input.sessionID = session.id
@@ -3461,7 +3592,7 @@ describe("session.agency-swarm", () => {
           type: "text",
           text: "hello",
         })
-        await Session.updateMessage({
+        const assistant = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "assistant",
           sessionID: session.id,
@@ -3487,6 +3618,14 @@ describe("session.agency-swarm", () => {
             completed: created + 2,
           },
         } as any)
+        await addCompletedTransferPart({
+          sessionID: session.id,
+          messageID: assistant.id,
+          tool: "transfer_to_support_agent",
+          output: '{"assistant":"support_agent"}',
+          start: created + 1,
+          end: created + 2,
+        })
 
         const { input } = helper()
         input.sessionID = session.id
@@ -3661,7 +3800,7 @@ describe("session.agency-swarm", () => {
           type: "text",
           text: "hello",
         })
-        await Session.updateMessage({
+        const assistant = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "assistant",
           sessionID: session.id,
@@ -3687,6 +3826,14 @@ describe("session.agency-swarm", () => {
             completed: handoffCompletedAt,
           },
         } as any)
+        await addCompletedTransferPart({
+          sessionID: session.id,
+          messageID: assistant.id,
+          tool: "transfer_to_support_agent",
+          output: '{"assistant":"support_agent"}',
+          start: handoffStartedAt,
+          end: handoffCompletedAt,
+        })
 
         const { input } = helper()
         input.sessionID = session.id
@@ -3762,7 +3909,7 @@ describe("session.agency-swarm", () => {
           type: "text",
           text: "hello",
         })
-        await Session.updateMessage({
+        const assistant = await Session.updateMessage({
           id: MessageID.ascending(),
           role: "assistant",
           sessionID: session.id,
@@ -3787,6 +3934,14 @@ describe("session.agency-swarm", () => {
             created: created + 1,
           },
         } as any)
+        await addCompletedTransferPart({
+          sessionID: session.id,
+          messageID: assistant.id,
+          tool: "transfer_to_support_agent",
+          output: '{"assistant":"support_agent"}',
+          start: created + 1,
+          end: created + 1,
+        })
 
         const { input } = helper()
         input.sessionID = session.id


### PR DESCRIPTION
### Issue for this PR

Closes #161
Closes #162
Closes #163

Depends on #160. This branch is based on the #160 handoff fix so the queue and recipient fixes compose with that change.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes three post-release Agent Swarm Run-mode regressions.

Queued Run-mode cancellation now deletes queued user prompts without aborting the active assistant turn. Pressing cancel with no queued prompts still aborts the active turn.

Agency Swarm handoff routing now requires explicit handoff evidence before adopting a stored assistant agent as the next recipient. Transfer tools, handoff output items, and `agent_updated_stream_event` handoff updates still persist and restore the handoff recipient, but normal assistant responses no longer become stale handoff state after selecting the swarm row or starting from a clean local cache.

### How did you verify your code works?

- `cd packages/opencode && bun test test/cli/tui/run-queued-messages.test.ts test/cli/tui/agency-target.test.ts test/cli/tui/prompt-framework-mode.test.tsx test/session/agency-swarm.test.ts`
- `bun typecheck`
- `cd packages/opencode && bun run test:agentswarm:e2e`
- `bun turbo test:ci`
- `git diff --check`

### Screenshots / recordings

No screenshot. The affected paths are covered by unit tests and the Agent Swarm terminal TUI e2e harness.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
