### PR TITLE
fix(launcher): recover corrupted venvs and slow startups

### DIFF
--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -7,8 +7,9 @@ const repoRoot = path.resolve(import.meta.dir, "../..")
 const packageRoot = path.join(repoRoot, "packages", "opencode")
 const modelsFixture = path.join(packageRoot, "test", "tool", "fixtures", "models-api.json")
 const discoveryTimeoutMs = process.env.CI ? 5_000 : 500
-const initialOutputAttemptCount = process.env.CI ? 3 : 2
-const initialOutputTimeoutMs = process.env.CI ? 15_000 : 5_000
+const initialOutputAttemptCount = 2
+const initialOutputTimeoutMs = process.env.CI ? 45_000 : 5_000
+const initialOutputRetryDelayMs = process.env.CI ? 1_000 : 250
 
 export type AgencyProtocolServer = {
   baseURL: string
@@ -205,7 +206,7 @@ export async function startTui(input: {
       timeoutMs: initialOutputTimeoutMs,
       onRetry: async () => {
         await closeProcess(proc)
-        await Bun.sleep(250)
+        await Bun.sleep(initialOutputRetryDelayMs)
         proc = spawnTuiProcess({ args, cwd: input.cwd, env })
         dataReceived = false
         exitCode = undefined

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -18,7 +18,11 @@ const tuiReadyTimeoutMs = process.env.CI ? 120_000 : 30_000
 const tuiInteractionTimeoutMs = process.env.CI ? 60_000 : 45_000
 
 async function waitForConfiguredDemoRecipient(tui: TuiProcess) {
-  await tui.waitForText("UserSupportAgent", tuiInteractionTimeoutMs)
+  await tui.waitFor(
+    () => tui.screen().includes("UserSupportAgent"),
+    "configured demo recipient",
+    tuiInteractionTimeoutMs,
+  )
 }
 
 afterEach(async () => {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -79,6 +79,7 @@ const VENV_CANARY_SCRIPT = ["import agency_swarm", "from agency_swarm.integratio
   "\n",
 )
 const VENV_CANARY_TIMEOUT_MS = 60 * 1000
+const SERVER_START_TIMEOUT_MS = 90 * 1000
 const SERVER_STDERR_COLLECT_TIMEOUT_MS = 1000
 const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
 const PROCESS_KILL_GRACE_MS = 5000
@@ -654,8 +655,10 @@ export async function prepareProjectLaunch(project: AgencyProject): Promise<Prep
 
 async function ensureProjectPython(directory: string) {
   const venvPython = getVenvPythonPath(directory)
+  const venvDir = path.resolve(path.join(directory, ".venv"))
   let selfHealing = false
   let corruptedVenv = false
+  const hasVenvPath = await Filesystem.exists(venvDir)
   const hasVenv = await Filesystem.exists(venvPython)
   if (hasVenv) {
     // Probing the venv's interpreter can throw if the base Python was removed
@@ -678,10 +681,11 @@ async function ensureProjectPython(directory: string) {
           : "Refreshing project dependencies. Streaming output to stderr.",
       )
       try {
-        await ensureLatestAgencySwarm(directory, [venvPython], {
+        const refresh = await ensureLatestAgencySwarm(directory, [venvPython], {
           logFile: refreshLogFile,
           timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
         })
+        if (refresh.pipCorrupted) corruptedVenv = true
       } catch {
         corruptedVenv = true
       }
@@ -703,9 +707,10 @@ async function ensureProjectPython(directory: string) {
         corruptedVenv = true
       }
     }
+  } else if (hasVenvPath) {
+    corruptedVenv = true
   }
 
-  const venvDir = path.resolve(path.join(directory, ".venv"))
   const detected = await findPythonExecutable(corruptedVenv ? venvDir : undefined)
   if (!detected) {
     if (corruptedVenv) {
@@ -722,8 +727,8 @@ async function ensureProjectPython(directory: string) {
   prompts.log.info(`Detected Python: ${formatPython(detected, rebuildCmd)}`)
 
   if (corruptedVenv) {
-    prompts.log.warn("Project `.venv` is missing module sources (corrupted install). Rebuilding...")
-    await rm(path.join(directory, ".venv"), { recursive: true, force: true })
+    prompts.log.warn("Project `.venv` is incomplete or corrupted. Rebuilding...")
+    await rm(venvDir, { recursive: true, force: true })
     selfHealing = true
   }
 
@@ -783,7 +788,9 @@ async function ensureProjectPython(directory: string) {
     throw new Error(await formatCanaryTimeoutFailure(directory, canary.stderr))
   }
   if (!canary.healthy) {
-    throw new Error(await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr))
+    throw new Error(
+      await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr, install.logFile),
+    )
   }
   prompts.log.success("Python environment ready")
   return [venvPython]
@@ -830,22 +837,23 @@ async function installProjectDependencies(
   return { ...result, hadManifests: false }
 }
 
-async function formatPostInstallCanaryFailure(directory: string, hadManifests: boolean, stderr: string) {
+async function formatPostInstallCanaryFailure(
+  directory: string,
+  hadManifests: boolean,
+  stderr: string,
+  logFile?: string,
+) {
   const summary = summarizeBridgeStderr(stderr)
   const shadowingHint = await formatShadowingHint(directory)
+  const logHint = logFile ? ` Check the log file at ${logFile}.` : ""
+  const detail = summary ? ` Details: ${summary}` : ""
   if (isImportLikeCanaryFailure(stderr)) {
     if (hadManifests) {
-      return summary
-        ? `Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint} Canary stderr: ${summary}`
-        : `Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint}`
+      return `The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint}${logHint}${detail}`
     }
-    return summary
-      ? `Canary import failed on fallback install. Inspect the stderr below and check for project-local fastapi.py/agency_swarm.py that may shadow installed packages.${shadowingHint} Canary stderr: ${summary}`
-      : `Canary import failed on fallback install. Inspect the stderr below and check for project-local fastapi.py/agency_swarm.py that may shadow installed packages.${shadowingHint}`
+    return `The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages. Check for project-local fastapi.py/agency_swarm.py files that may shadow installed packages.${shadowingHint}${logHint}${detail}`
   }
-  return summary
-    ? `Project \`.venv\` rebuilt successfully, but the Agency Swarm import canary still failed.${shadowingHint} Canary stderr: ${summary}`
-    : `Project \`.venv\` rebuilt successfully, but the Agency Swarm import canary still failed.${shadowingHint}`
+  return `The launcher recreated the local Python environment, but it still could not repair it.${shadowingHint}${logHint}${detail}`
 }
 
 async function formatCanaryTimeoutFailure(directory: string, stderr: string) {
@@ -906,7 +914,7 @@ async function ensureLatestAgencySwarm(
     logFile?: string
     timeoutMs?: number
   },
-) {
+): Promise<{ pipCorrupted: boolean }> {
   try {
     const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]"], {
       cwd: directory,
@@ -921,7 +929,7 @@ async function ensureLatestAgencySwarm(
           ? `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${result.logFile}.`
           : `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}.`,
       )
-      return
+      return { pipCorrupted: false }
     }
     if (result.code !== 0) {
       const summary = summarizeCommandOutput(result)
@@ -932,12 +940,14 @@ async function ensureLatestAgencySwarm(
             } The current venv package will be used as-is.`
           : "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
       )
+      return { pipCorrupted: isPipCorruptionFailure(`${result.stderr}\n${result.stdout}`) }
     }
   } catch {
     prompts.log.warn(
       "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
     )
   }
+  return { pipCorrupted: false }
 }
 
 async function createProjectCommandLogFile(directory: string, stem: string) {
@@ -1045,7 +1055,7 @@ async function waitForServer(input: {
   child: ReturnType<typeof Bun.spawn>
   stderr: ServerStderrCollector
 }) {
-  const deadline = Date.now() + 30000
+  const deadline = Date.now() + SERVER_START_TIMEOUT_MS
   const metadataURL = `${input.baseURL}/${LOCAL_AGENCY_ID}/get_metadata`
   while (Date.now() < deadline) {
     const exited = await Promise.race([input.child.exited.then((code: number) => code), sleep(200).then(() => null)])
@@ -1069,11 +1079,14 @@ async function waitForServer(input: {
 
   input.child.kill()
   const stderr = await input.stderr.read(SERVER_STDERR_COLLECT_TIMEOUT_MS)
-  const summary = summarizeBridgeStderr(stderr)
+  const summary = summarizeActionableBridgeStderr(stderr)
+  const warningSummary = summary ? "" : summarizeBridgeStderr(stderr)
   throw new Error(
     summary
-      ? `Timed out waiting for the Agency Swarm server to start. Last bridge output: ${summary}`
-      : "Timed out waiting for the Agency Swarm server to start",
+      ? `Timed out waiting for the Agency Swarm server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}. Last bridge output: ${summary}`
+      : warningSummary
+        ? `Timed out waiting for the Agency Swarm server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}. Bridge output only contained non-fatal startup warnings: ${warningSummary}`
+        : `Timed out waiting for the Agency Swarm server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}`,
   )
 }
 
@@ -1128,11 +1141,24 @@ function createServerStderrCollector(
 }
 
 export function summarizeBridgeStderr(stderr: string): string {
-  const trimmed = stderr.trim()
-  if (!trimmed) return ""
-  const lines = trimmed.split(/\r?\n/).filter((line) => line.trim().length > 0)
+  return summarizeBridgeStderrLines(splitStderrLines(stderr))
+}
+
+function summarizeActionableBridgeStderr(stderr: string): string {
+  return summarizeBridgeStderrLines(splitStderrLines(stderr).filter((line) => !isNonFatalBridgeStartupWarning(line)))
+}
+
+function summarizeBridgeStderrLines(lines: string[]): string {
+  if (lines.length === 0) return ""
   const tail = lines.slice(-5).join(" | ")
   return tail.length > 500 ? `${tail.slice(0, 500)}...` : tail
+}
+
+function splitStderrLines(stderr: string) {
+  return stderr
+    .trim()
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
 }
 
 function summarizeInstallerOutput(output: string) {
@@ -1153,6 +1179,21 @@ function summarizePythonTraceback(output: string) {
 function isPythonTracebackFinalExceptionLine(line: string) {
   if (/^\s/.test(line)) return false
   return /^[A-Za-z_][\w.]*:(?:\s|$)/.test(line.trimEnd())
+}
+
+function isPipCorruptionFailure(output: string) {
+  return (
+    /\bModuleNotFoundError:\s+No module named ['"]pip(?:['"]|\.)/.test(output) ||
+    /\bImportError:\s+cannot import name .* from ['"]pip/.test(output)
+  )
+}
+
+function isNonFatalBridgeStartupWarning(line: string) {
+  const trimmed = line.trim()
+  return (
+    /^Files folder '.+' does not exist\. Skipping\.\.\.$/.test(trimmed) ||
+    trimmed === "App token is not set. Authentication will be disabled."
+  )
 }
 
 async function hasGitHubTemplateFlow() {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -204,6 +204,167 @@ describe("agency-swarm npx onboarding", () => {
     ])
   })
 
+  test("prepareProjectLaunch recreates an incomplete `.venv` instead of overlaying it", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    const staleFile = path.join(dir.path, ".venv", "lib", "python3.12", "site-packages", "stale.py")
+    await mkdir(path.dirname(staleFile), { recursive: true })
+    await Bun.write(staleFile, "stale")
+
+    const confirm = spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+
+    const commands: string[][] = []
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("pip")) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "dependency install failed",
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow("Dependency install failed")
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(await Bun.file(staleFile).exists()).toBe(false)
+    expect(commands.some((cmd) => cmd.includes("venv"))).toBe(true)
+  })
+
+  test("prepareProjectLaunch recreates `.venv` when project pip is corrupted", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    const venvPython = path.join(
+      dir.path,
+      ".venv",
+      process.platform === "win32" ? "Scripts" : "bin",
+      process.platform === "win32" ? "python.exe" : "python",
+    )
+    const staleFile = path.join(dir.path, ".venv", "lib", "python3.12", "site-packages", "stale.py")
+    await mkdir(path.dirname(venvPython), { recursive: true })
+    await mkdir(path.dirname(staleFile), { recursive: true })
+    await Bun.write(venvPython, "")
+    await Bun.write(staleFile, "stale")
+
+    const confirm = spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    const commands: string[][] = []
+    const replacementPython = process.platform === "win32" ? "C:\\Python312\\python.exe" : "/usr/bin/python3.12"
+    const replacementPythonCommands =
+      process.platform === "win32"
+        ? [["py", "-3.13"], ["py", "-3.12"], ["python"], ["python3"]]
+        : [["python3.13"], ["python3.12"], ["python3"], ["python"]]
+    let pipRuns = 0
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        if (target.endsWith(process.platform === "win32" ? "\\python.exe" : "/python")) {
+          return {
+            exited: Promise.resolve(0),
+            stdout: `${target}\n3.12.7\n`,
+            stderr: "",
+          } as never
+        }
+        if (replacementPythonCommands.some((candidate) => candidate.every((part, index) => cmd[index] === part))) {
+          return {
+            exited: Promise.resolve(0),
+            stdout: `${replacementPython}\n3.12.7\n`,
+            stderr: "",
+          } as never
+        }
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        pipRuns += 1
+        return {
+          exited: Promise.resolve(pipRuns === 1 ? 1 : 0),
+          stdout: "",
+          stderr:
+            pipRuns === 1
+              ? [
+                  "Traceback (most recent call last):",
+                  '  File "<frozen runpy>", line 198, in _run_module_as_main',
+                  "ModuleNotFoundError: No module named 'pip._internal.cli.main'",
+                ].join("\n")
+              : "",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(await Bun.file(staleFile).exists()).toBe(false)
+    expect(commands.some((cmd) => cmd.includes("venv"))).toBe(true)
+    expect(pipRuns).toBe(2)
+    await launch?.cleanup?.()
+  })
+
   test("prepareProjectLaunch reruns the canary after rebuilding `.venv` and surfaces manifest import mismatches", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -290,9 +451,11 @@ describe("agency-swarm npx onboarding", () => {
     expect(error).toBeInstanceOf(Error)
     if (!error) throw new Error("Expected prepareProjectLaunch to fail")
     expect(error.message).toContain(
-      "Canary import failed. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.",
+      "The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages.",
     )
-    expect(error.message).not.toContain("Canary import failed on fallback install.")
+    expect(error.message).toContain("Check requirements.txt/pyproject.toml for agency-swarm version compatibility.")
+    expect(error.message).toContain("Check the log file at")
+    expect(error.message).not.toContain("Canary import failed")
     expect(error.message).toContain("LoadFileAttachment")
 
     const canaryCommands = commands.filter(isCanaryCommand)
@@ -774,6 +937,7 @@ describe("agency-swarm npx onboarding", () => {
     const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true as never)
     spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
 
+    let pipRuns = 0
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
@@ -785,11 +949,19 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (cmd.includes("venv")) {
         return {
-          exited: Promise.resolve(1),
+          exited: Promise.resolve(0),
           stdout: "",
-          stderr: `${pipTraceback}\n`,
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        pipRuns += 1
+        return {
+          exited: Promise.resolve(pipRuns === 1 ? 1 : 0),
+          stdout: "",
+          stderr: pipRuns === 1 ? `${pipTraceback}\n` : "",
         } as never
       }
       if (isCanaryCommand(cmd)) {
@@ -1219,7 +1391,7 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(Date, "now").mockImplementation(() => {
       const value = now
-      now = 30001
+      now = 90001
       return value
     })
     spyOn(globalThis, "fetch").mockRejectedValue(new Error("not ready") as never)
@@ -1280,8 +1452,103 @@ describe("agency-swarm npx onboarding", () => {
     if (!(outcome instanceof Error)) throw new Error("Expected prepareProjectLaunch to fail")
     expect(killSignals).toEqual([undefined, undefined])
     expect(outcome.message).toContain(
-      "Timed out waiting for the Agency Swarm server to start. Last bridge output: bridge still starting",
+      "Timed out waiting for the Agency Swarm server to start after 90 seconds. Last bridge output: bridge still starting",
     )
+  })
+
+  test("prepareProjectLaunch labels optional bridge warnings as non-fatal on readiness timeout", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    const realSetTimeout = globalThis.setTimeout
+    const serverStderr = createTextOutputStream(
+      [
+        "Files folder '/project/example_agent/files' does not exist. Skipping...",
+        "App token is not set. Authentication will be disabled.",
+      ].join("\n"),
+    )
+    const killSignals: Array<string | undefined> = []
+    let resolveServerExit!: (code: number) => void
+    let now = 0
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(Date, "now").mockImplementation(() => {
+      const value = now
+      now = 90001
+      return value
+    })
+    spyOn(globalThis, "fetch").mockRejectedValue(new Error("not ready") as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        return {
+          exited: new Promise<number>((resolve) => {
+            resolveServerExit = resolve
+          }),
+          stderr: serverStderr.stream,
+          kill(signal?: string) {
+            killSignals.push(signal)
+            if (killSignals.length > 1) resolveServerExit(1)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+    const pending = Symbol("pending")
+    const outcome = await Promise.race([
+      launch.then(
+        () => "resolved",
+        (error) => error,
+      ),
+      new Promise((resolve) => realSetTimeout(() => resolve(pending), 1500)),
+    ])
+
+    if (outcome === pending) {
+      serverStderr.close()
+      await launch.catch(() => undefined)
+    }
+
+    expect(outcome).not.toBe(pending)
+    expect(outcome).toBeInstanceOf(Error)
+    if (!(outcome instanceof Error)) throw new Error("Expected prepareProjectLaunch to fail")
+    expect(killSignals).toEqual([undefined, undefined])
+    expect(outcome.message).toContain("Timed out waiting for the Agency Swarm server to start after 90 seconds.")
+    expect(outcome.message).toContain("Bridge output only contained non-fatal startup warnings")
+    expect(outcome.message).not.toContain("Last bridge output")
   })
 
   test("prepareProjectLaunch does not fail healthy `.venv` launches when refresh logging cannot be created", async () => {
@@ -1568,7 +1835,7 @@ describe("agency-swarm npx onboarding", () => {
         agencyFile: path.join(dir.path, "agency.py"),
       }),
     ).rejects.toThrow(
-      "Canary import failed on fallback install. Inspect the stderr below and check for project-local fastapi.py/agency_swarm.py that may shadow installed packages.",
+      "The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages. Check for project-local fastapi.py/agency_swarm.py files that may shadow installed packages.",
     )
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #201

Also covers the May 5, 2026 local launcher failure where a project venv had broken `pip`, was rebuilt, then the FastAPI bridge timed out with only a non-fatal missing `files` folder warning in stderr.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Treats an existing project `.venv` directory without the expected Python interpreter as incomplete or corrupted. The launcher now removes that directory before creating a new venv, instead of overlaying a fresh virtualenv onto stale contents.

It also detects broken project `pip` failures like `ModuleNotFoundError: No module named 'pip._internal.cli.main'` during dependency refresh and routes them through the same venv rebuild path. Raw Python tracebacks stay in the saved log instead of being mirrored into the terminal.

It gives the Agency Swarm FastAPI bridge more realistic startup headroom and avoids presenting optional startup warnings, such as missing agent `files` folders, as the likely timeout cause.

The Agent Swarm TUI harness also now gives slow CI TUI child processes a longer first-output window before retrying and waits for the visible current agent before handoff-routing assertions. This fixes the repeated GitHub-only blank-start failure and the follow-up handoff readiness failure seen on PR #202.

### How did you verify your code works?

- `bun test test/agency-swarm/npx.test.ts --timeout 30000` from `packages/opencode` - 55 pass.
- `bun test --timeout 180000 --max-concurrency=1 ../../e2e/agent-swarm-tui` from `packages/opencode` - 17 pass.
- `bun run typecheck` from `packages/opencode` - pass.
- `git diff --check` - pass.
- `OPENCODE_VERSION=1.4.31 OPENCODE_CHANNEL=latest bun run script/build.ts --single` from `packages/opencode` - pass, smoke test reported `1.4.31`.
- Installed the fixed build at `/Users/nick/.bun/bin/agentswarm`, confirmed `agentswarm --version` reports `1.4.31`, and launched `/Users/nick/Desktop/agentswarm-test/my-agency` with `OPENCODE_DISABLE_AUTOUPDATE=true agentswarm .`; it reached the Agent Swarm TUI successfully.
- Verified `/Users/nick/Desktop/agentswarm-test/my-agency/.venv/bin/python -m pip --version` works and `agency_swarm.integrations.fastapi.run_fastapi` imports.
- High-reasoning Codex review against `vrsen/dev` on commit `968a750a4` returned no actionable findings.
- Push hook reran `bun turbo typecheck` - pass.
- GitHub checks on commit `968a750a4` passed, including Agent Swarm e2e.

### Screenshots / recordings

Not applicable; this is launcher recovery and test-harness logic covered by focused tests and the real local launch flow.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
