### PR TITLE
fix(launcher): recreate incomplete project venvs

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -654,8 +654,10 @@ export async function prepareProjectLaunch(project: AgencyProject): Promise<Prep
 
 async function ensureProjectPython(directory: string) {
   const venvPython = getVenvPythonPath(directory)
+  const venvDir = path.resolve(path.join(directory, ".venv"))
   let selfHealing = false
   let corruptedVenv = false
+  const hasVenvPath = await Filesystem.exists(venvDir)
   const hasVenv = await Filesystem.exists(venvPython)
   if (hasVenv) {
     // Probing the venv's interpreter can throw if the base Python was removed
@@ -703,9 +705,10 @@ async function ensureProjectPython(directory: string) {
         corruptedVenv = true
       }
     }
+  } else if (hasVenvPath) {
+    corruptedVenv = true
   }
 
-  const venvDir = path.resolve(path.join(directory, ".venv"))
   const detected = await findPythonExecutable(corruptedVenv ? venvDir : undefined)
   if (!detected) {
     if (corruptedVenv) {
@@ -722,8 +725,8 @@ async function ensureProjectPython(directory: string) {
   prompts.log.info(`Detected Python: ${formatPython(detected, rebuildCmd)}`)
 
   if (corruptedVenv) {
-    prompts.log.warn("Project `.venv` is missing module sources (corrupted install). Rebuilding...")
-    await rm(path.join(directory, ".venv"), { recursive: true, force: true })
+    prompts.log.warn("Project `.venv` is incomplete or corrupted. Rebuilding...")
+    await rm(venvDir, { recursive: true, force: true })
     selfHealing = true
   }
 
@@ -783,7 +786,9 @@ async function ensureProjectPython(directory: string) {
     throw new Error(await formatCanaryTimeoutFailure(directory, canary.stderr))
   }
   if (!canary.healthy) {
-    throw new Error(await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr))
+    throw new Error(
+      await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr, install.logFile),
+    )
   }
   prompts.log.success("Python environment ready")
   return [venvPython]
@@ -830,22 +835,23 @@ async function installProjectDependencies(
   return { ...result, hadManifests: false }
 }
 
-async function formatPostInstallCanaryFailure(directory: string, hadManifests: boolean, stderr: string) {
+async function formatPostInstallCanaryFailure(
+  directory: string,
+  hadManifests: boolean,
+  stderr: string,
+  logFile?: string,
+) {
   const summary = summarizeBridgeStderr(stderr)
   const shadowingHint = await formatShadowingHint(directory)
+  const logHint = logFile ? ` Check the log file at ${logFile}.` : ""
+  const detail = summary ? ` Details: ${summary}` : ""
   if (isImportLikeCanaryFailure(stderr)) {
     if (hadManifests) {
-      return summary
-        ? `Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint} Canary stderr: ${summary}`
-        : `Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint}`
+      return `The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint}${logHint}${detail}`
     }
-    return summary
-      ? `Canary import failed on fallback install. Inspect the stderr below and check for project-local fastapi.py/agency_swarm.py that may shadow installed packages.${shadowingHint} Canary stderr: ${summary}`
-      : `Canary import failed on fallback install. Inspect the stderr below and check for project-local fastapi.py/agency_swarm.py that may shadow installed packages.${shadowingHint}`
+    return `The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages. Check for project-local fastapi.py/agency_swarm.py files that may shadow installed packages.${shadowingHint}${logHint}${detail}`
   }
-  return summary
-    ? `Project \`.venv\` rebuilt successfully, but the Agency Swarm import canary still failed.${shadowingHint} Canary stderr: ${summary}`
-    : `Project \`.venv\` rebuilt successfully, but the Agency Swarm import canary still failed.${shadowingHint}`
+  return `The launcher recreated the local Python environment, but it still could not repair it.${shadowingHint}${logHint}${detail}`
 }
 
 async function formatCanaryTimeoutFailure(directory: string, stderr: string) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -204,6 +204,60 @@ describe("agency-swarm npx onboarding", () => {
     ])
   })
 
+  test("prepareProjectLaunch recreates an incomplete `.venv` instead of overlaying it", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    const staleFile = path.join(dir.path, ".venv", "lib", "python3.12", "site-packages", "stale.py")
+    await mkdir(path.dirname(staleFile), { recursive: true })
+    await Bun.write(staleFile, "stale")
+
+    const confirm = spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+
+    const commands: string[][] = []
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("pip")) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "dependency install failed",
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow("Dependency install failed")
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(await Bun.file(staleFile).exists()).toBe(false)
+    expect(commands.some((cmd) => cmd.includes("venv"))).toBe(true)
+  })
+
   test("prepareProjectLaunch reruns the canary after rebuilding `.venv` and surfaces manifest import mismatches", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -290,9 +344,11 @@ describe("agency-swarm npx onboarding", () => {
     expect(error).toBeInstanceOf(Error)
     if (!error) throw new Error("Expected prepareProjectLaunch to fail")
     expect(error.message).toContain(
-      "Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.",
+      "The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages.",
     )
-    expect(error.message).not.toContain("Canary import failed on fallback install.")
+    expect(error.message).toContain("Check requirements.txt/pyproject.toml for agency-swarm version compatibility.")
+    expect(error.message).toContain("Check the log file at")
+    expect(error.message).not.toContain("Canary import failed")
     expect(error.message).toContain("LoadFileAttachment")
 
     const canaryCommands = commands.filter(isCanaryCommand)
@@ -1568,7 +1624,7 @@ describe("agency-swarm npx onboarding", () => {
         agencyFile: path.join(dir.path, "agency.py"),
       }),
     ).rejects.toThrow(
-      "Canary import failed on fallback install. Inspect the stderr below and check for project-local fastapi.py/agency_swarm.py that may shadow installed packages.",
+      "The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages. Check for project-local fastapi.py/agency_swarm.py files that may shadow installed packages.",
     )
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #201

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Treats an existing project `.venv` directory without the expected Python interpreter as incomplete or corrupted. The launcher removes that directory before creating a new venv instead of overlaying a fresh virtualenv onto stale contents.

It also adjusts the post-rebuild import failure copy so users see an actionable environment repair failure with the rebuild log path when available.

### How did you verify your code works?

- `bun test test/agency-swarm/npx.test.ts` from `packages/opencode` — 53 pass.
- `bun typecheck` — pass.
- `git diff --check` — pass.
- `bun x prettier --check packages/opencode/src/agency-swarm/npx.ts packages/opencode/test/agency-swarm/npx.test.ts` — pass.
- Push hook reran `bun turbo typecheck` — pass.
- Codex high review on the same diff found no actionable regressions.

### Screenshots / recordings

Not applicable; this is launcher recovery logic covered by focused tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
