### PR TITLE
fix: harden release gate checks

### DIFF
--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -7,11 +7,17 @@ const repoRoot = path.resolve(import.meta.dir, "../..")
 const packageRoot = path.join(repoRoot, "packages", "opencode")
 const modelsFixture = path.join(packageRoot, "test", "tool", "fixtures", "models-api.json")
 const discoveryTimeoutMs = process.env.CI ? 5_000 : 500
+const initialOutputAttemptCount = process.env.CI ? 3 : 2
 const initialOutputTimeoutMs = process.env.CI ? 15_000 : 5_000
 
 export type AgencyProtocolServer = {
   baseURL: string
-  requests: Array<{ path: string; body: Record<string, unknown> }>
+  requests: Array<{
+    path: string
+    body: Record<string, unknown>
+    releaseStream?: () => void
+    streamClosed?: Promise<void>
+  }>
   stop(): void
 }
 
@@ -46,8 +52,24 @@ export async function startAgencyProtocolServer(
 
       if (url.pathname === `/${fixture.agencyID}/get_response_stream`) {
         const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
-        requests.push({ path: url.pathname, body })
-        return new Response(await fixture.stream(body, requests.length), {
+        let releaseStream!: () => void
+        const streamReleased = new Promise<void>((resolve) => {
+          releaseStream = resolve
+        })
+        let closed = false
+        let resolveStreamClosed!: () => void
+        const streamClosed = new Promise<void>((resolve) => {
+          resolveStreamClosed = resolve
+        })
+        const closeStream = () => {
+          if (closed) return
+          closed = true
+          resolveStreamClosed()
+        }
+        requests.push({ path: url.pathname, body, releaseStream, streamClosed })
+        const responseBody = await fixture.stream(body, requests.length, streamReleased, closeStream)
+        if (!(responseBody instanceof ReadableStream)) closeStream()
+        return new Response(responseBody, {
           headers: {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -179,9 +201,11 @@ export async function startTui(input: {
       hasOutput: () => dataReceived,
       getExitCode: () => exitCode,
       history: () => stripAnsi(raw),
+      attemptCount: initialOutputAttemptCount,
       timeoutMs: initialOutputTimeoutMs,
       onRetry: async () => {
         await closeProcess(proc)
+        await Bun.sleep(250)
         proc = spawnTuiProcess({ args, cwd: input.cwd, env })
         dataReceived = false
         exitCode = undefined
@@ -252,7 +276,12 @@ export async function writeAgencyProject(dir: string) {
 type AgencyFixture = {
   agencyID: string
   metadata: Record<string, unknown>
-  stream(body: Record<string, unknown>, requestCount: number): BodyInit | Promise<BodyInit>
+  stream(
+    body: Record<string, unknown>,
+    requestCount: number,
+    streamReleased: Promise<void>,
+    closeStream: () => void,
+  ): BodyInit | Promise<BodyInit>
 }
 
 const qaAgencyFixture: AgencyFixture = {
@@ -285,10 +314,10 @@ const qaAgencyFixture: AgencyFixture = {
       },
     ],
   },
-  stream(body, requestCount) {
+  stream(body, requestCount, streamReleased, closeStream) {
     const message = typeof body.message === "string" ? body.message : ""
     if (message.includes("issue 172 hold")) {
-      return delayedSse(
+      return controlledSse(
         [
           ["meta", { run_id: `run_e2e_${requestCount}` }],
           [
@@ -307,7 +336,8 @@ const qaAgencyFixture: AgencyFixture = {
           ],
           ["end", {}],
         ],
-        8_000,
+        streamReleased,
+        closeStream,
       )
     }
     return sse([
@@ -672,14 +702,22 @@ function sse(events: Array<[event: string, data: Record<string, unknown>]>) {
   return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("")
 }
 
-function delayedSse(events: Array<[event: string, data: Record<string, unknown>]>, delayMs: number) {
+function controlledSse(
+  events: Array<[event: string, data: Record<string, unknown>]>,
+  streamReleased: Promise<void>,
+  closeStream: () => void,
+) {
   const encoder = new TextEncoder()
   return new ReadableStream({
     async start(controller) {
       controller.enqueue(encoder.encode(sse(events.slice(0, 1))))
-      await new Promise((resolve) => setTimeout(resolve, delayMs))
+      await streamReleased
       controller.enqueue(encoder.encode(sse(events.slice(1))))
       controller.close()
+      closeStream()
+    },
+    cancel() {
+      closeStream()
     },
   })
 }
@@ -737,16 +775,21 @@ async function waitForInitialOutput(input: {
   hasOutput: () => boolean
   getExitCode: () => number | undefined
   history: () => string
+  attemptCount: number
   timeoutMs: number
   onRetry: () => Promise<void>
 }) {
-  try {
-    await waitForInitialOutputOnce(input, "initial TUI output")
-  } catch {
-    const exitCode = input.getExitCode()
-    if (exitCode !== undefined) throw initialOutputExitError(exitCode, "initial TUI output", input.history())
-    await input.onRetry()
-    await waitForInitialOutputOnce(input, "initial TUI output after retry")
+  for (let attempt = 1; attempt <= input.attemptCount; attempt++) {
+    const message = attempt === 1 ? "initial TUI output" : `initial TUI output after retry ${attempt - 1}`
+    try {
+      await waitForInitialOutputOnce(input, message)
+      return
+    } catch {
+      const exitCode = input.getExitCode()
+      if (exitCode !== undefined) throw initialOutputExitError(exitCode, message, input.history())
+      if (attempt === input.attemptCount) throw initialOutputTimeoutError(message, input.history())
+      await input.onRetry()
+    }
   }
 }
 
@@ -768,13 +811,17 @@ async function waitForInitialOutputOnce(
       }
       return false
     },
-    () => `Timed out waiting for ${message}`,
+    () => initialOutputTimeoutError(message, input.history()).message,
     input.timeoutMs,
   )
 }
 
 function initialOutputExitError(exitCode: number, message: string, history: string) {
   return new Error(`TUI exited with code ${exitCode} before ${message}.\n\nHistory tail:\n${tail(history)}`)
+}
+
+function initialOutputTimeoutError(message: string, history: string) {
+  return new Error(`Timed out waiting for ${message}.\n\nHistory tail:\n${tail(history)}`)
 }
 
 function cleanEnv(env: Record<string, string | undefined>) {

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -426,6 +426,9 @@ describe("Agent Swarm terminal TUI e2e", () => {
       "first issue 172 agency request",
       tuiInteractionTimeoutMs,
     )
+    const activeRequest = currentServer.requests[0]
+    expect(activeRequest?.releaseStream).toBeDefined()
+    expect(activeRequest?.streamClosed).toBeDefined()
 
     currentTui.write("second issue 172 prompt SHOULD_NOT_SEND\r")
     await currentTui.waitForText("QUEUED", tuiInteractionTimeoutMs)
@@ -433,7 +436,14 @@ describe("Agent Swarm terminal TUI e2e", () => {
     await Bun.sleep(100)
     currentTui.write("\x1b")
     await currentTui.waitForText("Cancelled 1 queued message", tuiInteractionTimeoutMs)
-    await Bun.sleep(8_500)
+    activeRequest!.releaseStream!()
+    await activeRequest!.streamClosed
+    await currentTui.waitForText("completed first issue 172 prompt", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => !currentTui!.screen().includes("interrupt"),
+      "TUI idle after active issue 172 stream",
+      tuiInteractionTimeoutMs,
+    )
 
     expect(currentServer.requests.map((request) => request.body.message)).toEqual(["first issue 172 hold"])
   })

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1145,14 +1145,14 @@ function summarizePythonTraceback(output: string) {
   const lines = output
     .trim()
     .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-  if (!lines.some((line) => line === "Traceback (most recent call last):")) return ""
-  return lines.findLast(isPythonTracebackFinalExceptionLine) ?? ""
+    .filter((line) => line.trim().length > 0)
+  if (!lines.some((line) => line.trim() === "Traceback (most recent call last):")) return ""
+  return lines.findLast(isPythonTracebackFinalExceptionLine)?.trim() ?? ""
 }
 
 function isPythonTracebackFinalExceptionLine(line: string) {
-  return /^[A-Za-z_][\w.]*:(?:\s|$)/.test(line)
+  if (/^\s/.test(line)) return false
+  return /^[A-Za-z_][\w.]*:(?:\s|$)/.test(line.trimEnd())
 }
 
 async function hasGitHubTemplateFlow() {
@@ -1410,7 +1410,7 @@ function createUserStderrWriter(streamToStderr: boolean, suppressPythonTraceback
       return
     }
     if (suppressingTraceback) {
-      if (isPythonTracebackFinalExceptionLine(trimmed)) suppressingTraceback = false
+      if (isPythonTracebackFinalExceptionLine(line)) suppressingTraceback = false
       return
     }
     if (!streamToStderr) return

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -761,6 +761,7 @@ describe("agency-swarm npx onboarding", () => {
     const pipTraceback = [
       "Traceback (most recent call last):",
       '  File "<frozen runpy>", line 198, in _run_module_as_main',
+      "    config: dict = {'pip': 'broken'}",
       '  File "<frozen runpy>", line 88, in _run_code',
       `  File "${path.join(dir.path, ".venv", "lib", "python3.13", "site-packages", "pip", "__main__.py")}", line 22, in <module>`,
       "    from pip._internal.cli.main import main as _main",
@@ -822,6 +823,7 @@ describe("agency-swarm npx onboarding", () => {
     const mirroredOutput = stderrWrite.mock.calls.map((call) => call[0]).join("")
     expect(mirroredOutput).not.toContain("Traceback (most recent call last):")
     expect(mirroredOutput).not.toContain("<frozen runpy>")
+    expect(mirroredOutput).not.toContain("config: dict")
     expect(mirroredOutput).not.toContain("foo")
     expect(mirroredOutput).not.toContain("pip._internal.cli.main")
     expect(warn).toHaveBeenCalledWith(


### PR DESCRIPTION
### Issue for this PR

Closes #195

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two blockers found while preparing the next patch release without attachments.

First, the Agent Swarm TUI e2e harness now gives CI one more bounded no-output startup attempt, keeps process exits as immediate failures, adds a short settle before respawn, and includes the history tail in timeout errors. It also shortens the queued-cancel fixture hold so the active SSE request stays below Bun request timeout while still proving that Esc twice cancels the queued prompt without canceling the active run.

Second, Python traceback suppression now preserves leading whitespace when deciding whether a line is the final exception line. This prevents indented Python source lines like `config: dict = ...` from ending suppression early and leaking the rest of the traceback to user stderr.

### How did you verify your code works?

- `bun x prettier --write e2e/agent-swarm-tui/harness.ts e2e/agent-swarm-tui/terminal-tui.test.ts packages/opencode/src/agency-swarm/npx.ts packages/opencode/test/agency-swarm/npx.test.ts`
- `bun test test/agency-swarm/npx.test.ts`
- `bun test --timeout 180000 --max-concurrency=1 ../../e2e/agent-swarm-tui/terminal-tui.test.ts -t "Esc twice cancels queued Run-mode prompt before active stream drains"`
- `bun --cwd packages/opencode test:agentswarm:e2e:ci`
- `bun typecheck`
- `bun turbo test:ci`
- Codex review against `vrsen/dev`: no findings

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
