### PR TITLE
feat(agency-swarm): render image generation outputs

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -113,6 +113,12 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
   - Implementation: `findCallID` and the `tool_output` branch in `handleRunItemEvent` in `packages/opencode/src/session/agency-swarm.ts`.
   - Added by: `e28e3a02`
 
+- **Hosted image generation outputs render as attachments**
+  - Intent: show OpenAI Agents SDK image-generation results as generated images instead of dumping base64 payloads into the tool output text.
+  - Behavior: Agency Swarm `image_generation_call` results attach a data-url image file to the tool result and keep the visible output concise.
+  - Implementation: `toolOutput` in `packages/opencode/src/session/agency-swarm.ts`.
+  - Added by: this PR.
+
 ## CLI/TUI UX
 
 - **`/auth` is separate from `/connect`**

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -165,6 +165,7 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
   - Surface bridge error frames as session errors.
   - Strip Codex OAuth from non-OpenAI LiteLLM agency runs.
   - Preserve Agency tool-output metadata.
+  - Render hosted image-generation tool results as image attachments, not base64 text.
   - Hide Builder, Plan, `/editor`, `/variants`, `/init`, `/review`, and other upstream-native surfaces that are disabled in Run mode.
   - Limit `/models` and `/auth` to Agency-supported providers.
   - Keep `agency-swarm/default` active over stale stored model state until the user changes it.

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -20,7 +20,7 @@ import { CODEX_API_BASE_URL, extractAccountId, refreshAccessToken } from "@/plug
 import { Provider } from "@/provider/provider"
 import { Session } from "@/session"
 import { MessageV2 } from "@/session/message-v2"
