### PR TITLE
fix(launcher): bootstrap uv inside project venv

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -239,8 +239,8 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
 
 - **Launcher manages Python dependency setup with uv**
   - Intent: keep the project backend package ready for the launcher path without overriding user dependency manifests.
-  - Behavior: the launcher creates `.venv` with uv, re-runs `requirements.txt` or `pyproject.toml` installs with uv when present, and only installs or refreshes `agency-swarm[fastapi,litellm]` when no manifest exists.
-  - Implementation: `installProjectDependencies` and `ensureLatestAgencySwarm` in `packages/opencode/src/agency-swarm/npx.ts`.
+  - Behavior: the launcher creates or repairs `.venv` with Python, installs uv into that project `.venv` with pip, then uses launcher-managed local uv for fast `requirements.txt`, `pyproject.toml`, and fallback `agency-swarm[fastapi,litellm]` installs.
+  - Implementation: `ensureLocalUv`, `installProjectDependencies`, and `ensureLatestAgencySwarm` in `packages/opencode/src/agency-swarm/npx.ts`.
   - Added by: `a77de00c`
 
 - **Run-mode attachments use structured Agency Swarm messages**

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -37,8 +37,9 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
    - If the user chooses connect, build session-scoped Agency provider config for the selected server.
 4. Prepare a local project.
    - Verify Python 3.12+ and `agency_swarm`.
-   - Reuse `.venv`, or repair/create it with uv.
-   - Re-run `requirements.txt` or `pyproject.toml` installs with uv when present; use launcher-managed `agency-swarm[fastapi,litellm]` only when no manifest exists.
+   - Reuse `.venv`, or repair/create it with Python.
+   - Install or repair launcher-managed uv inside `.venv` with pip, then use local uv for fast dependency setup.
+   - Re-run `requirements.txt` or `pyproject.toml` installs with local uv when present; use launcher-managed `agency-swarm[fastapi,litellm]` only when no manifest exists.
    - Start the local FastAPI bridge and point the TUI at `local-agency`.
 5. Recover local project context for resume.
    - Use the fork run-session record when its saved directory still matches the session directory.
@@ -72,8 +73,9 @@ Do not document upstream-only OpenCode behavior here. Generic session navigation
 - Expected path:
   - Offer `Use detected Agency Swarm project` as the first onboarding choice.
   - Reuse a healthy `.venv`.
-  - Re-run `requirements.txt` or `pyproject.toml` installs with uv while respecting pins, without a second unpinned `agency-swarm` upgrade.
-  - Use uv for launcher-managed fallback installs into `.venv`.
+  - Install or repair launcher-managed uv inside `.venv` with Python and pip.
+  - Re-run `requirements.txt` or `pyproject.toml` installs with the local `.venv` uv for speed while respecting pins, without a second unpinned `agency-swarm` upgrade.
+  - Use local `.venv` uv for launcher-managed fallback installs into `.venv`.
   - Rebuild a broken `.venv` when Python 3.12+ is available.
   - Start the local FastAPI bridge and open the TUI in Run mode against `local-agency`.
 - Expected failures:

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -56,10 +56,6 @@ interface DependencyInstallResult extends CommandResult {
   hadManifests: boolean
 }
 
