### PR TITLE
test(agent-swarm): harden blank TUI startup retries

### DIFF
--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -7,9 +7,9 @@ const repoRoot = path.resolve(import.meta.dir, "../..")
 const packageRoot = path.join(repoRoot, "packages", "opencode")
 const modelsFixture = path.join(packageRoot, "test", "tool", "fixtures", "models-api.json")
 const discoveryTimeoutMs = process.env.CI ? 5_000 : 500
-const initialOutputAttemptCount = 2
+const initialOutputAttemptCount = process.env.CI ? 3 : 2
 const initialOutputTimeoutMs = process.env.CI ? 45_000 : 5_000
-const initialOutputRetryDelayMs = process.env.CI ? 1_000 : 250
+const initialOutputRetryDelayMs = process.env.CI ? 500 : 250
 
 export type AgencyProtocolServer = {
   baseURL: string


### PR DESCRIPTION
### Issue for this PR

Fixes #193.

Follow-up to #202 after the merged `dev` run failed Agent Swarm e2e on commit `0b86e9e74`.

Evidence: [default-branch test run 25354614727](https://github.com/VRSEN/agentswarm-cli/actions/runs/25354614727) failed because `SendMessage delegation does not switch control to the delegated agent` hit two blank TUI child starts in a row: no initial terminal output after 45 seconds, then no output after one retry.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Changes the Agent Swarm TUI e2e CI startup retry shape from two 45-second waits to three 45-second waits with a shorter retry delay.

The failed child processes produced no terminal output at all, so restarting the blank child one more time is the useful recovery action. The per-attempt CI slow-start tolerance stays at 45 seconds, while the extra retry gives CI another chance to recover from silent PTY child startup hangs.

Local runs keep the previous two-attempt, five-second startup policy.

### How did you verify your code works?

- `bun test --timeout 180000 --max-concurrency=1 ../../e2e/agent-swarm-tui` from `packages/opencode` - 17 pass.
- `bun run typecheck` from `packages/opencode` - pass.
- `git diff --check` - pass.
- Push hook reran `bun turbo typecheck` - pass.

### Screenshots / recordings

Not applicable; this is CI harness retry behavior for terminal e2e startup.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
