### PR TITLE
fix(tui): ignore nested agency handoff metadata

### DIFF
--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -11,6 +11,7 @@ Source of truth: `FORK_CHANGELOG.md` defines intentional fork behavior, and `USE
 - `FORK_CHANGELOG.md` CLI/TUI UX: selecting a specific agent routes the next prompt to that agent.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: prompt submit reaches a local Agency Swarm protocol server with the configured agent.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: ordinary `SendMessage` delegation with `recipient_agent` does not switch the user's active recipient.
+- `FORK_CHANGELOG.md` Agency Swarm Integration: nested `SendMessage` handoff-like metadata does not switch the user's active recipient.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: `transfer_to_*` handoff events switch control to the target agent for the next turn.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: `agent_updated_stream_event` handoffs without separate transfer tool parts switch control to the target agent.
 - `USER_FLOWS.md` Auto-Start Detected Local Project: launcher mode shows the detected-project choice before `.venv` work begins.

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -13,6 +13,7 @@ Source of truth: `FORK_CHANGELOG.md` defines intentional fork behavior, and `USE
 - `FORK_CHANGELOG.md` Agency Swarm Integration: ordinary `SendMessage` delegation with `recipient_agent` does not switch the user's active recipient.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: nested `SendMessage` handoff-like metadata does not switch the user's active recipient.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: `transfer_to_*` handoff events switch control to the target agent for the next turn.
+- `FORK_CHANGELOG.md` Agency Swarm Integration: later nested handoff-like metadata does not override an earlier top-level handoff recipient.
 - `FORK_CHANGELOG.md` Agency Swarm Integration: `agent_updated_stream_event` handoffs without separate transfer tool parts switch control to the target agent.
 - `USER_FLOWS.md` Auto-Start Detected Local Project: launcher mode shows the detected-project choice before `.venv` work begins.
 

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -414,22 +414,19 @@ const tuiDemoAgencyFixture: AgencyFixture = {
           },
         ],
         [
-          "data",
+          "messages",
           {
-            type: "raw_response_event",
-            callerAgent: "MathAgent",
-            parent_run_id: `run_tui_demo_${requestCount}`,
-            data: {
-              type: "response.output_item.done",
-              output_index: "2",
-              item: {
+            new_messages: [
+              {
                 type: "handoff_output_item",
                 call_id: "call_nested_handoff_mixed",
+                callerAgent: "MathAgent",
+                parent_run_id: `run_tui_demo_${requestCount}`,
                 output: {
                   assistant: "UserSupportAgent",
                 },
               },
-            },
+            ],
           },
         ],
         [

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -319,6 +319,67 @@ const tuiDemoAgencyFixture: AgencyFixture = {
   },
   stream(body, requestCount) {
     const message = typeof body.message === "string" ? body.message.toLowerCase() : ""
+    if (message.includes("nested delegate")) {
+      return sse([
+        ["meta", { run_id: `run_tui_demo_${requestCount}` }],
+        [
+          "data",
+          {
+            type: "raw_response_event",
+            agent: "UserSupportAgent",
+            data: {
+              type: "response.output_item.added",
+              output_index: "1",
+              item: {
+                type: "function_call",
+                id: "fc_send_message_nested",
+                call_id: "call_send_message_nested",
+                name: "SendMessage",
+                arguments: JSON.stringify({
+                  recipient_agent: "MathAgent",
+                  message: "Please calculate this.",
+                }),
+              },
+            },
+          },
+        ],
+        [
+          "data",
+          {
+            type: "agent_updated_stream_event",
+            callerAgent: "UserSupportAgent",
+            parent_run_id: `run_tui_demo_${requestCount}`,
+            new_agent: {
+              id: "MathAgent",
+              name: "MathAgent",
+            },
+          },
+        ],
+        [
+          "messages",
+          {
+            new_messages: [
+              {
+                type: "function_call_output",
+                call_id: "call_send_message_nested",
+                output: JSON.stringify({
+                  recipient_agent: "MathAgent",
+                  response: "Nested delegation completed without transfer.",
+                }),
+              },
+              {
+                id: `msg_nested_delegate_${requestCount}`,
+                type: "message",
+                role: "assistant",
+                agent: "MathAgent",
+                content: [{ type: "output_text", text: "Nested SendMessage delegation finished." }],
+              },
+            ],
+          },
+        ],
+        ["end", {}],
+      ])
+    }
     if (message.includes("delegate")) {
       return sse([
         ["meta", { run_id: `run_tui_demo_${requestCount}` }],

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -380,6 +380,87 @@ const tuiDemoAgencyFixture: AgencyFixture = {
         ["end", {}],
       ])
     }
+    if (message.includes("mixed handoff")) {
+      return sse([
+        ["meta", { run_id: `run_tui_demo_${requestCount}` }],
+        [
+          "data",
+          {
+            type: "raw_response_event",
+            agent: "UserSupportAgent",
+            data: {
+              type: "response.output_item.added",
+              output_index: "1",
+              item: {
+                type: "function_call",
+                id: "fc_transfer_math_mixed",
+                call_id: "call_transfer_math_mixed",
+                name: "transfer_to_math_agent",
+                arguments: "{}",
+              },
+            },
+          },
+        ],
+        [
+          "messages",
+          {
+            new_messages: [
+              {
+                type: "handoff_output_item",
+                call_id: "call_transfer_math_mixed",
+                output: '{"assistant":"MathAgent"}',
+              },
+            ],
+          },
+        ],
+        [
+          "data",
+          {
+            type: "raw_response_event",
+            callerAgent: "MathAgent",
+            parent_run_id: `run_tui_demo_${requestCount}`,
+            data: {
+              type: "response.output_item.done",
+              output_index: "2",
+              item: {
+                type: "handoff_output_item",
+                call_id: "call_nested_handoff_mixed",
+                output: {
+                  assistant: "UserSupportAgent",
+                },
+              },
+            },
+          },
+        ],
+        [
+          "data",
+          {
+            type: "agent_updated_stream_event",
+            callerAgent: "MathAgent",
+            parent_run_id: `run_tui_demo_${requestCount}`,
+            new_agent: {
+              id: "UserSupportAgent",
+              name: "UserSupportAgent",
+            },
+          },
+        ],
+        [
+          "messages",
+          {
+            new_messages: [
+              {
+                id: `msg_mixed_handoff_${requestCount}`,
+                type: "message",
+                role: "assistant",
+                agent: "UserSupportAgent",
+                content: [{ type: "output_text", text: "Math handoff finished after nested delegation." }],
+              },
+            ],
+          },
+        ],
+        ["end", {}],
+      ])
+    }
     if (message.includes("delegate")) {
       return sse([
         ["meta", { run_id: `run_tui_demo_${requestCount}` }],

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -276,6 +276,44 @@ describe("Agent Swarm terminal TUI e2e", () => {
     ).toBeFalse()
   })
 
+  test("top-level handoff wins over later nested handoff-like metadata", async () => {
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+    })
+
+    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    currentTui.write("mixed handoff with nested delegation\r")
+    await currentTui.waitForText("Math handoff finished after nested delegation.", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 1,
+      "mixed handoff request",
+      tuiInteractionTimeoutMs,
+    )
+
+    currentTui.write("continue after mixed handoff\r")
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 2,
+      "post-mixed-handoff request",
+      tuiInteractionTimeoutMs,
+    )
+
+    const handoffBody = currentServer.requests[0]?.body
+    expect(handoffBody?.message).toContain("mixed handoff with nested delegation")
+    expect(handoffBody).toMatchObject({
+      recipient_agent: "UserSupportAgent",
+    })
+    const nextBody = currentServer.requests[1]?.body
+    expect(nextBody?.message).toContain("continue after mixed handoff")
+    expect(nextBody).toMatchObject({
+      recipient_agent: "MathAgent",
+    })
+    expect(nextBody?.chat_history.some((item: any) => item?.type === "handoff_output_item")).toBeFalse()
+  })
+
   test("agent_updated_stream_event-only handoff switches control to the target agent", async () => {
     currentServer = await startTuiDemoAgencyServer()
     currentTui = await startTui({

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -198,6 +198,45 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(nextBody?.chat_history.some((item: any) => item?.type === "handoff_output_item")).toBeFalse()
   })
 
+  test("nested SendMessage handoff-like metadata does not switch control", async () => {
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+    })
+
+    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    currentTui.write("nested delegate with forwarded handoff metadata\r")
+    await currentTui.waitForText("Nested SendMessage delegation finished.", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 1,
+      "nested delegate request",
+      tuiInteractionTimeoutMs,
+    )
+
+    currentTui.write("plain followup after nested delegation\r")
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 2,
+      "post-nested-delegation request",
+      tuiInteractionTimeoutMs,
+    )
+
+    const delegateBody = currentServer.requests[0]?.body
+    expect(delegateBody?.message).toContain("nested delegate with forwarded handoff metadata")
+    expect(delegateBody).toMatchObject({
+      recipient_agent: "UserSupportAgent",
+    })
+    const nextBody = currentServer.requests[1]?.body
+    expect(nextBody?.message).toContain("plain followup after nested delegation")
+    expect(nextBody).toMatchObject({
+      recipient_agent: "UserSupportAgent",
+    })
+    expect(nextBody?.chat_history.some((item: any) => item?.type === "function_call_output")).toBeTrue()
+    expect(nextBody?.chat_history.some((item: any) => item?.type === "handoff_output_item")).toBeFalse()
+  })
+
   test("transfer_to handoff switches control to the target agent for the next turn", async () => {
     currentServer = await startTuiDemoAgencyServer()
     currentTui = await startTui({

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -17,6 +17,10 @@ const tempDirs: string[] = []
 const tuiReadyTimeoutMs = process.env.CI ? 60_000 : 30_000
 const tuiInteractionTimeoutMs = process.env.CI ? 60_000 : 45_000
 
+async function waitForConfiguredDemoRecipient(tui: TuiProcess) {
+  await tui.waitForText("UserSupportAgent", tuiInteractionTimeoutMs)
+}
+
 afterEach(async () => {
   await currentTui?.close()
   currentTui = undefined
@@ -173,6 +177,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     })
 
     await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    await waitForConfiguredDemoRecipient(currentTui)
     currentTui.write("delegate normal sendmessage\r")
     await currentTui.waitForText("Delegated to MathAgent with SendMessage.", tuiInteractionTimeoutMs)
     await currentTui.waitFor(() => currentServer!.requests.length === 1, "delegate request", tuiInteractionTimeoutMs)
@@ -208,6 +213,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     })
 
     await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    await waitForConfiguredDemoRecipient(currentTui)
     currentTui.write("nested delegate with forwarded handoff metadata\r")
     await currentTui.waitForText("Nested SendMessage delegation finished.", tuiInteractionTimeoutMs)
     await currentTui.waitFor(
@@ -247,6 +253,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     })
 
     await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    await waitForConfiguredDemoRecipient(currentTui)
     currentTui.write("please handoff this calculation\r")
     await currentTui.waitForText("Math agent now has control.", tuiInteractionTimeoutMs)
     await currentTui.waitFor(() => currentServer!.requests.length === 1, "handoff request", tuiInteractionTimeoutMs)
@@ -286,6 +293,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     })
 
     await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    await waitForConfiguredDemoRecipient(currentTui)
     currentTui.write("mixed handoff with nested delegation\r")
     await currentTui.waitForText("Math handoff finished after nested delegation.", tuiInteractionTimeoutMs)
     await currentTui.waitFor(
@@ -324,6 +332,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     })
 
     await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    await waitForConfiguredDemoRecipient(currentTui)
     currentTui.write("please live handoff this calculation\r")
     await currentTui.waitForText("Live agent update moved control to MathAgent.", tuiInteractionTimeoutMs)
     await currentTui.waitFor(

--- a/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
@@ -1,6 +1,10 @@
 import { displayAgentName } from "@/agent/display"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
-import { hasAgencyHandoffEvidence, isAgencyAgentUpdatedHandoffMetadata } from "@/session/agency-swarm-utils"
+import {
+  hasAgencyHandoffEvidence,
+  isAgencyAgentUpdatedHandoffMetadata,
+  isTopLevelAgencyHandoffMetadata,
+} from "@/session/agency-swarm-utils"
 import * as Locale from "@/util/locale"
 
 export type AgencyHandoffMessage = {
@@ -248,12 +252,22 @@ export function resolveAgencyHandoffRecipientFromMessages(input: {
 
 export function resolveAgencyHandoffRecipientFromParts(parts: AgencyHandoffPart[]) {
   for (const part of parts.toReversed()) {
-    const metadataAgent = readAgentUpdatedHandoffMetadataAgent(part.metadata)
+    const partMetadata = part.metadata
+    const stateMetadata = part.state?.metadata
+    const metadataAgent = isTopLevelAgencyHandoffMetadata(partMetadata)
+      ? readAgentUpdatedHandoffMetadataAgent(partMetadata)
+      : undefined
     if (metadataAgent) return metadataAgent
     if (part.type !== "tool") continue
-    const outputAgent = readHandoffOutputAgent(part.state?.output) ?? readHandoffMetadataAgent(part.state?.metadata)
+    const outputAgent =
+      isTopLevelAgencyHandoffMetadata(partMetadata) && isTopLevelAgencyHandoffMetadata(stateMetadata)
+        ? (readHandoffOutputAgent(part.state?.output) ?? readHandoffMetadataAgent(stateMetadata))
+        : undefined
     if (outputAgent) return outputAgent
-    const toolAgent = readTransferToolAgent(part.tool)
+    const toolAgent =
+      isTopLevelAgencyHandoffMetadata(partMetadata) && isTopLevelAgencyHandoffMetadata(stateMetadata)
+        ? readTransferToolAgent(part.tool)
+        : undefined
     if (toolAgent) return toolAgent
   }
   return undefined

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -32,17 +32,22 @@ export function compactMetadata(input: AgencySwarmEventMeta): Record<string, unk
   return payload
 }
 
-export function extractFunctionCallOutputs(newMessages: unknown[]): Array<{ callID: string; output: string }> {
-  const outputs: Array<{ callID: string; output: string }> = []
+export function extractFunctionCallOutputs(
+  newMessages: unknown[],
+): Array<{ callID: string; output: string; metadata: AgencySwarmEventMeta; itemType?: string }> {
+  const outputs: Array<{ callID: string; output: string; metadata: AgencySwarmEventMeta; itemType?: string }> = []
   for (const raw of newMessages) {
     const message = asRecord(raw)
     if (!message) continue
-    if (!isAgencyToolOutputType(asString(message["type"]))) continue
+    const itemType = asString(message["type"])
+    if (!isAgencyToolOutputType(itemType)) continue
     const callID = asString(message["call_id"])
     if (!callID) continue
     outputs.push({
       callID,
       output: stringifyToolOutput(message["output"]),
+      metadata: extractEventMeta(message),
+      itemType,
     })
   }
   return outputs

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -57,12 +57,21 @@ export function hasAgencyHandoffEvidence(parts: readonly unknown[] | undefined) 
   return parts.some((part) => {
     const record = asRecord(part)
     if (!record) return false
-    if (isAgencyAgentUpdatedHandoffMetadata(asRecord(record["metadata"]))) return true
-    if (asString(record["type"]) !== "tool") return false
-    if (isAgencyHandoffToolName(asString(record["tool"]))) return true
-
     const state = asRecord(record["state"])
-    const metadata = asRecord(record["metadata"]) ?? asRecord(state?.["metadata"])
+    const partMetadata = asRecord(record["metadata"])
+    const stateMetadata = asRecord(state?.["metadata"])
+    if (isAgencyAgentUpdatedHandoffMetadata(partMetadata) && isTopLevelAgencyHandoffMetadata(partMetadata)) return true
+    if (asString(record["type"]) !== "tool") return false
+    if (
+      isAgencyHandoffToolName(asString(record["tool"])) &&
+      isTopLevelAgencyHandoffMetadata(partMetadata) &&
+      isTopLevelAgencyHandoffMetadata(stateMetadata)
+    ) {
+      return true
+    }
+
+    const metadata = partMetadata ?? stateMetadata
+    if (!isTopLevelAgencyHandoffMetadata(metadata)) return false
     return isAgencyHandoffOutputMetadata(metadata)
   })
 }
@@ -71,11 +80,25 @@ export function isAgencyAgentUpdatedHandoffMetadata(metadata: Record<string, unk
   return asString(metadata?.["agency_handoff_event"]) === "agent_updated_stream_event"
 }
 
+export function isTopLevelAgencyHandoffMetadata(metadata: Record<string, unknown> | undefined) {
+  if (!metadata) return true
+  if (asString(metadata["parent_run_id"]) || asString(metadata["parentRunID"]) || asString(metadata["parentRunId"])) {
+    return false
+  }
+  return !hasCallerAgentMarker(metadata["callerAgent"] ?? metadata["caller_agent"] ?? metadata["caller"])
+}
+
 function isAgencyHandoffOutputMetadata(metadata: Record<string, unknown> | undefined) {
   return (
     asString(metadata?.["type"]) === "handoff_output_item" ||
     asString(metadata?.["item_type"]) === "handoff_output_item"
   )
+}
+
+function hasCallerAgentMarker(value: unknown) {
+  if (value === undefined || value === null) return false
+  const caller = normalizeCallerAgent(asString(value))
+  return caller !== undefined && caller !== null
 }
 
 export function isAgencyHandoffToolName(value: string | undefined) {

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -17,9 +17,11 @@ export function normalizeCallerAgent(value: string | undefined): string | null |
 export function extractEventMeta(event: Record<string, unknown>): AgencySwarmEventMeta {
   return {
     agent: asString(event["agent"]),
-    callerAgent: normalizeCallerAgent(asString(event["callerAgent"])),
-    agentRunID: asString(event["agent_run_id"]),
-    parentRunID: asString(event["parent_run_id"]),
+    callerAgent: normalizeCallerAgent(
+      asString(event["callerAgent"]) ?? asString(event["caller_agent"]) ?? asString(event["caller"]),
+    ),
+    agentRunID: asString(event["agent_run_id"]) ?? asString(event["agentRunID"]) ?? asString(event["agentRunId"]),
+    parentRunID: asString(event["parent_run_id"]) ?? asString(event["parentRunID"]) ?? asString(event["parentRunId"]),
   }
 }
 

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -45,10 +45,11 @@ export function extractFunctionCallOutputs(
     if (!isAgencyToolOutputType(itemType)) continue
     const callID = asString(message["call_id"])
     if (!callID) continue
+    const messageMetadata = asRecord(message["metadata"])
     outputs.push({
       callID,
       output: stringifyToolOutput(message["output"]),
-      metadata: extractEventMeta(message),
+      metadata: extractEventMeta(messageMetadata ? { ...messageMetadata, ...message } : message),
       itemType,
     })
   }

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -580,7 +580,9 @@ export namespace SessionAgencySwarm {
     return normalizeCallerAgentValue(value)
   }
 
-  export function extractFunctionCallOutputs(newMessages: unknown[]): Array<{ callID: string; output: string }> {
+  export function extractFunctionCallOutputs(
+    newMessages: unknown[],
+  ): ReturnType<typeof extractFunctionCallOutputsFromMessages> {
     return extractFunctionCallOutputsFromMessages(newMessages)
   }
 
@@ -1210,7 +1212,7 @@ export namespace SessionAgencySwarm {
 
       for (const output of extractFunctionCallOutputsFromMessages(newMessages)) {
         const tool = ensureTool(output.callID, toolNameFor(output.callID))
-        yield* completeTool(output.callID, tool.tool, output.output, {})
+        yield* completeTool(output.callID, tool.tool, output.output, output.metadata, { item_type: output.itemType })
       }
 
       for (const raw of newMessages) {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -36,6 +36,7 @@ import {
   hasAgencyHandoffEvidence,
   isAgencyAgentUpdatedHandoffMetadata,
   isAgencyToolOutputType,
+  isTopLevelAgencyHandoffMetadata,
   normalizeCallerAgent as normalizeCallerAgentValue,
   parseToolInput,
   stringifyToolOutput,
@@ -645,6 +646,10 @@ export namespace SessionAgencySwarm {
       return handoffAgent && agentUpdatedHandoffAgents.has(handoffAgent)
         ? { agency_handoff_event: "agent_updated_stream_event", assistant: handoffAgent }
         : {}
+    }
+
+    const isTopLevelHandoffEvent = (meta: AgencySwarmEventMeta) => {
+      return isTopLevelAgencyHandoffMetadata(compactMetadata(meta))
     }
 
     const reasoningKey = (itemID: string, index: number) => `${itemID}:${index}`
@@ -1635,7 +1640,7 @@ export namespace SessionAgencySwarm {
             const maybeName = next
               ? (asString(next["id"]) ?? asString(next["name"]) ?? asString(next["label"]))
               : undefined
-            if (maybeName) {
+            if (maybeName && isTopLevelHandoffEvent(eventMeta)) {
               agentUpdatedHandoffAgents.add(maybeName)
               input.assistantMessage.agent = maybeName
               input.assistantMessage.mode = maybeName

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -2084,16 +2084,24 @@ export namespace SessionAgencySwarm {
 
   function resolveHandoffRecipientFromParts(parts: MessageV2.Part[]) {
     for (const part of parts.toReversed()) {
-      const metadataAgent = readAgentUpdatedHandoffMetadataAgent(
-        asRecord("metadata" in part ? part.metadata : undefined),
-      )
+      const partMetadata = asRecord("metadata" in part ? part.metadata : undefined)
+      const metadataAgent = isTopLevelAgencyHandoffMetadata(partMetadata)
+        ? readAgentUpdatedHandoffMetadataAgent(partMetadata)
+        : undefined
       if (metadataAgent) return metadataAgent
       if (part.type !== "tool") continue
+      const stateMetadata = asRecord("metadata" in part.state ? part.state.metadata : undefined)
       const outputAgent =
-        readHandoffOutputAgent(part.state.status === "completed" ? part.state.output : undefined) ??
-        readHandoffMetadataAgent("metadata" in part.state ? part.state.metadata : undefined)
+        isTopLevelAgencyHandoffMetadata(partMetadata) &&
+        isTopLevelAgencyHandoffMetadata(stateMetadata) &&
+        part.state.status === "completed"
+          ? (readHandoffOutputAgent(part.state.output) ?? readHandoffMetadataAgent(stateMetadata))
+          : undefined
       if (outputAgent) return outputAgent
-      const toolAgent = readTransferToolAgent(part.tool)
+      const toolAgent =
+        isTopLevelAgencyHandoffMetadata(partMetadata) && isTopLevelAgencyHandoffMetadata(stateMetadata)
+          ? readTransferToolAgent(part.tool)
+          : undefined
       if (toolAgent) return toolAgent
     }
     return undefined
@@ -2142,6 +2150,8 @@ export namespace SessionAgencySwarm {
       const item = history[index]
       const type = asString(item["type"])
       if (type === "handoff_output_item") {
+        const metadata = asRecord(item["metadata"])
+        if (!isTopLevelAgencyHandoffMetadata(item) || !isTopLevelAgencyHandoffMetadata(metadata)) continue
         const outputAgent = readHandoffOutputAgent(item["output"])
         if (outputAgent) return outputAgent
 

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -140,6 +140,55 @@ describe("agency target options", () => {
     })
   })
 
+  test("does not restore nested forwarded handoff metadata", () => {
+    expect(
+      resolveAgencyHandoffRecipientFromMessages({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "UserSupportAgent",
+        currentRecipientSelectedAt: 1,
+        sessionID: "session_1",
+        messages: [
+          {
+            id: "message_1",
+            role: "assistant",
+            providerID: "agency-swarm",
+            agent: "MathAgent",
+            time: {
+              completed: 2,
+            },
+          },
+        ],
+        partsByMessage: {
+          message_1: [
+            {
+              type: "text",
+              metadata: {
+                agency_handoff_event: "agent_updated_stream_event",
+                assistant: "MathAgent",
+                callerAgent: "UserSupportAgent",
+                parent_run_id: "run_parent",
+              },
+            },
+            {
+              type: "tool",
+              tool: "SendMessage",
+              state: {
+                status: "completed",
+                metadata: {
+                  item_type: "handoff_output_item",
+                  assistant: "MathAgent",
+                  callerAgent: "UserSupportAgent",
+                  parentRunID: "run_parent",
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toBeUndefined()
+  })
+
   test("restores handed off recipient from synced session messages", () => {
     expect(
       resolveAgencyHandoffRecipientFromMessages({

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -189,6 +189,68 @@ describe("agency target options", () => {
     ).toBeUndefined()
   })
 
+  test("restores top-level handoff over later nested forwarded metadata", () => {
+    expect(
+      resolveAgencyHandoffRecipientFromMessages({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "UserSupportAgent",
+        currentRecipientSelectedAt: 1,
+        sessionID: "session_1",
+        messages: [
+          {
+            id: "message_1",
+            role: "assistant",
+            providerID: "agency-swarm",
+            agent: "MathAgent",
+            time: {
+              completed: 2,
+            },
+          },
+        ],
+        partsByMessage: {
+          message_1: [
+            {
+              type: "tool",
+              tool: "transfer_to_SupportAgent",
+              state: {
+                status: "completed",
+              },
+            },
+            {
+              type: "text",
+              metadata: {
+                agency_handoff_event: "agent_updated_stream_event",
+                assistant: "MathAgent",
+                callerAgent: "SupportAgent",
+                parent_run_id: "run_parent",
+              },
+            },
+            {
+              type: "tool",
+              tool: "SendMessage",
+              state: {
+                status: "completed",
+                output: '{"assistant":"MathAgent"}',
+                metadata: {
+                  item_type: "handoff_output_item",
+                  assistant: "MathAgent",
+                  callerAgent: "SupportAgent",
+                  parentRunID: "run_parent",
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      sessionID: "session_1",
+      messageID: "message_1",
+      agent: "SupportAgent",
+      selectedAt: 1,
+    })
+  })
+
   test("restores handed off recipient from synced session messages", () => {
     expect(
       resolveAgencyHandoffRecipientFromMessages({

--- a/packages/opencode/test/session/agency-swarm-utils.test.ts
+++ b/packages/opencode/test/session/agency-swarm-utils.test.ts
@@ -110,6 +110,19 @@ describe("session.agency-swarm-utils", () => {
       agent_run_id: "run-1",
       parent_run_id: "parent-1",
     })
+    expect(
+      extractEventMeta({
+        agent: "Reviewer",
+        caller_agent: "Planner",
+        agentRunID: "run-2",
+        parentRunID: "parent-2",
+      }),
+    ).toEqual({
+      agent: "Reviewer",
+      callerAgent: "Planner",
+      agentRunID: "run-2",
+      parentRunID: "parent-2",
+    })
   })
 
   test("collectFileURLs keeps valid file parts and normalizes file URLs", () => {

--- a/packages/opencode/test/session/agency-swarm-utils.test.ts
+++ b/packages/opencode/test/session/agency-swarm-utils.test.ts
@@ -247,4 +247,41 @@ describe("session.agency-swarm-utils", () => {
       ]),
     ).toBeFalse()
   })
+
+  test("hasAgencyHandoffEvidence rejects nested forwarded handoff metadata", () => {
+    expect(
+      hasAgencyHandoffEvidence([
+        {
+          type: "tool",
+          tool: "transfer_to_MathAgent",
+          metadata: {
+            callerAgent: "UserSupportAgent",
+            parent_run_id: "run_parent",
+          },
+        },
+        {
+          type: "tool",
+          tool: "SendMessage",
+          state: {
+            status: "completed",
+            metadata: {
+              item_type: "handoff_output_item",
+              assistant: "MathAgent",
+              callerAgent: "UserSupportAgent",
+              parentRunID: "run_parent",
+            },
+          },
+        },
+        {
+          type: "text",
+          text: "Nested agent update.",
+          metadata: {
+            agency_handoff_event: "agent_updated_stream_event",
+            assistant: "MathAgent",
+            callerAgent: "UserSupportAgent",
+          },
+        },
+      ]),
+    ).toBeFalse()
+  })
 })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3562,6 +3562,131 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream does not restore recipient from nested forwarded agent_updated_stream_event", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        const sentRecipients: Array<string | undefined> = []
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["UserSupportAgent", "MathAgent"],
+          },
+          nodes: [
+            {
+              id: "UserSupportAgent",
+              type: "agent",
+              data: {
+                label: "User Support Agent",
+              },
+            },
+            {
+              id: "MathAgent",
+              type: "agent",
+              data: {
+                label: "Math Agent",
+              },
+            },
+          ],
+        })) as typeof AgencySwarmAdapter.getMetadata
+        let turn = 0
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          turn++
+          sentRecipients.push(args.recipientAgent ?? undefined)
+          if (turn === 1) {
+            yield {
+              type: "data",
+              payload: {
+                type: "agent_updated_stream_event",
+                callerAgent: "UserSupportAgent",
+                parent_run_id: "run_parent",
+                new_agent: {
+                  id: "MathAgent",
+                  label: "Math Agent",
+                },
+              },
+            }
+            yield {
+              type: "messages",
+              payload: {
+                new_messages: [
+                  {
+                    id: "msg_nested_delegate",
+                    type: "message",
+                    role: "assistant",
+                    agent: "MathAgent",
+                    content: [{ type: "output_text", text: "Nested delegation replied." }],
+                  },
+                ],
+              },
+            }
+          }
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "nested delegated handoff event" })
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "delegate with nested metadata",
+        })
+
+        const first = helper()
+        first.input.sessionID = session.id
+        first.input.assistantMessage.sessionID = session.id
+        first.input.assistantMessage.id = MessageID.ascending()
+        first.input.assistantMessage.parentID = user.id
+        first.input.userMessage.info.id = user.id
+        first.input.options.recipientAgent = "UserSupportAgent"
+        ;(first.input.options as any).recipientAgentSelectedAt = 1
+
+        const firstStream = await SessionAgencySwarm.stream(first.input)
+        for await (const _ of firstStream.fullStream) {
+        }
+
+        const second = helper()
+        second.input.sessionID = session.id
+        second.input.assistantMessage.sessionID = session.id
+        second.input.assistantMessage.id = MessageID.ascending()
+        second.input.userMessage.info.id = MessageID.ascending()
+        second.input.userMessage.parts = [{ type: "text", text: "follow up", ignored: false }] as any
+        second.input.options.recipientAgent = "UserSupportAgent"
+        ;(second.input.options as any).recipientAgentSelectedAt = 1
+
+        const secondStream = await SessionAgencySwarm.stream(second.input)
+        for await (const _ of secondStream.fullStream) {
+        }
+
+        expect(sentRecipients).toEqual(["UserSupportAgent", "UserSupportAgent"])
+      },
+    })
+  })
+
   test("stream keeps agent_updated handoff metadata when raw text is replayed by messages", async () => {
     await using tmp = await tmpdir({
       git: true,

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1842,8 +1842,8 @@ describe("session.agency-swarm", () => {
       {
         type: "handoff_output_item",
         call_id: "call_3",
-        callerAgent: "SupportAgent",
-        parent_run_id: "run_parent",
+        caller_agent: "SupportAgent",
+        parentRunID: "run_parent",
         output: { assistant: "MathAgent" },
       },
     ])
@@ -3624,8 +3624,8 @@ describe("session.agency-swarm", () => {
               type: "data",
               payload: {
                 type: "agent_updated_stream_event",
-                callerAgent: "UserSupportAgent",
-                parent_run_id: "run_parent",
+                caller_agent: "UserSupportAgent",
+                parentRunID: "run_parent",
                 new_agent: {
                   id: "MathAgent",
                   label: "Math Agent",

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3687,6 +3687,174 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream restores top-level handoff over later nested forwarded metadata", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        const sentRecipients: Array<string | undefined> = []
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["UserSupportAgent", "support_agent", "MathAgent"],
+          },
+          nodes: [
+            {
+              id: "UserSupportAgent",
+              type: "agent",
+              data: {
+                label: "User Support Agent",
+              },
+            },
+            {
+              id: "support_agent",
+              type: "agent",
+              data: {
+                label: "Support Agent",
+              },
+            },
+            {
+              id: "MathAgent",
+              type: "agent",
+              data: {
+                label: "Math Agent",
+              },
+            },
+          ],
+        })) as typeof AgencySwarmAdapter.getMetadata
+        let turn = 0
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          turn++
+          sentRecipients.push(args.recipientAgent ?? undefined)
+          if (turn === 1) {
+            yield {
+              type: "data",
+              payload: {
+                type: "raw_response_event",
+                data: {
+                  type: "response.output_item.added",
+                  output_index: 1,
+                  item: {
+                    type: "function_call",
+                    id: "fc_handoff",
+                    call_id: "call_handoff",
+                    name: "transfer_to_support_agent",
+                    arguments: "{}",
+                  },
+                },
+              },
+            }
+            yield {
+              type: "messages",
+              payload: {
+                new_messages: [
+                  {
+                    type: "handoff_output_item",
+                    call_id: "call_handoff",
+                    output: '{"assistant":"support_agent"}',
+                  },
+                ],
+              },
+            }
+            yield {
+              type: "data",
+              payload: {
+                type: "raw_response_event",
+                callerAgent: "support_agent",
+                parent_run_id: "run_parent",
+                data: {
+                  type: "response.output_item.done",
+                  output_index: 2,
+                  item: {
+                    type: "handoff_output_item",
+                    call_id: "call_nested_handoff",
+                    output: {
+                      assistant: "MathAgent",
+                    },
+                  },
+                },
+              },
+            }
+            yield {
+              type: "messages",
+              payload: {
+                new_messages: [
+                  {
+                    id: "msg_mixed_nested_delegate",
+                    type: "message",
+                    role: "assistant",
+                    agent: "MathAgent",
+                    content: [{ type: "output_text", text: "Nested delegation replied after handoff." }],
+                  },
+                ],
+              },
+            }
+          }
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "mixed handoff nested delegate" })
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "handoff then delegate",
+        })
+
+        const first = helper()
+        first.input.sessionID = session.id
+        first.input.assistantMessage.sessionID = session.id
+        first.input.assistantMessage.id = MessageID.ascending()
+        first.input.assistantMessage.parentID = user.id
+        first.input.userMessage.info.id = user.id
+        first.input.options.recipientAgent = "UserSupportAgent"
+        ;(first.input.options as any).recipientAgentSelectedAt = 1
+
+        const firstStream = await SessionAgencySwarm.stream(first.input)
+        for await (const _ of firstStream.fullStream) {
+        }
+
+        const second = helper()
+        second.input.sessionID = session.id
+        second.input.assistantMessage.sessionID = session.id
+        second.input.assistantMessage.id = MessageID.ascending()
+        second.input.userMessage.info.id = MessageID.ascending()
+        second.input.userMessage.parts = [{ type: "text", text: "follow up", ignored: false }] as any
+        second.input.options.recipientAgent = "UserSupportAgent"
+        ;(second.input.options as any).recipientAgentSelectedAt = 1
+
+        const secondStream = await SessionAgencySwarm.stream(second.input)
+        for await (const _ of secondStream.fullStream) {
+        }
+
+        expect(sentRecipients).toEqual(["UserSupportAgent", "support_agent"])
+      },
+    })
+  })
+
   test("stream keeps agent_updated handoff metadata when raw text is replayed by messages", async () => {
     await using tmp = await tmpdir({
       git: true,

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1839,11 +1839,27 @@ describe("session.agency-swarm", () => {
       { type: "message", id: "m1" },
       { type: "function_call_output", call_id: "call_1", output: { value: 42 } },
       { type: "function_call_output", call_id: "call_2", output: "done" },
+      {
+        type: "handoff_output_item",
+        call_id: "call_3",
+        callerAgent: "SupportAgent",
+        parent_run_id: "run_parent",
+        output: { assistant: "MathAgent" },
+      },
     ])
 
     expect(outputs).toEqual([
-      { callID: "call_1", output: '{\n  "value": 42\n}' },
-      { callID: "call_2", output: "done" },
+      { callID: "call_1", output: '{\n  "value": 42\n}', metadata: {}, itemType: "function_call_output" },
+      { callID: "call_2", output: "done", metadata: {}, itemType: "function_call_output" },
+      {
+        callID: "call_3",
+        output: '{\n  "assistant": "MathAgent"\n}',
+        metadata: {
+          callerAgent: "SupportAgent",
+          parentRunID: "run_parent",
+        },
+        itemType: "handoff_output_item",
+      },
     ])
   })
 
@@ -3766,22 +3782,19 @@ describe("session.agency-swarm", () => {
               },
             }
             yield {
-              type: "data",
+              type: "messages",
               payload: {
-                type: "raw_response_event",
-                callerAgent: "support_agent",
-                parent_run_id: "run_parent",
-                data: {
-                  type: "response.output_item.done",
-                  output_index: 2,
-                  item: {
+                new_messages: [
+                  {
                     type: "handoff_output_item",
                     call_id: "call_nested_handoff",
+                    callerAgent: "support_agent",
+                    parent_run_id: "run_parent",
                     output: {
                       assistant: "MathAgent",
                     },
                   },
-                },
+                ],
               },
             }
             yield {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1842,8 +1842,10 @@ describe("session.agency-swarm", () => {
       {
         type: "handoff_output_item",
         call_id: "call_3",
-        caller_agent: "SupportAgent",
-        parentRunID: "run_parent",
+        metadata: {
+          caller_agent: "SupportAgent",
+          parentRunID: "run_parent",
+        },
         output: { assistant: "MathAgent" },
       },
     ])
@@ -3788,8 +3790,10 @@ describe("session.agency-swarm", () => {
                   {
                     type: "handoff_output_item",
                     call_id: "call_nested_handoff",
-                    callerAgent: "support_agent",
-                    parent_run_id: "run_parent",
+                    metadata: {
+                      caller_agent: "support_agent",
+                      parentRunID: "run_parent",
+                    },
                     output: {
                       assistant: "MathAgent",
                     },


### PR DESCRIPTION
### Issue for this PR

Fixes #173

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevents nested or forwarded Agency Swarm handoff-like metadata from switching the user-facing active recipient after ordinary `SendMessage` delegation.

Handoff evidence now has to be top-level. `parent_run_id` / `parentRunID` and non-null caller markers make `handoff_output_item`, `agent_updated_stream_event`, and nested `transfer_to_*` metadata non-authoritative for TUI recipient adoption and backend session recipient restore. Real top-level `transfer_to_*`, `handoff_output_item`, and `agent_updated_stream_event` handoffs still switch control.

### How did you verify your code works?

I first added regression coverage and confirmed latest-dev failed the nested cases: the follow-up after a nested `agent_updated_stream_event` routed to `MathAgent`, and nested handoff metadata was accepted as handoff evidence.

Then I ran:

- `cd packages/opencode && bun test test/session/agency-swarm-utils.test.ts test/cli/tui/agency-target.test.ts test/cli/tui/prompt-framework-mode.test.tsx test/session/agency-swarm.test.ts --timeout 30000`
- `cd packages/opencode && CI=1 bun run test:agentswarm:e2e`
- `bun typecheck`
- Push hook ran `bun turbo typecheck`.

### Screenshots / recordings

Not applicable. This is routing behavior covered by focused session/TUI tests and the Agent Swarm terminal e2e harness.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
