### PR TITLE
fix(agency-swarm): send dropped images as local files

### DIFF
--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -10,6 +10,7 @@ Source of truth: `FORK_CHANGELOG.md` defines intentional fork behavior, and `USE
 - `FORK_CHANGELOG.md` CLI/TUI UX: selecting a swarm row clears stale explicit agent routing before the next prompt.
 - `FORK_CHANGELOG.md` CLI/TUI UX: selecting a specific agent routes the next prompt to that agent.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: prompt submit reaches a local Agency Swarm protocol server with the configured agent.
+- `FORK_CHANGELOG.md` Agency Swarm Integration: bracketed-paste image paths reach the local Agency Swarm protocol server as file paths, not inline `data:` URLs.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: `transfer_to_*` handoff events switch control to the target agent for the next turn.
 - `USER_FLOWS.md` Auto-Start Detected Local Project: launcher mode shows the detected-project choice before `.venv` work begins.
 

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import {
@@ -26,13 +26,15 @@ afterEach(async () => {
 })
 
 describe("Agent Swarm terminal TUI e2e", () => {
+  const packageRoot = path.join(import.meta.dir, "..", "..", "packages", "opencode")
+
   test("launcher shows the detected-project choice before any venv work", async () => {
     const project = await mkdtemp(path.join(os.tmpdir(), "agentswarm-detected-project-"))
     tempDirs.push(project)
     await writeAgencyProject(project)
 
     currentTui = await startTui({
-      cwd: path.join(import.meta.dir, "..", "..", "packages", "opencode"),
+      cwd: packageRoot,
       env: {
         AGENTSWARM_LAUNCHER: "1",
         OPENCODE_CONFIG_CONTENT: undefined,
@@ -218,6 +220,38 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(body?.message).toContain("hello from terminal e2e")
     expect(body).toMatchObject({
       recipient_agent: "entry-agent",
+    })
+  })
+
+  test("bracketed-paste image paths reach the agency protocol server as local file paths", async () => {
+    currentServer = await startAgencyProtocolServer()
+    currentTui = await startTui({ baseURL: currentServer.baseURL })
+    const imageDir = await mkdtemp(path.join(os.tmpdir(), "agentswarm-image-drop-"))
+    tempDirs.push(imageDir)
+    const imagePath = path.join(imageDir, "red-dot.png")
+    await writeFile(
+      imagePath,
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    )
+
+    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    const pastedPath = path.relative(packageRoot, imagePath)
+    currentTui.write(`\x1b[200~${pastedPath}\x1b[201~`)
+    await currentTui.waitForText("[Image 1]", tuiInteractionTimeoutMs)
+    currentTui.write("please inspect this image\r")
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 1,
+      "image attachment request",
+      tuiInteractionTimeoutMs,
+    )
+
+    const body = currentServer.requests[0]?.body
+    expect(body?.message).toContain("[Image 1] please inspect this image")
+    expect(body?.file_urls).toEqual({
+      "red-dot.png": imagePath,
     })
   })
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1530,24 +1530,25 @@ export function Prompt(props: PromptProps) {
                 const isUrl = /^(https?):\/\//.test(filepath)
                 if (!isUrl) {
                   try {
-                    const mime = await Filesystem.mimeType(filepath)
-                    const filename = path.basename(filepath)
+                    const resolvedFilepath = path.resolve(filepath)
+                    const mime = await Filesystem.mimeType(resolvedFilepath)
+                    const filename = path.basename(resolvedFilepath)
                     // Handle SVG as raw text content, not as base64 image
                     if (mime === "image/svg+xml") {
-                      const content = await Filesystem.readText(filepath).catch(() => {})
+                      const content = await Filesystem.readText(resolvedFilepath).catch(() => {})
                       if (content) {
                         pasteText(content, `[SVG: ${filename ?? "image"}]`)
                         return
                       }
                     }
                     if (mime.startsWith("image/") || mime === "application/pdf") {
-                      const content = await Filesystem.readArrayBuffer(filepath)
+                      const content = await Filesystem.readArrayBuffer(resolvedFilepath)
                         .then((buffer) => Buffer.from(buffer).toString("base64"))
                         .catch(() => {})
                       if (content) {
                         await pasteAttachment({
                           filename,
-                          filepath,
+                          filepath: resolvedFilepath,
                           mime,
                           content,
                         })

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -1,5 +1,6 @@
 import type { MessageV2 } from "@/session/message-v2"
 import { mkdtempSync, writeFileSync } from "node:fs"
+import { rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -9,6 +10,11 @@ export type AgencySwarmEventMeta = {
   callerAgent?: string | null
   agentRunID?: string
   parentRunID?: string
+}
+
+type CollectFileURLOptions = {
+  allowLocalFilePaths?: boolean
+  materializedFilePaths?: string[]
 }
 
 export function normalizeCallerAgent(value: string | undefined): string | null | undefined {
@@ -116,7 +122,7 @@ export function stringifyToolOutput(output: unknown): string {
 
 export function collectFileURLs(
   message: MessageV2.WithParts,
-  options: { allowLocalFilePaths?: boolean } = {},
+  options: CollectFileURLOptions = {},
 ): Record<string, string> | undefined {
   const fileURLs: Record<string, string> = {}
   let index = 0
@@ -181,7 +187,7 @@ export function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>
 }
 
-function normalizeFileURL(part: MessageV2.FilePart, options: { allowLocalFilePaths?: boolean }): string | undefined {
+function normalizeFileURL(part: MessageV2.FilePart, options: CollectFileURLOptions): string | undefined {
   if (part.url.startsWith("file://")) {
     try {
       return fileURLToPath(part.url)
@@ -198,7 +204,10 @@ function normalizeFileURL(part: MessageV2.FilePart, options: { allowLocalFilePat
     if (isClipboardImage(part)) {
       if (options.allowLocalFilePaths) {
         const clipboardFile = materializeClipboardImage(part)
-        if (clipboardFile) return clipboardFile
+        if (clipboardFile) {
+          options.materializedFilePaths?.push(clipboardFile)
+          return clipboardFile
+        }
       }
 
       throw new Error(
@@ -221,8 +230,23 @@ function normalizeFileURL(part: MessageV2.FilePart, options: { allowLocalFilePat
   return undefined
 }
 
+export async function cleanupMaterializedFilePaths(filepaths: readonly string[]) {
+  const dirs = new Set<string>()
+  for (const filepath of filepaths) {
+    const dir = materializedClipboardDir(filepath)
+    if (dir) dirs.add(dir)
+  }
+  await Promise.all(Array.from(dirs, (dir) => rm(dir, { recursive: true, force: true })))
+}
+
 function isClipboardImage(part: MessageV2.FilePart) {
   return part.source?.type === "file" && part.source.path === "clipboard" && part.mime.startsWith("image/")
+}
+
+function materializedClipboardDir(filepath: string): string | undefined {
+  const dir = path.resolve(path.dirname(filepath))
+  const prefix = `${path.resolve(tmpdir())}${path.sep}agentswarm-clipboard-`
+  return dir.startsWith(prefix) ? dir : undefined
 }
 
 function materializeClipboardImage(part: MessageV2.FilePart): string | undefined {

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -1,6 +1,8 @@
 import type { MessageV2 } from "@/session/message-v2"
-import path from "path"
-import { fileURLToPath } from "url"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
 
 export type AgencySwarmEventMeta = {
   agent?: string
@@ -193,6 +195,17 @@ function normalizeFileURL(part: MessageV2.FilePart, options: { allowLocalFilePat
   }
 
   if (part.url.startsWith("data:")) {
+    if (isClipboardImage(part)) {
+      if (options.allowLocalFilePaths) {
+        const clipboardFile = materializeClipboardImage(part)
+        if (clipboardFile) return clipboardFile
+      }
+
+      throw new Error(
+        "Agent Swarm Run mode cannot send inline image data. Save the image as a local file and attach that file.",
+      )
+    }
+
     if (part.source?.type === "file" && part.source.path && path.isAbsolute(part.source.path)) {
       if (options.allowLocalFilePaths) return part.source.path
       throw new Error(
@@ -206,4 +219,44 @@ function normalizeFileURL(part: MessageV2.FilePart, options: { allowLocalFilePat
   }
 
   return undefined
+}
+
+function isClipboardImage(part: MessageV2.FilePart) {
+  return part.source?.type === "file" && part.source.path === "clipboard" && part.mime.startsWith("image/")
+}
+
+function materializeClipboardImage(part: MessageV2.FilePart): string | undefined {
+  const parsed = parseBase64DataURL(part.url)
+  if (!parsed?.mime.startsWith("image/")) return undefined
+
+  const dir = mkdtempSync(path.join(tmpdir(), "agentswarm-clipboard-"))
+  const filepath = path.join(dir, `clipboard-image${extensionForMime(parsed.mime)}`)
+  writeFileSync(filepath, Buffer.from(parsed.data, "base64"), { mode: 0o600 })
+  return filepath
+}
+
+function parseBase64DataURL(value: string): { mime: string; data: string } | undefined {
+  const match = /^data:([^;,]+);base64,(.*)$/s.exec(value)
+  if (!match) return undefined
+  const [, mime, data] = match
+  if (!mime || data === undefined) return undefined
+  return {
+    mime,
+    data,
+  }
+}
+
+function extensionForMime(mime: string): string {
+  switch (mime) {
+    case "image/jpeg":
+      return ".jpg"
+    case "image/png":
+      return ".png"
+    case "image/webp":
+      return ".webp"
+    case "image/gif":
+      return ".gif"
+    default:
+      return ".img"
+  }
 }

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -106,14 +106,17 @@ export function stringifyToolOutput(output: unknown): string {
   }
 }
 
-export function collectFileURLs(message: MessageV2.WithParts): Record<string, string> | undefined {
+export function collectFileURLs(
+  message: MessageV2.WithParts,
+  options: { allowLocalFilePaths?: boolean } = {},
+): Record<string, string> | undefined {
   const fileURLs: Record<string, string> = {}
   let index = 0
 
   for (const part of message.parts) {
     if (part.type !== "file") continue
 
-    const source = normalizeFileURL(part.url)
+    const source = normalizeFileURL(part, options)
     if (!source) continue
 
     const filename = part.filename || path.basename(source) || `file_${index++}`
@@ -170,21 +173,30 @@ export function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>
 }
 
-function normalizeFileURL(url: string): string | undefined {
-  if (url.startsWith("file://")) {
+function normalizeFileURL(part: MessageV2.FilePart, options: { allowLocalFilePaths?: boolean }): string | undefined {
+  if (part.url.startsWith("file://")) {
     try {
-      return fileURLToPath(url)
+      return fileURLToPath(part.url)
     } catch {
       return undefined
     }
   }
 
-  if (url.startsWith("http://") || url.startsWith("https://")) {
-    return url
+  if (part.url.startsWith("http://") || part.url.startsWith("https://")) {
+    return part.url
   }
 
-  if (url.startsWith("data:")) {
-    return url
+  if (part.url.startsWith("data:")) {
+    if (part.source?.type === "file" && part.source.path && path.isAbsolute(part.source.path)) {
+      if (options.allowLocalFilePaths) return part.source.path
+      throw new Error(
+        "Agent Swarm Run mode cannot send local image files to a remote Agency server. Use an http(s) URL or run against a local Agency server.",
+      )
+    }
+
+    throw new Error(
+      "Agent Swarm Run mode cannot send inline image data. Save the image as a local file and attach that file.",
+    )
   }
 
   return undefined

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -174,9 +174,7 @@ export namespace SessionAgencySwarm {
     const explicitModel = explicit && asString(explicit["model"])
     const requestedModel = explicitModel ? normalizeExplicitClientConfigModel(explicitModel) : sessionLitellmModel
     const forwardGenerated =
-      isLocalAgencyUpstreamURL(baseURL) ||
-      Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS ||
-      forwardUpstreamCredentials === true
+      isLocalAgencyURL(baseURL) || Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS || forwardUpstreamCredentials === true
     const skipOpenAIApiKey = hasExplicitOpenAIApiKey(config) || !!readCredentialHeaders(config)
     const rawGenerated = forwardGenerated
       ? await buildAuthClientConfig(await Auth.all(), await listProvidersForEnvCheck(), await getEnvForClientConfig(), {
@@ -520,8 +518,8 @@ export namespace SessionAgencySwarm {
     }
   }
 
-  /** Loopback + common dev hostnames (Docker Desktop, etc.) where forwarding upstream API keys to a local bridge is expected. */
-  function isLocalAgencyUpstreamURL(baseURL: string) {
+  /** Loopback + common dev hostnames (Docker Desktop, etc.) treated as a local Agency for upstream credential and local-file forwarding. */
+  function isLocalAgencyURL(baseURL: string) {
     try {
       const parsed = new URL(baseURL)
       const h = parsed.hostname.toLowerCase()
@@ -534,16 +532,6 @@ export namespace SessionAgencySwarm {
         h === "host.docker.internal" ||
         h === "kubernetes.docker.internal"
       )
-    } catch {
-      return false
-    }
-  }
-
-  function isLoopbackAgencyURL(baseURL: string) {
-    try {
-      const parsed = new URL(baseURL)
-      const h = parsed.hostname.toLowerCase()
-      return h === "127.0.0.1" || h === "0.0.0.0" || h === "localhost" || h === "::1" || h === "[::1]"
     } catch {
       return false
     }
@@ -603,7 +591,7 @@ export namespace SessionAgencySwarm {
 
     const outgoingMessage = buildOutgoingMessage(input.userMessage)
     const fileURLs = collectFileURLs(input.userMessage, {
-      allowLocalFilePaths: isLoopbackAgencyURL(input.options.baseURL),
+      allowLocalFilePaths: isLocalAgencyURL(input.options.baseURL),
     })
     const mentionedRecipient = findRecipientAgent(input.userMessage)
 

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -174,7 +174,9 @@ export namespace SessionAgencySwarm {
     const explicitModel = explicit && asString(explicit["model"])
     const requestedModel = explicitModel ? normalizeExplicitClientConfigModel(explicitModel) : sessionLitellmModel
     const forwardGenerated =
-      isLocalAgencyURL(baseURL) || Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS || forwardUpstreamCredentials === true
+      isLocalAgencyUpstreamURL(baseURL) ||
+      Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS ||
+      forwardUpstreamCredentials === true
     const skipOpenAIApiKey = hasExplicitOpenAIApiKey(config) || !!readCredentialHeaders(config)
     const rawGenerated = forwardGenerated
       ? await buildAuthClientConfig(await Auth.all(), await listProvidersForEnvCheck(), await getEnvForClientConfig(), {
@@ -518,8 +520,8 @@ export namespace SessionAgencySwarm {
     }
   }
 
-  /** Loopback + common dev hostnames (Docker Desktop, etc.) treated as a local Agency for upstream credential and local-file forwarding. */
-  function isLocalAgencyURL(baseURL: string) {
+  /** Loopback + common dev hostnames (Docker Desktop, etc.) where forwarding upstream API keys to a local bridge is expected. */
+  function isLocalAgencyUpstreamURL(baseURL: string) {
     try {
       const parsed = new URL(baseURL)
       const h = parsed.hostname.toLowerCase()
@@ -532,6 +534,16 @@ export namespace SessionAgencySwarm {
         h === "host.docker.internal" ||
         h === "kubernetes.docker.internal"
       )
+    } catch {
+      return false
+    }
+  }
+
+  function isLoopbackAgencyURL(baseURL: string) {
+    try {
+      const parsed = new URL(baseURL)
+      const h = parsed.hostname.toLowerCase()
+      return h === "127.0.0.1" || h === "0.0.0.0" || h === "localhost" || h === "::1" || h === "[::1]"
     } catch {
       return false
     }
@@ -591,7 +603,7 @@ export namespace SessionAgencySwarm {
 
     const outgoingMessage = buildOutgoingMessage(input.userMessage)
     const fileURLs = collectFileURLs(input.userMessage, {
-      allowLocalFilePaths: isLocalAgencyURL(input.options.baseURL),
+      allowLocalFilePaths: isLoopbackAgencyURL(input.options.baseURL),
     })
     const mentionedRecipient = findRecipientAgent(input.userMessage)
 

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -174,9 +174,7 @@ export namespace SessionAgencySwarm {
     const explicitModel = explicit && asString(explicit["model"])
     const requestedModel = explicitModel ? normalizeExplicitClientConfigModel(explicitModel) : sessionLitellmModel
     const forwardGenerated =
-      isLocalAgencyUpstreamURL(baseURL) ||
-      Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS ||
-      forwardUpstreamCredentials === true
+      isLocalAgencyURL(baseURL) || Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS || forwardUpstreamCredentials === true
     const skipOpenAIApiKey = hasExplicitOpenAIApiKey(config) || !!readCredentialHeaders(config)
     const rawGenerated = forwardGenerated
       ? await buildAuthClientConfig(await Auth.all(), await listProvidersForEnvCheck(), await getEnvForClientConfig(), {
@@ -520,8 +518,8 @@ export namespace SessionAgencySwarm {
     }
   }
 
-  /** Loopback + common dev hostnames (Docker Desktop, etc.) where forwarding upstream API keys to a local bridge is expected. */
-  function isLocalAgencyUpstreamURL(baseURL: string) {
+  /** Loopback + common dev hostnames (Docker Desktop, etc.) where local-only forwarding is expected. */
+  function isLocalAgencyURL(baseURL: string) {
     try {
       const parsed = new URL(baseURL)
       const h = parsed.hostname.toLowerCase()
@@ -534,16 +532,6 @@ export namespace SessionAgencySwarm {
         h === "host.docker.internal" ||
         h === "kubernetes.docker.internal"
       )
-    } catch {
-      return false
-    }
-  }
-
-  function isLoopbackAgencyURL(baseURL: string) {
-    try {
-      const parsed = new URL(baseURL)
-      const h = parsed.hostname.toLowerCase()
-      return h === "127.0.0.1" || h === "0.0.0.0" || h === "localhost" || h === "::1" || h === "[::1]"
     } catch {
       return false
     }
@@ -603,7 +591,7 @@ export namespace SessionAgencySwarm {
 
     const outgoingMessage = buildOutgoingMessage(input.userMessage)
     const fileURLs = collectFileURLs(input.userMessage, {
-      allowLocalFilePaths: isLoopbackAgencyURL(input.options.baseURL),
+      allowLocalFilePaths: isLocalAgencyURL(input.options.baseURL),
     })
     const mentionedRecipient = findRecipientAgent(input.userMessage)
 

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -538,6 +538,16 @@ export namespace SessionAgencySwarm {
     }
   }
 
+  function isLoopbackAgencyURL(baseURL: string) {
+    try {
+      const parsed = new URL(baseURL)
+      const h = parsed.hostname.toLowerCase()
+      return h === "127.0.0.1" || h === "0.0.0.0" || h === "localhost" || h === "::1" || h === "[::1]"
+    } catch {
+      return false
+    }
+  }
+
   export async function resolveAgency(options: RuntimeOptions): Promise<string> {
     if (options.agency) {
       return options.agency
@@ -591,7 +601,9 @@ export namespace SessionAgencySwarm {
     }
 
     const outgoingMessage = buildOutgoingMessage(input.userMessage)
-    const fileURLs = collectFileURLs(input.userMessage)
+    const fileURLs = collectFileURLs(input.userMessage, {
+      allowLocalFilePaths: isLoopbackAgencyURL(input.options.baseURL),
+    })
     const mentionedRecipient = findRecipientAgent(input.userMessage)
 
     const tools = new Map<string, Tool>()

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -28,6 +28,7 @@ import {
   asRawString,
   asString,
   buildOutgoingMessage,
+  cleanupMaterializedFilePaths,
   compactMetadata,
   collectFileURLs,
   extractEventMeta,
@@ -590,9 +591,26 @@ export namespace SessionAgencySwarm {
     }
 
     const outgoingMessage = buildOutgoingMessage(input.userMessage)
-    const fileURLs = collectFileURLs(input.userMessage, {
-      allowLocalFilePaths: isLocalAgencyURL(input.options.baseURL),
-    })
+    const materializedFilePaths: string[] = []
+    const cleanupMaterializedFiles = async () => {
+      try {
+        await cleanupMaterializedFilePaths(materializedFilePaths)
+      } catch (error) {
+        log.warn("failed to clean up materialized clipboard image files", {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+    let fileURLs: Record<string, string> | undefined
+    try {
+      fileURLs = collectFileURLs(input.userMessage, {
+        allowLocalFilePaths: isLocalAgencyURL(input.options.baseURL),
+        materializedFilePaths,
+      })
+    } catch (error) {
+      await cleanupMaterializedFiles()
+      throw error
+    }
     const mentionedRecipient = findRecipientAgent(input.userMessage)
 
     const tools = new Map<string, Tool>()
@@ -1513,7 +1531,7 @@ export namespace SessionAgencySwarm {
       input.abort.addEventListener("abort", onAbort, { once: true })
     }
 
-    const fullStream = (async function* () {
+    const stream = (async function* () {
       yield { type: "start" }
       yield { type: "start-step" }
       let streamError: Error | undefined
@@ -1932,6 +1950,14 @@ export namespace SessionAgencySwarm {
 
       yield {
         type: "finish",
+      }
+    })()
+
+    const fullStream = (async function* () {
+      try {
+        yield* stream
+      } finally {
+        await cleanupMaterializedFiles()
       }
     })()
 

--- a/packages/opencode/test/session/agency-swarm-utils.test.ts
+++ b/packages/opencode/test/session/agency-swarm-utils.test.ts
@@ -137,14 +137,66 @@ describe("session.agency-swarm-utils", () => {
             mime: "image/png",
             url: "data:image/png;base64,AAA=",
             filename: "inline.png",
+            source: {
+              type: "file",
+              path: "/tmp/inline.png",
+              text: {
+                value: "[Image 1]",
+                start: 0,
+                end: 9,
+              },
+            },
           }),
         ]),
+        {
+          allowLocalFilePaths: true,
+        },
       ),
     ).toEqual({
       "spec.md": "/tmp/spec.md",
       "plan.pdf": "https://example.com/plan.pdf",
-      "inline.png": "data:image/png;base64,AAA=",
+      "inline.png": "/tmp/inline.png",
     })
+  })
+
+  test("collectFileURLs blocks data URL attachments without an allowed local file path", () => {
+    expect(() =>
+      collectFileURLs(
+        msg([
+          file("part-1", {
+            type: "file",
+            mime: "image/png",
+            url: "data:image/png;base64,AAA=",
+            filename: "inline.png",
+          }),
+        ]),
+      ),
+    ).toThrow("Agent Swarm Run mode cannot send inline image data")
+
+    expect(() =>
+      collectFileURLs(
+        msg([
+          file("part-1", {
+            type: "file",
+            mime: "image/png",
+            url: "data:image/png;base64,AAA=",
+            filename: "inline.png",
+            source: {
+              type: "file",
+              path: "/tmp/inline.png",
+              text: {
+                value: "[Image 1]",
+                start: 0,
+                end: 9,
+              },
+            },
+          }),
+        ]),
+        {
+          allowLocalFilePaths: false,
+        },
+      ),
+    ).toThrow("Agent Swarm Run mode cannot send local image files to a remote Agency server")
   })
 
   test("buildOutgoingMessage and findRecipientAgent use the final visible parts", () => {

--- a/packages/opencode/test/session/agency-swarm-utils.test.ts
+++ b/packages/opencode/test/session/agency-swarm-utils.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test"
+import { readFile, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 import { MessageV2 } from "../../src/session/message-v2"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
@@ -197,6 +200,71 @@ describe("session.agency-swarm-utils", () => {
         },
       ),
     ).toThrow("Agent Swarm Run mode cannot send local image files to a remote Agency server")
+  })
+
+  test("collectFileURLs materializes clipboard images for local Agency servers", async () => {
+    const content = Buffer.from("clipboard image")
+    const result = collectFileURLs(
+      msg([
+        file("part-1", {
+          type: "file",
+          mime: "image/png",
+          url: `data:image/png;base64,${content.toString("base64")}`,
+          filename: "clipboard",
+          source: {
+            type: "file",
+            path: "clipboard",
+            text: {
+              value: "[Image 1]",
+              start: 0,
+              end: 9,
+            },
+          },
+        }),
+      ]),
+      {
+        allowLocalFilePaths: true,
+      },
+    )
+
+    const filepath = result?.["clipboard"]
+    expect(filepath).toBeDefined()
+    expect(path.isAbsolute(filepath!)).toBeTrue()
+    expect(filepath!.startsWith(path.join(os.tmpdir(), "agentswarm-clipboard-"))).toBeTrue()
+    expect(path.basename(filepath!)).toBe("clipboard-image.png")
+
+    try {
+      await expect(readFile(filepath!)).resolves.toEqual(content)
+    } finally {
+      await rm(path.dirname(filepath!), { recursive: true, force: true })
+    }
+  })
+
+  test("collectFileURLs blocks clipboard images for remote Agency servers", () => {
+    expect(() =>
+      collectFileURLs(
+        msg([
+          file("part-1", {
+            type: "file",
+            mime: "image/png",
+            url: "data:image/png;base64,AAA=",
+            filename: "clipboard",
+            source: {
+              type: "file",
+              path: "clipboard",
+              text: {
+                value: "[Image 1]",
+                start: 0,
+                end: 9,
+              },
+            },
+          }),
+        ]),
+        {
+          allowLocalFilePaths: false,
+        },
+      ),
+    ).toThrow("Agent Swarm Run mode cannot send inline image data")
   })
 
   test("buildOutgoingMessage and findRecipientAgent use the final visible parts", () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { readFile, rm } from "node:fs/promises"
 import { createServer } from "node:http"
 import type { AddressInfo } from "node:net"
+import path from "node:path"
 import { Auth } from "../../src/auth"
 import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
 import { AgencySwarmHistory } from "../../src/agency-swarm/history"
@@ -235,6 +237,92 @@ describe("session.agency-swarm", () => {
     expect(captured).toEqual({
       "red-dot.png": "/tmp/red-dot.png",
     })
+  })
+
+  test("stream materializes clipboard data URL images for loopback Agency servers", async () => {
+    mockHistory()
+    const content = Buffer.from("clipboard image")
+    let captured: Record<string, string> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.fileURLs
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.userMessage.parts = [
+      {
+        type: "text",
+        text: "[Image 1] inspect this image",
+        ignored: false,
+      },
+      {
+        type: "file",
+        mime: "image/png",
+        filename: "clipboard",
+        url: `data:image/png;base64,${content.toString("base64")}`,
+        source: {
+          type: "file",
+          path: "clipboard",
+          text: {
+            value: "[Image 1]",
+            start: 0,
+            end: 9,
+          },
+        },
+      },
+    ] as any
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    const filepath = captured?.["clipboard"]
+    expect(filepath).toBeDefined()
+    expect(path.isAbsolute(filepath!)).toBeTrue()
+    expect(path.basename(filepath!)).toBe("clipboard-image.png")
+    try {
+      await expect(readFile(filepath!)).resolves.toEqual(content)
+    } finally {
+      await rm(path.dirname(filepath!), { recursive: true, force: true })
+    }
+  })
+
+  test("stream rejects clipboard data URL images for remote Agency servers", async () => {
+    mockHistory()
+    let called = false
+    AgencySwarmAdapter.streamRun = async function* () {
+      called = true
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.baseURL = "https://agency.example.com"
+    input.userMessage.parts = [
+      {
+        type: "text",
+        text: "[Image 1] inspect this image",
+        ignored: false,
+      },
+      {
+        type: "file",
+        mime: "image/png",
+        filename: "clipboard",
+        url: "data:image/png;base64,AAA=",
+        source: {
+          type: "file",
+          path: "clipboard",
+          text: {
+            value: "[Image 1]",
+            start: 0,
+            end: 9,
+          },
+        },
+      },
+    ] as any
+
+    await expect(SessionAgencySwarm.stream(input)).rejects.toThrow("Agent Swarm Run mode cannot send inline image data")
+    expect(called).toBeFalse()
   })
 
   for (const baseURL of ["http://host.docker.internal:8000", "http://kubernetes.docker.internal:8000"]) {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
-import { readFile, rm } from "node:fs/promises"
+import { readFile } from "node:fs/promises"
 import { createServer } from "node:http"
 import type { AddressInfo } from "node:net"
 import path from "node:path"
@@ -239,17 +239,8 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream materializes clipboard data URL images for loopback Agency servers", async () => {
-    mockHistory()
-    const content = Buffer.from("clipboard image")
-    let captured: Record<string, string> | undefined
-    AgencySwarmAdapter.streamRun = async function* (input) {
-      captured = input.fileURLs
-      yield { type: "end" }
-    } as typeof AgencySwarmAdapter.streamRun
-
-    const { input } = helper()
-    input.userMessage.parts = [
+  const clipboardImageParts = (content: Buffer) =>
+    [
       {
         type: "text",
         text: "[Image 1] inspect this image",
@@ -272,6 +263,21 @@ describe("session.agency-swarm", () => {
       },
     ] as any
 
+  test("stream materializes clipboard data URL images for loopback Agency servers", async () => {
+    mockHistory()
+    const content = Buffer.from("clipboard image")
+    let captured: Record<string, string> | undefined
+    let observedContent: Buffer | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.fileURLs
+      const filepath = input.fileURLs?.["clipboard"]
+      if (filepath) observedContent = await readFile(filepath)
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.userMessage.parts = clipboardImageParts(content)
+
     const stream = await SessionAgencySwarm.stream(input)
     for await (const _event of stream.fullStream) {
       // consume
@@ -281,11 +287,76 @@ describe("session.agency-swarm", () => {
     expect(filepath).toBeDefined()
     expect(path.isAbsolute(filepath!)).toBeTrue()
     expect(path.basename(filepath!)).toBe("clipboard-image.png")
-    try {
-      await expect(readFile(filepath!)).resolves.toEqual(content)
-    } finally {
-      await rm(path.dirname(filepath!), { recursive: true, force: true })
+    expect(observedContent).toEqual(content)
+    await expect(readFile(filepath!)).rejects.toThrow()
+  })
+
+  test("stream cleans up materialized clipboard images when Agency streaming fails", async () => {
+    mockHistory()
+    const content = Buffer.from("clipboard image")
+    let captured: Record<string, string> | undefined
+    let observedContent: Buffer | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.fileURLs
+      const filepath = input.fileURLs?.["clipboard"]
+      if (filepath) observedContent = await readFile(filepath)
+      throw new Error("backend failed")
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.userMessage.parts = clipboardImageParts(content)
+
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: any[] = []
+    for await (const event of stream.fullStream) {
+      events.push(event)
     }
+
+    const filepath = captured?.["clipboard"]
+    expect(filepath).toBeDefined()
+    expect(observedContent).toEqual(content)
+    expect(events.at(-1)?.type).toBe("error")
+    expect(events.at(-1)?.error.message).toBe("backend failed")
+    await expect(readFile(filepath!)).rejects.toThrow()
+  })
+
+  test("stream cleans up materialized clipboard images when the stream is closed", async () => {
+    mockHistory()
+    const content = Buffer.from("clipboard image")
+    let captured: Record<string, string> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.fileURLs
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.content_part.added",
+            item_id: "item_1",
+            content_index: 0,
+            part: {
+              type: "output_text",
+            },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.userMessage.parts = clipboardImageParts(content)
+
+    const stream = await SessionAgencySwarm.stream(input)
+    expect((await stream.fullStream.next()).value.type).toBe("start")
+    expect((await stream.fullStream.next()).value.type).toBe("start-step")
+    expect((await stream.fullStream.next()).value.type).toBe("text-start")
+
+    const filepath = captured?.["clipboard"]
+    expect(filepath).toBeDefined()
+    await expect(readFile(filepath!)).resolves.toEqual(content)
+
+    await stream.fullStream.return(undefined)
+    await expect(readFile(filepath!)).rejects.toThrow()
   })
 
   test("stream rejects clipboard data URL images for remote Agency servers", async () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -237,6 +237,49 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream sends local source paths for dropped data URL images to Docker Desktop Agency servers", async () => {
+    mockHistory()
+    let captured: Record<string, string> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.fileURLs
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.baseURL = "http://host.docker.internal:8000"
+    input.userMessage.parts = [
+      {
+        type: "text",
+        text: "[Image 1] inspect this image",
+        ignored: false,
+      },
+      {
+        type: "file",
+        mime: "image/png",
+        filename: "red-dot.png",
+        url: "data:image/png;base64,AAA=",
+        source: {
+          type: "file",
+          path: "/tmp/red-dot.png",
+          text: {
+            value: "[Image 1]",
+            start: 0,
+            end: 9,
+          },
+        },
+      },
+    ] as any
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      "red-dot.png": "/tmp/red-dot.png",
+    })
+  })
+
   test("optionsFromProvider maps supported FastAPI request options", () => {
     const options = SessionAgencySwarm.optionsFromProvider({
       id: "agency-swarm" as any,

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -237,49 +237,6 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream sends local source paths for dropped data URL images to Docker Desktop Agency servers", async () => {
-    mockHistory()
-    let captured: Record<string, string> | undefined
-    AgencySwarmAdapter.streamRun = async function* (input) {
-      captured = input.fileURLs
-      yield { type: "end" }
-    } as typeof AgencySwarmAdapter.streamRun
-
-    const { input } = helper()
-    input.options.baseURL = "http://host.docker.internal:8000"
-    input.userMessage.parts = [
-      {
-        type: "text",
-        text: "[Image 1] inspect this image",
-        ignored: false,
-      },
-      {
-        type: "file",
-        mime: "image/png",
-        filename: "red-dot.png",
-        url: "data:image/png;base64,AAA=",
-        source: {
-          type: "file",
-          path: "/tmp/red-dot.png",
-          text: {
-            value: "[Image 1]",
-            start: 0,
-            end: 9,
-          },
-        },
-      },
-    ] as any
-
-    const stream = await SessionAgencySwarm.stream(input)
-    for await (const _event of stream.fullStream) {
-      // consume
-    }
-
-    expect(captured).toEqual({
-      "red-dot.png": "/tmp/red-dot.png",
-    })
-  })
-
   test("optionsFromProvider maps supported FastAPI request options", () => {
     const options = SessionAgencySwarm.optionsFromProvider({
       id: "agency-swarm" as any,

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -237,6 +237,51 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  for (const baseURL of ["http://host.docker.internal:8000", "http://kubernetes.docker.internal:8000"]) {
+    test(`stream sends local source paths for dropped data URL images to ${new URL(baseURL).hostname} Agency servers`, async () => {
+      mockHistory()
+      let captured: Record<string, string> | undefined
+      AgencySwarmAdapter.streamRun = async function* (input) {
+        captured = input.fileURLs
+        yield { type: "end" }
+      } as typeof AgencySwarmAdapter.streamRun
+
+      const { input } = helper()
+      input.options.baseURL = baseURL
+      input.userMessage.parts = [
+        {
+          type: "text",
+          text: "[Image 1] inspect this image",
+          ignored: false,
+        },
+        {
+          type: "file",
+          mime: "image/png",
+          filename: "red-dot.png",
+          url: "data:image/png;base64,AAA=",
+          source: {
+            type: "file",
+            path: "/tmp/red-dot.png",
+            text: {
+              value: "[Image 1]",
+              start: 0,
+              end: 9,
+            },
+          },
+        },
+      ] as any
+
+      const stream = await SessionAgencySwarm.stream(input)
+      for await (const _event of stream.fullStream) {
+        // consume
+      }
+
+      expect(captured).toEqual({
+        "red-dot.png": "/tmp/red-dot.png",
+      })
+    })
+  }
+
   test("optionsFromProvider maps supported FastAPI request options", () => {
     const options = SessionAgencySwarm.optionsFromProvider({
       id: "agency-swarm" as any,

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -195,6 +195,48 @@ describe("session.agency-swarm", () => {
     expect(called).toBeFalse()
   })
 
+  test("stream sends local source paths for dropped data URL images to loopback Agency servers", async () => {
+    mockHistory()
+    let captured: Record<string, string> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.fileURLs
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.userMessage.parts = [
+      {
+        type: "text",
+        text: "[Image 1] inspect this image",
+        ignored: false,
+      },
+      {
+        type: "file",
+        mime: "image/png",
+        filename: "red-dot.png",
+        url: "data:image/png;base64,AAA=",
+        source: {
+          type: "file",
+          path: "/tmp/red-dot.png",
+          text: {
+            value: "[Image 1]",
+            start: 0,
+            end: 9,
+          },
+        },
+      },
+    ] as any
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      "red-dot.png": "/tmp/red-dot.png",
+    })
+  })
+
   test("optionsFromProvider maps supported FastAPI request options", () => {
     const options = SessionAgencySwarm.optionsFromProvider({
       id: "agency-swarm" as any,


### PR DESCRIPTION
### Issue for this PR

Closes #176

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Dropped images can arrive in the TUI as inline `data:` URLs. Run mode was forwarding those URLs to Agency Swarm as `file_urls`, which produced an opaque unsupported-scheme error.

This PR keeps local dropped-file source paths when the Agency server is local, blocks local file forwarding to remote Agency servers, and shows a clear error for inline-only `data:` attachments that cannot be sent safely.

### How did you verify your code works?

- Reproduced #176 on `agentswarm-cli@1.4.28` with a local protocol server and captured the unsupported `data:` URL failure in issue #176.
- Added session tests for local dropped-file paths, inline `data:` blocking, and remote-server blocking.
- Added Agent Swarm TUI e2e coverage for bracketed-paste image paths reaching the local Agency protocol server as file paths.
- Ran focused session tests, Agent Swarm TUI e2e, typecheck, and the PR branch push hook.

### Screenshots / recordings

Not applicable. This is attachment routing behavior covered by protocol-level assertions and the Agent Swarm TUI e2e harness.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
