### PR TITLE
fix(opencode): harden downstream product profile builds

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -16,7 +16,13 @@ await import("./generate.ts")
 
 import { Script } from "@opencode-ai/script"
 import pkg from "../package.json"
-import { createPlatformPackageMetadata, createReleaseVersionValues, resolveBuildVersion } from "./version"
+import {
+  createAgentSwarmPlatformOptionalDependencyTarget,
+  createPlatformPackageMetadata,
+  createReleaseVersionValues,
+  resolveReleaseRepo,
+  resolveBuildVersion,
+} from "./version"
 
 const binary = "agentswarm"
 const scope = pkg.platformScope
@@ -38,7 +44,10 @@ const productDefines = Object.fromEntries(
 )
 const buildVersion = resolveBuildVersion(process.env, Script.version)
 const versionValues = createReleaseVersionValues(buildVersion)
-const userAgentPackage = process.env.AGENTSWARM_PRODUCT_PACKAGE_NAME || "agentswarm-cli"
+const releaseRepo = resolveReleaseRepo(process.env)
+// Product package overrides are for compiled runtime copy and the user agent;
+// generated platform optional-dependency package names stay fixed below.
+const runtimePackageName = process.env.AGENTSWARM_PRODUCT_PACKAGE_NAME || "agentswarm-cli"
 // Load migrations from migration directories
 const migrationDirs = (
   await fs.promises.readdir(path.join(dir, "migration"), {
@@ -192,17 +201,14 @@ if (!skipInstall) {
   await $`bun install --os="*" --cpu="*" @parcel/watcher@${pkg.dependencies["@parcel/watcher"]}`
 }
 for (const item of targets) {
-  const target = [
-    pkg.name,
-    // changing to win32 flags npm for some reason
-    item.os === "win32" ? "windows" : item.os,
-    item.arch,
-    item.avx2 === false ? "baseline" : undefined,
-    item.abi === undefined ? undefined : item.abi,
-  ]
-    .filter(Boolean)
-    .join("-")
-  const name = scope ? `${scope}/${target}` : target
+  const { target, name } = createAgentSwarmPlatformOptionalDependencyTarget({
+    platformScope: scope,
+    os: item.os,
+    arch: item.arch,
+    abi: item.abi,
+    avx2: item.avx2,
+  })
+  const bunTarget = target.replace(pkg.name, "bun")
   console.log(`building ${target}`)
   await $`mkdir -p dist/${target}/bin`
 
@@ -228,9 +234,9 @@ for (const item of targets) {
       autoloadDotenv: false,
       autoloadTsconfig: true,
       autoloadPackageJson: true,
-      target: target.replace(pkg.name, "bun") as any,
+      target: bunTarget as any,
       outfile: `dist/${target}/bin/${binary}`,
-      execArgv: [`--user-agent=${userAgentPackage}/${buildVersion}`, "--use-system-ca", "--"],
+      execArgv: [`--user-agent=${runtimePackageName}/${buildVersion}`, "--use-system-ca", "--"],
       windows: {},
     },
     files: embeddedFileMap ? { "opencode-web-ui.gen.ts": embeddedFileMap } : {},
@@ -283,7 +289,10 @@ if (Script.release) {
       await $`zip -r ../../${key}.zip *`.cwd(`dist/${key}/bin`)
     }
   }
-  await $`gh release upload ${versionValues.releaseTag} ./dist/*.zip ./dist/*.tar.gz --clobber --repo ${process.env.GH_REPO}`
+  if (!releaseRepo) {
+    throw new Error("Release upload requires AGENTSWARM_PRODUCT_RELEASE_REPO or GH_REPO")
+  }
+  await $`gh release upload ${versionValues.releaseTag} ./dist/*.zip ./dist/*.tar.gz --clobber --repo ${releaseRepo}`
 }
 
 export { binaries }

--- a/packages/opencode/script/version.ts
+++ b/packages/opencode/script/version.ts
@@ -14,9 +14,41 @@ export function createPlatformPackageMetadata(input: { name: string; buildVersio
   }
 }
 
+const AGENTSWARM_PLATFORM_OPTIONAL_DEPENDENCY_NAME = "agentswarm-cli"
+
+export function createAgentSwarmPlatformOptionalDependencyTarget(input: {
+  platformScope?: string
+  os: string
+  arch: string
+  abi?: string
+  avx2?: false
+}) {
+  // Keep this independent from AGENTSWARM_PRODUCT_PACKAGE_NAME. The bin wrapper
+  // and postinstall script resolve platform optional dependencies with this base.
+  const target = [
+    AGENTSWARM_PLATFORM_OPTIONAL_DEPENDENCY_NAME,
+    input.os === "win32" ? "windows" : input.os,
+    input.arch,
+    input.avx2 === false ? "baseline" : undefined,
+    input.abi,
+  ]
+    .filter(Boolean)
+    .join("-")
+  return {
+    target,
+    name: input.platformScope ? `${input.platformScope}/${target}` : target,
+  }
+}
+
 export function createReleaseVersionValues(buildVersion: string) {
   return {
     binaryVersion: buildVersion,
     releaseTag: `v${buildVersion}`,
   }
+}
+
+export function resolveReleaseRepo(
+  env: NodeJS.ProcessEnv | { AGENTSWARM_PRODUCT_RELEASE_REPO?: string; GH_REPO?: string },
+) {
+  return env.AGENTSWARM_PRODUCT_RELEASE_REPO || env.GH_REPO
 }

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -381,9 +381,28 @@ export async function detectAgencyProject(
     return {
       directory: dir,
       agencyFile,
-      moduleName: path.basename(entryFile, ".py"),
+      moduleName: agencyEntryModuleName(entryFile),
     } satisfies AgencyProject
   }
+}
+
+function agencyEntryModuleName(entryFile: string) {
+  return entryFile
+    .replace(/\\/g, "/")
+    .replace(/\.py$/, "")
+    .split("/")
+    .filter((part) => part && part !== ".")
+    .join(".")
+}
+
+async function requireDetectedStarterProject(directory: string, profile: Pick<ProductProfile, "agencyEntryFiles">) {
+  const project = await detectAgencyProject(directory, profile)
+  if (!project) {
+    throw new Error(
+      `Starter template did not contain a configured Agency Swarm entry file: ${profile.agencyEntryFiles.join(", ")}`,
+    )
+  }
+  return project
 }
 
 export function formatProjectLabel(
@@ -592,6 +611,8 @@ async function createStarterProject(input: {
   prompts.log.info("2. Create the starter project.")
   prompts.log.info(`   This gives the terminal UI a ready-to-run ${input.profile.name} project to launch.`)
 
+  const starterProfile = input.profile.customStarter ? input.profile : AgencyProduct
+
   if (input.profile.customStarter) {
     const name = input.profile.starterProjectName
     const targetDirectory = path.join(input.baseDirectory, name)
@@ -608,11 +629,7 @@ async function createStarterProject(input: {
       force: true,
     }).catch(() => undefined)
     await runCommand(["git", "init", "-b", "main"], { cwd: targetDirectory })
-    return {
-      directory: targetDirectory,
-      agencyFile: path.join(targetDirectory, input.profile.agencyEntryFiles[0]),
-      moduleName: path.basename(input.profile.agencyEntryFiles[0], ".py"),
-    }
+    return requireDetectedStarterProject(targetDirectory, starterProfile)
   }
 
   const repoName = await prompts.text({
@@ -701,11 +718,7 @@ async function createStarterProject(input: {
     throw error
   }
 
-  return {
-    directory: targetDirectory,
-    agencyFile: path.join(targetDirectory, input.profile.agencyEntryFiles[0]),
-    moduleName: path.basename(input.profile.agencyEntryFiles[0], ".py"),
-  }
+  return requireDetectedStarterProject(targetDirectory, starterProfile)
 }
 
 export async function prepareProjectLaunch(project: AgencyProject): Promise<PreparedNpxLaunch | undefined> {

--- a/packages/opencode/test/agency-swarm/build-version.test.ts
+++ b/packages/opencode/test/agency-swarm/build-version.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { createPlatformPackageMetadata, createReleaseVersionValues, resolveBuildVersion } from "../../script/version"
+import {
+  createAgentSwarmPlatformOptionalDependencyTarget,
+  createPlatformPackageMetadata,
+  createReleaseVersionValues,
+  resolveReleaseRepo,
+  resolveBuildVersion,
+} from "../../script/version"
 
 describe("resolveBuildVersion", () => {
   test("uses the downstream product version when both version env values are set", () => {
@@ -37,10 +43,75 @@ describe("build metadata version wiring", () => {
     })
   })
 
+  test("keeps platform optional-dependency names separate from product package metadata", () => {
+    expect(
+      createPlatformPackageMetadata({
+        name: "@agency-swarm/custom-cli",
+        buildVersion: "2.0.0-downstream",
+        os: "darwin",
+        arch: "arm64",
+      }).name,
+    ).toBe("@agency-swarm/custom-cli")
+
+    expect(
+      createAgentSwarmPlatformOptionalDependencyTarget({
+        platformScope: "@vrsen",
+        os: "darwin",
+        arch: "arm64",
+      }),
+    ).toEqual({
+      target: "agentswarm-cli-darwin-arm64",
+      name: "@vrsen/agentswarm-cli-darwin-arm64",
+    })
+  })
+
+  test("keeps Agent Swarm platform package target names for baseline and musl artifacts", () => {
+    expect(
+      createAgentSwarmPlatformOptionalDependencyTarget({
+        platformScope: "@vrsen",
+        os: "win32",
+        arch: "x64",
+        avx2: false,
+      }),
+    ).toEqual({
+      target: "agentswarm-cli-windows-x64-baseline",
+      name: "@vrsen/agentswarm-cli-windows-x64-baseline",
+    })
+
+    expect(
+      createAgentSwarmPlatformOptionalDependencyTarget({
+        platformScope: "@vrsen",
+        os: "linux",
+        arch: "x64",
+        abi: "musl",
+      }),
+    ).toEqual({
+      target: "agentswarm-cli-linux-x64-musl",
+      name: "@vrsen/agentswarm-cli-linux-x64-musl",
+    })
+  })
+
   test("creates release values from the build version", () => {
     expect(createReleaseVersionValues("2.0.0-downstream")).toEqual({
       binaryVersion: "2.0.0-downstream",
       releaseTag: "v2.0.0-downstream",
     })
+  })
+
+  test("resolves the downstream release repo before the default GitHub repo", () => {
+    expect(
+      resolveReleaseRepo({
+        AGENTSWARM_PRODUCT_RELEASE_REPO: "example/product-cli",
+        GH_REPO: "VRSEN/agentswarm-cli",
+      }),
+    ).toBe("example/product-cli")
+  })
+
+  test("keeps Agent Swarm release repo behavior when no downstream repo is set", () => {
+    expect(resolveReleaseRepo({ GH_REPO: "VRSEN/agentswarm-cli" })).toBe("VRSEN/agentswarm-cli")
+  })
+
+  test("leaves release repo unresolved when release mode has no repo", () => {
+    expect(resolveReleaseRepo({})).toBeUndefined()
   })
 })

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -2910,10 +2910,11 @@ describe("agency-swarm npx onboarding", () => {
     expect(project?.moduleName).toBe("agency")
   })
 
-  test("detectAgencyProject uses configured generic entry files", async () => {
+  test("detectAgencyProject uses configured nested entry files", async () => {
     await using dir = await tmpdir()
+    await mkdir(path.join(dir.path, "src"))
     await Bun.write(
-      path.join(dir.path, "main.py"),
+      path.join(dir.path, "src", "main.py"),
       [
         "from agency_swarm import Agency",
         "",
@@ -2922,11 +2923,14 @@ describe("agency-swarm npx onboarding", () => {
       ].join("\n"),
     )
 
-    const project = await detectAgencyProject(dir.path, downstreamProfile)
+    const project = await detectAgencyProject(dir.path, {
+      ...downstreamProfile,
+      agencyEntryFiles: ["src/main.py"],
+    })
 
     expect(project?.directory).toBe(dir.path)
-    expect(project?.agencyFile).toBe(path.join(dir.path, "main.py"))
-    expect(project?.moduleName).toBe("main")
+    expect(project?.agencyFile).toBe(path.join(dir.path, "src", "main.py"))
+    expect(project?.moduleName).toBe("src.main")
   })
 
   test("detectAgencyProject does not detect swarm.py in the default Agent Swarm profile", async () => {
@@ -3011,6 +3015,164 @@ describe("agency-swarm npx onboarding", () => {
     expect(launch?.runProjectDirectory).toBe(target)
     expect(commands.find((cmd) => cmd[1]?.endsWith("launch_agency.py"))?.at(-1)).toBe("main")
     expect(launch?.configContent).toContain("agency-swarm/default")
+
+    await launch?.cleanup?.()
+  })
+
+  test("prepareNpxLaunch uses the default starter entry for entry-file-only profiles", async () => {
+    await using dir = await tmpdir()
+    const profile = {
+      custom: true,
+      name: "Example Product",
+      customStarter: false,
+      starterTemplateRepo: "agency-ai-solutions/agency-starter-template",
+      starterProjectName: "my-agency",
+      agencyEntryFiles: ["main.py"],
+    }
+    const name = "entry-only-starter"
+    const target = path.join(dir.path, name)
+    const commands: string[][] = []
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+    spyOn(prompts, "outro").mockImplementation(() => undefined as never)
+    spyOn(prompts, "select").mockResolvedValue("starter" as never)
+    spyOn(prompts, "text").mockResolvedValue(name as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+
+      if (cmd[0] === "gh") {
+        return { exited: Promise.resolve(1), stdout: "", stderr: "gh unavailable" } as never
+      }
+
+      if (cmd[0] === "git" && cmd[1] === "clone") {
+        mkdirSync(path.join(target, ".venv", process.platform === "win32" ? "Scripts" : "bin"), { recursive: true })
+        writeFileSync(
+          path.join(target, "agency.py"),
+          "from agency_swarm import Agency\n\ndef create_agency():\n    return Agency()\n",
+        )
+        writeFileSync(getTestVenvPython(target), "")
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (cmd[0] === "git" && cmd[1] === "init") {
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (isUvVersionCommand(cmd)) {
+        return { exited: Promise.resolve(0), stdout: "uv 0.8.0\n", stderr: "" } as never
+      }
+
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return { exited: Promise.resolve(0), stdout: `${cmd[0]}\n3.12.7\n`, stderr: "" } as never
+      }
+
+      if (isPythonPipInstallUvCommand(cmd) || isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareNpxLaunch(dir.path, profile)
+
+    expect(commands).toContainEqual(["git", "clone", "--depth=1", starterTemplateUrl(), target])
+    expect(launch?.runProjectDirectory).toBe(target)
+    expect(commands.find((cmd) => cmd[1]?.endsWith("launch_agency.py"))?.at(-1)).toBe("agency")
+
+    await launch?.cleanup?.()
+  })
+
+  test("prepareNpxLaunch launches the cloned starter entry that exists", async () => {
+    await using dir = await tmpdir()
+    const profile = {
+      ...downstreamProfile,
+      agencyEntryFiles: ["missing.py", "src/main.py"],
+    }
+    const target = path.join(dir.path, profile.starterProjectName)
+    const commands: string[][] = []
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+    spyOn(prompts, "outro").mockImplementation(() => undefined as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      commands.push(cmd)
+
+      if (cmd[0] === "git" && cmd[1] === "clone") {
+        mkdirSync(path.join(target, "src"), { recursive: true })
+        mkdirSync(path.join(target, ".venv", process.platform === "win32" ? "Scripts" : "bin"), { recursive: true })
+        writeFileSync(
+          path.join(target, "src", "main.py"),
+          "from agency_swarm import Agency\n\ndef create_agency():\n    return Agency()\n",
+        )
+        writeFileSync(getTestVenvPython(target), "")
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (cmd[0] === "git" && cmd[1] === "init") {
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (isUvVersionCommand(cmd)) {
+        return { exited: Promise.resolve(0), stdout: "uv 0.8.0\n", stderr: "" } as never
+      }
+
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return { exited: Promise.resolve(0), stdout: `${cmd[0]}\n3.12.7\n`, stderr: "" } as never
+      }
+
+      if (isPythonPipInstallUvCommand(cmd) || isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareNpxLaunch(dir.path, profile)
+
+    expect(commands).toContainEqual(["git", "clone", "--depth=1", starterTemplateUrl(profile), target])
+    expect(launch?.runProjectDirectory).toBe(target)
+    expect(commands.find((cmd) => cmd[1]?.endsWith("launch_agency.py"))?.at(-1)).toBe("src.main")
 
     await launch?.cleanup?.()
   })


### PR DESCRIPTION
## Summary
- keep the generated internal binary path stable as `bin/agentswarm` while allowing downstream product copy and version metadata
- resolve release upload repo from the product profile
- handle nested and fallback starter entry files during npx launch

## Checks
- `bun test test/agency-swarm/build-version.test.ts test/agency-swarm/npx.test.ts test/agency-swarm/product.test.ts --timeout 30000`
- `bun typecheck`
- `bun turbo test:ci`
- `git diff --check`
- OpenSwarm-profile local build and binary smoke: `--version` returned `1.0.1-rc.1`, `--help` showed OpenSwarm copy while the internal binary remained `bin/agentswarm`
- independent Codex review: no findings