### PR TITLE
fix(npx): hide raw pip refresh tracebacks

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1148,7 +1148,11 @@ function summarizePythonTraceback(output: string) {
     .map((line) => line.trim())
     .filter(Boolean)
   if (!lines.some((line) => line === "Traceback (most recent call last):")) return ""
-  return lines.findLast((line) => /^[A-Za-z_][\w.]*Error:/.test(line)) ?? ""
+  return lines.findLast(isPythonTracebackFinalExceptionLine) ?? ""
+}
+
+function isPythonTracebackFinalExceptionLine(line: string) {
+  return /^[A-Za-z_][\w.]*(?::(?:\s|$)|$)/.test(line)
 }
 
 async function hasGitHubTemplateFlow() {
@@ -1406,7 +1410,7 @@ function createUserStderrWriter(streamToStderr: boolean, suppressPythonTraceback
       return
     }
     if (suppressingTraceback) {
-      if (/^[A-Za-z_][\w.]*Error:/.test(trimmed)) suppressingTraceback = false
+      if (isPythonTracebackFinalExceptionLine(trimmed)) suppressingTraceback = false
       return
     }
     if (!streamToStderr) return

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -61,7 +61,13 @@ interface RunCommandOptions {
   env?: NodeJS.ProcessEnv
   logFile?: string
   streamOutputToStderr?: boolean
+  suppressPythonTracebackStderr?: boolean
   timeoutMs?: number
+}
+
+interface OutputWriter {
+  write: (chunk: string) => void
+  close?: () => void
 }
 
 interface ServerStderrCollector {
@@ -906,6 +912,7 @@ async function ensureLatestAgencySwarm(
       cwd: directory,
       logFile: options?.logFile,
       streamOutputToStderr: true,
+      suppressPythonTracebackStderr: true,
       timeoutMs: options?.timeoutMs,
     })
     if (result.timedOut) {
@@ -951,7 +958,7 @@ async function tryCreateProjectCommandLogFile(directory: string, stem: string, l
 }
 
 function summarizeCommandOutput(result: Pick<CommandResult, "stdout" | "stderr">) {
-  return summarizeBridgeStderr(result.stderr) || summarizeBridgeStderr(result.stdout)
+  return summarizeInstallerOutput(result.stderr) || summarizeInstallerOutput(result.stdout)
 }
 
 function formatCommandFailure(result: CommandResult, fallback: string) {
@@ -1128,6 +1135,22 @@ export function summarizeBridgeStderr(stderr: string): string {
   return tail.length > 500 ? `${tail.slice(0, 500)}...` : tail
 }
 
+function summarizeInstallerOutput(output: string) {
+  const tracebackSummary = summarizePythonTraceback(output)
+  if (tracebackSummary) return tracebackSummary
+  return summarizeBridgeStderr(output)
+}
+
+function summarizePythonTraceback(output: string) {
+  const lines = output
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+  if (!lines.some((line) => line === "Traceback (most recent call last):")) return ""
+  return lines.findLast((line) => /^[A-Za-z_][\w.]*Error:/.test(line)) ?? ""
+}
+
 async function hasGitHubTemplateFlow() {
   const gh = await runCommand(["gh", "--version"])
   if (gh.code !== 0) return false
@@ -1235,14 +1258,19 @@ async function getFreePort() {
 
 async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<CommandResult> {
   const commandLog = openCommandLog(options?.logFile)
-  const writeChunk = (chunk: string) => {
-    if (options?.streamOutputToStderr) {
+  const writeChunk = (chunk: string, streamToStderr: boolean) => {
+    if (streamToStderr) {
       try {
         process.stderr.write(chunk)
       } catch {}
     }
     commandLog.write(chunk)
   }
+  const stderrWriter = createStderrCommandWriter({
+    commandLog,
+    streamToStderr: options?.streamOutputToStderr === true,
+    suppressPythonTracebacks: options?.suppressPythonTracebackStderr === true,
+  })
   try {
     const proc = Bun.spawn({
       cmd,
@@ -1280,8 +1308,12 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
           })
     const [result, stdout, stderr] = await Promise.all([
       timeoutResult ? Promise.race([exitResult, timeoutResult]) : exitResult,
-      readCommandOutput(proc.stdout, writeChunk, outputAbort.signal),
-      readCommandOutput(proc.stderr, writeChunk, outputAbort.signal),
+      readCommandOutput(
+        proc.stdout,
+        (chunk) => writeChunk(chunk, options?.streamOutputToStderr === true),
+        outputAbort.signal,
+      ),
+      readCommandOutput(proc.stderr, stderrWriter, outputAbort.signal),
     ])
     const logFile = await closeCommandLog(commandLog)
     return { code: result.code, stdout, stderr, timedOut: result.timedOut, logFile }
@@ -1346,18 +1378,83 @@ function openCommandLog(logFile?: string) {
   }
 }
 
+function createStderrCommandWriter(input: {
+  commandLog: ReturnType<typeof openCommandLog>
+  streamToStderr: boolean
+  suppressPythonTracebacks: boolean
+}): OutputWriter {
+  const userWriter = createUserStderrWriter(input.streamToStderr, input.suppressPythonTracebacks)
+  return {
+    write(chunk) {
+      input.commandLog.write(chunk)
+      userWriter.write(chunk)
+    },
+    close() {
+      userWriter.close?.()
+    },
+  }
+}
+
+function createUserStderrWriter(streamToStderr: boolean, suppressPythonTracebacks: boolean): OutputWriter {
+  let pending = ""
+  let suppressingTraceback = false
+
+  const writeLine = (line: string) => {
+    const trimmed = line.trim()
+    if (suppressPythonTracebacks && !suppressingTraceback && trimmed === "Traceback (most recent call last):") {
+      suppressingTraceback = true
+      return
+    }
+    if (suppressingTraceback) {
+      if (/^[A-Za-z_][\w.]*Error:/.test(trimmed)) suppressingTraceback = false
+      return
+    }
+    if (!streamToStderr) return
+    try {
+      process.stderr.write(line)
+    } catch {}
+  }
+
+  return {
+    write(chunk) {
+      const text = pending + chunk
+      const lines = text.split(/(?<=\n)/)
+      pending = lines.at(-1)?.endsWith("\n") ? "" : (lines.pop() ?? "")
+      for (const line of lines) {
+        writeLine(line)
+      }
+    },
+    close() {
+      if (!pending) return
+      writeLine(pending)
+      pending = ""
+    },
+  }
+}
+
 async function closeCommandLog(log: ReturnType<typeof openCommandLog>) {
   await log.close()
   return log.getLogFile()
 }
 
+function writeOutput(writer: ((chunk: string) => void) | OutputWriter, chunk: string) {
+  if (typeof writer === "function") writer(chunk)
+  else writer.write(chunk)
+}
+
+function closeOutputWriter(writer: ((chunk: string) => void) | OutputWriter | undefined) {
+  if (typeof writer === "function") return
+  writer?.close?.()
+}
+
 async function readCommandOutput(
   output: string | ReadableStream<Uint8Array> | null | undefined,
-  writer?: (chunk: string) => void,
+  writer?: ((chunk: string) => void) | OutputWriter,
   signal?: AbortSignal,
 ) {
   if (typeof output === "string") {
-    if (output && writer) writer(output)
+    if (output && writer) writeOutput(writer, output)
+    closeOutputWriter(writer)
     return output
   }
   if (!output) return ""
@@ -1376,12 +1473,12 @@ async function readCommandOutput(
       if (done || signal?.aborted) break
       if (!value || value.length === 0) continue
       const chunk = decoder.decode(value, { stream: true })
-      if (writer) writer(chunk)
+      if (writer) writeOutput(writer, chunk)
       text += chunk
     }
     const tail = decoder.decode()
     if (tail) {
-      if (writer) writer(tail)
+      if (writer) writeOutput(writer, tail)
       text += tail
     }
     return text
@@ -1389,6 +1486,7 @@ async function readCommandOutput(
     if (signal?.aborted) return text
     throw error
   } finally {
+    closeOutputWriter(writer)
     signal?.removeEventListener("abort", abortRead)
   }
 }

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1152,7 +1152,7 @@ function summarizePythonTraceback(output: string) {
 }
 
 function isPythonTracebackFinalExceptionLine(line: string) {
-  return /^[A-Za-z_][\w.]*(?::(?:\s|$)|$)/.test(line)
+  return /^[A-Za-z_][\w.]*:(?:\s|$)/.test(line)
 }
 
 async function hasGitHubTemplateFlow() {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -742,7 +742,7 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
-  test("prepareProjectLaunch keeps broken pip refresh tracebacks in the log instead of mirroring them", async () => {
+  test("prepareProjectLaunch resumes stderr after a non-Error pip refresh traceback", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
     await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
@@ -764,7 +764,8 @@ describe("agency-swarm npx onboarding", () => {
       '  File "<frozen runpy>", line 88, in _run_code',
       `  File "${path.join(dir.path, ".venv", "lib", "python3.13", "site-packages", "pip", "__main__.py")}", line 22, in <module>`,
       "    from pip._internal.cli.main import main as _main",
-      "ModuleNotFoundError: No module named 'pip._internal.cli.main'",
+      "Exception: pip bootstrap failed",
+      "later stderr after traceback",
     ].join("\n")
 
     const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
@@ -819,11 +820,12 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     const mirroredOutput = stderrWrite.mock.calls.map((call) => call[0]).join("")
+    expect(mirroredOutput).toContain("later stderr after traceback")
     expect(mirroredOutput).not.toContain("Traceback (most recent call last):")
     expect(mirroredOutput).not.toContain("pip._internal.cli.main")
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("ModuleNotFoundError: No module named 'pip._internal.cli.main'"),
-    )
+    expect(mirroredOutput).not.toContain("Exception: pip bootstrap failed")
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Exception: pip bootstrap failed"))
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("Traceback (most recent call last):"))
 
     const refreshLogs = Array.fromAsync(new Bun.Glob("*-launcher-refresh.log").scan(launcherLogDirectory(dir.path)))
     const logFiles = await refreshLogs
@@ -831,6 +833,8 @@ describe("agency-swarm npx onboarding", () => {
     const logContent = await Bun.file(path.join(launcherLogDirectory(dir.path), logFiles[0]!)).text()
     expect(logContent).toContain("Traceback (most recent call last):")
     expect(logContent).toContain("pip._internal.cli.main")
+    expect(logContent).toContain("Exception: pip bootstrap failed")
+    expect(logContent).toContain("later stderr after traceback")
 
     await launch?.cleanup?.()
   })

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -742,6 +742,99 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
+  test("prepareProjectLaunch keeps broken pip refresh tracebacks in the log instead of mirroring them", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    const pipTraceback = [
+      "Traceback (most recent call last):",
+      '  File "<frozen runpy>", line 198, in _run_module_as_main',
+      '  File "<frozen runpy>", line 88, in _run_code',
+      `  File "${path.join(dir.path, ".venv", "lib", "python3.13", "site-packages", "pip", "__main__.py")}", line 22, in <module>`,
+      "    from pip._internal.cli.main import main as _main",
+      "ModuleNotFoundError: No module named 'pip._internal.cli.main'",
+    ].join("\n")
+
+    const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.13.3\n`,
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: `${pipTraceback}\n`,
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    const mirroredOutput = stderrWrite.mock.calls.map((call) => call[0]).join("")
+    expect(mirroredOutput).not.toContain("Traceback (most recent call last):")
+    expect(mirroredOutput).not.toContain("pip._internal.cli.main")
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("ModuleNotFoundError: No module named 'pip._internal.cli.main'"),
+    )
+
+    const refreshLogs = Array.fromAsync(new Bun.Glob("*-launcher-refresh.log").scan(launcherLogDirectory(dir.path)))
+    const logFiles = await refreshLogs
+    expect(logFiles).toHaveLength(1)
+    const logContent = await Bun.file(path.join(launcherLogDirectory(dir.path), logFiles[0]!)).text()
+    expect(logContent).toContain("Traceback (most recent call last):")
+    expect(logContent).toContain("pip._internal.cli.main")
+
+    await launch?.cleanup?.()
+  })
+
   test("prepareProjectLaunch survives refresh log stream failures", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -764,6 +764,7 @@ describe("agency-swarm npx onboarding", () => {
       '  File "<frozen runpy>", line 88, in _run_code',
       `  File "${path.join(dir.path, ".venv", "lib", "python3.13", "site-packages", "pip", "__main__.py")}", line 22, in <module>`,
       "    from pip._internal.cli.main import main as _main",
+      "    foo",
       "ModuleNotFoundError: No module named 'pip._internal.cli.main'",
     ].join("\n")
 
@@ -821,6 +822,7 @@ describe("agency-swarm npx onboarding", () => {
     const mirroredOutput = stderrWrite.mock.calls.map((call) => call[0]).join("")
     expect(mirroredOutput).not.toContain("Traceback (most recent call last):")
     expect(mirroredOutput).not.toContain("<frozen runpy>")
+    expect(mirroredOutput).not.toContain("foo")
     expect(mirroredOutput).not.toContain("pip._internal.cli.main")
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("ModuleNotFoundError: No module named 'pip._internal.cli.main'"),
@@ -833,6 +835,7 @@ describe("agency-swarm npx onboarding", () => {
     const logContent = await Bun.file(path.join(launcherLogDirectory(dir.path), logFiles[0]!)).text()
     expect(logContent).toContain("Traceback (most recent call last):")
     expect(logContent).toContain("<frozen runpy>")
+    expect(logContent).toContain("foo")
     expect(logContent).toContain("pip._internal.cli.main")
     expect(logContent).toContain("ModuleNotFoundError: No module named 'pip._internal.cli.main'")
 

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -742,6 +742,103 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
+  test("prepareProjectLaunch keeps broken pip ModuleNotFoundError tracebacks in the log instead of mirroring them", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    const pipTraceback = [
+      "Traceback (most recent call last):",
+      '  File "<frozen runpy>", line 198, in _run_module_as_main',
+      '  File "<frozen runpy>", line 88, in _run_code',
+      `  File "${path.join(dir.path, ".venv", "lib", "python3.13", "site-packages", "pip", "__main__.py")}", line 22, in <module>`,
+      "    from pip._internal.cli.main import main as _main",
+      "ModuleNotFoundError: No module named 'pip._internal.cli.main'",
+    ].join("\n")
+
+    const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.13.3\n`,
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: `${pipTraceback}\n`,
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    const mirroredOutput = stderrWrite.mock.calls.map((call) => call[0]).join("")
+    expect(mirroredOutput).not.toContain("Traceback (most recent call last):")
+    expect(mirroredOutput).not.toContain("<frozen runpy>")
+    expect(mirroredOutput).not.toContain("pip._internal.cli.main")
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("ModuleNotFoundError: No module named 'pip._internal.cli.main'"),
+    )
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("Traceback (most recent call last):"))
+
+    const refreshLogs = Array.fromAsync(new Bun.Glob("*-launcher-refresh.log").scan(launcherLogDirectory(dir.path)))
+    const logFiles = await refreshLogs
+    expect(logFiles).toHaveLength(1)
+    const logContent = await Bun.file(path.join(launcherLogDirectory(dir.path), logFiles[0]!)).text()
+    expect(logContent).toContain("Traceback (most recent call last):")
+    expect(logContent).toContain("<frozen runpy>")
+    expect(logContent).toContain("pip._internal.cli.main")
+    expect(logContent).toContain("ModuleNotFoundError: No module named 'pip._internal.cli.main'")
+
+    await launch?.cleanup?.()
+  })
+
   test("prepareProjectLaunch resumes stderr after a non-Error pip refresh traceback", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)


### PR DESCRIPTION
### Issue for this PR

Closes #190

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Suppresses raw Python traceback frames from the user-visible dependency refresh stream when a project venv has a broken pip installation.

The full refresh output still goes to the launcher log for diagnostics, and the terminal keeps a concise warning with the final exception summary.

### How did you verify your code works?

- Reproduced the broken-pip refresh path with a focused regression test.
- `cd packages/opencode && bun test test/agency-swarm/npx.test.ts`
- `bun typecheck`
- Independent Codex review found no findings after the traceback-boundary tests were restored.

### Screenshots / recordings

Not applicable. This is terminal startup output handling; the regression tests assert the user-visible stderr and log output.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
