### PR TITLE
fix(session): avoid queued agency recipient leak

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -71,6 +71,10 @@ const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested struc
 const log = Log.create({ service: "session.prompt" })
 const elog = EffectLogger.create({ service: "session.prompt" })
 
+type RunLoopInput = LoopInput & {
+  readonly promptMessageID?: MessageID
+}
+
 export function shouldUseAgencySwarmBridge(input: {
   resolvedProviderID: string
   agentProviderID?: string
@@ -1271,7 +1275,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         }
 
         if (input.noReply === true) return message
-        return yield* loop({ sessionID: input.sessionID, agencyRecipientAgent: input.agencyRecipientAgent })
+        return yield* loop({
+          sessionID: input.sessionID,
+          agencyRecipientAgent: input.agencyRecipientAgent,
+          promptMessageID: message.info.id,
+        })
       },
     )
 
@@ -1283,9 +1291,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       throw new Error("Impossible")
     })
 
-    const runLoop: (input: LoopInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(function* (
-      input: LoopInput,
-    ) {
+    const runLoop = Effect.fn("SessionPrompt.run")(function* (input: RunLoopInput) {
       const sessionID = input.sessionID
       const ctx = yield* InstanceState.context
       const slog = elog.with({ sessionID })
@@ -1451,7 +1457,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     providerID: lastUser.model.providerID,
                     modelID: lastUser.model.modelID,
                   },
-                  recipientAgent: lastUser.agencyRecipientAgent ?? input.agencyRecipientAgent,
+                  recipientAgent:
+                    lastUser.agencyRecipientAgent ??
+                    (lastUser.id === input.promptMessageID ? input.agencyRecipientAgent : undefined),
                 }),
             })
             if (result === "stop") return "break" as const
@@ -1570,9 +1578,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       return yield* lastAssistant(sessionID)
     })
 
-    const loop: (input: LoopInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.loop")(function* (
-      input: LoopInput,
-    ) {
+    const loop = Effect.fn("SessionPrompt.loop")(function* (input: RunLoopInput) {
       return yield* state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input))
     })
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -70,6 +70,105 @@ function defer<T>() {
   return { promise, resolve }
 }
 
