### PR TITLE
fix: sanitize handoff history replay

### DIFF
--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -194,6 +194,12 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(nextBody).toMatchObject({
       recipient_agent: "MathAgent",
     })
+    expect(nextBody?.chat_history.some((item: any) => item?.type === "handoff_output_item")).toBeFalse()
+    expect(
+      nextBody?.chat_history.some(
+        (item: any) => item?.type === "message" && item?.role === "assistant" && !item?.content,
+      ),
+    ).toBeFalse()
   })
 
   test("prompt submit reaches the agency protocol server with the configured agent", async () => {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1559,13 +1559,14 @@ export namespace SessionAgencySwarm {
       if (rebuiltHistoryFromMessages) {
         await AgencySwarmHistory.appendMessages(scope, rebuiltHistoryFromMessages)
       }
+      const transportChatHistory = sanitizeAgencyHistoryForTransport(chatHistory)
 
       try {
         for await (const frame of AgencySwarmAdapter.streamRun({
           baseURL: input.options.baseURL,
           agency,
           message: outgoingMessage,
-          chatHistory,
+          chatHistory: transportChatHistory,
           recipientAgent,
           additionalInstructions: input.options.additionalInstructions,
           userContext: input.options.userContext,
@@ -2194,6 +2195,19 @@ export namespace SessionAgencySwarm {
         timestamp: msg.info.time.created,
       },
     ]
+  }
+
+  function sanitizeAgencyHistoryForTransport(history: Array<Record<string, unknown>>) {
+    return history.filter((item) => {
+      const type = asString(item["type"])
+      if (type === "handoff_output_item") return false
+      if (type !== "message") return true
+      if (asString(item["role"]) !== "assistant") return true
+      const content = item["content"]
+      if (Array.isArray(content)) return content.length > 0
+      if (typeof content === "string") return content.length > 0
+      return content !== undefined && content !== null
+    })
   }
 
   function extractCallerAgent(msg: MessageV2.WithParts): string | null {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3173,6 +3173,7 @@ describe("session.agency-swarm", () => {
         mockHistory()
         let turn = 0
         let sentRecipient: string | undefined
+        const sentHistories: unknown[][] = []
         AgencySwarmAdapter.getMetadata = (async () => ({
           metadata: {
             agents: ["support_agent", "MathAgent"],
@@ -3181,6 +3182,7 @@ describe("session.agency-swarm", () => {
         AgencySwarmAdapter.streamRun = async function* (args) {
           turn++
           sentRecipient = args.recipientAgent ?? undefined
+          sentHistories.push(args.chatHistory)
           if (turn === 1) {
             yield {
               type: "data",
@@ -3277,6 +3279,7 @@ describe("session.agency-swarm", () => {
         }
 
         expect(sentRecipient).toBe("support_agent")
+        expect(sentHistories[1]?.some((item) => (item as any)?.type === "handoff_output_item")).toBeFalse()
       },
     })
   })


### PR DESCRIPTION
## Summary
- keep local handoff history available for recipient resolution
- remove Agency Swarm-only handoff markers from transport chat_history before sending the next request
- assert the TUI handoff follow-up request keeps the target agent while excluding invalid history items

Closes #169

## Proof
- Red focused test reproduced handoff_output_item leaking into second-turn chat_history before the fix
- bun test test/session/agency-swarm.test.ts
- bun run test:agentswarm:e2e
- bun typecheck