### PR TITLE
fix(launcher): avoid deleting resolved uv during venv rebuild

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -727,7 +727,7 @@ async function ensureProjectPython(directory: string) {
   const rebuildCmd = corruptedVenv ? [detected.executable] : detected.cmd
   prompts.log.info(`Detected Python: ${formatPython(detected, rebuildCmd)}`)
 
-  const uv = corruptedVenv ? await findUv() : undefined
+  const uv = corruptedVenv ? await findUv({ excludeUnder: venvDir }) : undefined
   if (corruptedVenv) {
     prompts.log.warn("Project `.venv` is incomplete or corrupted. Rebuilding...")
     await rm(venvDir, { recursive: true, force: true })
@@ -1243,16 +1243,46 @@ function isPythonTracebackFinalExceptionLine(line: string) {
   return /^[A-Za-z_][\w.]*:(?:\s|$)/.test(line.trimEnd())
 }
 
-async function findUv(): Promise<UvInfo> {
-  const result = await runCommand(["uv", "--version"])
-  if (result.code !== 0) {
-    throw new Error(
-      "uv was not found. Install uv and rerun `npx @vrsen/agentswarm`; the launcher does not bootstrap uv with pip.",
-    )
+async function findUv(options?: { excludeUnder?: string }): Promise<UvInfo> {
+  if (!options?.excludeUnder) {
+    const result = await runCommand(["uv", "--version"])
+    if (result.code !== 0) {
+      throw new Error(
+        "uv was not found. Install uv and rerun `npx @vrsen/agentswarm`; the launcher does not bootstrap uv with pip.",
+      )
+    }
+    return {
+      cmd: ["uv"],
+    }
   }
-  return {
-    cmd: ["uv"],
+
+  const env = stripVenvFromEnv(process.env, options.excludeUnder)
+  const pathKey = process.platform === "win32" ? "Path" : "PATH"
+  const rawPath = env[pathKey] ?? env.PATH ?? ""
+  const sep = process.platform === "win32" ? ";" : ":"
+  const names = process.platform === "win32" ? ["uv.exe", "uv.cmd", "uv.bat", "uv"] : ["uv"]
+  for (const dir of rawPath.split(sep)) {
+    if (!dir) continue
+    for (const name of names) {
+      const candidate = path.join(dir, name)
+      if (!existsSync(candidate)) continue
+      const result = await runCommand([candidate, "--version"], { env })
+      if (result.code === 0) {
+        return {
+          cmd: [candidate],
+        }
+      }
+    }
   }
+  const result = await runCommand(["uv", "--version"], { env })
+  if (result.code === 0) {
+    return {
+      cmd: ["uv"],
+    }
+  }
+  throw new Error(
+    "uv was not found. Install uv and rerun `npx @vrsen/agentswarm`; the launcher does not bootstrap uv with pip.",
+  )
 }
 
 function isUvLaunchFailure(output: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #213

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the launcher rebuilds a corrupted project `.venv`, it resolves `uv` outside that `.venv` and reuses that executable for the rebuild.

This prevents the self-heal path from selecting `.venv/bin/uv`, deleting `.venv`, and then losing the `uv` command it was about to run.

### How did you verify your code works?

- Built a local packaged `agentswarm` binary from this branch with `bun run --cwd packages/opencode build --single --skip-install --skip-embed-web-ui`.
- Ran that binary against a throwaway Agency project copied from `agency-swarm/examples/interactive/tui.py` with a deliberately corrupted `.venv`: broken `.venv/bin/python`, stale `.venv/bin/uv` first in `PATH`, and stale site-packages content.
- Confirmed the launcher selected the detected project, rebuilt `.venv`, installed `agency-swarm==1.9.8`, printed `Python environment ready`, started the local FastAPI bridge, and opened the TUI.
- `bun test ./test/agency-swarm/npx.test.ts` from `packages/opencode`: 65 passed.
- `bun typecheck` from `packages/opencode`: passed.
- `git diff --check`: passed.

### Screenshots / recordings

Not applicable; this is launcher self-heal behavior. The verification above used the real terminal launcher and TUI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