+function queuedAgencyRecipientScenario(input: {
+  secondRecipient?: string
+  expectedRecipients: (string | undefined)[]
+}) {
+  return provideTmpdirInstance(
+    (_dir) =>
+      Effect.gen(function* () {
+        const originalMetadata = AgencySwarmAdapter.getMetadata
+        const originalStream = AgencySwarmAdapter.streamRun
+        const firstStarted = defer<void>()
+        const finishFirst = defer<void>()
+        const recipients: (string | undefined)[] = []
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            AgencySwarmAdapter.getMetadata = originalMetadata
+            AgencySwarmAdapter.streamRun = originalStream
+          }),
+        )
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["MathAgent", "support_agent"],
+          },
+        })) as typeof AgencySwarmAdapter.getMetadata
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          recipients.push(args.recipientAgent ?? undefined)
+          if (recipients.length === 1) {
+            firstStarted.resolve()
+            await finishFirst.promise
+          }
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({
+          title: "Queued agency recipients",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const model = {
+          providerID: ProviderID.make("agency-swarm"),
+          modelID: ModelID.make("default"),
+        }
+
+        const first = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model,
+            agencyRecipientAgent: "MathAgent",
+            parts: [{ type: "text", text: "first" }],
+          })
+          .pipe(Effect.forkChild)
+        yield* Effect.promise(() => firstStarted.promise)
+
+        const second = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model,
+            ...(input.secondRecipient !== undefined ? { agencyRecipientAgent: input.secondRecipient } : {}),
+            parts: [{ type: "text", text: "second" }],
+          })
+          .pipe(Effect.forkChild)
+        yield* waitForQueuedUser()
+        finishFirst.resolve()
+
+        const [firstExit, secondExit] = yield* Effect.all([Fiber.await(first), Fiber.await(second)])
+        expect(Exit.isSuccess(firstExit)).toBe(true)
+        expect(Exit.isSuccess(secondExit)).toBe(true)
+        expect(recipients).toEqual(input.expectedRecipients)
+
+        function waitForQueuedUser() {
+          return Effect.gen(function* () {
+            for (let attempt = 0; attempt < 20; attempt++) {
+              const messages = yield* sessions.messages({ sessionID: chat.id })
+              if (messages.filter((item) => item.info.role === "user").length === 2) return
+              yield* Effect.sleep(10)
+            }
+            throw new Error("Queued prompt was not persisted before the active run completed")
+          })
+        }
+      }),
+    {
+      git: true,
+      config: {
+        model: "agency-swarm/default",
+        provider: {
+          "agency-swarm": {
+            options: {
+              baseURL: "http://127.0.0.1:8000",
+              agency: "builder",
+            },
+          },
+        },
+      },
+    },
+  )
+}
+
 function withSh<A, E, R>(fx: () => Effect.Effect<A, E, R>) {
   return Effect.acquireUseRelease(
     Effect.sync(() => {
@@ -447,99 +546,19 @@ it.live("static loop consumes queued replies across turns", () =>
 it.live(
   "queued agency prompts keep their own recipient overrides",
   () =>
-    provideTmpdirInstance(
-      (_dir) =>
-        Effect.gen(function* () {
-          const originalMetadata = AgencySwarmAdapter.getMetadata
-          const originalStream = AgencySwarmAdapter.streamRun
-          const firstStarted = defer<void>()
-          const finishFirst = defer<void>()
-          const recipients: (string | undefined)[] = []
-          yield* Effect.addFinalizer(() =>
-            Effect.sync(() => {
-              AgencySwarmAdapter.getMetadata = originalMetadata
-              AgencySwarmAdapter.streamRun = originalStream
-            }),
-          )
-          AgencySwarmAdapter.getMetadata = (async () => ({
-            metadata: {
-              agents: ["MathAgent", "support_agent"],
-            },
-          })) as typeof AgencySwarmAdapter.getMetadata
-          AgencySwarmAdapter.streamRun = async function* (args) {
-            recipients.push(args.recipientAgent ?? undefined)
-            if (recipients.length === 1) {
-              firstStarted.resolve()
-              await finishFirst.promise
-            }
-            yield { type: "end" }
-          } as typeof AgencySwarmAdapter.streamRun
+    queuedAgencyRecipientScenario({
+      secondRecipient: "support_agent",
+      expectedRecipients: ["MathAgent", "support_agent"],
+    }),
+  3_000,
+)
 
-          const prompt = yield* SessionPrompt.Service
-          const sessions = yield* Session.Service
-          const chat = yield* sessions.create({
-            title: "Queued agency recipients",
-            permission: [{ permission: "*", pattern: "*", action: "allow" }],
-          })
-          const model = {
-            providerID: ProviderID.make("agency-swarm"),
-            modelID: ModelID.make("default"),
-          }
-
-          const first = yield* prompt
-            .prompt({
-              sessionID: chat.id,
-              agent: "build",
-              model,
-              agencyRecipientAgent: "MathAgent",
-              parts: [{ type: "text", text: "first" }],
-            })
-            .pipe(Effect.forkChild)
-          yield* Effect.promise(() => firstStarted.promise)
-
-          const second = yield* prompt
-            .prompt({
-              sessionID: chat.id,
-              agent: "build",
-              model,
-              agencyRecipientAgent: "support_agent",
-              parts: [{ type: "text", text: "second" }],
-            })
-            .pipe(Effect.forkChild)
-          yield* waitForQueuedUser()
-          finishFirst.resolve()
-
-          const [firstExit, secondExit] = yield* Effect.all([Fiber.await(first), Fiber.await(second)])
-          expect(Exit.isSuccess(firstExit)).toBe(true)
-          expect(Exit.isSuccess(secondExit)).toBe(true)
-          expect(recipients).toEqual(["MathAgent", "support_agent"])
-
-          function waitForQueuedUser() {
-            return Effect.gen(function* () {
-              for (let attempt = 0; attempt < 20; attempt++) {
-                const messages = yield* sessions.messages({ sessionID: chat.id })
-                if (messages.filter((item) => item.info.role === "user").length === 2) return
-                yield* Effect.sleep(10)
-              }
-              throw new Error("Queued prompt was not persisted before the active run completed")
-            })
-          }
-        }),
-      {
-        git: true,
-        config: {
-          model: "agency-swarm/default",
-          provider: {
-            "agency-swarm": {
-              options: {
-                baseURL: "http://127.0.0.1:8000",
-                agency: "builder",
-              },
-            },
-          },
-        },
-      },
-    ),
+it.live(
+  "queued agency prompt without a recipient does not inherit the active recipient",
+  () =>
+    queuedAgencyRecipientScenario({
+      expectedRecipients: ["MathAgent", undefined],
+    }),
   3_000,
 )
 


### PR DESCRIPTION
### Issue for this PR

Closes #175

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Queued Agency Swarm prompts can be processed by the first active run loop. Before this change, a queued prompt with no recipient could fall back to the first prompt's `agencyRecipientAgent`, sending the queued message to the wrong agent.

This threads the originating user message id into the internal run loop. The fallback recipient is only used for that originating prompt, while later queued prompts rely on their own persisted recipient value.

### How did you verify your code works?

- Added a regression test where the first queued prompt selects `MathAgent` and the second prompt has no recipient; the second transport call receives no recipient override.
- Kept coverage where a second queued prompt with its own recipient still uses that recipient.
- Ran focused prompt tests, package typecheck, root typecheck, diff check, and pre-push typecheck.
- GPT-5.5 high review worker: no findings.
- Claude Opus 4.7 max review: no findings.

### Screenshots / recordings

Not a UI rendering change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
