### PR TITLE
fix: reasoning pruning fix

### DIFF
--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -2269,7 +2269,6 @@ export namespace SessionAgencySwarm {
     return history.filter((item) => {
       const type = asString(item["type"])
       if (type === "handoff_output_item") return false
-      if (type === "reasoning" || (type !== "message" && asString(item["id"])?.startsWith("rs_"))) return false
       if (type !== "message") return true
       if (asString(item["role"]) !== "assistant") return true
       const content = item["content"]

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -2266,16 +2266,31 @@ export namespace SessionAgencySwarm {
   }
 
   function sanitizeAgencyHistoryForTransport(history: Array<Record<string, unknown>>) {
-    return history.filter((item) => {
+    return history.flatMap((item) => {
       const type = asString(item["type"])
-      if (type === "handoff_output_item") return false
-      if (type !== "message") return true
-      if (asString(item["role"]) !== "assistant") return true
-      const content = item["content"]
-      if (Array.isArray(content)) return content.length > 0
-      if (typeof content === "string") return content.length > 0
-      return content !== undefined && content !== null
+      if (type === "handoff_output_item" || type === "item_reference") return []
+      if (
+        type === "message" &&
+        asString(item["role"]) === "assistant" &&
+        !hasReplayableMessageContent(item["content"])
+      ) {
+        return []
+      }
+      return [stripOpenAIResponseItemID(item)]
     })
+  }
+
+  function stripOpenAIResponseItemID(item: Record<string, unknown>) {
+    if (!Object.prototype.hasOwnProperty.call(item, "id")) return item
+    const result = { ...item }
+    delete result["id"]
+    return result
+  }
+
+  function hasReplayableMessageContent(content: unknown) {
+    if (Array.isArray(content)) return content.length > 0
+    if (typeof content === "string") return content.length > 0
+    return content !== undefined && content !== null
   }
 
   function extractCallerAgent(msg: MessageV2.WithParts): string | null {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3219,7 +3219,7 @@ describe("session.agency-swarm", () => {
     expect(sentHistory).toEqual(storedHistory)
   })
 
-  test("stream keeps stored Responses reasoning while pruning handoff-only transport items", async () => {
+  test("stream strips stored Responses item ids while pruning handoff-only transport items", async () => {
     const storedHistory = [
       {
         type: "message",
@@ -3241,6 +3241,10 @@ describe("session.agency-swarm", () => {
       {
         id: "rs_ref_stale",
         summary: [{ type: "summary_text", text: "private ref state" }],
+      },
+      {
+        type: "item_reference",
+        id: "rs_ref_rejected",
       },
       {
         type: "handoff_output_item",
@@ -3276,29 +3280,25 @@ describe("session.agency-swarm", () => {
     expect(sentHistory).toEqual([
       {
         type: "message",
-        id: "msg_kept",
         role: "assistant",
         content: [{ type: "output_text", text: "HANDOFF_AGENT_ACTIVE" }],
       },
       {
         type: "message",
-        id: "rs_message_kept",
         role: "assistant",
         content: [{ type: "output_text", text: "normal message with backend rs id" }],
       },
       {
         type: "reasoning",
-        id: "rs_stale",
         summary: [{ type: "summary_text", text: "private chain state" }],
       },
       {
-        id: "rs_ref_stale",
         summary: [{ type: "summary_text", text: "private ref state" }],
       },
     ])
   })
 
-  test("stream keeps Responses reasoning and stored output items after handoff", async () => {
+  test("stream strips stored Responses item ids after handoff", async () => {
     const storedHistory = [
       {
         type: "message",
@@ -3370,37 +3370,31 @@ describe("session.agency-swarm", () => {
     expect(sentHistory).toEqual([
       {
         type: "message",
-        id: "msg_before_handoff",
         role: "assistant",
         content: [{ type: "output_text", text: "Preparing transfer." }],
       },
       {
         type: "reasoning",
-        id: "rs_required",
         summary: [{ type: "summary_text", text: "choose handoff target" }],
       },
       {
         type: "function_call",
-        id: "fc_handoff",
         call_id: "call_handoff",
         name: "transfer_to_math_agent",
         arguments: "{}",
       },
       {
         type: "reasoning",
-        id: "rs_required_message",
         summary: [{ type: "summary_text", text: "start handoff response" }],
       },
       {
         type: "message",
-        id: "msg_after_handoff",
         role: "assistant",
         agent: "MathAgent",
         content: [{ type: "output_text", text: "Math agent now has control." }],
       },
       {
         type: "reasoning",
-        id: "rs_orphan",
         summary: [{ type: "summary_text", text: "stale private state" }],
       },
     ])

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3219,7 +3219,7 @@ describe("session.agency-swarm", () => {
     expect(sentHistory).toEqual(storedHistory)
   })
 
-  test("stream removes stored Responses reasoning items without dropping rs-prefixed messages", async () => {
+  test("stream keeps stored Responses reasoning while pruning handoff-only transport items", async () => {
     const storedHistory = [
       {
         type: "message",
@@ -3285,6 +3285,123 @@ describe("session.agency-swarm", () => {
         id: "rs_message_kept",
         role: "assistant",
         content: [{ type: "output_text", text: "normal message with backend rs id" }],
+      },
+      {
+        type: "reasoning",
+        id: "rs_stale",
+        summary: [{ type: "summary_text", text: "private chain state" }],
+      },
+      {
+        id: "rs_ref_stale",
+        summary: [{ type: "summary_text", text: "private ref state" }],
+      },
+    ])
+  })
+
+  test("stream keeps Responses reasoning and stored output items after handoff", async () => {
+    const storedHistory = [
+      {
+        type: "message",
+        id: "msg_before_handoff",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Preparing transfer." }],
+      },
+      {
+        type: "reasoning",
+        id: "rs_required",
+        summary: [{ type: "summary_text", text: "choose handoff target" }],
+      },
+      {
+        type: "function_call",
+        id: "fc_handoff",
+        call_id: "call_handoff",
+        name: "transfer_to_math_agent",
+        arguments: "{}",
+      },
+      {
+        type: "handoff_output_item",
+        call_id: "call_handoff",
+        output: { assistant: "MathAgent" },
+      },
+      {
+        type: "reasoning",
+        id: "rs_required_message",
+        summary: [{ type: "summary_text", text: "start handoff response" }],
+      },
+      {
+        type: "message",
+        id: "msg_after_handoff",
+        role: "assistant",
+        agent: "MathAgent",
+        content: [{ type: "output_text", text: "Math agent now has control." }],
+      },
+      {
+        type: "reasoning",
+        id: "rs_orphan",
+        summary: [{ type: "summary_text", text: "stale private state" }],
+      },
+    ]
+    let sentHistory: unknown
+    AgencySwarmHistory.load = (async () => ({
+      scope: "http://127.0.0.1:8000|builder|session_1",
+      chat_history: storedHistory as any,
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.load
+    AgencySwarmHistory.appendMessages = (async () => ({
+      scope: "scope",
+      chat_history: [],
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.appendMessages
+    AgencySwarmHistory.setLastRunID = (async () => ({
+      scope: "scope",
+      chat_history: [],
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.setLastRunID
+    AgencySwarmAdapter.streamRun = async function* (args) {
+      sentHistory = args.chatHistory
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _ of stream.fullStream) {
+    }
+
+    expect(sentHistory).toEqual([
+      {
+        type: "message",
+        id: "msg_before_handoff",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Preparing transfer." }],
+      },
+      {
+        type: "reasoning",
+        id: "rs_required",
+        summary: [{ type: "summary_text", text: "choose handoff target" }],
+      },
+      {
+        type: "function_call",
+        id: "fc_handoff",
+        call_id: "call_handoff",
+        name: "transfer_to_math_agent",
+        arguments: "{}",
+      },
+      {
+        type: "reasoning",
+        id: "rs_required_message",
+        summary: [{ type: "summary_text", text: "start handoff response" }],
+      },
+      {
+        type: "message",
+        id: "msg_after_handoff",
+        role: "assistant",
+        agent: "MathAgent",
+        content: [{ type: "output_text", text: "Math agent now has control." }],
+      },
+      {
+        type: "reasoning",
+        id: "rs_orphan",
+        summary: [{ type: "summary_text", text: "stale private state" }],
       },
     ])
   })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3239,10 +3239,6 @@ describe("session.agency-swarm", () => {
         summary: [{ type: "summary_text", text: "private chain state" }],
       },
       {
-        id: "rs_ref_stale",
-        summary: [{ type: "summary_text", text: "private ref state" }],
-      },
-      {
         type: "item_reference",
         id: "rs_ref_rejected",
       },
@@ -3291,9 +3287,6 @@ describe("session.agency-swarm", () => {
       {
         type: "reasoning",
         summary: [{ type: "summary_text", text: "private chain state" }],
-      },
-      {
-        summary: [{ type: "summary_text", text: "private ref state" }],
       },
     ])
   })


### PR DESCRIPTION
### Issue for this PR

Closes #191

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes Agency Swarm handoff history replay for browser-auth / `store=false` Responses requests.

After a handoff, stored Agency Swarm history can include OpenAI Responses item IDs such as `rs_*`, `msg_*`, and `fc_*`. With `store=false`, those IDs are not persisted by OpenAI, so replaying them on a later user turn can fail with “item not found”. PR #186 also pruned typed `reasoning` items while leaving `function_call` items, which could replay a function call without the reasoning item that preceded it.

This change keeps valid replayable history items, including typed `reasoning` and `function_call` items, but strips raw Responses `id` fields before sending history again. It continues to drop Agency Swarm handoff-only transport items and ID-based `item_reference` entries that are unsafe to replay as server references.

This is fork-specific Agency Swarm transport-history sanitation in `packages/opencode/src/session/agency-swarm.ts`; upstream OpenCode does not have this Agency Swarm transport file.

### How did you verify your code works?

- `cd packages/opencode && bun test ./test/session/agency-swarm.test.ts -t "stream strips stored Responses item ids"`
  - `stream strips stored Responses item ids while pruning handoff-only transport items` proves the #167 class: typed replayable items keep their content but lose stored top-level Responses IDs, `item_reference` is dropped, and `handoff_output_item` is not replayed.
  - `stream strips stored Responses item ids after handoff` proves #191: typed `reasoning` items are retained around a `function_call` during handoff replay while their stored `rs_*` / `fc_*` / `msg_*` IDs are removed.
- `cd packages/opencode && bun test ./test/session/agency-swarm.test.ts`
- `bun typecheck`
- `bun turbo test:ci`

No live browser-auth UI QA was run for this PR update.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
