### PR TITLE
test: harden Agent Swarm e2e startup

### DIFF
--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -6,6 +6,8 @@ import { spawn, type Proc } from "../../packages/opencode/src/pty/pty.bun"
 const repoRoot = path.resolve(import.meta.dir, "../..")
 const packageRoot = path.join(repoRoot, "packages", "opencode")
 const modelsFixture = path.join(packageRoot, "test", "tool", "fixtures", "models-api.json")
+const discoveryTimeoutMs = process.env.CI ? 5_000 : 500
+const initialOutputTimeoutMs = process.env.CI ? 15_000 : 5_000
 
 export type AgencyProtocolServer = {
   baseURL: string
@@ -114,7 +116,7 @@ export async function startTui(input: {
               baseURL: input.baseURL,
               agency: input.agency ?? "local-agency",
               recipientAgent: input.recipientAgent ?? "entry-agent",
-              discoveryTimeoutMs: 500,
+              discoveryTimeoutMs,
               token: "bridge-token",
               clientConfig: {
                 apiKey: "not-a-live-key",
@@ -152,21 +154,37 @@ export async function startTui(input: {
     ...(configContent && input.configSource !== "file" ? { OPENCODE_CONFIG_CONTENT: configContent } : {}),
     ...(input.env ?? {}),
   })
-  const proc = spawn(process.execPath, ["--conditions=browser", "./src/index.ts", ...args], {
-    cwd: input.cwd ?? packageRoot,
-    cols: 100,
-    rows: 30,
-    name: "xterm-256color",
-    env: cleanEnv(env),
-  })
+  let proc = spawnTuiProcess({ args, cwd: input.cwd, env })
 
-  proc.onData((chunk) => {
-    raw += chunk
-    if (raw.length > 200_000) raw = raw.slice(-120_000)
-    screen.feed(chunk)
-  })
-  proc.onExit((event) => {
-    exitCode = event.exitCode
+  let dataReceived = false
+  let activeProc = proc
+  const attachProcess = (next: Proc) => {
+    activeProc = next
+    next.onData((chunk) => {
+      if (next !== activeProc) return
+      dataReceived = true
+      raw += chunk
+      if (raw.length > 200_000) raw = raw.slice(-120_000)
+      screen.feed(chunk)
+    })
+    next.onExit((event) => {
+      if (next !== activeProc) return
+      exitCode = event.exitCode
+    })
+  }
+  attachProcess(proc)
+
+  await waitForInitialOutput({
+    hasOutput: () => dataReceived,
+    getExitCode: () => exitCode,
+    timeoutMs: initialOutputTimeoutMs,
+    onRetry: async () => {
+      await closeProcess(proc)
+      proc = spawnTuiProcess({ args, cwd: input.cwd, env })
+      dataReceived = false
+      exitCode = undefined
+      attachProcess(proc)
+    },
   })
 
   return {
@@ -207,6 +225,16 @@ export async function startTui(input: {
       await rm(root, { recursive: true, force: true })
     },
   }
+}
+
+function spawnTuiProcess(input: { args: string[]; cwd?: string; env: Record<string, string | undefined> }) {
+  return spawn(process.execPath, ["--conditions=browser", "./src/index.ts", ...input.args], {
+    cwd: input.cwd ?? packageRoot,
+    cols: 100,
+    rows: 30,
+    name: "xterm-256color",
+    env: cleanEnv(input.env),
+  })
 }
 
 export async function writeAgencyProject(dir: string) {
@@ -690,6 +718,28 @@ async function waitFor(predicate: () => boolean, failure: () => string, timeoutM
   }
   if (lastError) throw lastError
   throw new Error(failure())
+}
+
+async function waitForInitialOutput(input: {
+  hasOutput: () => boolean
+  getExitCode: () => number | undefined
+  timeoutMs: number
+  onRetry: () => Promise<void>
+}) {
+  await waitFor(
+    () => input.hasOutput() || input.getExitCode() !== undefined,
+    () => "Timed out waiting for initial TUI output",
+    input.timeoutMs,
+  ).catch(async (error) => {
+    await input.onRetry()
+    await waitFor(
+      () => input.hasOutput() || input.getExitCode() !== undefined,
+      () => "Timed out waiting for initial TUI output after retry",
+      input.timeoutMs,
+    )
+    if (input.hasOutput()) return
+    throw error
+  })
 }
 
 function cleanEnv(env: Record<string, string | undefined>) {

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -174,19 +174,24 @@ export async function startTui(input: {
   }
   attachProcess(proc)
 
-  await waitForInitialOutput({
-    hasOutput: () => dataReceived,
-    getExitCode: () => exitCode,
-    history: () => stripAnsi(raw),
-    timeoutMs: initialOutputTimeoutMs,
-    onRetry: async () => {
-      await closeProcess(proc)
-      proc = spawnTuiProcess({ args, cwd: input.cwd, env })
-      dataReceived = false
-      exitCode = undefined
-      attachProcess(proc)
-    },
-  })
+  try {
+    await waitForInitialOutput({
+      hasOutput: () => dataReceived,
+      getExitCode: () => exitCode,
+      history: () => stripAnsi(raw),
+      timeoutMs: initialOutputTimeoutMs,
+      onRetry: async () => {
+        await closeProcess(proc)
+        proc = spawnTuiProcess({ args, cwd: input.cwd, env })
+        dataReceived = false
+        exitCode = undefined
+        attachProcess(proc)
+      },
+    })
+  } catch (error) {
+    await cleanupTuiProcess(proc, root, exitCode === undefined)
+    throw error
+  }
 
   return {
     root,
@@ -222,8 +227,7 @@ export async function startTui(input: {
       )
     },
     async close() {
-      await closeProcess(proc)
-      await rm(root, { recursive: true, force: true })
+      await cleanupTuiProcess(proc, root, exitCode === undefined)
     },
   }
 }
@@ -703,6 +707,14 @@ async function closeProcess(proc: Proc) {
   if (!exited) proc.kill("SIGKILL")
   await wait(1000)
   dispose?.()
+}
+
+async function cleanupTuiProcess(proc: Proc, root: string, closeActiveProcess: boolean) {
+  try {
+    if (closeActiveProcess) await closeProcess(proc)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
 }
 
 async function waitFor(predicate: () => boolean, failure: () => string, timeoutMs: number) {

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -177,6 +177,7 @@ export async function startTui(input: {
   await waitForInitialOutput({
     hasOutput: () => dataReceived,
     getExitCode: () => exitCode,
+    history: () => stripAnsi(raw),
     timeoutMs: initialOutputTimeoutMs,
     onRetry: async () => {
       await closeProcess(proc)
@@ -723,23 +724,45 @@ async function waitFor(predicate: () => boolean, failure: () => string, timeoutM
 async function waitForInitialOutput(input: {
   hasOutput: () => boolean
   getExitCode: () => number | undefined
+  history: () => string
   timeoutMs: number
   onRetry: () => Promise<void>
 }) {
-  await waitFor(
-    () => input.hasOutput() || input.getExitCode() !== undefined,
-    () => "Timed out waiting for initial TUI output",
-    input.timeoutMs,
-  ).catch(async (error) => {
+  try {
+    await waitForInitialOutputOnce(input, "initial TUI output")
+  } catch {
+    const exitCode = input.getExitCode()
+    if (exitCode !== undefined) throw initialOutputExitError(exitCode, "initial TUI output", input.history())
     await input.onRetry()
-    await waitFor(
-      () => input.hasOutput() || input.getExitCode() !== undefined,
-      () => "Timed out waiting for initial TUI output after retry",
-      input.timeoutMs,
-    )
-    if (input.hasOutput()) return
-    throw error
-  })
+    await waitForInitialOutputOnce(input, "initial TUI output after retry")
+  }
+}
+
+async function waitForInitialOutputOnce(
+  input: {
+    hasOutput: () => boolean
+    getExitCode: () => number | undefined
+    history: () => string
+    timeoutMs: number
+  },
+  message: string,
+) {
+  await waitFor(
+    () => {
+      if (input.hasOutput()) return true
+      const exitCode = input.getExitCode()
+      if (exitCode !== undefined) {
+        throw initialOutputExitError(exitCode, message, input.history())
+      }
+      return false
+    },
+    () => `Timed out waiting for ${message}`,
+    input.timeoutMs,
+  )
+}
+
+function initialOutputExitError(exitCode: number, message: string, history: string) {
+  return new Error(`TUI exited with code ${exitCode} before ${message}.\n\nHistory tail:\n${tail(history)}`)
 }
 
 function cleanEnv(env: Record<string, string | undefined>) {


### PR DESCRIPTION
### Issue for this PR

Closes #193

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Hardens the Agent Swarm TUI e2e harness startup gate. CI now gets a longer initial discovery window, one blank-start retry, and a clear early-exit error instead of a silent timeout. The failure path also cleans up the PTY process and temp directory before returning the error.

This is limited to `e2e/agent-swarm-tui/harness.ts`; it does not change product runtime code.

### How did you verify your code works?

- `bun x prettier --write ../../e2e/agent-swarm-tui/harness.ts`
- `bun run test:agentswarm:e2e` from `packages/opencode`: 17 passed
- `bun --cwd packages/opencode test:agentswarm:e2e:ci`: 17 passed
- `bun run typecheck` from `packages/opencode`: passed
- `bun typecheck`: passed
- `bun turbo typecheck`: passed from push hook
- Codex review against `vrsen/dev`: no actionable regressions

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