-interface UvInfo {
-  cmd: string[]
-}
-
 interface RunCommandOptions {
   cwd?: string
   env?: NodeJS.ProcessEnv
@@ -683,14 +679,27 @@ async function ensureProjectPython(directory: string) {
       const refreshLogFile = await tryCreateProjectCommandLogFile(directory, "launcher-refresh", "launcher refresh")
       prompts.log.info(
         refreshLogFile
-          ? `Refreshing project dependencies with uv. Streaming output to stderr. Full log: ${refreshLogFile}`
-          : "Refreshing project dependencies with uv. Streaming output to stderr.",
+          ? `Refreshing project dependencies with local uv. Streaming output to stderr. Full log: ${refreshLogFile}`
+          : "Refreshing project dependencies with local uv. Streaming output to stderr.",
       )
-      const refresh = await refreshProjectDependencies(directory, venvPython, {
-        logFile: refreshLogFile,
-        timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
-      })
-      if (refresh.installerFailed) corruptedVenv = true
+      let localUv: string | undefined
+      try {
+        localUv = await ensureLocalUv(directory, venvPython, {
+          logFile: refreshLogFile,
+          timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+        })
+      } catch {
+        prompts.log.warn(
+          "Local uv could not be installed, so dependency refresh was skipped. The current venv package set will be used as-is.",
+        )
+      }
+      if (localUv) {
+        const refresh = await refreshProjectDependencies(directory, venvPython, localUv, {
+          logFile: refreshLogFile,
+          timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+        })
+        if (refresh.installerFailed) corruptedVenv = true
+      }
       if (!corruptedVenv) {
         prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
         let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
@@ -728,7 +737,6 @@ async function ensureProjectPython(directory: string) {
   const rebuildCmd = corruptedVenv ? [detected.executable] : detected.cmd
   prompts.log.info(`Detected Python: ${formatPython(detected, rebuildCmd)}`)
 
-  const uv = corruptedVenv ? await findUv({ excludeUnder: venvDir }) : undefined
   if (corruptedVenv) {
     prompts.log.warn("Project `.venv` is incomplete or corrupted. Rebuilding...")
     await rm(venvDir, { recursive: true, force: true })
@@ -754,10 +762,9 @@ async function ensureProjectPython(directory: string) {
     }
   }
 
-  const rebuildUv = uv ?? (await findUv())
   const spinner = prompts.spinner()
   spinner.start("Creating `.venv`")
-  const created = await runCommand([...rebuildUv.cmd, "venv", "--python", detected.executable, ".venv"], {
+  const created = await runCommand([...rebuildCmd, "-m", "venv", ".venv"], {
     cwd: directory,
   })
   if (created.code !== 0) {
@@ -772,7 +779,12 @@ async function ensureProjectPython(directory: string) {
       ? `Installing project dependencies. Streaming output to stderr. Full log: ${installLogFile}`
       : "Installing project dependencies. Streaming output to stderr.",
   )
-  const install = await installProjectDependencies(directory, venvPython, {
+  const localUv = await ensureLocalUv(directory, venvPython, {
+    forceInstall: true,
+    logFile: installLogFile,
+    timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+  })
+  const install = await installProjectDependencies(directory, venvPython, localUv, {
     logFile: installLogFile,
     timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
   })
@@ -803,16 +815,16 @@ async function ensureProjectPython(directory: string) {
 async function installProjectDependencies(
   directory: string,
   venvPython: string,
+  localUv: string,
   options: {
     logFile?: string
     timeoutMs: number
   },
 ): Promise<DependencyInstallResult> {
-  const uv = await findUv()
   const requirements = path.join(directory, "requirements.txt")
   if (await Filesystem.exists(requirements)) {
     const result = await runCommand(
-      [...uv.cmd, "pip", "install", "--python", venvPython, "--upgrade", "-r", "requirements.txt"],
+      [localUv, "pip", "install", "--python", venvPython, "--upgrade", "-r", "requirements.txt"],
       {
         cwd: directory,
         logFile: options.logFile,
@@ -825,7 +837,7 @@ async function installProjectDependencies(
 
   const pyproject = path.join(directory, "pyproject.toml")
   if (await Filesystem.exists(pyproject)) {
-    const result = await runCommand([...uv.cmd, "pip", "install", "--python", venvPython, "--upgrade", "-e", "."], {
+    const result = await runCommand([localUv, "pip", "install", "--python", venvPython, "--upgrade", "-e", "."], {
       cwd: directory,
       logFile: options.logFile,
       streamOutputToStderr: true,
@@ -835,7 +847,7 @@ async function installProjectDependencies(
   }
 
   const result = await runCommand(
-    [...uv.cmd, "pip", "install", "--python", venvPython, FALLBACK_AGENCY_SWARM_REQUIREMENT],
+    [localUv, "pip", "install", "--python", venvPython, FALLBACK_AGENCY_SWARM_REQUIREMENT],
     {
       logFile: options.logFile,
       streamOutputToStderr: true,
@@ -848,47 +860,37 @@ async function installProjectDependencies(
 async function refreshProjectDependencies(
   directory: string,
   venvPython: string,
+  localUv: string,
   options: {
     logFile?: string
     timeoutMs: number
   },
 ): Promise<{ installerFailed: boolean }> {
-  try {
-    if (!(await hasDependencyManifest(directory))) {
-      return await ensureLatestAgencySwarm(directory, venvPython, options)
-    }
+  if (!(await hasDependencyManifest(directory))) {
+    return await ensureLatestAgencySwarm(directory, venvPython, localUv, options)
+  }
 
-    const result = await installProjectDependencies(directory, venvPython, options)
-    if (result.timedOut) {
-      prompts.log.warn(
-        result.logFile
-          ? `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}. Check the log file at ${result.logFile}.`
-          : `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}.`,
-      )
-      return { installerFailed: false }
-    }
-    if (result.code !== 0) {
-      const summary = summarizeCommandOutput(result)
-      prompts.log.warn(
-        summary
-          ? `Could not refresh project dependencies from the manifest. Installer output: ${summary}.${
-              result.logFile ? ` Check the log file at ${result.logFile}.` : ""
-            } The current venv package set will be used as-is.`
-          : "Could not refresh project dependencies from the manifest. The current venv package set will be used as-is.",
-      )
-      return { installerFailed: isUvLaunchFailure(`${result.stderr}\n${result.stdout}`) }
-    }
-  } catch (error) {
-    if (!isUvUnavailableError(error)) throw error
+  const result = await installProjectDependencies(directory, venvPython, localUv, options)
+  if (result.timedOut) {
     prompts.log.warn(
-      "uv was not found, so project dependency refresh was skipped. The current venv package set will be used as-is.",
+      result.logFile
+        ? `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}. Check the log file at ${result.logFile}.`
+        : `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}.`,
     )
+    return { installerFailed: false }
+  }
+  if (result.code !== 0) {
+    const summary = summarizeCommandOutput(result)
+    prompts.log.warn(
+      summary
+        ? `Could not refresh project dependencies from the manifest. Installer output: ${summary}.${
+            result.logFile ? ` Check the log file at ${result.logFile}.` : ""
+          } The current venv package set will be used as-is.`
+        : "Could not refresh project dependencies from the manifest. The current venv package set will be used as-is.",
+    )
+    return { installerFailed: isUvLaunchFailure(`${result.stderr}\n${result.stdout}`) }
   }
   return { installerFailed: false }
-}
-
-function isUvUnavailableError(error: unknown) {
-  return error instanceof Error && error.message.includes("uv was not found")
 }
 
 async function formatPostInstallCanaryFailure(
@@ -964,15 +966,15 @@ async function venvCanaryPasses(python: string[], options?: { cwd?: string; incl
 async function ensureLatestAgencySwarm(
   directory: string,
   venvPython: string,
+  localUv: string,
   options?: {
     logFile?: string
     timeoutMs?: number
   },
 ): Promise<{ installerFailed: boolean }> {
-  const uv = await findUv()
   try {
     const result = await runCommand(
-      [...uv.cmd, "pip", "install", "--python", venvPython, "--upgrade", "agency-swarm[fastapi,litellm]"],
+      [localUv, "pip", "install", "--python", venvPython, "--upgrade", "agency-swarm[fastapi,litellm]"],
       {
         cwd: directory,
         logFile: options?.logFile,
@@ -1004,6 +1006,51 @@ async function ensureLatestAgencySwarm(
     prompts.log.warn("Could not refresh launcher-managed agency-swarm. The current venv package will be used as-is.")
   }
   return { installerFailed: false }
+}
+
+async function ensureLocalUv(
+  directory: string,
+  venvPython: string,
+  options: {
+    forceInstall?: boolean
+    logFile?: string
+    timeoutMs: number
+  },
+) {
+  const localUv = getVenvUvPath(directory)
+  if (!options.forceInstall && (await localUvWorks(localUv))) return localUv
+
+  const result = await runCommand([venvPython, "-m", "pip", "install", "--upgrade", "uv"], {
+    cwd: directory,
+    logFile: options.logFile,
+    streamOutputToStderr: true,
+    timeoutMs: options.timeoutMs,
+  })
+  if (result.timedOut) {
+    throw new Error(
+      result.logFile
+        ? `Project Python environment setup timed out while installing uv after ${formatInstallDuration(options.timeoutMs)}. Check the log file at ${result.logFile}.`
+        : `Project Python environment setup timed out while installing uv after ${formatInstallDuration(options.timeoutMs)}.`,
+    )
+  }
+  if (result.code !== 0) {
+    throw new Error(formatCommandFailure(result, "Project Python environment setup failed while installing uv"))
+  }
+  try {
+    const verified = await runCommand([localUv, "--version"])
+    if (verified.code === 0) return localUv
+  } catch {}
+
+  throw new Error("Project Python environment setup installed uv, but the local `.venv` uv command is not runnable.")
+}
+
+async function localUvWorks(localUv: string) {
+  try {
+    const result = await runCommand([localUv, "--version"])
+    return result.code === 0
+  } catch {
+    return false
+  }
 }
 
 async function hasDependencyManifest(directory: string) {
@@ -1277,48 +1324,6 @@ function isPythonTracebackFinalExceptionLine(line: string) {
   return /^[A-Za-z_][\w.]*:(?:\s|$)/.test(line.trimEnd())
 }
 
-async function findUv(options?: { excludeUnder?: string }): Promise<UvInfo> {
-  if (!options?.excludeUnder) {
-    const result = await runCommand(["uv", "--version"])
-    if (result.code !== 0) {
-      throw new Error(
-        "uv was not found. Install uv and rerun `npx @vrsen/agentswarm`; the launcher does not bootstrap uv with pip.",
-      )
-    }
-    return {
-      cmd: ["uv"],
-    }
-  }
-
-  const env = stripVenvFromEnv(process.env, options.excludeUnder)
-  const pathKey = process.platform === "win32" ? "Path" : "PATH"
-  const rawPath = env[pathKey] ?? env.PATH ?? ""
-  const sep = process.platform === "win32" ? ";" : ":"
-  const names = process.platform === "win32" ? ["uv.exe", "uv.cmd", "uv.bat", "uv"] : ["uv"]
-  for (const dir of rawPath.split(sep)) {
-    if (!dir) continue
-    for (const name of names) {
-      const candidate = path.join(dir, name)
-      if (!existsSync(candidate)) continue
-      const result = await runCommand([candidate, "--version"], { env })
-      if (result.code === 0) {
-        return {
-          cmd: [candidate],
-        }
-      }
-    }
-  }
-  const result = await runCommand(["uv", "--version"], { env })
-  if (result.code === 0) {
-    return {
-      cmd: ["uv"],
-    }
-  }
-  throw new Error(
-    "uv was not found. Install uv and rerun `npx @vrsen/agentswarm`; the launcher does not bootstrap uv with pip.",
-  )
-}
-
 function isUvLaunchFailure(output: string) {
   return /uv(?:\.exe)?:?\s+(?:command not found|not found|No such file or directory|ENOENT)/i.test(output)
 }
@@ -1439,6 +1444,11 @@ function formatPython(info: PythonInfo | undefined, cmd: string[]) {
 function getVenvPythonPath(directory: string) {
   if (process.platform === "win32") return path.join(directory, ".venv", "Scripts", "python.exe")
   return path.join(directory, ".venv", "bin", "python")
+}
+
+function getVenvUvPath(directory: string) {
+  if (process.platform === "win32") return path.join(directory, ".venv", "Scripts", "uv.exe")
+  return path.join(directory, ".venv", "bin", "uv")
 }
 
 async function getFreePort() {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -235,7 +235,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -261,9 +261,9 @@ describe("agency-swarm npx onboarding", () => {
 
     const installCommand = commands.find(isUvPipInstallCommand)
 
-    expect(commands.filter(isUvVenvCommand)).toEqual([["uv", "venv", "--python", "/usr/bin/python3.12", ".venv"]])
+    expect(commands.filter(isPythonVenvCommand)).toEqual([["python3.12", "-m", "venv", ".venv"]])
     expect(installCommand).toEqual([
-      "uv",
+      getTestVenvUv(dir.path),
       "pip",
       "install",
       "--python",
@@ -272,7 +272,7 @@ describe("agency-swarm npx onboarding", () => {
     ])
   })
 
-  test("prepareProjectLaunch fails clearly when uv is missing", async () => {
+  test("prepareProjectLaunch fails clearly when local uv bootstrap fails", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
 
@@ -293,18 +293,18 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
           stderr: "",
         } as never
       }
-      if (isUvVersionCommand(cmd)) {
+      if (isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(1),
           stdout: "",
-          stderr: "uv: command not found",
+          stderr: "No matching distribution found for uv",
         } as never
       }
       throw new Error(`Unexpected command: ${cmd.join(" ")}`)
@@ -315,9 +315,9 @@ describe("agency-swarm npx onboarding", () => {
         directory: dir.path,
         agencyFile: path.join(dir.path, "agency.py"),
       }),
-    ).rejects.toThrow("uv was not found. Install uv and rerun `npx @vrsen/agentswarm`")
+    ).rejects.toThrow("Project Python environment setup failed while installing uv")
 
-    expect(commands.some((cmd) => cmd[0] === "uv" && isUvPipInstallCommand(cmd))).toBe(false)
+    expect(commands.some(isUvPipInstallCommand)).toBe(false)
   })
 
   test("prepareProjectLaunch installs requirements without a second agency-swarm upgrade", async () => {
@@ -351,7 +351,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -366,6 +366,13 @@ describe("agency-swarm npx onboarding", () => {
         } as never
       }
       if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isUvPipInstallCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -396,7 +403,7 @@ describe("agency-swarm npx onboarding", () => {
     const venvPython = getTestVenvPython(dir.path)
     const uvInstallCommands = commands.filter(isUvPipInstallCommand)
     expect(uvInstallCommands).toEqual([
-      ["uv", "pip", "install", "--python", venvPython, "--upgrade", "-r", "requirements.txt"],
+      [getTestVenvUv(dir.path), "pip", "install", "--python", venvPython, "--upgrade", "-r", "requirements.txt"],
     ])
     expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
 
@@ -434,7 +441,12 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv") || isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+      if (
+        isPythonVenvCommand(cmd) ||
+        isPythonPipInstallUvCommand(cmd) ||
+        isUvPipInstallCommand(cmd) ||
+        isCanaryCommand(cmd)
+      ) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -464,7 +476,7 @@ describe("agency-swarm npx onboarding", () => {
 
     const uvInstallCommands = commands.filter(isUvPipInstallCommand)
     expect(uvInstallCommands).toEqual([
-      ["uv", "pip", "install", "--python", getTestVenvPython(dir.path), "--upgrade", "-e", "."],
+      [getTestVenvUv(dir.path), "pip", "install", "--python", getTestVenvPython(dir.path), "--upgrade", "-e", "."],
     ])
     expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
 
@@ -530,9 +542,18 @@ describe("agency-swarm npx onboarding", () => {
 
     const uvInstallCommands = commands.filter(isUvPipInstallCommand)
     expect(uvInstallCommands).toEqual([
-      ["uv", "pip", "install", "--python", getTestVenvPython(dir.path), "--upgrade", "-r", "requirements.txt"],
+      [
+        getTestVenvUv(dir.path),
+        "pip",
+        "install",
+        "--python",
+        getTestVenvPython(dir.path),
+        "--upgrade",
+        "-r",
+        "requirements.txt",
+      ],
     ])
-    expect(commands.some((cmd) => cmd.includes("venv"))).toBe(false)
+    expect(commands.some(isPythonVenvCommand)).toBe(false)
     expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
     expect(commands.findIndex(isUvPipInstallCommand)).toBeLessThan(commands.findIndex(isCanaryCommand))
 
@@ -598,16 +619,98 @@ describe("agency-swarm npx onboarding", () => {
 
     const uvInstallCommands = commands.filter(isUvPipInstallCommand)
     expect(uvInstallCommands).toEqual([
-      ["uv", "pip", "install", "--python", getTestVenvPython(dir.path), "--upgrade", "-e", "."],
+      [getTestVenvUv(dir.path), "pip", "install", "--python", getTestVenvPython(dir.path), "--upgrade", "-e", "."],
     ])
-    expect(commands.some((cmd) => cmd.includes("venv"))).toBe(false)
+    expect(commands.some(isPythonVenvCommand)).toBe(false)
     expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
     expect(commands.findIndex(isUvPipInstallCommand)).toBeLessThan(commands.findIndex(isCanaryCommand))
 
     await launch?.cleanup?.()
   })
 
-  test("prepareProjectLaunch keeps a healthy existing venv when uv is missing", async () => {
+  test("prepareProjectLaunch bootstraps local uv for a healthy existing venv", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await writeVenvPython(dir.path)
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    const commands: string[][] = []
+    let uvInstalled = false
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(uvInstalled ? 0 : 1),
+          stdout: "",
+          stderr: uvInstalled ? "" : "uv: command not found",
+        } as never
+      }
+      if (isPythonPipInstallUvCommand(cmd)) {
+        uvInstalled = true
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isUvPipInstallCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+    })
+
+    expect(warn).not.toHaveBeenCalled()
+    expect(commands.some(isPythonPipInstallUvCommand)).toBe(true)
+    expect(commands.some(isUvPipInstallCommand)).toBe(true)
+    expect(commands.some(isPythonVenvCommand)).toBe(false)
+    expect(commands.some(isCanaryCommand)).toBe(true)
+
+    await launch?.cleanup?.()
+  })
+
+  test("prepareProjectLaunch continues healthy existing venv launches when local uv bootstrap fails", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
     await writeVenvPython(dir.path)
@@ -626,6 +729,13 @@ describe("agency-swarm npx onboarding", () => {
           exited: Promise.resolve(1),
           stdout: "",
           stderr: "uv: command not found",
+        } as never
+      }
+      if (isPythonPipInstallUvCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "No matching distribution found for uv",
         } as never
       }
       if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
@@ -665,16 +775,17 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(warn).toHaveBeenCalledWith(
-      "uv was not found, so project dependency refresh was skipped. The current venv package set will be used as-is.",
+      "Local uv could not be installed, so dependency refresh was skipped. The current venv package set will be used as-is.",
     )
+    expect(commands.some(isPythonPipInstallUvCommand)).toBe(true)
     expect(commands.some(isUvPipInstallCommand)).toBe(false)
-    expect(commands.some(isUvVenvCommand)).toBe(false)
+    expect(commands.some(isPythonVenvCommand)).toBe(false)
     expect(commands.some(isCanaryCommand)).toBe(true)
 
     await launch?.cleanup?.()
   })
 
-  test("prepareProjectLaunch preserves corrupted existing venv when rebuild needs missing uv", async () => {
+  test("prepareProjectLaunch surfaces local uv bootstrap failure while rebuilding corrupted venv", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
     await writeVenvPython(dir.path)
@@ -688,16 +799,14 @@ describe("agency-swarm npx onboarding", () => {
 
     const commands: string[][] = []
     const replacementPython = process.platform === "win32" ? "C:\\Python312\\python.exe" : "/usr/bin/python3.12"
-    let uvVersionAttempts = 0
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
       if (!cmd) throw new Error("Missing command")
       if (isUvVersionCommand(cmd)) {
-        uvVersionAttempts += 1
         return {
-          exited: Promise.resolve(1),
+          exited: Promise.resolve(0),
           stdout: "",
-          stderr: "uv: command not found",
+          stderr: "",
         } as never
       }
       commands.push(cmd)
@@ -725,6 +834,20 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "ModuleNotFoundError: No module named 'agency_swarm'",
         } as never
       }
+      if (isPythonVenvCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPythonPipInstallUvCommand(cmd)) {
+        return {
+          exited: Promise.resolve(1),
+          stdout: "",
+          stderr: "No matching distribution found for uv",
+        } as never
+      }
       throw new Error(`Unexpected command: ${cmd.join(" ")}`)
     })
 
@@ -733,14 +856,12 @@ describe("agency-swarm npx onboarding", () => {
         directory: dir.path,
         agencyFile: path.join(dir.path, "agency.py"),
       }),
-    ).rejects.toThrow("uv was not found. Install uv and rerun `npx @vrsen/agentswarm`")
+    ).rejects.toThrow("Project Python environment setup failed while installing uv")
 
     expect(confirm).not.toHaveBeenCalled()
-    expect(uvVersionAttempts).toBeGreaterThanOrEqual(2)
-    expect(await Bun.file(getTestVenvPython(dir.path)).exists()).toBe(true)
-    expect(await Bun.file(staleFile).exists()).toBe(true)
-    expect(commands.some(isUvVenvCommand)).toBe(false)
-    expect(commands.some(isUvPipInstallCommand)).toBe(false)
+    expect(await Bun.file(staleFile).exists()).toBe(false)
+    expect(commands.some(isPythonVenvCommand)).toBe(true)
+    expect(commands.some(isUvPipInstallCommand)).toBe(true)
   })
 
   test("prepareProjectLaunch recreates an incomplete `.venv` instead of overlaying it", async () => {
@@ -775,7 +896,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -801,7 +922,7 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(confirm).not.toHaveBeenCalled()
     expect(await Bun.file(staleFile).exists()).toBe(false)
-    expect(commands.filter(isUvVenvCommand)).toEqual([["uv", "venv", "--python", "/usr/bin/python3.12", ".venv"]])
+    expect(commands.filter(isPythonVenvCommand)).toEqual([["/usr/bin/python3.12", "-m", "venv", ".venv"]])
   })
 
   test("prepareProjectLaunch recreates `.venv` when uv cannot refresh launcher-managed dependencies", async () => {
@@ -857,7 +978,7 @@ describe("agency-swarm npx onboarding", () => {
           } as never
         }
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -902,7 +1023,7 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(confirm).not.toHaveBeenCalled()
     expect(await Bun.file(staleFile).exists()).toBe(false)
-    expect(commands.filter(isUvVenvCommand)).toEqual([["uv", "venv", "--python", replacementPython, ".venv"]])
+    expect(commands.filter(isPythonVenvCommand)).toEqual([[replacementPython, "-m", "venv", ".venv"]])
     expect(uvInstallRuns).toBe(2)
     await launch?.cleanup?.()
   })
@@ -970,7 +1091,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: canaryStderr,
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1046,7 +1167,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1084,8 +1205,9 @@ describe("agency-swarm npx onboarding", () => {
       stop() {},
     } as never)
     spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    let timeoutCurrentInstall = false
     spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
-      if (typeof fn === "function") fn()
+      if (timeoutCurrentInstall && typeof fn === "function") fn()
       return 1 as never
     }) as unknown as typeof setTimeout)
     spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined as never)
@@ -1107,7 +1229,15 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonPipInstallUvCommand(cmd)) {
+        timeoutCurrentInstall = false
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPythonVenvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1115,6 +1245,7 @@ describe("agency-swarm npx onboarding", () => {
         } as never
       }
       if (isUvPipInstallCommand(cmd)) {
+        timeoutCurrentInstall = true
         let resolveExit!: (code: number) => void
         const exited = new Promise<number>((resolve) => {
           resolveExit = resolve
@@ -1160,8 +1291,9 @@ describe("agency-swarm npx onboarding", () => {
       stop() {},
     } as never)
     spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    let timeoutCurrentInstall = false
     spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
-      if (typeof fn === "function") fn()
+      if (timeoutCurrentInstall && typeof fn === "function") fn()
       return 1 as never
     }) as unknown as typeof setTimeout)
     spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined as never)
@@ -1183,7 +1315,15 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonPipInstallUvCommand(cmd)) {
+        timeoutCurrentInstall = false
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPythonVenvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1191,6 +1331,7 @@ describe("agency-swarm npx onboarding", () => {
         } as never
       }
       if (isUvPipInstallCommand(cmd)) {
+        timeoutCurrentInstall = true
         let resolveExit!: (code: number) => void
         const stderr = createTextOutputStream("still working...\n")
         return {
@@ -1240,8 +1381,9 @@ describe("agency-swarm npx onboarding", () => {
       stop() {},
     } as never)
     spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    let timeoutCurrentInstall = false
     spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
-      if (typeof fn === "function") fn()
+      if (timeoutCurrentInstall && typeof fn === "function") fn()
       return 1 as never
     }) as unknown as typeof setTimeout)
     spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined as never)
@@ -1263,7 +1405,15 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonPipInstallUvCommand(cmd)) {
+        timeoutCurrentInstall = false
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPythonVenvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1271,6 +1421,7 @@ describe("agency-swarm npx onboarding", () => {
         } as never
       }
       if (isUvPipInstallCommand(cmd)) {
+        timeoutCurrentInstall = true
         let resolveExit!: (code: number) => void
         const stderr = createTextOutputStream("still working...\n")
         return {
@@ -1343,7 +1494,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1447,7 +1598,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "ERROR: No matching distribution found for agency-swarm[fastapi,litellm]",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1483,7 +1634,7 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(info).toHaveBeenCalledWith(
-      expect.stringContaining("Refreshing project dependencies with uv. Streaming output to stderr."),
+      expect.stringContaining("Refreshing project dependencies with local uv. Streaming output to stderr."),
     )
     expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Collecting agency-swarm...\n")
     expect(stderrWrite.mock.calls.map((call) => call[0])).toContain(
@@ -1547,7 +1698,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -2383,7 +2534,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -2461,7 +2612,7 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -2502,8 +2653,9 @@ describe("agency-swarm npx onboarding", () => {
     } as never)
     spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(Date.prototype, "toISOString").mockReturnValue(iso)
+    let timeoutCurrentInstall = false
     spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
-      if (typeof fn === "function") fn()
+      if (timeoutCurrentInstall && typeof fn === "function") fn()
       return 1 as never
     }) as unknown as typeof setTimeout)
     spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined as never)
@@ -2526,7 +2678,15 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (cmd.includes("venv")) {
+      if (isPythonPipInstallUvCommand(cmd)) {
+        timeoutCurrentInstall = false
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (isPythonVenvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -2534,6 +2694,7 @@ describe("agency-swarm npx onboarding", () => {
         } as never
       }
       if (isUvPipInstallCommand(cmd)) {
+        timeoutCurrentInstall = true
         let resolveExit!: (code: number) => void
         const exited = new Promise<number>((resolve) => {
           resolveExit = resolve
@@ -3293,7 +3454,7 @@ function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {
         stderr: canaryStderr,
       } as never
     }
-    if (cmd.includes("venv")) {
+    if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
       return {
         exited: Promise.resolve(0),
         stdout: "",
@@ -3332,6 +3493,15 @@ function getTestVenvPython(directory: string) {
   )
 }
 
+function getTestVenvUv(directory: string) {
+  return path.join(
+    directory,
+    ".venv",
+    process.platform === "win32" ? "Scripts" : "bin",
+    process.platform === "win32" ? "uv.exe" : "uv",
+  )
+}
+
 function createTextOutputStream(initial?: string) {
   let controller!: ReadableStreamDefaultController<Uint8Array>
   const encoder = new TextEncoder()
@@ -3360,15 +3530,24 @@ function createTextOutputStream(initial?: string) {
 }
 
 function isUvPipInstallCommand(cmd: string[]) {
-  return cmd[0] === "uv" && cmd[1] === "pip" && cmd[2] === "install"
+  return isLocalUvCommand(cmd[0]) && cmd[1] === "pip" && cmd[2] === "install"
 }
 
-function isUvVenvCommand(cmd: string[]) {
-  return cmd[0] === "uv" && cmd[1] === "venv"
+function isPythonVenvCommand(cmd: string[]) {
+  return cmd[1] === "-m" && cmd[2] === "venv" && cmd[3] === ".venv"
 }
 
 function isUvVersionCommand(cmd: string[]) {
-  return cmd[0] === "uv" && cmd[1] === "--version"
+  return isLocalUvCommand(cmd[0]) && cmd[1] === "--version"
+}
+
+function isPythonPipInstallUvCommand(cmd: string[]) {
+  return cmd[1] === "-m" && cmd[2] === "pip" && cmd[3] === "install" && cmd[4] === "--upgrade" && cmd[5] === "uv"
+}
+
+function isLocalUvCommand(command: string | undefined) {
+  if (!command) return false
+  return path.basename(command) === (process.platform === "win32" ? "uv.exe" : "uv")
 }
 
 function isReplacementPythonProbe(cmd: string[]) {


### PR DESCRIPTION
### Issue for this PR

Closes #219

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps the Agent Swarm launcher as a one-command setup path.

The launcher now creates or repairs the project `.venv` with Python, installs `uv` into that `.venv` with pip, then uses local `.venv` `uv` for fast dependency installs.

Users no longer need to install `uv` first. Existing healthy `.venv` launches still continue if local `uv` cannot be installed; the launcher skips refresh and runs the canary.

### How did you verify your code works?

- `cd packages/opencode && bun test ./test/agency-swarm/npx.test.ts` — 67 pass, 0 fail
- `cd packages/opencode && bun typecheck`
- `git diff --check`
- Fresh review worker found no issues.
- Pre-push `bun turbo typecheck` passed.

### Screenshots / recordings

N/A. This changes launcher setup behavior, not UI layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
