### PR TITLE
fix(cli): remove legacy agencii alias

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -160,7 +160,7 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
 - **Agency backend management commands are debugging and development tools**
   - Intent: keep backend lifecycle commands available for debugging and development without treating them as the main end-user path.
   - Behavior: the fork exposes backend install and maintenance commands, but they are debugging and development tools rather than core product surface.
-  - Implementation: `AgenciiCommand` in `packages/opencode/src/cli/cmd/agencii.ts`.
+  - Implementation: `AgencyCommand` in `packages/opencode/src/cli/cmd/agency.ts`.
   - Added by: `14abd070`
 
 - **Agent Builder instructions are retuned for Agency Swarm repos**

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -10,7 +10,7 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
 - Local Agency Swarm project detection, Python environment repair, bridge startup, starter creation, and external server connection.
 - Run mode, including Agency backend discovery, agent targeting, auth, reconnect, and hidden upstream-native commands.
 - Fork branding, tips, theme, config precedence, upgrade channel limits, and session sharing carry-forward.
-- Developer/debug backend management commands exposed as `agentswarm agency` and `agentswarm agencii`.
+- Developer/debug backend management commands exposed as `agentswarm agency`.
 
 ## Entry Points
 
@@ -21,7 +21,7 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
 - Resume and continue: reuse saved local Agency project context before the TUI opens when the session was an Agency run session.
 - TUI Run mode: connects to Agency Swarm, hides or limits upstream-native surfaces, and routes auth or connection failures to the fork dialogs.
 - `agentswarm pr <number>`: preserves fork branding and imports approved `https://opncd.ai/s/<id>` share links before reopening `agentswarm`.
-- `agentswarm agency ...` and `agentswarm agencii ...`: developer/debug commands for backend configuration and inspection.
+- `agentswarm agency ...`: developer/debug commands for backend configuration and inspection.
 
 ## Decision Tree
 
@@ -194,7 +194,7 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
 
 ### Backend Management
 
-- Trigger: run `agentswarm agency ...` or the legacy alias `agentswarm agencii ...`.
+- Trigger: run `agentswarm agency ...`.
 - Expected path:
   - Treat this group as developer/debug surface, not the primary end-user onboarding path.
   - `connect` stores normalized backend config and optional bearer token.
@@ -229,7 +229,7 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
 - Config precedence: `packages/opencode/src/config/paths.ts`, `packages/opencode/src/config/config.ts`, `packages/opencode/src/cli/cmd/tui/config/tui.ts`.
 - Upgrade channel limits: `packages/opencode/src/installation/index.ts`, `packages/opencode/src/cli/cmd/upgrade.ts`.
 - Share carry-forward and PR reopen: `packages/opencode/src/share/share-next.ts`, `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`, `packages/opencode/src/cli/cmd/pr.ts`, `README.md`.
-- Backend management commands: `packages/opencode/src/cli/cmd/agencii.ts`.
+- Backend management commands: `packages/opencode/src/cli/cmd/agency.ts`.
 
 ## Tracked Gaps
 

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -164,7 +164,6 @@ const LAUNCHER_SUBCOMMANDS = new Set([
   "pr",
   "session",
   "agency",
-  "agencii",
   "plugin",
   "db",
 ])

--- a/packages/opencode/src/cli/cmd/agency.ts
+++ b/packages/opencode/src/cli/cmd/agency.ts
@@ -8,20 +8,20 @@ import { Auth } from "@/auth"
 import * as Config from "@/config/config"
 import path from "path"
 
