### PR TITLE
fix(launcher): clarify agency startup failures

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -646,6 +646,7 @@ export async function prepareProjectLaunch(project: AgencyProject): Promise<Prep
   const python = await ensureProjectPython(project.directory)
   if (!python) return
 
+  prompts.log.info("Starting your agency project.")
   const server = await startProjectServer(project.directory, python)
   return {
     directory: project.directory,
@@ -699,7 +700,7 @@ async function ensureProjectPython(directory: string) {
           canary = { healthy: false, stderr: "", timedOut: false }
         }
         if (canary.healthy) {
-          prompts.log.success("Python environment ready")
+          prompts.log.success("Agency Swarm packages ready")
           return [venvPython]
         }
         if (canary.timedOut) {
@@ -795,7 +796,7 @@ async function ensureProjectPython(directory: string) {
       await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr, install.logFile),
     )
   }
-  prompts.log.success("Python environment ready")
+  prompts.log.success("Agency Swarm packages ready")
   return [venvPython]
 }
 
@@ -1099,6 +1100,7 @@ async function startProjectServer(directory: string, python: string[]) {
     await waitForServer({
       baseURL: `http://127.0.0.1:${port}`,
       child,
+      directory,
       stderr,
     })
   } catch (error) {
@@ -1115,6 +1117,7 @@ async function startProjectServer(directory: string, python: string[]) {
 async function waitForServer(input: {
   baseURL: string
   child: ReturnType<typeof Bun.spawn>
+  directory: string
   stderr: ServerStderrCollector
 }) {
   const deadline = Date.now() + SERVER_START_TIMEOUT_MS
@@ -1123,12 +1126,7 @@ async function waitForServer(input: {
     const exited = await Promise.race([input.child.exited.then((code: number) => code), sleep(200).then(() => null)])
     if (typeof exited === "number") {
       const stderr = await input.stderr.read(SERVER_STDERR_COLLECT_TIMEOUT_MS)
-      const summary = summarizeBridgeStderr(stderr)
-      throw new Error(
-        summary
-          ? `Agency Swarm server exited with code ${exited}: ${summary}`
-          : `Agency Swarm server exited with code ${exited}`,
-      )
+      throw new Error(formatAgencyServerExitFailure(exited, stderr, input.directory))
     }
 
     try {
@@ -1150,6 +1148,42 @@ async function waitForServer(input: {
         ? `Timed out waiting for the Agency Swarm server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}. Bridge output only contained non-fatal startup warnings: ${warningSummary}`
         : `Timed out waiting for the Agency Swarm server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}`,
   )
+}
+
+function formatAgencyServerExitFailure(exited: number, stderr: string, directory: string) {
+  const projectFailure = formatAgencyProjectStartupFailure(stderr, directory)
+  if (projectFailure) return projectFailure
+  const summary = summarizeBridgeStderr(stderr)
+  return summary
+    ? `Agency Swarm server exited with code ${exited}: ${summary}`
+    : `Agency Swarm server exited with code ${exited}`
+}
+
+function formatAgencyProjectStartupFailure(stderr: string, directory: string) {
+  const exception = summarizePythonTraceback(stderr)
+  if (!exception) return
+  const frame = findAgencyPyFrame(stderr, directory)
+  const importFailure = /^(?:[\w.]+\.)?(?:ImportError|ModuleNotFoundError):/.test(exception)
+  const title = importFailure ? "Your agency project could not load." : "Your agency project failed to start."
+  const location = frame ? `\nAt: agency.py:${frame.line}${frame.source ? `\n${frame.source}` : ""}` : ""
+  const recovery = importFailure
+    ? "Fix the missing import or dependency in this project, then run agentswarm again."
+    : "Fix the error above, then run agentswarm again."
+  return `${title}\n${exception}${location}\n${recovery}`
+}
+
+function findAgencyPyFrame(stderr: string, directory: string) {
+  const lines = stderr.split(/\r?\n/)
+  const agencyFile = path.resolve(directory, "agency.py")
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const match = lines[index]?.match(/^\s*File "([^"]*agency\.py)", line (\d+),/)
+    if (!match) continue
+    if (path.resolve(match[1] ?? "") !== agencyFile) continue
+    return {
+      line: match[2] ?? "?",
+      source: lines[index + 1]?.trim(),
+    }
+  }
 }
 
 function createServerStderrCollector(

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1879,6 +1879,90 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
+  test("prepareProjectLaunch explains agency.py import failures after packages are ready", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const success = spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+    const traceback = [
+      "Traceback (most recent call last):",
+      '  File "/tmp/agentswarm-npx-test/launch_agency.py", line 1, in <module>',
+      "    from agency import create_agency",
+      `  File "${path.join(dir.path, "agency.py")}", line 2, in <module>`,
+      "    import codex_missing_import_for_canary_test",
+      '  File "/site-packages/not_the_project/agency.py", line 99, in helper',
+      "    raise ModuleNotFoundError(\"No module named 'codex_missing_import_for_canary_test'\")",
+      "ModuleNotFoundError: No module named 'codex_missing_import_for_canary_test'",
+    ].join("\n")
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        return {
+          exited: Promise.resolve(1),
+          stderr: traceback,
+          kill() {},
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const outcome = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    }).catch((error) => error)
+
+    expect(outcome).toBeInstanceOf(Error)
+    if (!(outcome instanceof Error)) throw new Error("Expected prepareProjectLaunch to fail")
+    expect(outcome.message).toContain("Your agency project could not load.")
+    expect(outcome.message).toContain("ModuleNotFoundError: No module named 'codex_missing_import_for_canary_test'")
+    expect(outcome.message).toContain("At: agency.py:2")
+    expect(outcome.message).not.toContain("agency.py:99")
+    expect(outcome.message).toContain("import codex_missing_import_for_canary_test")
+    expect(outcome.message).toContain(
+      "Fix the missing import or dependency in this project, then run agentswarm again.",
+    )
+    expect(outcome.message).not.toContain("Agency Swarm server exited with code 1")
+    expect(success).toHaveBeenCalledWith("Agency Swarm packages ready")
+    expect(info).toHaveBeenCalledWith("Starting your agency project.")
+  })
+
   test("prepareProjectLaunch times out when the import canary hangs", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)


### PR DESCRIPTION
### Issue for this PR

Closes #217

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Clarifies local project startup failures after the Agency Swarm package import check passes.

The launcher now says `Agency Swarm packages ready`, then `Starting your agency project.` If the local server exits with a Python traceback from the project `agency.py`, it reports the project error directly instead of showing only the generic server-exit wording.

This keeps the current Run-mode failure honest and leaves Builder-based repair as a future explicit recovery flow.

### How did you verify your code works?

- `bun test ./test/agency-swarm/npx.test.ts --timeout 30000` from `packages/opencode` passed: 66 tests.
- `bun typecheck` from `packages/opencode` passed.
- `git diff --check` passed.
- `OPENCODE_VERSION=1.4.32 bun run build --single --skip-embed-web-ui` from `packages/opencode` passed.
- Built binary was run against a local project with a deliberate missing import in `agency.py`; it printed `Agency Swarm packages ready`, `Starting your agency project.`, and the actionable project error.
- After restoring `agency.py`, the same built binary reached the TUI.
- Local Codex review against `vrsen/dev` returned no actionable correctness issues after the frame-matching fix.

### Screenshots / recordings

Terminal proof was captured locally through the built binary. No screenshot is attached because this is launcher terminal copy before the TUI opens.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
