### PR TITLE
fix(launcher): manage Agency Swarm deps with uv

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -237,10 +237,10 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
   - Implementation: `ensureProjectPython`, `installProjectDependencies`, and `venvCanaryPasses` in `packages/opencode/src/agency-swarm/npx.ts`.
   - Added by: `f10d9d84`
 
-- **Launcher refreshes `agency-swarm` inside the project `.venv`**
-  - Intent: keep the project backend package fresh enough for the launcher path to work.
-  - Behavior: the launcher upgrades the project `agency-swarm` install inside `.venv` before running, including after fresh or rebuilt dependency installs.
-  - Implementation: `ensureLatestAgencySwarm` in `packages/opencode/src/agency-swarm/npx.ts`.
+- **Launcher manages Python dependency setup with uv**
+  - Intent: keep the project backend package ready for the launcher path without overriding user dependency manifests.
+  - Behavior: the launcher creates `.venv` with uv, re-runs `requirements.txt` or `pyproject.toml` installs with uv when present, and only installs or refreshes `agency-swarm[fastapi,litellm]` when no manifest exists.
+  - Implementation: `installProjectDependencies` and `ensureLatestAgencySwarm` in `packages/opencode/src/agency-swarm/npx.ts`.
   - Added by: `a77de00c`
 
 - **Run-mode attachments use structured Agency Swarm messages**

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -239,7 +239,7 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
 
 - **Launcher refreshes `agency-swarm` inside the project `.venv`**
   - Intent: keep the project backend package fresh enough for the launcher path to work.
-  - Behavior: the launcher upgrades the project `agency-swarm` install inside `.venv` before running when needed.
+  - Behavior: the launcher upgrades the project `agency-swarm` install inside `.venv` before running, including after fresh or rebuilt dependency installs.
   - Implementation: `ensureLatestAgencySwarm` in `packages/opencode/src/agency-swarm/npx.ts`.
   - Added by: `a77de00c`
 

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -38,7 +38,7 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
 4. Prepare a local project.
    - Verify Python 3.12+ and `agency_swarm`.
    - Reuse, repair, or create `.venv`.
-   - Upgrade the project `agency-swarm[fastapi,litellm]` install when needed.
+   - Upgrade the project `agency-swarm[fastapi,litellm]` install after reuse, creation, or repair.
    - Start the local FastAPI bridge and point the TUI at `local-agency`.
 5. Recover local project context for resume.
    - Use the fork run-session record when its saved directory still matches the session directory.
@@ -72,7 +72,7 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
 - Expected path:
   - Offer `Use detected Agency Swarm project` as the first onboarding choice.
   - Reuse a healthy `.venv`.
-  - Upgrade the existing project `agency-swarm[fastapi,litellm]` install.
+  - Upgrade the project `agency-swarm[fastapi,litellm]` install before import verification, including after fresh or rebuilt dependency installs.
   - Rebuild a broken `.venv` when Python 3.12+ is available.
   - Start the local FastAPI bridge and open the TUI in Run mode against `local-agency`.
 - Expected failures:

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -37,8 +37,8 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
    - If the user chooses connect, build session-scoped Agency provider config for the selected server.
 4. Prepare a local project.
    - Verify Python 3.12+ and `agency_swarm`.
-   - Reuse, repair, or create `.venv`.
-   - Upgrade the project `agency-swarm[fastapi,litellm]` install after reuse, creation, or repair.
+   - Reuse `.venv`, or repair/create it with uv.
+   - Re-run `requirements.txt` or `pyproject.toml` installs with uv when present; use launcher-managed `agency-swarm[fastapi,litellm]` only when no manifest exists.
    - Start the local FastAPI bridge and point the TUI at `local-agency`.
 5. Recover local project context for resume.
    - Use the fork run-session record when its saved directory still matches the session directory.
@@ -72,7 +72,8 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
 - Expected path:
   - Offer `Use detected Agency Swarm project` as the first onboarding choice.
   - Reuse a healthy `.venv`.