-export const AgenciiCommand = cmd({
-  command: ["agency", "agencii"],
+export const AgencyCommand = cmd({
+  command: "agency",
   describe: "Agency Swarm backend management: connect, discover agencies, set default agency, Agent Builder helpers",
   builder: (yargs: Argv) =>
     yargs
-      .command(AgenciiConnectCommand)
-      .command(AgenciiAgenciesCommand)
-      .command(AgenciiUseCommand)
-      .command(AgenciiAgentCommand)
+      .command(AgencyConnectCommand)
+      .command(AgencyAgenciesCommand)
+      .command(AgencyUseCommand)
+      .command(AgencyAgentCommand)
       .demandCommand(),
   async handler() {},
 })
 
-const AgenciiConnectCommand = cmd({
+const AgencyConnectCommand = cmd({
   command: "connect",
   describe: "set Agency Swarm backend URL in global config",
   builder: (yargs: Argv) =>
@@ -64,7 +64,7 @@ const AgenciiConnectCommand = cmd({
   },
 })
 
-const AgenciiAgenciesCommand = cmd({
+const AgencyAgenciesCommand = cmd({
   command: "agencies",
   describe: "discover agencies from the configured Agency Swarm backend",
   builder: (yargs: Argv) =>
@@ -92,7 +92,7 @@ const AgenciiAgenciesCommand = cmd({
       })
 
       if (discovered.agencies.length === 0) {
-        UI.println(`No agencies discovered. Try \`${AgencyProduct.cmd} agencii use <agency-id> --url ...\`.`)
+        UI.println(`No agencies discovered. Try \`${AgencyProduct.cmd} agency use <agency-id> --url ...\`.`)
         return
       }
 
@@ -105,7 +105,7 @@ const AgenciiAgenciesCommand = cmd({
   },
 })
 
-const AgenciiUseCommand = cmd({
+const AgencyUseCommand = cmd({
   command: "use <agency>",
   describe: "set default Agency Swarm agency in global config",
   builder: (yargs: Argv) =>
@@ -167,14 +167,14 @@ const AgenciiUseCommand = cmd({
   },
 })
 
-const AgenciiAgentCommand = cmd({
+const AgencyAgentCommand = cmd({
   command: "agent",
   describe: "Agency Swarm Agent Builder helpers",
-  builder: (yargs: Argv) => yargs.command(AgenciiAgentNewCommand).demandCommand(),
+  builder: (yargs: Argv) => yargs.command(AgencyAgentNewCommand).demandCommand(),
   async handler() {},
 })
 
-const AgenciiAgentNewCommand = cmd({
+const AgencyAgentNewCommand = cmd({
   command: "new <name>",
   describe: "create a new Agency Swarm agent scaffold via `agency-swarm create-agent-template`",
   builder: (yargs: Argv) =>
@@ -291,8 +291,7 @@ export function runtimeOptions(
   const fromConfigBaseURL =
     readString(options?.["baseURL"]) ?? readString(options?.["base_url"]) ?? AgencySwarmAdapter.DEFAULT_BASE_URL
   const fromConfigToken = readString(options?.["token"])
-  const fromAuthToken =
-    auth?.type === "api" ? auth.key : auth?.type === "wellknown" ? auth.token : undefined
+  const fromAuthToken = auth?.type === "api" ? auth.key : auth?.type === "wellknown" ? auth.token : undefined
   const fromConfigTimeout =
     readPositiveNumber(options?.["discoveryTimeoutMs"]) ??
     readPositiveNumber(options?.["discovery_timeout_ms"]) ??
@@ -301,9 +300,12 @@ export function runtimeOptions(
   const baseURL = AgencySwarmAdapter.normalizeBaseURL(
     typeof args.url === "string" && args.url.trim() ? args.url.trim() : fromConfigBaseURL,
   )
-  const token = typeof args.token === "string" && args.token.trim() ? args.token.trim() : fromAuthToken ?? fromConfigToken
+  const token =
+    typeof args.token === "string" && args.token.trim() ? args.token.trim() : (fromAuthToken ?? fromConfigToken)
   const timeout =
-    typeof args.timeout === "number" && Number.isFinite(args.timeout) && args.timeout > 0 ? args.timeout : fromConfigTimeout
+    typeof args.timeout === "number" && Number.isFinite(args.timeout) && args.timeout > 0
+      ? args.timeout
+      : fromConfigTimeout
 
   return {
     baseURL,

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -178,7 +178,7 @@ export function DialogAgent() {
           agency: "__empty__",
         },
         title: "No agencies discovered",
-        description: `Check ${providerOptions().baseURL} and run \`agentswarm agencii agencies\``,
+        description: `Check ${providerOptions().baseURL} and run \`agentswarm agency agencies\``,
         disabled: true,
         category: "agency-swarm",
       })

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -37,7 +37,7 @@ import { Database } from "./storage"
 import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
 import { Heap } from "./cli/heap"
-import { AgenciiCommand } from "./cli/cmd/agencii"
+import { AgencyCommand } from "./cli/cmd/agency"
 import { AgencyProduct } from "./agency-swarm/product"
 import { drizzle } from "drizzle-orm/bun-sqlite"
 import { ensureProcessMetadata } from "@opencode-ai/core/util/opencode-process"
@@ -178,7 +178,7 @@ const cli = yargs(args)
   .command(GithubCommand)
   .command(PrCommand)
   .command(SessionCommand)
-  .command(AgenciiCommand)
+  .command(AgencyCommand)
   .command(PluginCommand)
   .command(DbCommand)
   .fail((msg, err) => {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -560,7 +560,7 @@ export namespace SessionAgencySwarm {
       throw new Error(
         [
           "No agencies were discovered from agency-swarm OpenAPI metadata.",
-          "Configure provider.options.agency in your config, or run `agentswarm agencii use <agency-id>`.",
+          "Configure provider.options.agency in your config, or run `agentswarm agency use <agency-id>`.",
         ].join(" "),
       )
     }
@@ -569,7 +569,7 @@ export namespace SessionAgencySwarm {
       [
         "Multiple agencies were discovered but no default agency is configured.",
         `Available agencies: ${availableAgencies.join(", ")}.`,
-        "Set provider.options.agency or run `agentswarm agencii use <agency-id>`.",
+        "Set provider.options.agency or run `agentswarm agency use <agency-id>`.",
       ].join(" "),
     )
   }

--- a/packages/opencode/test/cli/agency.test.ts
+++ b/packages/opencode/test/cli/agency.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
-import { connectOptions, runtimeOptions } from "../../src/cli/cmd/agencii"
+import { connectOptions, runtimeOptions } from "../../src/cli/cmd/agency"
 
-describe("agencii", () => {
+describe("agency", () => {
   test("connect options clear remembered agency state", () => {
     expect(connectOptions("http://127.0.0.1:9000")).toEqual({
       baseURL: "http://127.0.0.1:9000",


### PR DESCRIPTION
### Issue for this PR

Closes #177

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Removes the legacy `agencii` backend-management alias so Agent Swarm exposes only `agentswarm agency ...`.

The change updates the command registration, launcher subcommand detection, TUI/error copy, fork docs, and the focused CLI test import/name. It also renames the command module and test file from `agencii` to `agency` so the internal names match the public command.

### How did you verify your code works?

- Confirmed no tracked file still contains `agencii` or `Agencii`.
- Ran `cd packages/opencode && bun test test/cli/agency.test.ts`.
- Ran `cd packages/opencode && bun typecheck`.
- Ran `agentswarm agency --help` through `bun run --conditions=browser src/index.ts agency --help` and confirmed the backend-management command appears as `agentswarm agency`.

### Screenshots / recordings

Not applicable; command/docs cleanup only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