-import { SessionID } from "@/session/schema"
+import { PartID, SessionID } from "@/session/schema"
 import { Log } from "@/util"
 import semver from "semver"
 import {
@@ -97,6 +97,11 @@ export namespace SessionAgencySwarm {
     started: boolean
     running: boolean
     done: boolean
+  }
+
+  type ToolOutput = {
+    output: string
+    attachments?: MessageV2.FilePart[]
   }
 
   export function optionsFromProvider(provider: Provider.Info | undefined): RuntimeOptions {
@@ -792,12 +797,45 @@ export namespace SessionAgencySwarm {
       return stringifyToolOutput(asRecord(item["input"]) ?? asRecord(item["action"]) ?? {})
     }
 
-    const toolOutput = (itemType: string, item: Record<string, unknown> | undefined) => {
-      if (!item) return ""
-      if (item["output"] !== undefined) return stringifyToolOutput(item["output"])
-      if (itemType === "file_search_call") return stringifyToolOutput(item["results"] ?? item)
-      if (itemType === "mcp_call") return stringifyToolOutput(item["result"] ?? item)
-      return stringifyToolOutput(item)
+    const toolOutput = (callID: string, itemType: string, item: Record<string, unknown> | undefined) => {
+      if (!item) return { output: "" }
+      if (itemType === "image_generation_call") {
+        const result = asString(item["result"])
+        if (result) {
+          const format = imageGenerationFormat(item)
+          return {
+            output: "Generated image attached.",
+            attachments: [
+              {
+                id: PartID.ascending(),
+                sessionID: input.sessionID,
+                messageID: input.assistantMessage.id,
+                type: "file" as const,
+                mime: `image/${format.mime}`,
+                filename: `image-generation-${callID}.${format.extension}`,
+                url: `data:image/${format.mime};base64,${result}`,
+              },
+            ],
+          }
+        }
+      }
+      if (item["output"] !== undefined) return { output: stringifyToolOutput(item["output"]) }
+      if (itemType === "file_search_call") return { output: stringifyToolOutput(item["results"] ?? item) }
+      if (itemType === "mcp_call") return { output: stringifyToolOutput(item["result"] ?? item) }
+      return { output: stringifyToolOutput(item) }
+    }
+
+    const imageGenerationFormat = (item: Record<string, unknown>) => {
+      const value = asString(item["output_format"]) ?? asString(item["format"])
+      switch (value?.toLowerCase()) {
+        case "jpeg":
+        case "jpg":
+          return { mime: "jpeg", extension: "jpg" }
+        case "webp":
+          return { mime: "webp", extension: "webp" }
+        default:
+          return { mime: "png", extension: "png" }
+      }
     }
 
     const isToolOutputItem = (itemType: string) => itemType.endsWith("_output") || isAgencyToolOutputType(itemType)
@@ -1140,7 +1178,7 @@ export namespace SessionAgencySwarm {
     const completeTool = (
       callID: string,
       toolName: string,
-      output: string,
+      output: string | ToolOutput,
       meta: AgencySwarmEventMeta,
       extra?: Record<string, unknown>,
     ) => {
@@ -1150,17 +1188,19 @@ export namespace SessionAgencySwarm {
         return parts
       }
       tool.done = true
+      const result = typeof output === "string" ? { output } : output
       parts.push({
         type: "tool-result",
         toolCallId: callID,
         input: parseToolInput(tool.raw),
         output: {
-          output,
+          output: result.output,
           title: "",
           metadata: mergeMeta(meta, {
             call_id: callID,
             ...(extra ?? {}),
           }),
+          attachments: result.attachments,
         },
       })
       return parts
@@ -1254,6 +1294,20 @@ export namespace SessionAgencySwarm {
         yield* completeTool(output.callID, tool.tool, output.output, output.metadata, { item_type: output.itemType })
       }
 
+      for (const image of extractImageGenerationCallsFromMessages(newMessages)) {
+        const tool = ensureTool(image.callID, toolNameFor(image.callID))
+        yield* completeTool(
+          image.callID,
+          tool.tool,
+          toolOutput(image.callID, "image_generation_call", image.item),
+          image.metadata,
+          {
+            item_type: "image_generation_call",
+            source: "messages",
+          },
+        )
+      }
+
       for (const raw of newMessages) {
         const message = asRecord(raw)
         if (!message || asString(message["type"]) !== "message") continue
@@ -1269,6 +1323,29 @@ export namespace SessionAgencySwarm {
           ...agentUpdatedHandoffMetadata(messageMeta.agent),
         })
       }
+    }
+
+    const extractImageGenerationCallsFromMessages = (newMessages: unknown[]) => {
+      const images: Array<{
+        callID: string
+        item: Record<string, unknown>
+        metadata: AgencySwarmEventMeta
+      }> = []
+      for (const raw of newMessages) {
+        const message = asRecord(raw)
+        if (!message) continue
+        if (asString(message["type"]) !== "image_generation_call") continue
+        if (!asString(message["result"])) continue
+        const callID = asString(message["call_id"]) || asString(message["id"])
+        if (!callID) continue
+        const messageMetadata = asRecord(message["metadata"])
+        images.push({
+          callID,
+          item: message,
+          metadata: extractEventMeta(messageMetadata ? { ...messageMetadata, ...message } : message),
+        })
+      }
+      return images
     }
 
     const handleOutputItemAdded = (
@@ -1324,7 +1401,7 @@ export namespace SessionAgencySwarm {
         return completeTool(
           callID,
           tool.tool,
-          toolOutput(itemType, item),
+          toolOutput(callID, itemType, item),
           eventMeta,
           outputMeta(outputIndex, {
             item_id: itemID,
@@ -1373,7 +1450,7 @@ export namespace SessionAgencySwarm {
         return completeTool(
           callID,
           tool.tool,
-          toolOutput(itemType, item),
+          toolOutput(callID, itemType, item),
           eventMeta,
           outputMeta(outputIndex, { item_type: itemType }),
         )
@@ -1397,7 +1474,7 @@ export namespace SessionAgencySwarm {
         if (itemType === "function_call") {
           return parts
         }
-        return [...parts, ...completeTool(callID, toolName, toolOutput(itemType, item), eventMeta, metadata)]
+        return [...parts, ...completeTool(callID, toolName, toolOutput(callID, itemType, item), eventMeta, metadata)]
       }
 
       return []
@@ -1437,11 +1514,20 @@ export namespace SessionAgencySwarm {
         if (!callID) return []
         const tool = ensureTool(callID, toolNameFor(callID))
         const output = item?.["output"] ?? rawItem["output"]
-        if (output === undefined) return []
-        return completeTool(callID, tool.tool, stringifyToolOutput(output), eventMeta, {
-          item_type: itemType || undefined,
-          source: "run_item_stream_event",
-        })
+        if (output === undefined && !(itemType === "image_generation_call" && rawItem["result"] !== undefined))
+          return []
+        return completeTool(
+          callID,
+          tool.tool,
+          itemType === "image_generation_call" && rawItem["result"] !== undefined
+            ? toolOutput(callID, itemType, rawItem)
+            : stringifyToolOutput(output),
+          eventMeta,
+          {
+            item_type: itemType || undefined,
+            source: "run_item_stream_event",
+          },
+        )
       }
 
       if (name === "message_output_created" && itemType === "message") {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -2960,6 +2960,98 @@ describe("session.agency-swarm", () => {
     expect(types.at(-2)).toBe("finish-step")
   })
 
+  test("stream maps OpenAI image generation calls to image attachments", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: {
+              type: "image_generation_call",
+              id: "ig_1",
+              status: "in_progress",
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "1",
+            item: {
+              type: "image_generation_call",
+              id: "ig_1",
+              status: "completed",
+              result: "aW1hZ2U=",
+              output_format: "png",
+            },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: any[] = []
+    for await (const event of stream.fullStream) {
+      events.push(event)
+    }
+
+    const result = events.find((event) => event.type === "tool-result")
+    expect(result?.output?.output).toBe("Generated image attached.")
+    expect(result?.output?.attachments?.[0]).toMatchObject({
+      type: "file",
+      mime: "image/png",
+      filename: "image-generation-ig_1.png",
+      url: "data:image/png;base64,aW1hZ2U=",
+    })
+  })
+
+  test("stream maps message-frame image generation calls to image attachments", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "messages",
+        payload: {
+          new_messages: [
+            {
+              type: "image_generation_call",
+              id: "ig_messages",
+              status: "completed",
+              result: "aW1hZ2U=",
+              output_format: "webp",
+            },
+          ],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: any[] = []
+    for await (const event of stream.fullStream) {
+      events.push(event)
+    }
+
+    const result = events.find((event) => event.type === "tool-result")
+    expect(result?.output?.output).toBe("Generated image attached.")
+    expect(result?.output?.attachments?.[0]).toMatchObject({
+      type: "file",
+      mime: "image/webp",
+      filename: "image-generation-ig_messages.webp",
+      url: "data:image/webp;base64,aW1hZ2U=",
+    })
+  })
+
   test("stream skips stale configured recipient agent based on live metadata", async () => {
     mockHistory()
     let sentRecipient: string | undefined


### PR DESCRIPTION
### Issue for this PR

N/A - feature follow-up chained after #211.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Renders OpenAI Agents SDK `image_generation_call` results from Agency Swarm runs as image attachments instead of showing the base64 result in tool output text.

The mapping handles both raw Responses stream events and final `messages` frames, so hosted image generation results attach as data-url image files whether the bridge forwards incremental events or final message items.

### How did you verify your code works?

- `bun x prettier --write FORK_CHANGELOG.md USER_FLOWS.md packages/opencode/src/session/agency-swarm.ts packages/opencode/test/session/agency-swarm.test.ts`
- `cd packages/opencode && bun test --timeout 30000 ./test/session/agency-swarm.test.ts` — 107 pass
- `cd packages/opencode && bun typecheck`
- `bun turbo test:ci`
- `git diff --check`
- local Codex review reported no actionable correctness issues after the messages-frame fix
- push hook ran `bun turbo typecheck` — 13 successful tasks

### Screenshots / recordings

N/A. This changes stream-to-message attachment mapping, not TUI layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