-  - Upgrade the project `agency-swarm[fastapi,litellm]` install before import verification, including after fresh or rebuilt dependency installs.
+  - Re-run `requirements.txt` or `pyproject.toml` installs with uv while respecting pins, without a second unpinned `agency-swarm` upgrade.
+  - Use uv for launcher-managed fallback installs into `.venv`.
   - Rebuild a broken `.venv` when Python 3.12+ is available.
   - Start the local FastAPI bridge and open the TUI in Run mode against `local-agency`.
 - Expected failures:

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -727,6 +727,7 @@ async function ensureProjectPython(directory: string) {
   const rebuildCmd = corruptedVenv ? [detected.executable] : detected.cmd
   prompts.log.info(`Detected Python: ${formatPython(detected, rebuildCmd)}`)
 
+  const uv = corruptedVenv ? await findUv() : undefined
   if (corruptedVenv) {
     prompts.log.warn("Project `.venv` is incomplete or corrupted. Rebuilding...")
     await rm(venvDir, { recursive: true, force: true })
@@ -752,10 +753,10 @@ async function ensureProjectPython(directory: string) {
     }
   }
 
-  const uv = await findUv()
+  const rebuildUv = uv ?? (await findUv())
   const spinner = prompts.spinner()
   spinner.start("Creating `.venv`")
-  const created = await runCommand([...uv.cmd, "venv", "--python", detected.executable, ".venv"], {
+  const created = await runCommand([...rebuildUv.cmd, "venv", "--python", detected.executable, ".venv"], {
     cwd: directory,
   })
   if (created.code !== 0) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -851,31 +851,42 @@ async function refreshProjectDependencies(
     timeoutMs: number
   },
 ): Promise<{ installerFailed: boolean }> {
-  if (!(await hasDependencyManifest(directory))) {
-    return ensureLatestAgencySwarm(directory, venvPython, options)
-  }
+  try {
+    if (!(await hasDependencyManifest(directory))) {
+      return await ensureLatestAgencySwarm(directory, venvPython, options)
+    }
 
-  const result = await installProjectDependencies(directory, venvPython, options)
-  if (result.timedOut) {
+    const result = await installProjectDependencies(directory, venvPython, options)
+    if (result.timedOut) {
+      prompts.log.warn(
+        result.logFile
+          ? `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}. Check the log file at ${result.logFile}.`
+          : `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}.`,
+      )
+      return { installerFailed: false }
+    }
+    if (result.code !== 0) {
+      const summary = summarizeCommandOutput(result)
+      prompts.log.warn(
+        summary
+          ? `Could not refresh project dependencies from the manifest. Installer output: ${summary}.${
+              result.logFile ? ` Check the log file at ${result.logFile}.` : ""
+            } The current venv package set will be used as-is.`
+          : "Could not refresh project dependencies from the manifest. The current venv package set will be used as-is.",
+      )
+      return { installerFailed: isUvLaunchFailure(`${result.stderr}\n${result.stdout}`) }
+    }
+  } catch (error) {
+    if (!isUvUnavailableError(error)) throw error
     prompts.log.warn(
-      result.logFile
-        ? `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}. Check the log file at ${result.logFile}.`
-        : `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}.`,
+      "uv was not found, so project dependency refresh was skipped. The current venv package set will be used as-is.",
     )
-    return { installerFailed: false }
-  }
-  if (result.code !== 0) {
-    const summary = summarizeCommandOutput(result)
-    prompts.log.warn(
-      summary
-        ? `Could not refresh project dependencies from the manifest. Installer output: ${summary}.${
-            result.logFile ? ` Check the log file at ${result.logFile}.` : ""
-          } The current venv package set will be used as-is.`
-        : "Could not refresh project dependencies from the manifest. The current venv package set will be used as-is.",
-    )
-    return { installerFailed: isUvLaunchFailure(`${result.stderr}\n${result.stdout}`) }
   }
   return { installerFailed: false }
+}
+
+function isUvUnavailableError(error: unknown) {
+  return error instanceof Error && error.message.includes("uv was not found")
 }
 
 async function formatPostInstallCanaryFailure(

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -782,6 +782,10 @@ async function ensureProjectPython(directory: string) {
   if (install.code !== 0) {
     throw new Error(formatCommandFailure(install, "Dependency install failed"))
   }
+  await ensureLatestAgencySwarm(directory, [venvPython], {
+    logFile: installLogFile,
+    timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+  })
   prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
   const canary = await venvCanaryPasses([venvPython], { cwd: directory, includeStderr: true })
   if (canary.timedOut) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -56,6 +56,10 @@ interface DependencyInstallResult extends CommandResult {
   hadManifests: boolean
 }
 
+interface UvInfo {
+  cmd: string[]
+}
+
 interface RunCommandOptions {
   cwd?: string
   env?: NodeJS.ProcessEnv
@@ -83,6 +87,7 @@ const SERVER_START_TIMEOUT_MS = 90 * 1000
 const SERVER_STDERR_COLLECT_TIMEOUT_MS = 1000
 const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
 const PROCESS_KILL_GRACE_MS = 5000
+const FALLBACK_AGENCY_SWARM_REQUIREMENT = "agency-swarm[fastapi,litellm]>=1.9.6"
 
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
@@ -677,18 +682,14 @@ async function ensureProjectPython(directory: string) {
       const refreshLogFile = await tryCreateProjectCommandLogFile(directory, "launcher-refresh", "launcher refresh")
       prompts.log.info(
         refreshLogFile
-          ? `Refreshing project dependencies. Streaming output to stderr. Full log: ${refreshLogFile}`
-          : "Refreshing project dependencies. Streaming output to stderr.",
+          ? `Refreshing project dependencies with uv. Streaming output to stderr. Full log: ${refreshLogFile}`
+          : "Refreshing project dependencies with uv. Streaming output to stderr.",
       )
-      try {
-        const refresh = await ensureLatestAgencySwarm(directory, [venvPython], {
-          logFile: refreshLogFile,
-          timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
-        })
-        if (refresh.pipCorrupted) corruptedVenv = true
-      } catch {
-        corruptedVenv = true
-      }
+      const refresh = await refreshProjectDependencies(directory, venvPython, {
+        logFile: refreshLogFile,
+        timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+      })
+      if (refresh.installerFailed) corruptedVenv = true
       if (!corruptedVenv) {
         prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
         let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
@@ -751,9 +752,10 @@ async function ensureProjectPython(directory: string) {
     }
   }
 
+  const uv = await findUv()
   const spinner = prompts.spinner()
   spinner.start("Creating `.venv`")
-  const created = await runCommand([...rebuildCmd, "-m", "venv", ".venv"], {
+  const created = await runCommand([...uv.cmd, "venv", "--python", detected.executable, ".venv"], {
     cwd: directory,
   })
   if (created.code !== 0) {
@@ -768,7 +770,7 @@ async function ensureProjectPython(directory: string) {
       ? `Installing project dependencies. Streaming output to stderr. Full log: ${installLogFile}`
       : "Installing project dependencies. Streaming output to stderr.",
   )
-  const install = await installProjectDependencies(directory, [venvPython], {
+  const install = await installProjectDependencies(directory, venvPython, {
     logFile: installLogFile,
     timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
   })
@@ -782,10 +784,6 @@ async function ensureProjectPython(directory: string) {
   if (install.code !== 0) {
     throw new Error(formatCommandFailure(install, "Dependency install failed"))
   }
-  await ensureLatestAgencySwarm(directory, [venvPython], {
-    logFile: installLogFile,
-    timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
-  })
   prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
   const canary = await venvCanaryPasses([venvPython], { cwd: directory, includeStderr: true })
   if (canary.timedOut) {
@@ -802,26 +800,30 @@ async function ensureProjectPython(directory: string) {
 
 async function installProjectDependencies(
   directory: string,
-  python: string[],
+  venvPython: string,
   options: {
     logFile?: string
     timeoutMs: number
   },
 ): Promise<DependencyInstallResult> {
+  const uv = await findUv()
   const requirements = path.join(directory, "requirements.txt")
   if (await Filesystem.exists(requirements)) {
-    const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "-r", "requirements.txt"], {
-      cwd: directory,
-      logFile: options.logFile,
-      streamOutputToStderr: true,
-      timeoutMs: options.timeoutMs,
-    })
+    const result = await runCommand(
+      [...uv.cmd, "pip", "install", "--python", venvPython, "--upgrade", "-r", "requirements.txt"],
+      {
+        cwd: directory,
+        logFile: options.logFile,
+        streamOutputToStderr: true,
+        timeoutMs: options.timeoutMs,
+      },
+    )
     return { ...result, hadManifests: true }
   }
 
   const pyproject = path.join(directory, "pyproject.toml")
   if (await Filesystem.exists(pyproject)) {
-    const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "-e", "."], {
+    const result = await runCommand([...uv.cmd, "pip", "install", "--python", venvPython, "--upgrade", "-e", "."], {
       cwd: directory,
       logFile: options.logFile,
       streamOutputToStderr: true,
@@ -831,7 +833,7 @@ async function installProjectDependencies(
   }
 
   const result = await runCommand(
-    [...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]>=1.9.6"],
+    [...uv.cmd, "pip", "install", "--python", venvPython, FALLBACK_AGENCY_SWARM_REQUIREMENT],
     {
       logFile: options.logFile,
       streamOutputToStderr: true,
@@ -839,6 +841,41 @@ async function installProjectDependencies(
     },
   )
   return { ...result, hadManifests: false }
+}
+
+async function refreshProjectDependencies(
+  directory: string,
+  venvPython: string,
+  options: {
+    logFile?: string
+    timeoutMs: number
+  },
+): Promise<{ installerFailed: boolean }> {
+  if (!(await hasDependencyManifest(directory))) {
+    return ensureLatestAgencySwarm(directory, venvPython, options)
+  }
+
+  const result = await installProjectDependencies(directory, venvPython, options)
+  if (result.timedOut) {
+    prompts.log.warn(
+      result.logFile
+        ? `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}. Check the log file at ${result.logFile}.`
+        : `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}.`,
+    )
+    return { installerFailed: false }
+  }
+  if (result.code !== 0) {
+    const summary = summarizeCommandOutput(result)
+    prompts.log.warn(
+      summary
+        ? `Could not refresh project dependencies from the manifest. Installer output: ${summary}.${
+            result.logFile ? ` Check the log file at ${result.logFile}.` : ""
+          } The current venv package set will be used as-is.`
+        : "Could not refresh project dependencies from the manifest. The current venv package set will be used as-is.",
+    )
+    return { installerFailed: isUvLaunchFailure(`${result.stderr}\n${result.stdout}`) }
+  }
+  return { installerFailed: false }
 }
 
 async function formatPostInstallCanaryFailure(
@@ -913,45 +950,54 @@ async function venvCanaryPasses(python: string[], options?: { cwd?: string; incl
 
 async function ensureLatestAgencySwarm(
   directory: string,
-  python: string[],
+  venvPython: string,
   options?: {
     logFile?: string
     timeoutMs?: number
   },
-): Promise<{ pipCorrupted: boolean }> {
+): Promise<{ installerFailed: boolean }> {
+  const uv = await findUv()
   try {
-    const result = await runCommand([...python, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]"], {
-      cwd: directory,
-      logFile: options?.logFile,
-      streamOutputToStderr: true,
-      suppressPythonTracebackStderr: true,
-      timeoutMs: options?.timeoutMs,
-    })
+    const result = await runCommand(
+      [...uv.cmd, "pip", "install", "--python", venvPython, "--upgrade", "agency-swarm[fastapi,litellm]"],
+      {
+        cwd: directory,
+        logFile: options?.logFile,
+        streamOutputToStderr: true,
+        suppressPythonTracebackStderr: true,
+        timeoutMs: options?.timeoutMs,
+      },
+    )
     if (result.timedOut) {
       prompts.log.warn(
         result.logFile
-          ? `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${result.logFile}.`
-          : `Timed out while refreshing agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}.`,
+          ? `Timed out while refreshing launcher-managed agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${result.logFile}.`
+          : `Timed out while refreshing launcher-managed agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}.`,
       )
-      return { pipCorrupted: false }
+      return { installerFailed: false }
     }
     if (result.code !== 0) {
       const summary = summarizeCommandOutput(result)
       prompts.log.warn(
         summary
-          ? `Could not refresh agency-swarm to the latest version. Installer output: ${summary}.${
+          ? `Could not refresh launcher-managed agency-swarm. Installer output: ${summary}.${
               result.logFile ? ` Check the log file at ${result.logFile}.` : ""
             } The current venv package will be used as-is.`
-          : "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
+          : "Could not refresh launcher-managed agency-swarm. The current venv package will be used as-is.",
       )
-      return { pipCorrupted: isPipCorruptionFailure(`${result.stderr}\n${result.stdout}`) }
+      return { installerFailed: isUvLaunchFailure(`${result.stderr}\n${result.stdout}`) }
     }
   } catch {
-    prompts.log.warn(
-      "Could not refresh agency-swarm to the latest version. The current venv package will be used as-is.",
-    )
+    prompts.log.warn("Could not refresh launcher-managed agency-swarm. The current venv package will be used as-is.")
   }
-  return { pipCorrupted: false }
+  return { installerFailed: false }
+}
+
+async function hasDependencyManifest(directory: string) {
+  return (
+    (await Filesystem.exists(path.join(directory, "requirements.txt"))) ||
+    (await Filesystem.exists(path.join(directory, "pyproject.toml")))
+  )
 }
 
 async function createProjectCommandLogFile(directory: string, stem: string) {
@@ -1185,11 +1231,20 @@ function isPythonTracebackFinalExceptionLine(line: string) {
   return /^[A-Za-z_][\w.]*:(?:\s|$)/.test(line.trimEnd())
 }
 
-function isPipCorruptionFailure(output: string) {
-  return (
-    /\bModuleNotFoundError:\s+No module named ['"]pip(?:['"]|\.)/.test(output) ||
-    /\bImportError:\s+cannot import name .* from ['"]pip/.test(output)
-  )
+async function findUv(): Promise<UvInfo> {
+  const result = await runCommand(["uv", "--version"])
+  if (result.code !== 0) {
+    throw new Error(
+      "uv was not found. Install uv and rerun `npx @vrsen/agentswarm`; the launcher does not bootstrap uv with pip.",
+    )
+  }
+  return {
+    cmd: ["uv"],
+  }
+}
+
+function isUvLaunchFailure(output: string) {
+  return /uv(?:\.exe)?:?\s+(?:command not found|not found|No such file or directory|ENOENT)/i.test(output)
 }
 
 function isNonFatalBridgeStartupWarning(line: string) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -269,6 +269,82 @@ describe("agency-swarm npx onboarding", () => {
     ])
   })
 
+  test("prepareProjectLaunch refreshes agency-swarm after manifest installs before canary", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await Bun.write(path.join(dir.path, "requirements.txt"), "agency-swarm==1.9.6\n")
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    const commands: string[][] = []
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    const venvPython = getTestVenvPython(dir.path)
+    const pipCommands = commands.filter(isPipInstallCommand)
+    expect(pipCommands).toHaveLength(2)
+    expect(pipCommands[0]).toEqual([venvPython, "-m", "pip", "install", "--upgrade", "-r", "requirements.txt"])
+    expect(pipCommands[1]).toEqual([venvPython, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]"])
+    expect(commands.findIndex((cmd) => cmd === pipCommands[1])).toBeLessThan(commands.findIndex(isCanaryCommand))
+
+    await launch?.cleanup?.()
+  })
+
   test("prepareProjectLaunch recreates an incomplete `.venv` instead of overlaying it", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -422,7 +498,7 @@ describe("agency-swarm npx onboarding", () => {
     expect(confirm).not.toHaveBeenCalled()
     expect(await Bun.file(staleFile).exists()).toBe(false)
     expect(commands.some((cmd) => cmd.includes("venv"))).toBe(true)
-    expect(pipRuns).toBe(2)
+    expect(pipRuns).toBe(3)
     await launch?.cleanup?.()
   })
 
@@ -2617,6 +2693,15 @@ function launcherLogDirectory(directory: string) {
 
 function launcherLogFilePath(directory: string, stem: string, iso: string) {
   return path.join(launcherLogDirectory(directory), `${iso.replaceAll(":", "").replaceAll(".", "")}-${stem}.log`)
+}
+
+function getTestVenvPython(directory: string) {
+  return path.join(
+    directory,
+    ".venv",
+    process.platform === "win32" ? "Scripts" : "bin",
+    process.platform === "win32" ? "python.exe" : "python",
+  )
 }
 
 function createTextOutputStream(initial?: string) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -674,6 +674,75 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
+  test("prepareProjectLaunch preserves corrupted existing venv when rebuild needs missing uv", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await writeVenvPython(dir.path)
+    const staleFile = path.join(dir.path, ".venv", "lib", "python3.12", "site-packages", "stale.py")
+    await mkdir(path.dirname(staleFile), { recursive: true })
+    await Bun.write(staleFile, "stale")
+
+    const confirm = spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+
+    const commands: string[][] = []
+    const replacementPython = process.platform === "win32" ? "C:\\Python312\\python.exe" : "/usr/bin/python3.12"
+    let uvVersionAttempts = 0
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        uvVersionAttempts += 1
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "uv: command not found",
+        } as never
+      }
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        if (target.endsWith(process.platform === "win32" ? "\\python.exe" : "/python")) {
+          return {
+            exited: Promise.resolve(0),
+            stdout: `${target}\n3.12.7\n`,
+            stderr: "",
+          } as never
+        }
+        if (isReplacementPythonProbe(cmd)) {
+          return {
+            exited: Promise.resolve(0),
+            stdout: `${replacementPython}\n3.12.7\n`,
+            stderr: "",
+          } as never
+        }
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "ModuleNotFoundError: No module named 'agency_swarm'",
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow("uv was not found. Install uv and rerun `npx @vrsen/agentswarm`")
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(uvVersionAttempts).toBeGreaterThanOrEqual(2)
+    expect(await Bun.file(getTestVenvPython(dir.path)).exists()).toBe(true)
+    expect(await Bun.file(staleFile).exists()).toBe(true)
+    expect(commands.some(isUvVenvCommand)).toBe(false)
+    expect(commands.some(isUvPipInstallCommand)).toBe(false)
+  })
+
   test("prepareProjectLaunch recreates an incomplete `.venv` instead of overlaying it", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -220,6 +220,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       commands.push(cmd)
       if (cmd.includes("-c")) {
         return {
@@ -235,7 +242,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("pip")) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
           stdout: "",
@@ -252,35 +259,28 @@ describe("agency-swarm npx onboarding", () => {
       }),
     ).rejects.toThrow("fallback install failed")
 
-    const installCommand = commands.find((cmd) => cmd.includes("pip"))
+    const installCommand = commands.find(isUvPipInstallCommand)
 
+    expect(commands.filter(isUvVenvCommand)).toEqual([["uv", "venv", "--python", "/usr/bin/python3.12", ".venv"]])
     expect(installCommand).toEqual([
-      path.join(
-        dir.path,
-        ".venv",
-        process.platform === "win32" ? "Scripts" : "bin",
-        process.platform === "win32" ? "python.exe" : "python",
-      ),
-      "-m",
+      "uv",
       "pip",
       "install",
-      "--upgrade",
+      "--python",
+      getTestVenvPython(dir.path),
       "agency-swarm[fastapi,litellm]>=1.9.6",
     ])
   })
 
-  test("prepareProjectLaunch refreshes agency-swarm after manifest installs before canary", async () => {
+  test("prepareProjectLaunch fails clearly when uv is missing", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
-    await Bun.write(path.join(dir.path, "requirements.txt"), "agency-swarm==1.9.6\n")
 
     spyOn(prompts, "confirm").mockResolvedValue(true as never)
     spyOn(prompts, "spinner").mockReturnValue({
       start() {},
       stop() {},
     } as never)
-    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
-
     const commands: string[][] = []
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
@@ -300,7 +300,65 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "uv: command not found",
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    await expect(
+      prepareProjectLaunch({
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+      }),
+    ).rejects.toThrow("uv was not found. Install uv and rerun `npx @vrsen/agentswarm`")
+
+    expect(commands.some((cmd) => cmd[0] === "uv" && isUvPipInstallCommand(cmd))).toBe(false)
+  })
+
+  test("prepareProjectLaunch installs requirements without a second agency-swarm upgrade", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await Bun.write(path.join(dir.path, "requirements.txt"), "agency-swarm==1.9.6\n")
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    const commands: string[][] = []
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -336,11 +394,215 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     const venvPython = getTestVenvPython(dir.path)
-    const pipCommands = commands.filter(isPipInstallCommand)
-    expect(pipCommands).toHaveLength(2)
-    expect(pipCommands[0]).toEqual([venvPython, "-m", "pip", "install", "--upgrade", "-r", "requirements.txt"])
-    expect(pipCommands[1]).toEqual([venvPython, "-m", "pip", "install", "--upgrade", "agency-swarm[fastapi,litellm]"])
-    expect(commands.findIndex((cmd) => cmd === pipCommands[1])).toBeLessThan(commands.findIndex(isCanaryCommand))
+    const uvInstallCommands = commands.filter(isUvPipInstallCommand)
+    expect(uvInstallCommands).toEqual([
+      ["uv", "pip", "install", "--python", venvPython, "--upgrade", "-r", "requirements.txt"],
+    ])
+    expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
+
+    await launch?.cleanup?.()
+  })
+
+  test("prepareProjectLaunch installs pyproject without a second agency-swarm upgrade", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await Bun.write(path.join(dir.path, "pyproject.toml"), "[project]\ndependencies = ['agency-swarm==1.9.6']\n")
+
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    const commands: string[][] = []
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "/usr/bin/python3.12\n3.12.7\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("venv") || isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    const uvInstallCommands = commands.filter(isUvPipInstallCommand)
+    expect(uvInstallCommands).toEqual([
+      ["uv", "pip", "install", "--python", getTestVenvPython(dir.path), "--upgrade", "-e", "."],
+    ])
+    expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
+
+    await launch?.cleanup?.()
+  })
+
+  test("prepareProjectLaunch refreshes existing requirements venv without unpinned agency-swarm upgrade", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await Bun.write(path.join(dir.path, "requirements.txt"), "agency-swarm==1.9.6\n")
+    await writeVenvPython(dir.path)
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    const commands: string[][] = []
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    const uvInstallCommands = commands.filter(isUvPipInstallCommand)
+    expect(uvInstallCommands).toEqual([
+      ["uv", "pip", "install", "--python", getTestVenvPython(dir.path), "--upgrade", "-r", "requirements.txt"],
+    ])
+    expect(commands.some((cmd) => cmd.includes("venv"))).toBe(false)
+    expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
+    expect(commands.findIndex(isUvPipInstallCommand)).toBeLessThan(commands.findIndex(isCanaryCommand))
+
+    await launch?.cleanup?.()
+  })
+
+  test("prepareProjectLaunch refreshes existing pyproject venv without unpinned agency-swarm upgrade", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await Bun.write(path.join(dir.path, "pyproject.toml"), "[project]\ndependencies = ['agency-swarm==1.9.6']\n")
+    await writeVenvPython(dir.path)
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    const commands: string[][] = []
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
+      commands.push(cmd)
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    const uvInstallCommands = commands.filter(isUvPipInstallCommand)
+    expect(uvInstallCommands).toEqual([
+      ["uv", "pip", "install", "--python", getTestVenvPython(dir.path), "--upgrade", "-e", "."],
+    ])
+    expect(commands.some((cmd) => cmd.includes("venv"))).toBe(false)
+    expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
+    expect(commands.findIndex(isUvPipInstallCommand)).toBeLessThan(commands.findIndex(isCanaryCommand))
 
     await launch?.cleanup?.()
   })
@@ -362,6 +624,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       commands.push(cmd)
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         return {
@@ -377,7 +646,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("pip")) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
           stdout: "",
@@ -396,10 +665,10 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(confirm).not.toHaveBeenCalled()
     expect(await Bun.file(staleFile).exists()).toBe(false)
-    expect(commands.some((cmd) => cmd.includes("venv"))).toBe(true)
+    expect(commands.filter(isUvVenvCommand)).toEqual([["uv", "venv", "--python", "/usr/bin/python3.12", ".venv"]])
   })
 
-  test("prepareProjectLaunch recreates `.venv` when project pip is corrupted", async () => {
+  test("prepareProjectLaunch recreates `.venv` when uv cannot refresh launcher-managed dependencies", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
     const venvPython = path.join(
@@ -423,10 +692,17 @@ describe("agency-swarm npx onboarding", () => {
 
     const commands: string[][] = []
     const replacementPython = process.platform === "win32" ? "C:\\Python312\\python.exe" : "/usr/bin/python3.12"
-    let pipRuns = 0
+    let uvInstallRuns = 0
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       commands.push(cmd)
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
@@ -452,19 +728,12 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
-        pipRuns += 1
+      if (isUvPipInstallCommand(cmd)) {
+        uvInstallRuns += 1
         return {
-          exited: Promise.resolve(pipRuns === 1 ? 1 : 0),
+          exited: Promise.resolve(uvInstallRuns === 1 ? 1 : 0),
           stdout: "",
-          stderr:
-            pipRuns === 1
-              ? [
-                  "Traceback (most recent call last):",
-                  '  File "<frozen runpy>", line 198, in _run_module_as_main',
-                  "ModuleNotFoundError: No module named 'pip._internal.cli.main'",
-                ].join("\n")
-              : "",
+          stderr: uvInstallRuns === 1 ? "uv: command not found" : "",
         } as never
       }
       if (isCanaryCommand(cmd)) {
@@ -497,8 +766,8 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(confirm).not.toHaveBeenCalled()
     expect(await Bun.file(staleFile).exists()).toBe(false)
-    expect(commands.some((cmd) => cmd.includes("venv"))).toBe(true)
-    expect(pipRuns).toBe(3)
+    expect(commands.filter(isUvVenvCommand)).toEqual([["uv", "venv", "--python", replacementPython, ".venv"]])
+    expect(uvInstallRuns).toBe(2)
     await launch?.cleanup?.()
   })
 
@@ -533,6 +802,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       commands.push(cmd)
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
@@ -565,7 +841,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("pip")) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -620,6 +896,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         return {
           exited: Promise.resolve(0),
@@ -634,7 +917,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: installExited,
           stdout: "Resolving packages...\n",
@@ -674,6 +957,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         return {
           exited: Promise.resolve(0),
@@ -688,7 +978,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         let resolveExit!: (code: number) => void
         const exited = new Promise<number>((resolve) => {
           resolveExit = resolve
@@ -743,6 +1033,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         return {
           exited: Promise.resolve(0),
@@ -757,7 +1054,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         let resolveExit!: (code: number) => void
         const stderr = createTextOutputStream("still working...\n")
         return {
@@ -816,6 +1113,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         return {
           exited: Promise.resolve(0),
@@ -830,7 +1134,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         let resolveExit!: (code: number) => void
         const stderr = createTextOutputStream("still working...\n")
         return {
@@ -888,6 +1192,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
         return {
@@ -903,7 +1214,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -978,6 +1289,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
         return {
@@ -986,7 +1304,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
           stdout: "Collecting agency-swarm...\n",
@@ -1029,7 +1347,7 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(info).toHaveBeenCalledWith(
-      expect.stringContaining("Refreshing project dependencies. Streaming output to stderr."),
+      expect.stringContaining("Refreshing project dependencies with uv. Streaming output to stderr."),
     )
     expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Collecting agency-swarm...\n")
     expect(stderrWrite.mock.calls.map((call) => call[0])).toContain(
@@ -1078,6 +1396,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
         return {
@@ -1093,7 +1418,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         pipRuns += 1
         return {
           exited: Promise.resolve(pipRuns === 1 ? 1 : 0),
@@ -1187,6 +1512,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
         return {
@@ -1195,7 +1527,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
           stdout: "",
@@ -1279,6 +1611,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
         return {
@@ -1287,7 +1626,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
           stdout: "Collecting agency-swarm...\n",
@@ -1351,6 +1690,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       commands.push(cmd)
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
@@ -1360,7 +1706,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1435,6 +1781,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
         if (target.endsWith(process.platform === "win32" ? "\\python.exe" : "/python")) {
@@ -1450,7 +1803,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1536,6 +1889,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
         return {
@@ -1544,7 +1904,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1631,6 +1991,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
         return {
@@ -1639,7 +2006,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1714,6 +2081,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
         return {
@@ -1722,7 +2096,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1774,6 +2148,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         const target = cmd[0] ?? ""
         return {
@@ -1789,7 +2170,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "Collecting agency-swarm...\n",
@@ -1846,6 +2227,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         return {
           exited: Promise.resolve(0),
@@ -1860,7 +2248,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
           stdout: "",
@@ -1904,6 +2292,13 @@ describe("agency-swarm npx onboarding", () => {
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
         return {
           exited: Promise.resolve(0),
@@ -1918,7 +2313,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPipInstallCommand(cmd)) {
+      if (isUvPipInstallCommand(cmd)) {
         let resolveExit!: (code: number) => void
         const exited = new Promise<number>((resolve) => {
           resolveExit = resolve
@@ -2637,10 +3032,23 @@ async function writeAgency(dir: string) {
   )
 }
 
+async function writeVenvPython(dir: string) {
+  const venvPython = getTestVenvPython(dir)
+  await mkdir(path.dirname(venvPython), { recursive: true })
+  await Bun.write(venvPython, "")
+}
+
 function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
   spyOn(Bun, "spawn").mockImplementation((options: any) => {
     const cmd = options?.cmd as string[] | undefined
     if (!cmd) throw new Error("Missing command")
+    if (isUvVersionCommand(cmd)) {
+      return {
+        exited: Promise.resolve(0),
+        stdout: "uv 0.8.0\n",
+        stderr: "",
+      } as never
+    }
     if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
       const target = cmd[0] ?? ""
       if (target.endsWith(process.platform === "win32" ? "\\python.exe" : "/python")) {
@@ -2672,7 +3080,7 @@ function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
         stderr: "",
       } as never
     }
-    if (cmd.includes("pip")) {
+    if (isUvPipInstallCommand(cmd)) {
       return {
         exited: Promise.resolve(0),
         stdout: "",
@@ -2731,8 +3139,16 @@ function createTextOutputStream(initial?: string) {
   }
 }
 
-function isPipInstallCommand(cmd: string[]) {
-  return cmd[1] === "-m" && cmd[2] === "pip" && cmd[3] === "install"
+function isUvPipInstallCommand(cmd: string[]) {
+  return cmd[0] === "uv" && cmd[1] === "pip" && cmd[2] === "install"
+}
+
+function isUvVenvCommand(cmd: string[]) {
+  return cmd[0] === "uv" && cmd[1] === "venv"
+}
+
+function isUvVersionCommand(cmd: string[]) {
+  return cmd[0] === "uv" && cmd[1] === "--version"
 }
 
 function isReplacementPythonProbe(cmd: string[]) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -607,6 +607,73 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
+  test("prepareProjectLaunch keeps a healthy existing venv when uv is missing", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await writeVenvPython(dir.path)
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    const commands: string[][] = []
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "uv: command not found",
+        } as never
+      }
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    expect(warn).toHaveBeenCalledWith(
+      "uv was not found, so project dependency refresh was skipped. The current venv package set will be used as-is.",
+    )
+    expect(commands.some(isUvPipInstallCommand)).toBe(false)
+    expect(commands.some(isUvVenvCommand)).toBe(false)
+    expect(commands.some(isCanaryCommand)).toBe(true)
+
+    await launch?.cleanup?.()
+  })
+
   test("prepareProjectLaunch recreates an incomplete `.venv` instead of overlaying it", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)


### PR DESCRIPTION
### Issue for this PR

Closes #210

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Reworks the launcher dependency path so the TUI-managed Python environment is managed by uv instead of Python pip.

The original PR direction was wrong: it added a second unpinned `agency-swarm` upgrade after manifest installs. This version removes that extra upgrade. If a project has `requirements.txt` or `pyproject.toml`, the launcher re-runs that manifest with uv and respects the project pins. If there is no manifest, the launcher owns the fallback `agency-swarm[fastapi,litellm]` install and refreshes it on existing `.venv` launches.

It also creates or rebuilds `.venv` with `uv venv --python <detected-python> .venv`, then installs with `uv pip install --python <venv-python> ...`. `uv pip` is uv's installer interface; the launcher no longer calls `python -m pip` or bootstraps uv through pip. Existing healthy `.venv` launches remain usable if uv is missing, and corrupted `.venv` directories are not deleted until uv availability is confirmed.

### How did you verify your code works?

- `bun x prettier --write FORK_CHANGELOG.md USER_FLOWS.md packages/opencode/src/agency-swarm/npx.ts packages/opencode/test/agency-swarm/npx.test.ts`
- `cd packages/opencode && bun test ./test/agency-swarm/npx.test.ts` — 65 pass
- `cd packages/opencode && bun typecheck`
- `git diff --check`
- push hook ran `bun turbo typecheck` — 13 successful tasks
- local Codex review on the final head reported no actionable correctness issues

### Screenshots / recordings

N/A. This changes launcher dependency setup, not TUI visuals.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
