### PR TITLE
fix(launcher): walk PATH for python3.<minor> instead of hardcoded list

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -3,7 +3,7 @@ import net from "node:net"
 import os from "node:os"
 import path from "node:path"
 import { createWriteStream, existsSync, statSync } from "node:fs"
-import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
 import { AgencySwarmRunSession } from "./run-session"
 import { SERVER_LAUNCHER_SCRIPT } from "./server-launcher"
@@ -1203,11 +1203,44 @@ async function hasGitHubTemplateFlow() {
   return auth.code === 0
 }
 
+// Walk $PATH for python3.<minor> binaries and order them oldest-first within the
+// supported range. Hardcoded candidates (e.g. python3.13, python3.12) go stale at
+// every Python release and miss versions installed only with their fully-qualified
+// name — for example Homebrew installs python@3.14 as a dependency without
+// overriding the unversioned `python3`, which on macOS still resolves to Apple's
+// stock 3.9.6, so probing the bare `python3` reports an unsupported interpreter.
+//
+// We prefer the oldest >=3.12 because agency-swarm's pinned dependency graph
+// historically lags behind the newest CPython release (e.g. agency-swarm 1.9.7
+// pins datamodel-code-generator<0.34, whose PythonVersion enum tops out at 3.13),
+// so an older interpreter is the safer default when multiple are installed.
+export async function collectUnixPythonCandidates(): Promise<string[][]> {
+  const found = new Map<string, number>()
+  for (const dir of (process.env.PATH ?? "").split(":")) {
+    if (!dir) continue
+    let entries: string[]
+    try {
+      entries = await readdir(dir)
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const match = entry.match(/^python3\.(\d+)$/)
+      if (!match) continue
+      const minor = Number(match[1])
+      if (minor < 12) continue
+      if (!found.has(entry)) found.set(entry, minor)
+    }
+  }
+  const versioned = [...found.entries()].sort(([, a], [, b]) => a - b).map(([name]) => [name])
+  return [...versioned, ["python3"], ["python"]]
+}
+
 async function findPythonExecutable(excludeUnder?: string) {
   const candidates: string[][] =
     process.platform === "win32"
       ? [["py", "-3.13"], ["py", "-3.12"], ["python"], ["python3"]]
-      : [["python3.13"], ["python3.12"], ["python3"], ["python"]]
+      : await collectUnixPythonCandidates()
 
   const excludeRoot = excludeUnder ? path.resolve(excludeUnder) : undefined
   const excludePrefix = excludeRoot ? excludeRoot + path.sep : undefined

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1203,17 +1203,10 @@ async function hasGitHubTemplateFlow() {
   return auth.code === 0
 }
 
-// Walk $PATH for python3.<minor> binaries and order them oldest-first within the
-// supported range. Hardcoded candidates (e.g. python3.13, python3.12) go stale at
-// every Python release and miss versions installed only with their fully-qualified
-// name — for example Homebrew installs python@3.14 as a dependency without
-// overriding the unversioned `python3`, which on macOS still resolves to Apple's
-// stock 3.9.6, so probing the bare `python3` reports an unsupported interpreter.
-//
-// We prefer the oldest >=3.12 because agency-swarm's pinned dependency graph
-// historically lags behind the newest CPython release (e.g. agency-swarm 1.9.7
-// pins datamodel-code-generator<0.34, whose PythonVersion enum tops out at 3.13),
-// so an older interpreter is the safer default when multiple are installed.
+// Walk $PATH for python3.<minor> binaries before trying unqualified names. Some
+// installers leave `python3` pointed at an older system interpreter while exposing
+// supported versions only through their fully qualified names, such as python3.14.
+// Prefer the oldest supported version when several are installed.
 export async function collectUnixPythonCandidates(): Promise<string[][]> {
   const found = new Map<string, number>()
   for (const dir of (process.env.PATH ?? "").split(":")) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -168,6 +168,24 @@ describe("agency-swarm npx onboarding", () => {
   )
 
   test.skipIf(process.platform === "win32")(
+    "collectUnixPythonCandidates finds python3.14 when it is the only supported versioned binary",
+    async () => {
+      await using dir = await tmpdir()
+      await Bun.write(path.join(dir.path, "python3.9"), "")
+      await Bun.write(path.join(dir.path, "python3.14"), "")
+
+      const originalPath = process.env.PATH
+      process.env.PATH = dir.path
+      try {
+        const candidates = await collectUnixPythonCandidates()
+        expect(candidates.map(([name]) => name)).toEqual(["python3.14", "python3", "python"])
+      } finally {
+        process.env.PATH = originalPath
+      }
+    },
+  )
+
+  test.skipIf(process.platform === "win32")(
     "collectUnixPythonCandidates skips python3.<minor> below 3.12 and ignores junk entries",
     async () => {
       await using dir = await tmpdir()

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -6,6 +6,7 @@ import * as prompts from "@clack/prompts"
 import {
   buildAgencyConfig,
   buildPythonEnv,
+  collectUnixPythonCandidates,
   detectAgencyProject,
   formatProjectLabel,
   LAUNCHER_ENTRY_ENV,
@@ -141,6 +142,52 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(env.PYTHONPATH).toBe(`/tmp/project${path.delimiter}/existing/path`)
   })
+
+  test.skipIf(process.platform === "win32")(
+    "collectUnixPythonCandidates discovers any python3.<minor> on PATH and orders them oldest-first",
+    async () => {
+      await using oldDir = await tmpdir()
+      await using newDir = await tmpdir()
+      await Bun.write(path.join(oldDir.path, "python3.12"), "")
+      await Bun.write(path.join(newDir.path, "python3.14"), "")
+      await Bun.write(path.join(newDir.path, "python3"), "")
+      await Bun.write(path.join(newDir.path, "python3.99"), "") // far-future version
+
+      const originalPath = process.env.PATH
+      process.env.PATH = [oldDir.path, newDir.path].join(":")
+      try {
+        const candidates = await collectUnixPythonCandidates()
+        const versioned = candidates.map(([name]) => name).filter((name) => /^python3\.\d+$/.test(name))
+        expect(versioned).toEqual(["python3.12", "python3.14", "python3.99"])
+        expect(candidates.at(-2)).toEqual(["python3"])
+        expect(candidates.at(-1)).toEqual(["python"])
+      } finally {
+        process.env.PATH = originalPath
+      }
+    },
+  )
+
+  test.skipIf(process.platform === "win32")(
+    "collectUnixPythonCandidates skips python3.<minor> below 3.12 and ignores junk entries",
+    async () => {
+      await using dir = await tmpdir()
+      await Bun.write(path.join(dir.path, "python3.9"), "")
+      await Bun.write(path.join(dir.path, "python3.11"), "")
+      await Bun.write(path.join(dir.path, "python3.13"), "")
+      await Bun.write(path.join(dir.path, "python3.13-config"), "")
+      await Bun.write(path.join(dir.path, "python"), "")
+
+      const originalPath = process.env.PATH
+      process.env.PATH = dir.path
+      try {
+        const candidates = await collectUnixPythonCandidates()
+        const versioned = candidates.map(([name]) => name).filter((name) => /^python3\.\d+$/.test(name))
+        expect(versioned).toEqual(["python3.13"])
+      } finally {
+        process.env.PATH = originalPath
+      }
+    },
+  )
 
   test("prepareProjectLaunch installs LiteLLM extras when no dependency manifest exists", async () => {
     await using dir = await tmpdir()
@@ -282,10 +329,6 @@ describe("agency-swarm npx onboarding", () => {
 
     const commands: string[][] = []
     const replacementPython = process.platform === "win32" ? "C:\\Python312\\python.exe" : "/usr/bin/python3.12"
-    const replacementPythonCommands =
-      process.platform === "win32"
-        ? [["py", "-3.13"], ["py", "-3.12"], ["python"], ["python3"]]
-        : [["python3.13"], ["python3.12"], ["python3"], ["python"]]
     let pipRuns = 0
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
@@ -300,7 +343,7 @@ describe("agency-swarm npx onboarding", () => {
             stderr: "",
           } as never
         }
-        if (replacementPythonCommands.some((candidate) => candidate.every((part, index) => cmd[index] === part))) {
+        if (isReplacementPythonProbe(cmd)) {
           return {
             exited: Promise.resolve(0),
             stdout: `${replacementPython}\n3.12.7\n`,
@@ -406,7 +449,7 @@ describe("agency-swarm npx onboarding", () => {
             stderr: "",
           } as never
         }
-        if (cmd[0] === "python3.12") {
+        if (isReplacementPythonProbe(cmd)) {
           return {
             exited: Promise.resolve(0),
             stdout: `/usr/bin/python3.12\n3.12.7\n`,
@@ -2513,7 +2556,7 @@ function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
           stderr: "",
         } as never
       }
-      if (cmd[0] === "python3.12") {
+      if (isReplacementPythonProbe(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "/usr/bin/python3.12\n3.12.7\n",
@@ -2587,6 +2630,15 @@ function createTextOutputStream(initial?: string) {
 
 function isPipInstallCommand(cmd: string[]) {
   return cmd[1] === "-m" && cmd[2] === "pip" && cmd[3] === "install"
+}
+
+function isReplacementPythonProbe(cmd: string[]) {
+  const target = cmd[0] ?? ""
+  if (process.platform === "win32") {
+    if (target === "py" && (cmd[1]?.startsWith("-3.") ?? false)) return true
+    return target === "python" || target === "python3"
+  }
+  return target === "python" || target === "python3" || /^python3\.\d+$/.test(target)
 }
 
 function isCanaryCommand(cmd: string[]) {


### PR DESCRIPTION
### Issue for this PR

Closes #208

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The launcher used a hardcoded Unix probe list: `python3.13`, `python3.12`, `python3`, then `python`. That misses installs where the supported interpreter is available only as a fully versioned binary such as `python3.14`, while bare `python3` still points to an unsupported system interpreter.

This PR walks `PATH` for `python3.<minor>` executables with minor version 12 or newer, orders them oldest-first, then falls back to `python3` and `python`. The Windows path is unchanged.

This fixes only CLI discovery. VRSEN/OpenSwarm#4 also exposed an Agency Swarm dependency import failure on Python 3.14; that needs the separate Agency Swarm package fix before a fresh OpenSwarm install fully starts on Python 3.14.

### How did you verify your code works?

- `cd packages/opencode && bun test test/agency-swarm/npx.test.ts --test-name-pattern collectUnixPythonCandidates`
- `cd packages/opencode && bun test test/agency-swarm/npx.test.ts`
- `cd packages/opencode && bun typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR