### PR TITLE
fix(tui): keep SendMessage delegation from switching agents

### DIFF
--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -10,7 +10,9 @@ Source of truth: `FORK_CHANGELOG.md` defines intentional fork behavior, and `USE
 - `FORK_CHANGELOG.md` CLI/TUI UX: selecting a swarm row clears stale explicit agent routing before the next prompt.
 - `FORK_CHANGELOG.md` CLI/TUI UX: selecting a specific agent routes the next prompt to that agent.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: prompt submit reaches a local Agency Swarm protocol server with the configured agent.
+- `FORK_CHANGELOG.md` Agency Swarm Integration: ordinary `SendMessage` delegation with `recipient_agent` does not switch the user's active recipient.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: `transfer_to_*` handoff events switch control to the target agent for the next turn.
+- `FORK_CHANGELOG.md` Agency Swarm Integration: `agent_updated_stream_event` handoffs without separate transfer tool parts switch control to the target agent.
 - `USER_FLOWS.md` Auto-Start Detected Local Project: launcher mode shows the detected-project choice before `.venv` work begins.
 
 ## Manual Gap

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -295,6 +295,100 @@ const tuiDemoAgencyFixture: AgencyFixture = {
   },
   stream(body, requestCount) {
     const message = typeof body.message === "string" ? body.message.toLowerCase() : ""
+    if (message.includes("delegate")) {
+      return sse([
+        ["meta", { run_id: `run_tui_demo_${requestCount}` }],
+        [
+          "data",
+          {
+            type: "raw_response_event",
+            agent: "UserSupportAgent",
+            data: {
+              type: "response.output_item.added",
+              output_index: "1",
+              item: {
+                type: "function_call",
+                id: "fc_send_message",
+                call_id: "call_send_message",
+                name: "SendMessage",
+                arguments: JSON.stringify({
+                  recipient_agent: "MathAgent",
+                  message: "Please calculate this.",
+                }),
+              },
+            },
+          },
+        ],
+        [
+          "messages",
+          {
+            new_messages: [
+              {
+                id: `msg_delegate_${requestCount}`,
+                type: "message",
+                role: "assistant",
+                agent: "UserSupportAgent",
+                content: [{ type: "output_text", text: "Starting SendMessage delegation." }],
+              },
+            ],
+          },
+        ],
+        [
+          "messages",
+          {
+            new_messages: [
+              {
+                type: "function_call_output",
+                call_id: "call_send_message",
+                output: JSON.stringify({
+                  recipient_agent: "MathAgent",
+                  response: "Delegation completed without transfer.",
+                }),
+              },
+              {
+                id: `msg_delegate_${requestCount}`,
+                type: "message",
+                role: "assistant",
+                agent: "MathAgent",
+                content: [{ type: "output_text", text: "Delegated to MathAgent with SendMessage." }],
+              },
+            ],
+          },
+        ],
+        ["end", {}],
+      ])
+    }
+    if (message.includes("live handoff")) {
+      return sse([
+        ["meta", { run_id: `run_tui_demo_${requestCount}` }],
+        [
+          "data",
+          {
+            type: "agent_updated_stream_event",
+            agent: "MathAgent",
+            new_agent: {
+              id: "MathAgent",
+              name: "MathAgent",
+            },
+          },
+        ],
+        [
+          "messages",
+          {
+            new_messages: [
+              {
+                id: `msg_live_handoff_${requestCount}`,
+                type: "message",
+                role: "assistant",
+                agent: "MathAgent",
+                content: [{ type: "output_text", text: "Live agent update moved control to MathAgent." }],
+              },
+            ],
+          },
+        ],
+        ["end", {}],
+      ])
+    }
     if (message.includes("handoff")) {
       return sse([
         ["meta", { run_id: `run_tui_demo_${requestCount}` }],

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -14,8 +14,8 @@ import {
 let currentTui: TuiProcess | undefined
 let currentServer: AgencyProtocolServer | undefined
 const tempDirs: string[] = []
-const tuiReadyTimeoutMs = 30_000
-const tuiInteractionTimeoutMs = 45_000
+const tuiReadyTimeoutMs = process.env.CI ? 60_000 : 30_000
+const tuiInteractionTimeoutMs = process.env.CI ? 60_000 : 45_000
 
 afterEach(async () => {
   await currentTui?.close()
@@ -163,6 +163,41 @@ describe("Agent Swarm terminal TUI e2e", () => {
     })
   })
 
+  test("SendMessage delegation does not switch control to the delegated agent", async () => {
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+    })
+
+    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    currentTui.write("delegate normal sendmessage\r")
+    await currentTui.waitForText("Delegated to MathAgent with SendMessage.", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(() => currentServer!.requests.length === 1, "delegate request", tuiInteractionTimeoutMs)
+
+    currentTui.write("plain followup\r")
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 2,
+      "post-delegation request",
+      tuiInteractionTimeoutMs,
+    )
+
+    const delegateBody = currentServer.requests[0]?.body
+    expect(delegateBody?.message).toContain("delegate normal sendmessage")
+    expect(delegateBody).toMatchObject({
+      recipient_agent: "UserSupportAgent",
+    })
+    const nextBody = currentServer.requests[1]?.body
+    expect(nextBody?.message).toContain("plain followup")
+    expect(nextBody).toMatchObject({
+      recipient_agent: "UserSupportAgent",
+    })
+    expect(nextBody?.chat_history.some((item: any) => item?.type === "function_call_output")).toBeTrue()
+    expect(nextBody?.chat_history.some((item: any) => item?.type === "handoff_output_item")).toBeFalse()
+  })
+
   test("transfer_to handoff switches control to the target agent for the next turn", async () => {
     currentServer = await startTuiDemoAgencyServer()
     currentTui = await startTui({
@@ -200,6 +235,45 @@ describe("Agent Swarm terminal TUI e2e", () => {
         (item: any) => item?.type === "message" && item?.role === "assistant" && !item?.content,
       ),
     ).toBeFalse()
+  })
+
+  test("agent_updated_stream_event-only handoff switches control to the target agent", async () => {
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+    })
+
+    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    currentTui.write("please live handoff this calculation\r")
+    await currentTui.waitForText("Live agent update moved control to MathAgent.", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 1,
+      "live handoff request",
+      tuiInteractionTimeoutMs,
+    )
+
+    currentTui.write("continue after live handoff\r")
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 2,
+      "post-live-handoff request",
+      tuiInteractionTimeoutMs,
+    )
+
+    const handoffBody = currentServer.requests[0]?.body
+    expect(handoffBody?.message).toContain("please live handoff this calculation")
+    expect(handoffBody).toMatchObject({
+      recipient_agent: "UserSupportAgent",
+    })
+    const nextBody = currentServer.requests[1]?.body
+    expect(nextBody?.message).toContain("continue after live handoff")
+    expect(nextBody).toMatchObject({
+      recipient_agent: "MathAgent",
+    })
+    expect(nextBody?.chat_history.some((item: any) => item?.type === "function_call_output")).toBeFalse()
+    expect(nextBody?.chat_history.some((item: any) => item?.type === "handoff_output_item")).toBeFalse()
   })
 
   test("prompt submit reaches the agency protocol server with the configured agent", async () => {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -129,6 +129,14 @@ function fadeColor(color: RGBA, alpha: number) {
 
 let stashed: { prompt: PromptInfo; cursor: number } | undefined
 
+type AgencyAssistantMessageInfo = {
+  id: string
+  sessionID: string
+  role: string
+  providerID?: string
+  agent?: string
+}
+
 export function Prompt(props: PromptProps) {
   let input: TextareaRenderable
   let anchor: BoxRenderable
@@ -167,7 +175,7 @@ export function Prompt(props: PromptProps) {
       }
     | undefined
   >()
-  const observedAssistantAgentsByMessage = new Map<string, string>()
+  const assistantMessagesByID = new Map<string, AgencyAssistantMessageInfo>()
   const activeOrgName = createMemo(() => sync.data.console_state.activeOrgName)
   const canSwitchOrgs = createMemo(() => sync.data.console_state.switchableOrgCount > 1)
   const frameworkMode = createMemo(() =>
@@ -254,7 +262,7 @@ export function Prompt(props: PromptProps) {
       () => props.sessionID,
       () => {
         setHandoffRecipient(undefined)
-        observedAssistantAgentsByMessage.clear()
+        assistantMessagesByID.clear()
       },
     ),
   )
@@ -268,44 +276,58 @@ export function Prompt(props: PromptProps) {
     setHandoffRecipient(undefined)
   })
 
+  function partsWithUpdatedPart(updated: (typeof sync.data.part)[string][number]) {
+    const current = sync.data.part?.[updated.messageID] ?? []
+    const index = current.findIndex((part) => part.id === updated.id)
+    if (index === -1) return [...current, updated]
+    return current.map((part, currentIndex) => (currentIndex === index ? updated : part))
+  }
+
+  function adoptAgencyHandoffRecipient(info: AgencyAssistantMessageInfo, parts: (typeof sync.data.part)[string]) {
+    if (info.sessionID !== props.sessionID) return
+    if (info.role !== "assistant") return
+    if (info.providerID !== AgencySwarmAdapter.PROVIDER_ID) return
+
+    const options = agencyProviderOptions()
+    const handoffAgent = resolveAgencyHandoffRecipientFromParts(parts) ?? info.agent
+    if (!handoffAgent) return
+    if (
+      !shouldAdoptAgencyHandoffRecipient({
+        frameworkMode: frameworkMode(),
+        agency: options.agency,
+        currentRecipient: options.recipientAgent,
+        assistantAgent: handoffAgent,
+        handoffEvidence: hasAgencyHandoffEvidence(parts),
+      })
+    ) {
+      return
+    }
+
+    setHandoffRecipient({
+      sessionID: info.sessionID,
+      messageID: info.id,
+      agent: handoffAgent,
+      selectedAt: options.recipientAgentSelectedAt,
+    })
+  }
+
   onCleanup(
     event.on("message.updated", (evt) => {
       const info = evt.properties.info
-      if (info.sessionID !== props.sessionID) return
-      if (info.role !== "assistant") return
-      if (info.providerID !== AgencySwarmAdapter.PROVIDER_ID) return
-
-      const options = agencyProviderOptions()
+      assistantMessagesByID.set(info.id, info)
       const parts = sync.data.part?.[info.id] ?? []
-      const handoffAgent = resolveAgencyHandoffRecipientFromParts(parts) ?? info.agent
-      const explicitHandoffEvidence = hasAgencyHandoffEvidence(parts)
-      const previousAssistantAgent = observedAssistantAgentsByMessage.get(info.id)
-      const liveAgentUpdatedEvidence =
-        !explicitHandoffEvidence &&
-        status().type !== "idle" &&
-        !!previousAssistantAgent &&
-        previousAssistantAgent !== handoffAgent
-      if (handoffAgent) {
-        observedAssistantAgentsByMessage.set(info.id, handoffAgent)
-      }
-      if (
-        !shouldAdoptAgencyHandoffRecipient({
-          frameworkMode: frameworkMode(),
-          agency: options.agency,
-          currentRecipient: options.recipientAgent,
-          assistantAgent: handoffAgent,
-          handoffEvidence: explicitHandoffEvidence || liveAgentUpdatedEvidence,
-        })
-      ) {
-        return
-      }
-
-      setHandoffRecipient({
-        sessionID: info.sessionID,
-        messageID: info.id,
-        agent: handoffAgent,
-        selectedAt: options.recipientAgentSelectedAt,
-      })
+      adoptAgencyHandoffRecipient(info, parts)
+    }),
+  )
+  onCleanup(
+    event.on("message.part.updated", (evt) => {
+      const part = evt.properties.part
+      if (part.sessionID !== props.sessionID) return
+      const info =
+        assistantMessagesByID.get(part.messageID) ??
+        sync.data.message?.[part.sessionID]?.find((message) => message.id === part.messageID)
+      if (!info) return
+      adoptAgencyHandoffRecipient(info, partsWithUpdatedPart(part))
     }),
   )
   const editorPath = createMemo(() => editor.selection()?.filePath)

--- a/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
@@ -1,6 +1,6 @@
 import { displayAgentName } from "@/agent/display"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
-import { hasAgencyHandoffEvidence } from "@/session/agency-swarm-utils"
+import { hasAgencyHandoffEvidence, isAgencyAgentUpdatedHandoffMetadata } from "@/session/agency-swarm-utils"
 import * as Locale from "@/util/locale"
 
 export type AgencyHandoffMessage = {
@@ -17,6 +17,7 @@ export type AgencyHandoffMessage = {
 export type AgencyHandoffPart = {
   type: string
   tool?: string
+  metadata?: Record<string, unknown>
   state?: {
     status?: string
     output?: string
@@ -247,6 +248,8 @@ export function resolveAgencyHandoffRecipientFromMessages(input: {
 
 export function resolveAgencyHandoffRecipientFromParts(parts: AgencyHandoffPart[]) {
   for (const part of parts.toReversed()) {
+    const metadataAgent = readAgentUpdatedHandoffMetadataAgent(part.metadata)
+    if (metadataAgent) return metadataAgent
     if (part.type !== "tool") continue
     const outputAgent = readHandoffOutputAgent(part.state?.output) ?? readHandoffMetadataAgent(part.state?.metadata)
     if (outputAgent) return outputAgent
@@ -282,6 +285,11 @@ function readHandoffMetadataAgent(metadata: Record<string, unknown> | undefined)
   return readString(
     metadata["assistant"] ?? metadata["agent"] ?? metadata["recipientAgent"] ?? metadata["recipient_agent"],
   )
+}
+
+function readAgentUpdatedHandoffMetadataAgent(metadata: Record<string, unknown> | undefined) {
+  if (!isAgencyAgentUpdatedHandoffMetadata(metadata)) return undefined
+  return readHandoffMetadataAgent(metadata)
 }
 
 export function displayRunOnlyAgentLabel(input: {

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -56,13 +56,19 @@ export function hasAgencyHandoffEvidence(parts: readonly unknown[] | undefined) 
   if (!parts) return false
   return parts.some((part) => {
     const record = asRecord(part)
-    if (!record || asString(record["type"]) !== "tool") return false
+    if (!record) return false
+    if (isAgencyAgentUpdatedHandoffMetadata(asRecord(record["metadata"]))) return true
+    if (asString(record["type"]) !== "tool") return false
     if (isAgencyHandoffToolName(asString(record["tool"]))) return true
 
     const state = asRecord(record["state"])
     const metadata = asRecord(record["metadata"]) ?? asRecord(state?.["metadata"])
     return isAgencyHandoffOutputMetadata(metadata)
   })
+}
+
+export function isAgencyAgentUpdatedHandoffMetadata(metadata: Record<string, unknown> | undefined) {
+  return asString(metadata?.["agency_handoff_event"]) === "agent_updated_stream_event"
 }
 
 function isAgencyHandoffOutputMetadata(metadata: Record<string, unknown> | undefined) {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -34,6 +34,7 @@ import {
   extractFunctionCallOutputs as extractFunctionCallOutputsFromMessages,
   findRecipientAgent,
   hasAgencyHandoffEvidence,
+  isAgencyAgentUpdatedHandoffMetadata,
   isAgencyToolOutputType,
   normalizeCallerAgent as normalizeCallerAgentValue,
   parseToolInput,
@@ -615,6 +616,7 @@ export namespace SessionAgencySwarm {
     let cancelBeforeMetaTimer: ReturnType<typeof setTimeout> | undefined
     let streamAborted = false
     let hadDanglingTool = false
+    const agentUpdatedHandoffAgents = new Set<string>()
 
     const streamAbort = new AbortController()
     const streamSignal = AbortSignal.any([input.abort, streamAbort.signal])
@@ -636,6 +638,13 @@ export namespace SessionAgencySwarm {
       const key = textKey(itemID, index)
       const current = textBuffer.get(key) || ""
       return current === text && !textOpen.has(key)
+    }
+
+    const agentUpdatedHandoffMetadata = (agent: string | undefined) => {
+      const handoffAgent = agent ?? input.assistantMessage.agent
+      return handoffAgent && agentUpdatedHandoffAgents.has(handoffAgent)
+        ? { agency_handoff_event: "agent_updated_stream_event", assistant: handoffAgent }
+        : {}
     }
 
     const reasoningKey = (itemID: string, index: number) => `${itemID}:${index}`
@@ -1209,7 +1218,10 @@ export namespace SessionAgencySwarm {
         const text = extractMessageText(message)
         if (!text) continue
         if (shouldSkipDuplicateAssistantText(itemID, 0, text)) continue
-        yield* finishText(itemID, 0, text, messageMeta, { source: "messages" })
+        yield* finishText(itemID, 0, text, messageMeta, {
+          source: "messages",
+          ...agentUpdatedHandoffMetadata(messageMeta.agent),
+        })
       }
     }
 
@@ -1624,6 +1636,7 @@ export namespace SessionAgencySwarm {
               ? (asString(next["id"]) ?? asString(next["name"]) ?? asString(next["label"]))
               : undefined
             if (maybeName) {
+              agentUpdatedHandoffAgents.add(maybeName)
               input.assistantMessage.agent = maybeName
               input.assistantMessage.mode = maybeName
               await Session.updateMessage(input.assistantMessage)
@@ -1719,7 +1732,10 @@ export namespace SessionAgencySwarm {
                 contentIndex,
                 final,
                 eventMeta,
-                outputMeta(outputIndex, { content_index: contentIndex }),
+                outputMeta(outputIndex, {
+                  content_index: contentIndex,
+                  ...agentUpdatedHandoffMetadata(eventMeta.agent),
+                }),
               )
               continue
             }
@@ -2063,6 +2079,10 @@ export namespace SessionAgencySwarm {
 
   function resolveHandoffRecipientFromParts(parts: MessageV2.Part[]) {
     for (const part of parts.toReversed()) {
+      const metadataAgent = readAgentUpdatedHandoffMetadataAgent(
+        asRecord("metadata" in part ? part.metadata : undefined),
+      )
+      if (metadataAgent) return metadataAgent
       if (part.type !== "tool") continue
       const outputAgent =
         readHandoffOutputAgent(part.state.status === "completed" ? part.state.output : undefined) ??
@@ -2105,6 +2125,11 @@ export namespace SessionAgencySwarm {
     return asString(
       metadata["assistant"] ?? metadata["agent"] ?? metadata["recipientAgent"] ?? metadata["recipient_agent"],
     )
+  }
+
+  function readAgentUpdatedHandoffMetadataAgent(metadata: Record<string, unknown> | undefined) {
+    if (!isAgencyAgentUpdatedHandoffMetadata(metadata)) return undefined
+    return readHandoffMetadataAgent(metadata)
   }
 
   function resolveHandoffRecipientFromHistory(history: Array<Record<string, unknown>>) {

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -63,6 +63,83 @@ describe("agency target options", () => {
     ).toBe(false)
   })
 
+  test("does not restore SendMessage recipient_agent output as a handoff", () => {
+    expect(
+      resolveAgencyHandoffRecipientFromMessages({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "UserSupportAgent",
+        currentRecipientSelectedAt: 1,
+        sessionID: "session_1",
+        messages: [
+          {
+            id: "message_1",
+            role: "assistant",
+            providerID: "agency-swarm",
+            agent: "MathAgent",
+            time: {
+              completed: 2,
+            },
+          },
+        ],
+        partsByMessage: {
+          message_1: [
+            {
+              type: "tool",
+              tool: "SendMessage",
+              state: {
+                status: "completed",
+                output: '{"recipient_agent":"MathAgent","response":"Delegation completed without transfer."}',
+                metadata: {
+                  item_type: "function_call_output",
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toBeUndefined()
+  })
+
+  test("restores agent_updated_stream_event-only handoff metadata", () => {
+    expect(
+      resolveAgencyHandoffRecipientFromMessages({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "UserSupportAgent",
+        currentRecipientSelectedAt: 1,
+        sessionID: "session_1",
+        messages: [
+          {
+            id: "message_1",
+            role: "assistant",
+            providerID: "agency-swarm",
+            agent: "MathAgent",
+            time: {
+              completed: 2,
+            },
+          },
+        ],
+        partsByMessage: {
+          message_1: [
+            {
+              type: "text",
+              metadata: {
+                agency_handoff_event: "agent_updated_stream_event",
+                assistant: "MathAgent",
+              },
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      sessionID: "session_1",
+      messageID: "message_1",
+      agent: "MathAgent",
+      selectedAt: 1,
+    })
+  })
+
   test("restores handed off recipient from synced session messages", () => {
     expect(
       resolveAgencyHandoffRecipientFromMessages({

--- a/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
@@ -56,6 +56,11 @@ describe("prompt framework-mode footer", () => {
               name: "Slides Agent",
               isEntryPoint: false,
             },
+            {
+              id: "support_agent",
+              name: "Support Agent",
+              isEntryPoint: false,
+            },
           ],
           metadata: {},
         },
@@ -379,12 +384,36 @@ describe("prompt framework-mode footer", () => {
     })
     await flushEffects()
 
-    promptRef!.set({ input: "after live handoff", parts: [] })
+    promptRef!.set({ input: "after label-only update", parts: [] })
     await promptRef!.submit()
     await flushEffects()
 
     expect(prompt).toHaveBeenCalledTimes(3)
-    expect(calls[2][0].$body_agencyRecipientAgent).toBe("support_agent")
+    expect(calls[2][0].$body_agencyRecipientAgent).toBe("slides_agent")
+
+    eventHandlers["message.part.updated"]?.({
+      properties: {
+        part: {
+          id: "part_live_update",
+          sessionID: "session_1",
+          messageID: "message_assistant_live_update",
+          type: "text",
+          text: "Live handoff complete.",
+          metadata: {
+            agency_handoff_event: "agent_updated_stream_event",
+            assistant: "support_agent",
+          },
+        },
+      },
+    })
+    await flushEffects()
+
+    promptRef!.set({ input: "after live handoff", parts: [] })
+    await promptRef!.submit()
+    await flushEffects()
+
+    expect(prompt).toHaveBeenCalledTimes(4)
+    expect(calls[3][0].$body_agencyRecipientAgent).toBe("support_agent")
   })
 
   test("sends agency handoff recipient through the generated sdk prompt body", async () => {

--- a/packages/opencode/test/session/agency-swarm-utils.test.ts
+++ b/packages/opencode/test/session/agency-swarm-utils.test.ts
@@ -202,6 +202,21 @@ describe("session.agency-swarm-utils", () => {
     ).toBeTrue()
   })
 
+  test("hasAgencyHandoffEvidence accepts agent_updated_stream_event metadata", () => {
+    expect(
+      hasAgencyHandoffEvidence([
+        {
+          type: "text",
+          text: "Math agent now has control.",
+          metadata: {
+            agency_handoff_event: "agent_updated_stream_event",
+            assistant: "MathAgent",
+          },
+        },
+      ]),
+    ).toBeTrue()
+  })
+
   test("hasAgencyHandoffEvidence rejects non-handoff metadata", () => {
     expect(
       hasAgencyHandoffEvidence([

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3482,6 +3482,20 @@ describe("session.agency-swarm", () => {
                 },
               },
             }
+            yield {
+              type: "messages",
+              payload: {
+                new_messages: [
+                  {
+                    id: "msg_slides_handoff",
+                    type: "message",
+                    role: "assistant",
+                    agent: "slides_agent",
+                    content: [{ type: "output_text", text: "Slides agent has control." }],
+                  },
+                ],
+              },
+            }
             yield { type: "end" }
             return
           }
@@ -3518,10 +3532,183 @@ describe("session.agency-swarm", () => {
         first.input.userMessage.info.id = user.id
 
         const firstStream = await SessionAgencySwarm.stream(first.input)
-        for await (const _ of firstStream.fullStream) {
+        const firstEvents: any[] = []
+        for await (const event of firstStream.fullStream) {
+          firstEvents.push(event)
         }
 
         expect(first.input.assistantMessage.agent).toBe("slides_agent")
+        expect(
+          firstEvents.some(
+            (event) =>
+              event.providerMetadata?.agency_handoff_event === "agent_updated_stream_event" &&
+              event.providerMetadata?.assistant === "slides_agent",
+          ),
+        ).toBeTrue()
+
+        const second = helper()
+        second.input.sessionID = session.id
+        second.input.assistantMessage.sessionID = session.id
+        second.input.assistantMessage.id = MessageID.ascending()
+        second.input.userMessage.info.id = MessageID.ascending()
+        second.input.userMessage.parts = [{ type: "text", text: "continue", ignored: false }] as any
+
+        const secondStream = await SessionAgencySwarm.stream(second.input)
+        for await (const _ of secondStream.fullStream) {
+        }
+
+        expect(sentRecipient).toBe("slides_agent")
+      },
+    })
+  })
+
+  test("stream keeps agent_updated handoff metadata when raw text is replayed by messages", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        let sentRecipient: string | undefined
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["orchestrator", "slides_agent"],
+          },
+          nodes: [
+            {
+              id: "slides_agent",
+              type: "agent",
+              data: {
+                label: "Slides Agent",
+              },
+            },
+          ],
+        })) as typeof AgencySwarmAdapter.getMetadata
+        let turn = 0
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          turn++
+          if (turn === 1) {
+            yield {
+              type: "data",
+              payload: {
+                type: "agent_updated_stream_event",
+                new_agent: {
+                  id: "slides_agent",
+                  label: "Slides Agent",
+                },
+              },
+            }
+            yield {
+              type: "data",
+              payload: {
+                type: "raw_response_event",
+                data: {
+                  type: "response.output_item.added",
+                  output_index: 0,
+                  item: {
+                    id: "msg_slides_handoff",
+                    type: "message",
+                  },
+                },
+              },
+            }
+            yield {
+              type: "data",
+              payload: {
+                type: "raw_response_event",
+                data: {
+                  type: "response.output_text.delta",
+                  item_id: "msg_slides_handoff",
+                  output_index: 0,
+                  content_index: 0,
+                  delta: "Slides agent has control.",
+                },
+              },
+            }
+            yield {
+              type: "data",
+              payload: {
+                type: "raw_response_event",
+                data: {
+                  type: "response.output_text.done",
+                  item_id: "msg_slides_handoff",
+                  output_index: 0,
+                  content_index: 0,
+                  text: "Slides agent has control.",
+                },
+              },
+            }
+            yield {
+              type: "messages",
+              payload: {
+                new_messages: [
+                  {
+                    id: "msg_slides_handoff",
+                    type: "message",
+                    role: "assistant",
+                    agent: "slides_agent",
+                    content: [{ type: "output_text", text: "Slides agent has control." }],
+                  },
+                ],
+              },
+            }
+            yield { type: "end" }
+            return
+          }
+          sentRecipient = args.recipientAgent ?? undefined
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "handoff replay metadata" })
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "make slides",
+        })
+        const first = helper()
+        first.input.sessionID = session.id
+        first.input.assistantMessage.sessionID = session.id
+        first.input.assistantMessage.parentID = user.id
+        first.input.assistantMessage.id = MessageID.ascending()
+        first.input.userMessage.info.id = user.id
+
+        const firstStream = await SessionAgencySwarm.stream(first.input)
+        const firstEvents: any[] = []
+        for await (const event of firstStream.fullStream) {
+          firstEvents.push(event)
+        }
+
+        expect(
+          firstEvents.some(
+            (event) =>
+              event.type === "text-end" &&
+              event.providerMetadata?.agency_handoff_event === "agent_updated_stream_event" &&
+              event.providerMetadata?.assistant === "slides_agent",
+          ),
+        ).toBeTrue()
 
         const second = helper()
         second.input.sessionID = session.id


### PR DESCRIPTION
### Issue for this PR

Closes #173

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevents ordinary Agency Swarm `SendMessage` delegation from switching the TUI active recipient. Handoff recipient adoption now requires explicit Agency Swarm handoff evidence.

The fix preserves real handoffs from `transfer_to_*`, `handoff_output_item`, and live `agent_updated_stream_event` streams. Live agent updates are recorded as explicit metadata and adopted when the matching message part arrives, so normal assistant label changes stay non-authoritative.

### How did you verify your code works?

Reproduced on published `agentswarm-cli@1.4.28` in `/tmp/as173-repro`: `delegate normal sendmessage` incorrectly routed the follow-up prompt to `MathAgent`, while the real `transfer_to_math_agent` control path correctly routed the follow-up to `MathAgent`.

Local validation:

- `cd packages/opencode && bun test test/cli/tui/prompt-framework-mode.test.tsx`
- `cd packages/opencode && bun test test/cli/tui/agency-target.test.ts`
- `cd packages/opencode && bun test test/session/agency-swarm-utils.test.ts test/session/agency-swarm.test.ts --timeout 30000`
- `cd packages/opencode && CI=1 bun run test:agentswarm:e2e`
- `bun typecheck`
- Push hook ran `bun turbo typecheck`.
- Local Codex review of the final diff found no actionable bugs.

### Screenshots / recordings

Not applicable. This is routing behavior covered by focused session tests and the Agent Swarm TUI e2e harness.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
