### PR TITLE
fix(tui): drain queued run-mode cancels

### DIFF
--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -45,7 +45,7 @@ export async function startAgencyProtocolServer(
       if (url.pathname === `/${fixture.agencyID}/get_response_stream`) {
         const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
         requests.push({ path: url.pathname, body })
-        return new Response(fixture.stream(body, requests.length), {
+        return new Response(await fixture.stream(body, requests.length), {
           headers: {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -219,7 +219,7 @@ export async function writeAgencyProject(dir: string) {
 type AgencyFixture = {
   agencyID: string
   metadata: Record<string, unknown>
-  stream(body: Record<string, unknown>, requestCount: number): string
+  stream(body: Record<string, unknown>, requestCount: number): BodyInit | Promise<BodyInit>
 }
 
 const qaAgencyFixture: AgencyFixture = {
@@ -252,7 +252,31 @@ const qaAgencyFixture: AgencyFixture = {
       },
     ],
   },
-  stream(_body, requestCount) {
+  stream(body, requestCount) {
+    const message = typeof body.message === "string" ? body.message : ""
+    if (message.includes("issue 172 hold")) {
+      return delayedSse(
+        [
+          ["meta", { run_id: `run_e2e_${requestCount}` }],
+          [
+            "messages",
+            {
+              new_messages: [
+                {
+                  id: `msg_issue172_${requestCount}`,
+                  type: "message",
+                  role: "assistant",
+                  agent: "entry-agent",
+                  content: [{ type: "output_text", text: "completed first issue 172 prompt" }],
+                },
+              ],
+            },
+          ],
+          ["end", {}],
+        ],
+        8_000,
+      )
+    }
     return sse([
       ["meta", { run_id: `run_e2e_${requestCount}` }],
       ["end", {}],
@@ -380,6 +404,18 @@ const tuiDemoAgencyFixture: AgencyFixture = {
 
 function sse(events: Array<[event: string, data: Record<string, unknown>]>) {
   return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("")
+}
+
+function delayedSse(events: Array<[event: string, data: Record<string, unknown>]>, delayMs: number) {
+  const encoder = new TextEncoder()
+  return new ReadableStream({
+    async start(controller) {
+      controller.enqueue(encoder.encode(sse(events.slice(0, 1))))
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+      controller.enqueue(encoder.encode(sse(events.slice(1))))
+      controller.close()
+    },
+  })
 }
 
 async function closeProcess(proc: Proc) {

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -221,6 +221,29 @@ describe("Agent Swarm terminal TUI e2e", () => {
     })
   })
 
+  test("Esc twice cancels queued Run-mode prompt before active stream drains", async () => {
+    currentServer = await startAgencyProtocolServer()
+    currentTui = await startTui({ baseURL: currentServer.baseURL })
+
+    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    currentTui.write("first issue 172 hold\r")
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 1,
+      "first issue 172 agency request",
+      tuiInteractionTimeoutMs,
+    )
+
+    currentTui.write("second issue 172 prompt SHOULD_NOT_SEND\r")
+    await currentTui.waitForText("QUEUED", tuiInteractionTimeoutMs)
+    currentTui.write("\x1b")
+    await Bun.sleep(100)
+    currentTui.write("\x1b")
+    await currentTui.waitForText("Cancelled 1 queued message", tuiInteractionTimeoutMs)
+    await Bun.sleep(8_500)
+
+    expect(currentServer.requests.map((request) => request.body.message)).toEqual(["first issue 172 hold"])
+  })
+
   test("harness does not leak parent provider credentials to the agency protocol server", async () => {
     currentServer = await startAgencyProtocolServer()
     currentTui = await startTui({

--- a/packages/opencode/src/server/routes/instance/httpapi/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/session.ts
@@ -12,6 +12,7 @@ import { Session } from "@/session"
 import { SessionCompaction } from "@/session/compaction"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionPrompt } from "@/session/prompt"
+import { removeMessageAllowingQueued } from "@/session/queued-message"
 import { SessionRevert } from "@/session/revert"
 import { SessionRunState } from "@/session/run-state"
 import { SessionStatus } from "@/session/status"
@@ -835,10 +836,7 @@ export const sessionHandlers = Layer.unwrap(
         Instance.restore(instance, () =>
           AppRuntime.runPromise(
             Effect.gen(function* () {
-              const state = yield* SessionRunState.Service
-              const session = yield* Session.Service
-              yield* state.assertNotBusy(ctx.params.sessionID)
-              yield* session.removeMessage(ctx.params)
+              yield* removeMessageAllowingQueued(ctx.params)
             }).pipe(Effect.provide(SessionRunState.defaultLayer), Effect.provide(Session.defaultLayer)),
           ),
         ),

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -6,7 +6,7 @@ import z from "zod"
 import { Session } from "@/session"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionPrompt } from "@/session/prompt"
-import { SessionRunState } from "@/session/run-state"
+import { removeMessageAllowingQueued } from "@/session/queued-message"
 import { SessionCompaction } from "@/session/compaction"
 import { SessionRevert } from "@/session/revert"
 import { SessionShare } from "@/share"
@@ -752,10 +752,7 @@ export const SessionRoutes = lazy(() =>
       async (c) =>
         jsonRequest("SessionRoutes.deleteMessage", c, function* () {
           const params = c.req.valid("param")
-          const state = yield* SessionRunState.Service
-          const session = yield* Session.Service
-          yield* state.assertNotBusy(params.sessionID)
-          yield* session.removeMessage({
+          yield* removeMessageAllowingQueued({
             sessionID: params.sessionID,
             messageID: params.messageID,
           })

--- a/packages/opencode/src/session/queued-message.ts
+++ b/packages/opencode/src/session/queued-message.ts
@@ -8,14 +8,13 @@ export function isQueuedAfterActiveAssistant(input: {
   messages: readonly MessageV2.WithParts[]
   messageID: MessageID
 }) {
-  const activeAssistant = input.messages.findLast(
+  const activeAssistantIndex = input.messages.findLastIndex(
     (message) => message.info.role === "assistant" && !message.info.time.completed,
   )
-  if (!activeAssistant) return false
-  return input.messages.some(
-    (message) =>
-      message.info.role === "user" && message.info.id === input.messageID && message.info.id > activeAssistant.info.id,
-  )
+  if (activeAssistantIndex === -1) return false
+  const messageIndex = input.messages.findIndex((message) => message.info.id === input.messageID)
+  if (messageIndex === -1) return false
+  return input.messages[messageIndex]?.info.role === "user" && messageIndex > activeAssistantIndex
 }
 
 export const removeMessageAllowingQueued = Effect.fn("SessionQueuedMessage.removeMessageAllowingQueued")(

--- a/packages/opencode/src/session/queued-message.ts
+++ b/packages/opencode/src/session/queued-message.ts
@@ -1,0 +1,36 @@
+import { Effect } from "effect"
+import * as Session from "./session"
+import { MessageV2 } from "./message-v2"
+import { MessageID, SessionID } from "./schema"
+import { SessionRunState } from "./run-state"
+
+export function isQueuedAfterActiveAssistant(input: {
+  messages: readonly MessageV2.WithParts[]
+  messageID: MessageID
+}) {
+  const activeAssistant = input.messages.findLast(
+    (message) => message.info.role === "assistant" && !message.info.time.completed,
+  )
+  if (!activeAssistant) return false
+  return input.messages.some(
+    (message) =>
+      message.info.role === "user" && message.info.id === input.messageID && message.info.id > activeAssistant.info.id,
+  )
+}
+
+export const removeMessageAllowingQueued = Effect.fn("SessionQueuedMessage.removeMessageAllowingQueued")(
+  function* (input: { sessionID: SessionID; messageID: MessageID }) {
+    const state = yield* SessionRunState.Service
+    const session = yield* Session.Service
+    const busy = yield* state.isBusy(input.sessionID)
+
+    if (busy) {
+      const messages = yield* session.messages({ sessionID: input.sessionID })
+      if (!isQueuedAfterActiveAssistant({ messages, messageID: input.messageID })) {
+        throw new Session.BusyError(input.sessionID)
+      }
+    }
+
+    yield* session.removeMessage(input)
+  },
+)

--- a/packages/opencode/src/session/queued-message.ts
+++ b/packages/opencode/src/session/queued-message.ts
@@ -24,6 +24,8 @@ export const removeMessageAllowingQueued = Effect.fn("SessionQueuedMessage.remov
     const busy = yield* state.isBusy(input.sessionID)
 
     if (busy) {
+      const running = yield* state.isRunning(input.sessionID)
+      if (!running) throw new Session.BusyError(input.sessionID)
       const messages = yield* session.messages({ sessionID: input.sessionID })
       if (!isQueuedAfterActiveAssistant({ messages, messageID: input.messageID })) {
         throw new Session.BusyError(input.sessionID)

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -9,6 +9,7 @@ import { SessionStatus } from "./status"
 export interface Interface {
   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void>
   readonly isBusy: (sessionID: SessionID) => Effect.Effect<boolean>
+  readonly isRunning: (sessionID: SessionID) => Effect.Effect<boolean>
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly ensureRunning: (
     sessionID: SessionID,
@@ -79,6 +80,11 @@ export const layer = Layer.effect(
       return data.runners.get(sessionID)?.busy === true
     })
 
+    const isRunning = Effect.fn("SessionRunState.isRunning")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      return data.runners.get(sessionID)?.state._tag === "Running"
+    })
+
     const cancel = Effect.fn("SessionRunState.cancel")(function* (sessionID: SessionID) {
       const data = yield* InstanceState.get(state)
       const existing = data.runners.get(sessionID)
@@ -105,7 +111,7 @@ export const layer = Layer.effect(
       return yield* (yield* runner(sessionID, onInterrupt)).startShell(work)
     })
 
-    return Service.of({ assertNotBusy, isBusy, cancel, ensureRunning, startShell })
+    return Service.of({ assertNotBusy, isBusy, isRunning, cancel, ensureRunning, startShell })
   }),
 )
 

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -8,6 +8,7 @@ import { SessionStatus } from "./status"
 
 export interface Interface {
   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void>
+  readonly isBusy: (sessionID: SessionID) => Effect.Effect<boolean>
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly ensureRunning: (
     sessionID: SessionID,
@@ -73,6 +74,11 @@ export const layer = Layer.effect(
       if (existing?.busy) throw new Session.BusyError(sessionID)
     })
 
+    const isBusy = Effect.fn("SessionRunState.isBusy")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      return data.runners.get(sessionID)?.busy === true
+    })
+
     const cancel = Effect.fn("SessionRunState.cancel")(function* (sessionID: SessionID) {
       const data = yield* InstanceState.get(state)
       const existing = data.runners.get(sessionID)
@@ -99,7 +105,7 @@ export const layer = Layer.effect(
       return yield* (yield* runner(sessionID, onInterrupt)).startShell(work)
     })
 
-    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
+    return Service.of({ assertNotBusy, isBusy, cancel, ensureRunning, startShell })
   }),
 )
 

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -303,8 +303,9 @@ describe("session HttpApi", () => {
         permission: [{ permission: "*", pattern: "*", action: "allow" }],
       })
       const model = { providerID: "agency-swarm", modelID: "default" }
-      const promptBody = (text: string) =>
+      const promptBody = (text: string, messageID?: MessageID) =>
         JSON.stringify({
+          ...(messageID ? { messageID } : {}),
           agent: "build",
           model,
           parts: [{ id: PartID.ascending(), type: "text", text }],
@@ -317,15 +318,14 @@ describe("session HttpApi", () => {
       })
       await firstStarted.promise
 
+      const secondMessageID = MessageID.ascending("msg_00000000000000000000000000")
       const second = app().request(pathFor(SessionPaths.prompt, { sessionID: session.id }), {
         method: "POST",
         headers,
-        body: promptBody("second issue 172 prompt SHOULD_NOT_SEND"),
+        body: promptBody("second issue 172 prompt SHOULD_NOT_SEND", secondMessageID),
       })
       const users = await waitForUserMessageCount(tmp.path, session.id, 2)
-      const queued = users.find((item) =>
-        item.parts.some((part) => part.type === "text" && part.text.includes("SHOULD_NOT_SEND")),
-      )
+      const queued = users.find((item) => item.info.id === secondMessageID)
       expect(queued).toBeTruthy()
 
       expect(

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -10,6 +10,7 @@ import { SessionPaths } from "../../src/server/routes/instance/httpapi/session"
 import { Session } from "../../src/session"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { MessageV2 } from "../../src/session/message-v2"
+import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
 import { Log } from "../../src/util"
 import { resetDatabase } from "../fixture/db"
 import { tmpdir } from "../fixture/fixture"
@@ -68,8 +69,31 @@ async function createTextMessage(directory: string, sessionID: SessionID, text: 
 }
 
 async function json<T>(response: Response) {
-  if (response.status !== 200) throw new Error(await response.text())
+  if (response.status !== 200) throw new Error(`${response.status}: ${await response.text()}`)
   return (await response.json()) as T
+}
+
+function defer<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+async function waitForUserMessageCount(directory: string, sessionID: SessionID, count: number) {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const messages = await Instance.provide({
+      directory,
+      fn: async () =>
+        runSession(Session.Service.use((svc) => svc.messages({ sessionID }))).then((items) =>
+          items.filter((item) => item.info.role === "user"),
+        ),
+    })
+    if (messages.length === count) return messages
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for ${count} user messages`)
 }
 
 afterEach(async () => {
@@ -235,6 +259,96 @@ describe("session HttpApi", () => {
         }),
       ),
     ).toBe(true)
+  })
+
+  test("deletes queued Run-mode message while active turn is busy", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        formatter: false,
+        lsp: false,
+        model: "agency-swarm/default",
+        provider: {
+          "agency-swarm": {
+            options: {
+              baseURL: "http://127.0.0.1:8000",
+              agency: "local-agency",
+            },
+          },
+        },
+      },
+    })
+    const originalMetadata = AgencySwarmAdapter.getMetadata
+    const originalStream = AgencySwarmAdapter.streamRun
+    const firstStarted = defer<void>()
+    const finishFirst = defer<void>()
+    const prompts: string[] = []
+
+    AgencySwarmAdapter.getMetadata = (async () => ({
+      metadata: { agents: ["entry-agent"] },
+    })) as typeof AgencySwarmAdapter.getMetadata
+    AgencySwarmAdapter.streamRun = async function* (args) {
+      prompts.push(args.message)
+      if (prompts.length === 1) {
+        firstStarted.resolve()
+        await finishFirst.promise
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    try {
+      const headers = { "x-opencode-directory": tmp.path, "content-type": "application/json" }
+      const session = await createSession(tmp.path, {
+        title: "queued delete",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      const model = { providerID: "agency-swarm", modelID: "default" }
+      const promptBody = (text: string) =>
+        JSON.stringify({
+          agent: "build",
+          model,
+          parts: [{ id: PartID.ascending(), type: "text", text }],
+        })
+
+      const first = app().request(pathFor(SessionPaths.prompt, { sessionID: session.id }), {
+        method: "POST",
+        headers,
+        body: promptBody("first issue 172 prompt"),
+      })
+      await firstStarted.promise
+
+      const second = app().request(pathFor(SessionPaths.prompt, { sessionID: session.id }), {
+        method: "POST",
+        headers,
+        body: promptBody("second issue 172 prompt SHOULD_NOT_SEND"),
+      })
+      const users = await waitForUserMessageCount(tmp.path, session.id, 2)
+      const queued = users.find((item) =>
+        item.parts.some((part) => part.type === "text" && part.text.includes("SHOULD_NOT_SEND")),
+      )
+      expect(queued).toBeTruthy()
+
+      expect(
+        await json<boolean>(
+          await app().request(
+            pathFor(SessionPaths.deleteMessage, {
+              sessionID: session.id,
+              messageID: queued!.info.id,
+            }),
+            { method: "DELETE", headers },
+          ),
+        ),
+      ).toBe(true)
+
+      finishFirst.resolve()
+      expect((await first).status).toBe(200)
+      expect((await second).status).toBe(200)
+      expect(prompts).toEqual(["first issue 172 prompt"])
+    } finally {
+      finishFirst.resolve()
+      AgencySwarmAdapter.getMetadata = originalMetadata
+      AgencySwarmAdapter.streamRun = originalStream
+    }
   })
 
   test("serves remaining non-LLM session mutation routes through Hono bridge", async () => {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -28,6 +28,7 @@ import { SessionSummary } from "../../src/session/summary"
 import { Instruction } from "../../src/session/instruction"
 import { SessionProcessor } from "../../src/session/processor"
 import { SessionPrompt } from "../../src/session/prompt"
+import { removeMessageAllowingQueued } from "../../src/session/queued-message"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
@@ -1590,6 +1591,42 @@ unix(
           const exit = yield* Fiber.await(loop)
           expect(Exit.isSuccess(exit)).toBe(true)
 
+          yield* Fiber.await(sh)
+        }),
+      { git: true, config: cfg },
+    ),
+  30_000,
+)
+
+unix(
+  "busy delete rejects loop queued behind shell",
+  () =>
+    provideTmpdirInstance(
+      (_dir) =>
+        Effect.gen(function* () {
+          const { prompt, chat } = yield* boot()
+          const sessions = yield* Session.Service
+
+          const sh = yield* prompt
+            .shell({ sessionID: chat.id, agent: "build", command: "sleep 30" })
+            .pipe(Effect.forkChild)
+          yield* Effect.sleep(50)
+
+          const loop = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+          yield* Effect.sleep(50)
+
+          const messages = yield* sessions.messages({ sessionID: chat.id })
+          const queued = messages.findLast((message) => message.info.role === "user")
+          expect(queued?.info.role).toBe("user")
+
+          const deleted = yield* removeMessageAllowingQueued({
+            sessionID: chat.id,
+            messageID: queued!.info.id,
+          }).pipe(Effect.exit)
+          expect(Exit.isFailure(deleted)).toBe(true)
+
+          yield* prompt.cancel(chat.id)
+          yield* Fiber.await(loop)
           yield* Fiber.await(sh)
         }),
       { git: true, config: cfg },


### PR DESCRIPTION
### Issue for this PR

Closes #172

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows deleting queued Run-mode user messages while an active assistant turn is still busy, but only when the message is queued after the active assistant message. Active and prior message deletion still uses the existing busy-session protection.

This fixes the race where the TUI showed `Cancelled 1 queued message` but the server rejected the delete as busy, so the queued prompt was still sent after the active turn finished.

### How did you verify your code works?

Reproduced on published `agentswarm-cli@1.4.28` in `/tmp/agentswarm-172-repro`: after pressing Esc twice, the delete request failed while the session was busy and the Agency harness later received the queued `SHOULD_NOT_SEND` prompt.

Local validation:

- Added regression first; it failed before the fix with `500` on queued message delete while the active turn was busy.
- `cd packages/opencode && bun test test/server/httpapi-session.test.ts`
- `cd packages/opencode && bun test test/cli/tui/run-queued-messages.test.ts test/effect/runner.test.ts`
- `cd packages/opencode && bun test --timeout 180000 ../../e2e/agent-swarm-tui/terminal-tui.test.ts --filter "Esc twice cancels queued Run-mode prompt before active stream drains"`
- `cd packages/opencode && bun typecheck`
- `bun turbo test:ci`
- Push hook ran `bun turbo typecheck`.

### Screenshots / recordings

Not applicable. This is a queue deletion/routing fix covered by the Agent Swarm TUI e2e harness.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
