### PR TITLE
fix: close release routing regressions

### DIFF
--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -2026,8 +2026,7 @@ export namespace SessionAgencySwarm {
       if (candidate.source === "message") return 0
       if (candidate.source === "prompt") return 1
       if (candidate.source === "config" && input.configuredRecipientSelectedAt) {
-        const sessionCompletedAt = sessionRecipient?.completedAt
-        if ((sessionCompletedAt && input.configuredRecipientSelectedAt > sessionCompletedAt) || input.historyRecipient)
+        if (sessionRecipient?.completedAt && input.configuredRecipientSelectedAt > sessionRecipient.completedAt)
           return 2
       }
       if (candidate.source === "session" || candidate.source === "history") return 3

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -391,6 +391,7 @@ export const User = Schema.Struct({
   }),
   system: Schema.optional(Schema.String),
   tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)),
+  agencyRecipientAgent: Schema.optional(Schema.String),
 })
   .annotate({ identifier: "UserMessage" })
   .pipe(withStatics((s) => ({ zod: zod(s) })))

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -931,6 +931,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         },
         system: input.system,
         format: input.format,
+        ...(input.agencyRecipientAgent ? { agencyRecipientAgent: input.agencyRecipientAgent } : {}),
       }
 
       yield* Effect.addFinalizer(() => instruction.clear(info.id))
@@ -1450,7 +1451,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     providerID: lastUser.model.providerID,
                     modelID: lastUser.model.modelID,
                   },
-                  recipientAgent: input.agencyRecipientAgent,
+                  recipientAgent: lastUser.agencyRecipientAgent ?? input.agencyRecipientAgent,
                 }),
             })
             if (result === "stop") return "break" as const

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3156,7 +3156,7 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream persists handed off recipient from final messages payload", async () => {
+  test("stream persists handed off recipient from final messages payload over stale configured selection", async () => {
     await using tmp = await tmpdir({
       git: true,
       config: {
@@ -3270,6 +3270,7 @@ describe("session.agency-swarm", () => {
         second.input.userMessage.info.id = MessageID.ascending()
         second.input.userMessage.parts = [{ type: "text", text: "follow up", ignored: false }] as any
         second.input.options.recipientAgent = "MathAgent"
+        ;(second.input.options as any).recipientAgentSelectedAt = 1
 
         const secondStream = await SessionAgencySwarm.stream(second.input)
         for await (const _ of secondStream.fullStream) {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -22,6 +22,7 @@ import { Session } from "../../src/session"
 import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
 import { SessionCompaction } from "../../src/session/compaction"
 import { SessionSummary } from "../../src/session/summary"
 import { Instruction } from "../../src/session/instruction"
@@ -441,6 +442,105 @@ it.live("static loop consumes queued replies across turns", () =>
     }),
     { git: true, config: providerCfg },
   ),
+)
+
+it.live(
+  "queued agency prompts keep their own recipient overrides",
+  () =>
+    provideTmpdirInstance(
+      (_dir) =>
+        Effect.gen(function* () {
+          const originalMetadata = AgencySwarmAdapter.getMetadata
+          const originalStream = AgencySwarmAdapter.streamRun
+          const firstStarted = defer<void>()
+          const finishFirst = defer<void>()
+          const recipients: (string | undefined)[] = []
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              AgencySwarmAdapter.getMetadata = originalMetadata
+              AgencySwarmAdapter.streamRun = originalStream
+            }),
+          )
+          AgencySwarmAdapter.getMetadata = (async () => ({
+            metadata: {
+              agents: ["MathAgent", "support_agent"],
+            },
+          })) as typeof AgencySwarmAdapter.getMetadata
+          AgencySwarmAdapter.streamRun = async function* (args) {
+            recipients.push(args.recipientAgent ?? undefined)
+            if (recipients.length === 1) {
+              firstStarted.resolve()
+              await finishFirst.promise
+            }
+            yield { type: "end" }
+          } as typeof AgencySwarmAdapter.streamRun
+
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const chat = yield* sessions.create({
+            title: "Queued agency recipients",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          const model = {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          }
+
+          const first = yield* prompt
+            .prompt({
+              sessionID: chat.id,
+              agent: "build",
+              model,
+              agencyRecipientAgent: "MathAgent",
+              parts: [{ type: "text", text: "first" }],
+            })
+            .pipe(Effect.forkChild)
+          yield* Effect.promise(() => firstStarted.promise)
+
+          const second = yield* prompt
+            .prompt({
+              sessionID: chat.id,
+              agent: "build",
+              model,
+              agencyRecipientAgent: "support_agent",
+              parts: [{ type: "text", text: "second" }],
+            })
+            .pipe(Effect.forkChild)
+          yield* waitForQueuedUser()
+          finishFirst.resolve()
+
+          const [firstExit, secondExit] = yield* Effect.all([Fiber.await(first), Fiber.await(second)])
+          expect(Exit.isSuccess(firstExit)).toBe(true)
+          expect(Exit.isSuccess(secondExit)).toBe(true)
+          expect(recipients).toEqual(["MathAgent", "support_agent"])
+
+          function waitForQueuedUser() {
+            return Effect.gen(function* () {
+              for (let attempt = 0; attempt < 20; attempt++) {
+                const messages = yield* sessions.messages({ sessionID: chat.id })
+                if (messages.filter((item) => item.info.role === "user").length === 2) return
+                yield* Effect.sleep(10)
+              }
+              throw new Error("Queued prompt was not persisted before the active run completed")
+            })
+          }
+        }),
+      {
+        git: true,
+        config: {
+          model: "agency-swarm/default",
+          provider: {
+            "agency-swarm": {
+              options: {
+                baseURL: "http://127.0.0.1:8000",
+                agency: "builder",
+              },
+            },
+          },
+        },
+      },
+    ),
+  3_000,
 )
 
 it.live("loop continues when finish is tool-calls", () =>

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2236,6 +2236,7 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
+      agencyRecipientAgent?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -2369,6 +2370,7 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
+      agencyRecipientAgent?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -2389,6 +2391,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "format" },
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
+            { in: "body", key: "agencyRecipientAgent" },
             { in: "body", key: "parts" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -577,6 +577,7 @@ export type UserMessage = {
   tools?: {
     [key: string]: boolean
   }
+  agencyRecipientAgent?: string
 }
 
 export type AssistantMessage = {
@@ -4034,6 +4035,7 @@ export type SessionPromptAsyncData = {
     format?: OutputFormat
     system?: string
     variant?: string
+    agencyRecipientAgent?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
   path: {


### PR DESCRIPTION
## Summary

Fixes the remaining release-review routing issues before `1.4.27`:

- persisted handoff history now beats stale configured recipients unless the user made a newer explicit selection
- queued Agency Swarm prompts keep their own recipient override instead of reusing the active run's override
- generated SDK types are refreshed for the prompt/user-message schema change

## Issues

Follow-up to #159, #161, #162, and #163 after PR #160 and PR #166.

## Verification

- red tests reproduced both release-review findings before the fix
- `bun test test/session/agency-swarm.test.ts`
- `bun test test/session/prompt.test.ts`
- focused TUI tests
- `bun typecheck`
- `bun run test:agentswarm:e2e`
- pre-push `bun turbo typecheck`

Browser-auth `rs_...` replay remains tracked separately in #167 and is not claimed fixed here.
