### PR TITLE
Fixed a bug where incorrect handoff message was saved in history

### DIFF
--- a/packages/opencode/src/agency-swarm/history.ts
+++ b/packages/opencode/src/agency-swarm/history.ts
@@ -95,9 +95,13 @@ export namespace AgencySwarmHistory {
 
   function asHistory(input: unknown): Array<Record<string, unknown>> {
     if (!Array.isArray(input)) return []
-    return input.filter(
-      (item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item),
-    )
+    return input.filter((item): item is Record<string, unknown> => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) return false
+      const record = item as Record<string, unknown>
+      if (record["type"] === "handoff_output_item") return false
+      if (record["type"] === "message" && !Object.prototype.hasOwnProperty.call(record, "content")) return false
+      return true
+    })
   }
 
   async function loadLegacy(scope: Scope): Promise<Entry | undefined> {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1626,19 +1626,6 @@ export namespace SessionAgencySwarm {
               input.assistantMessage.agent = maybeName
               input.assistantMessage.mode = maybeName
               await Session.updateMessage(input.assistantMessage)
-              await AgencySwarmHistory.appendMessages(scope, [
-                {
-                  type: "handoff_output_item",
-                  output: {
-                    assistant: maybeName,
-                  },
-                },
-                {
-                  type: "message",
-                  role: "assistant",
-                  agent: maybeName,
-                },
-              ])
             }
             continue
           }
@@ -2110,7 +2097,7 @@ export namespace SessionAgencySwarm {
     for (let index = history.length - 1; index >= 0; index--) {
       const item = history[index]
       const type = asString(item["type"])
-      if (type === "handoff_output_item") {
+      if (type === "function_call_output" || type === "handoff_output_item") {
         const outputAgent = readHandoffOutputAgent(item["output"])
         if (outputAgent) return outputAgent
 

--- a/packages/opencode/test/agency-swarm/history.test.ts
+++ b/packages/opencode/test/agency-swarm/history.test.ts
@@ -32,10 +32,14 @@ test("load falls back to legacy opencode storage and migrates entry", async () =
   }) as typeof Storage.write
   Bun.file = ((file: string) => ({
     json: async () => {
-      expect(file.endsWith(`/opencode/storage/agency_swarm_history/${hash}.json`)).toBeTrue()
+      expect(file.replaceAll("\\", "/").endsWith(`/opencode/storage/agency_swarm_history/${hash}.json`)).toBeTrue()
       return {
         scope: scopedKey,
-        chat_history: [{ type: "message", role: "assistant" }],
+        chat_history: [
+          { type: "message", role: "assistant", content: "kept" },
+          { type: "handoff_output_item", output: { assistant: "bad" } },
+          { type: "message", role: "assistant", agent: "bad" },
+        ],
         last_run_id: "run_1",
         updated_at: 123,
       }
@@ -46,7 +50,7 @@ test("load falls back to legacy opencode storage and migrates entry", async () =
 
   expect(entry).toEqual({
     scope: scopedKey,
-    chat_history: [{ type: "message", role: "assistant" }],
+    chat_history: [{ type: "message", role: "assistant", content: "kept" }],
     last_run_id: "run_1",
     updated_at: 123,
   })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3204,7 +3204,7 @@ describe("session.agency-swarm", () => {
               payload: {
                 new_messages: [
                   {
-                    type: "handoff_output_item",
+                    type: "function_call_output",
                     call_id: "call_handoff",
                     output: '{"assistant":"support_agent"}',
                   },
@@ -3435,7 +3435,7 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream routes next message to agent_updated handoff id", async () => {
+  test("stream does not persist agent_updated events as request history", async () => {
     await using tmp = await tmpdir({
       git: true,
       config: {
@@ -3466,8 +3466,10 @@ describe("session.agency-swarm", () => {
           ],
         })) as typeof AgencySwarmAdapter.getMetadata
         let turn = 0
+        const sentHistories: Array<Array<Record<string, unknown>>> = []
         AgencySwarmAdapter.streamRun = async function* (args) {
           turn++
+          sentHistories.push(args.chatHistory)
           if (turn === 1) {
             yield {
               type: "data",
@@ -3531,7 +3533,9 @@ describe("session.agency-swarm", () => {
         for await (const _ of secondStream.fullStream) {
         }
 
-        expect(sentRecipient).toBe("slides_agent")
+        expect(sentRecipient).toBeUndefined()
+        expect(sentHistories[1]?.some((item) => item.type === "handoff_output_item")).toBeFalse()
+        expect(sentHistories[1]?.some((item) => item.type === "message" && !("content" in item))).toBeFalse()
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #169

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a regression where Agency Swarm session history could include synthetic CLI-only handoff records that were later replayed to the backend as Responses input.

`handoff_output_item` is an Agents SDK run item type, not a valid Responses API input item type. The previous code also wrote an assistant `message` record with no `content`, which can fail replay with a missing `input[0].content` error.

This PR removes those synthetic writes from `agent_updated_stream_event`. Real handoff routing is recovered from the valid history shape Agency Swarm already stores: `function_call_output` with an output payload containing the target assistant. History normalization also drops already-persisted synthetic records so existing affected sessions can continue.

### How did you verify your code works?

Manually tested, additionally ran:

```bash
bun test --timeout 30000 ./test/session/agency-swarm.test.ts
bun test --timeout 30000 ./test/agency-swarm/history.test.ts
bun typecheck
bun turbo typecheck
```

### Screenshots / recordings

None

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR