### PR TITLE
fix(launcher): timeout import canary

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -49,6 +49,7 @@ interface PythonInfo {
 interface VenvCanaryResult {
   healthy: boolean
   stderr: string
+  timedOut: boolean
 }
 
 interface DependencyInstallResult extends CommandResult {
@@ -66,6 +67,7 @@ interface RunCommandOptions {
 const VENV_CANARY_SCRIPT = ["import agency_swarm", "from agency_swarm.integrations.fastapi import run_fastapi"].join(
   "\n",
 )
+const VENV_CANARY_TIMEOUT_MS = 60 * 1000
 const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
 const PROCESS_KILL_GRACE_MS = 5000
 
@@ -673,15 +675,18 @@ async function ensureProjectPython(directory: string) {
       }
       if (!corruptedVenv) {
         prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
-        let healthy = false
+        let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
         try {
-          healthy = await venvCanaryPasses([venvPython])
+          canary = await venvCanaryPasses([venvPython], { includeStderr: true })
         } catch {
-          healthy = false
+          canary = { healthy: false, stderr: "", timedOut: false }
         }
-        if (healthy) {
+        if (canary.healthy) {
           prompts.log.success("Python environment ready")
           return [venvPython]
+        }
+        if (canary.timedOut) {
+          throw new Error(await formatCanaryTimeoutFailure(directory, canary.stderr))
         }
         corruptedVenv = true
       }
@@ -762,6 +767,9 @@ async function ensureProjectPython(directory: string) {
   }
   prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
   const canary = await venvCanaryPasses([venvPython], { cwd: directory, includeStderr: true })
+  if (canary.timedOut) {
+    throw new Error(await formatCanaryTimeoutFailure(directory, canary.stderr))
+  }
   if (!canary.healthy) {
     throw new Error(await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr))
   }
@@ -828,6 +836,14 @@ async function formatPostInstallCanaryFailure(directory: string, hadManifests: b
     : `Project \`.venv\` rebuilt successfully, but the Agency Swarm import canary still failed.${shadowingHint}`
 }
 
+async function formatCanaryTimeoutFailure(directory: string, stderr: string) {
+  const summary = summarizeBridgeStderr(stderr)
+  const shadowingHint = await formatShadowingHint(directory)
+  return summary
+    ? `Agency Swarm import canary timed out after ${formatInstallDuration(VENV_CANARY_TIMEOUT_MS)}. Startup stopped instead of waiting indefinitely.${shadowingHint} Canary stderr: ${summary}`
+    : `Agency Swarm import canary timed out after ${formatInstallDuration(VENV_CANARY_TIMEOUT_MS)}. Startup stopped instead of waiting indefinitely.${shadowingHint}`
+}
+
 function isImportLikeCanaryFailure(stderr: string) {
   return /\b(?:ImportError|ModuleNotFoundError)\b/.test(stderr)
 }
@@ -857,17 +873,18 @@ async function venvCanaryPasses(python: string[], options?: { cwd?: string; incl
   // sitting next to `agency.py`) that shadow installed packages and falsely flag a healthy
   // .venv as broken. Callers that need the server-launch cwd (post-install verification)
   // pass it explicitly.
-  const result = await runCommand(
-    [...python, "-c", VENV_CANARY_SCRIPT],
-    options?.cwd ? { cwd: options.cwd } : undefined,
-  )
+  const result = await runCommand([...python, "-c", VENV_CANARY_SCRIPT], {
+    cwd: options?.cwd,
+    timeoutMs: VENV_CANARY_TIMEOUT_MS,
+  })
   if (options?.includeStderr) {
     return {
-      healthy: result.code === 0,
+      healthy: result.code === 0 && !result.timedOut,
       stderr: result.stderr,
+      timedOut: result.timedOut === true,
     }
   }
-  return result.code === 0
+  return result.code === 0 && !result.timedOut
 }
 
 async function ensureLatestAgencySwarm(

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -64,10 +64,16 @@ interface RunCommandOptions {
   timeoutMs?: number
 }
 
+interface ServerStderrCollector {
+  read(timeoutMs: number): Promise<string>
+  stop(): void
+}
+
 const VENV_CANARY_SCRIPT = ["import agency_swarm", "from agency_swarm.integrations.fastapi import run_fastapi"].join(
   "\n",
 )
 const VENV_CANARY_TIMEOUT_MS = 60 * 1000
+const SERVER_STDERR_COLLECT_TIMEOUT_MS = 1000
 const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
 const PROCESS_KILL_GRACE_MS = 5000
 
@@ -1001,10 +1007,11 @@ async function startProjectServer(directory: string, python: string[]) {
     await remove()
     throw error
   }
-  const stderrPromise = child.stderr ? new Response(child.stderr).text().catch(() => "") : Promise.resolve("")
+  const stderr = createServerStderrCollector(child.stderr)
 
   const cleanup = async () => {
     child.kill()
+    stderr.stop()
     await Promise.race([child.exited, sleep(5000)])
     await remove()
   }
@@ -1013,7 +1020,7 @@ async function startProjectServer(directory: string, python: string[]) {
     await waitForServer({
       baseURL: `http://127.0.0.1:${port}`,
       child,
-      stderrPromise,
+      stderr,
     })
   } catch (error) {
     await cleanup()
@@ -1029,14 +1036,14 @@ async function startProjectServer(directory: string, python: string[]) {
 async function waitForServer(input: {
   baseURL: string
   child: ReturnType<typeof Bun.spawn>
-  stderrPromise: Promise<string>
+  stderr: ServerStderrCollector
 }) {
   const deadline = Date.now() + 30000
   const metadataURL = `${input.baseURL}/${LOCAL_AGENCY_ID}/get_metadata`
   while (Date.now() < deadline) {
     const exited = await Promise.race([input.child.exited.then((code: number) => code), sleep(200).then(() => null)])
     if (typeof exited === "number") {
-      const stderr = await input.stderrPromise
+      const stderr = await input.stderr.read(SERVER_STDERR_COLLECT_TIMEOUT_MS)
       const summary = summarizeBridgeStderr(stderr)
       throw new Error(
         summary
@@ -1054,13 +1061,63 @@ async function waitForServer(input: {
   }
 
   input.child.kill()
-  const stderr = await input.stderrPromise
+  const stderr = await input.stderr.read(SERVER_STDERR_COLLECT_TIMEOUT_MS)
   const summary = summarizeBridgeStderr(stderr)
   throw new Error(
     summary
       ? `Timed out waiting for the Agency Swarm server to start. Last bridge output: ${summary}`
       : "Timed out waiting for the Agency Swarm server to start",
   )
+}
+
+function createServerStderrCollector(
+  output: string | ReadableStream<Uint8Array> | null | undefined,
+): ServerStderrCollector {
+  if (typeof output === "string") {
+    return {
+      read: async () => output,
+      stop() {},
+    }
+  }
+  if (!output) {
+    return {
+      read: async () => "",
+      stop() {},
+    }
+  }
+
+  const reader = output.getReader()
+  const decoder = new TextDecoder()
+  let text = ""
+  let settled = false
+  const done = (async () => {
+    try {
+      while (true) {
+        const chunk = await reader.read()
+        if (chunk.done) break
+        if (!chunk.value || chunk.value.length === 0) continue
+        text += decoder.decode(chunk.value, { stream: true })
+      }
+      text += decoder.decode()
+    } catch {
+      text += decoder.decode()
+    } finally {
+      settled = true
+    }
+  })()
+
+  return {
+    async read(timeoutMs: number) {
+      if (!settled) {
+        await Promise.race([done, sleep(timeoutMs)])
+      }
+      return text
+    },
+    stop() {
+      if (settled) return
+      void reader.cancel().catch(() => undefined)
+    },
+  }
 }
 
 export function summarizeBridgeStderr(stderr: string): string {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -889,6 +889,112 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
+  test("prepareProjectLaunch times out when the import canary hangs", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    const realSetTimeout = globalThis.setTimeout
+    const realClearTimeout = globalThis.clearTimeout
+    const killSignals: Array<string | undefined> = []
+    const canaryStderr = createTextOutputStream("importing openai types...\n")
+    let resolveCanary!: (code: number) => void
+    let canaryStarted = false
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
+      if (canaryStarted && typeof fn === "function") {
+        fn()
+        return 1 as never
+      }
+      return realSetTimeout(fn, 0) as never
+    }) as unknown as typeof setTimeout)
+    spyOn(globalThis, "clearTimeout").mockImplementation(((timer?: Parameters<typeof clearTimeout>[0]) => {
+      realClearTimeout(timer)
+    }) as typeof clearTimeout)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        if (target.endsWith(process.platform === "win32" ? "\\python.exe" : "/python")) {
+          return {
+            exited: Promise.resolve(0),
+            stdout: `${target}\n3.12.7\n`,
+            stderr: "",
+          } as never
+        }
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        canaryStarted = true
+        return {
+          exited: new Promise<number>((resolve) => {
+            resolveCanary = resolve
+          }),
+          stdout: "",
+          stderr: canaryStderr.stream,
+          kill(signal?: string) {
+            killSignals.push(signal)
+            if (signal === "SIGKILL") {
+              canaryStderr.close()
+              resolveCanary(1)
+            }
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+    const pending = Symbol("pending")
+    const outcome = await Promise.race([
+      launch.then(
+        () => "resolved",
+        (error) => error,
+      ),
+      new Promise((resolve) => realSetTimeout(() => resolve(pending), 20)),
+    ])
+
+    if (outcome === pending) {
+      canaryStderr.close()
+      resolveCanary(1)
+      await launch.catch(() => undefined)
+    }
+
+    expect(outcome).not.toBe(pending)
+    expect(outcome).toBeInstanceOf(Error)
+    if (!(outcome instanceof Error)) throw new Error("Expected prepareProjectLaunch to fail")
+    expect(killSignals).toEqual([undefined, "SIGKILL"])
+    expect(outcome.message).toContain("Agency Swarm import canary timed out after 1 minute")
+  })
+
   test("prepareProjectLaunch does not fail healthy `.venv` launches when refresh logging cannot be created", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -995,6 +995,96 @@ describe("agency-swarm npx onboarding", () => {
     expect(outcome.message).toContain("Agency Swarm import canary timed out after 1 minute")
   })
 
+  test("prepareProjectLaunch returns when server readiness timeout stderr does not close", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    const realSetTimeout = globalThis.setTimeout
+    const serverStderr = createTextOutputStream("bridge still starting\n")
+    const killSignals: Array<string | undefined> = []
+    let resolveServerExit!: (code: number) => void
+    let now = 0
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(Date, "now").mockImplementation(() => {
+      const value = now
+      now = 30001
+      return value
+    })
+    spyOn(globalThis, "fetch").mockRejectedValue(new Error("not ready") as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        return {
+          exited: new Promise<number>((resolve) => {
+            resolveServerExit = resolve
+          }),
+          stderr: serverStderr.stream,
+          kill(signal?: string) {
+            killSignals.push(signal)
+            if (killSignals.length > 1) resolveServerExit(1)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+    const pending = Symbol("pending")
+    const outcome = await Promise.race([
+      launch.then(
+        () => "resolved",
+        (error) => error,
+      ),
+      new Promise((resolve) => realSetTimeout(() => resolve(pending), 1500)),
+    ])
+
+    if (outcome === pending) {
+      serverStderr.close()
+      await launch.catch(() => undefined)
+    }
+
+    expect(outcome).not.toBe(pending)
+    expect(outcome).toBeInstanceOf(Error)
+    if (!(outcome instanceof Error)) throw new Error("Expected prepareProjectLaunch to fail")
+    expect(killSignals).toEqual([undefined, undefined])
+    expect(outcome.message).toContain(
+      "Timed out waiting for the Agency Swarm server to start. Last bridge output: bridge still starting",
+    )
+  })
+
   test("prepareProjectLaunch does not fail healthy `.venv` launches when refresh logging cannot be created", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)


### PR DESCRIPTION
### Issue for this PR

Closes #184

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bounds the local project startup checks so the launcher cannot wait forever before the TUI opens.

- The Agency Swarm import canary now times out after 1 minute through the existing command timeout path.
- FastAPI bridge startup now collects stderr incrementally and bounds stderr reads during child-exit and readiness-timeout paths, preserving available bridge output without waiting for a stuck stream to close.

### How did you verify your code works?

- `bun test test/agency-swarm/npx.test.ts -t "prepareProjectLaunch times out when the import canary hangs"`
- `bun test test/agency-swarm/npx.test.ts -t "prepareProjectLaunch returns when server readiness timeout stderr does not close"`
- `bun test test/agency-swarm/npx.test.ts`
- `bun typecheck`
- Local Codex review against `vrsen/dev`: no actionable regressions found

A full `agentswarm .` smoke against the user-owned stuck QA process was not run. The covered launcher paths use deterministic child-process tests instead.

### Screenshots / recordings

N/A - startup timeout handling only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR