### PR TITLE
fix(tui): use message order for queued cancels

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts
@@ -13,13 +13,14 @@ export function collectQueuedRunModeMessages(input: {
   messages: readonly Message[]
   parts: Record<string, Part[] | undefined>
 }): QueuedRunModeMessage[] {
-  const activeAssistant = input.messages.findLast(
+  const activeAssistantIndex = input.messages.findLastIndex(
     (message): message is AssistantMessage => message.role === "assistant" && !message.time.completed,
   )
-  if (!activeAssistant) return []
+  if (activeAssistantIndex === -1) return []
 
   return input.messages
-    .filter((message): message is UserMessage => message.role === "user" && message.id > activeAssistant.id)
+    .slice(activeAssistantIndex + 1)
+    .filter((message): message is UserMessage => message.role === "user")
     .map((message) => ({
       message,
       prompt: promptFromMessageParts(input.parts[message.id] ?? []),

--- a/packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts
@@ -13,12 +13,13 @@ export function collectQueuedRunModeMessages(input: {
   messages: readonly Message[]
   parts: Record<string, Part[] | undefined>
 }): QueuedRunModeMessage[] {
-  const activeAssistantIndex = input.messages.findLastIndex(
+  const messages = input.messages.toSorted(compareMessageOrder)
+  const activeAssistantIndex = messages.findLastIndex(
     (message): message is AssistantMessage => message.role === "assistant" && !message.time.completed,
   )
   if (activeAssistantIndex === -1) return []
 
-  return input.messages
+  return messages
     .slice(activeAssistantIndex + 1)
     .filter((message): message is UserMessage => message.role === "user")
     .map((message) => ({
@@ -57,4 +58,10 @@ function promptFromMessageParts(parts: readonly Part[]): PromptInfo {
     },
     { input: "", parts: [] } as PromptInfo,
   )
+}
+
+function compareMessageOrder(a: Message, b: Message) {
+  const time = a.time.created - b.time.created
+  if (time !== 0) return time
+  return a.id.localeCompare(b.id)
 }

--- a/packages/opencode/test/cli/tui/run-queued-messages.test.ts
+++ b/packages/opencode/test/cli/tui/run-queued-messages.test.ts
@@ -57,6 +57,40 @@ describe("run-mode queued messages", () => {
     expect(queued.map((item) => item.prompt.input)).toEqual(["second", "third"])
   })
 
+  test("uses message order instead of lexicographic ids", () => {
+    const queued = collectQueuedRunModeMessages({
+      messages: [
+        {
+          id: "msg_z",
+          role: "assistant",
+          sessionID: "ses_1",
+          parentID: "msg_parent",
+          time: { created: 1 },
+          agent: "build",
+          mode: "build",
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        {
+          id: "msg_a",
+          role: "user",
+          sessionID: "ses_1",
+          time: { created: 2 },
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+        },
+      ],
+      parts: {
+        msg_a: [{ id: "part_1", sessionID: "ses_1", messageID: "msg_a", type: "text", text: "queued" }],
+      },
+    })
+
+    expect(queued.map((item) => item.message.id)).toEqual(["msg_a"])
+  })
+
   test("queued cancel removes queued Run-mode user messages without aborting the active turn", async () => {
     const calls: string[] = []
 

--- a/packages/opencode/test/cli/tui/run-queued-messages.test.ts
+++ b/packages/opencode/test/cli/tui/run-queued-messages.test.ts
@@ -57,9 +57,17 @@ describe("run-mode queued messages", () => {
     expect(queued.map((item) => item.prompt.input)).toEqual(["second", "third"])
   })
 
-  test("uses message order instead of lexicographic ids", () => {
+  test("uses chronological order when the sync store is sorted by id", () => {
     const queued = collectQueuedRunModeMessages({
       messages: [
+        {
+          id: "msg_a",
+          role: "user",
+          sessionID: "ses_1",
+          time: { created: 2 },
+          agent: "build",
+          model: { providerID: "agency-swarm", modelID: "default" },
+        },
         {
           id: "msg_z",
           role: "assistant",
@@ -73,14 +81,6 @@ describe("run-mode queued messages", () => {
           tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
           providerID: "agency-swarm",
           modelID: "default",
-        },
-        {
-          id: "msg_a",
-          role: "user",
-          sessionID: "ses_1",
-          time: { created: 2 },
-          agent: "build",
-          model: { providerID: "agency-swarm", modelID: "default" },
         },
       ],
       parts: {


### PR DESCRIPTION
Summary

- Updates Run-mode queued cancel collection to use message order after the active assistant turn instead of lexicographic message IDs.
- Adds a focused regression for IDs that sort before the active assistant despite being later in message order.

Context

This is a follow-up hardening fix for the queued-cancel path from #172. PR #180 fixed the original busy-delete race; this PR keeps the TUI-side queued-message detection aligned with the server-side message-order check.

Checks

- `bun x prettier --write packages/opencode/src/cli/cmd/tui/util/run-queued-messages.ts packages/opencode/test/cli/tui/run-queued-messages.test.ts`
- `cd packages/opencode && bun test test/cli/tui/run-queued-messages.test.ts`
- `cd packages/opencode && bun typecheck`
- push hook: `bun turbo typecheck`