### PR TITLE
fix(opencode): honor downstream product wordmark

### DIFF
--- a/packages/opencode/src/agency-swarm/product.ts
+++ b/packages/opencode/src/agency-swarm/product.ts
@@ -13,6 +13,7 @@ declare const AGENTSWARM_PRODUCT_ENTRY_FILES: string | undefined
 export namespace AgencyProduct {
   export interface Profile {
     custom: boolean
+    customBranding: boolean
     customStarter: boolean
     name: string
     cmd: string
@@ -29,6 +30,7 @@ export namespace AgencyProduct {
 
   const defaults: Profile = {
     custom: false,
+    customBranding: false,
     customStarter: false,
     name: "Agent Swarm",
     cmd: "agentswarm",
@@ -102,10 +104,12 @@ export namespace AgencyProduct {
       agencyEntryFiles: readEntryFiles(readValue(env, "AGENTSWARM_PRODUCT_ENTRY_FILES")),
     }
     const custom = Object.values(overrides).some((value) => value !== undefined)
+    const customBranding = overrides.name !== undefined
     const customStarter = overrides.starterTemplateRepo !== undefined || overrides.starterProjectName !== undefined
 
     return {
       custom,
+      customBranding,
       customStarter,
       name: overrides.name ?? defaults.name,
       cmd: overrides.cmd ?? defaults.cmd,
@@ -124,6 +128,7 @@ export namespace AgencyProduct {
   const current = resolve()
 
   export const custom = current.custom
+  export const customBranding = current.customBranding
   export const customStarter = current.customStarter
   export const name = current.name
   export const packageName = current.packageName

--- a/packages/opencode/src/cli/cmd/tui/component/logo.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/logo.tsx
@@ -2,6 +2,7 @@ import { TextAttributes, RGBA } from "@opentui/core"
 import { For, type JSX } from "solid-js"
 import { useTheme, tint } from "@tui/context/theme"
 import { logo, marks } from "@/cli/logo"
+import { AgencyProduct } from "@/agency-swarm/product"
 
 // Shadow markers (rendered chars in parens):
 // _ = full shadow cell (space with bg=shadow)
@@ -9,8 +10,13 @@ import { logo, marks } from "@/cli/logo"
 // ~ = shadow top only (▀ with fg=shadow)
 const SHADOW_MARKER = new RegExp(`[${marks}]`)
 
+export function textLogo(product = AgencyProduct.resolve()) {
+  return product.customBranding ? product.name : undefined
+}
+
 export function Logo() {
   const { theme } = useTheme()
+  const custom = textLogo()
 
   const renderLine = (line: string, fg: RGBA, bold: boolean): JSX.Element[] => {
     const shadow = tint(theme.background, fg, 0.25)
@@ -68,6 +74,16 @@ export function Logo() {
     }
 
     return elements
+  }
+
+  if (custom) {
+    return (
+      <box>
+        <text fg={theme.primary} attributes={TextAttributes.BOLD} selectable={false}>
+          {custom}
+        </text>
+      </box>
+    )
   }
 
   return (

--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -2,6 +2,7 @@ import z from "zod"
 import { EOL } from "os"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { logo as glyphs } from "./logo"
+import { AgencyProduct } from "../agency-swarm/product"
 
 export const CancelledError = NamedError.create("UICancelledError", z.void())
 
@@ -39,7 +40,11 @@ export function empty() {
   blank = true
 }
 
-export function logo(pad?: string) {
+export function logo(pad?: string, product = AgencyProduct.resolve()) {
+  if (product.customBranding) {
+    return [pad, product.name].filter(Boolean).join("")
+  }
+
   if (!process.stdout.isTTY && !process.stderr.isTTY) {
     const result = []
     for (const [index, left] of glyphs.left.entries()) {

--- a/packages/opencode/test/agency-swarm/product.test.ts
+++ b/packages/opencode/test/agency-swarm/product.test.ts
@@ -6,6 +6,7 @@ describe("AgencyProduct profile", () => {
     const profile = AgencyProduct.resolve({})
 
     expect(profile.custom).toBe(false)
+    expect(profile.customBranding).toBe(false)
     expect(profile.name).toBe("Agent Swarm")
     expect(profile.cmd).toBe("agentswarm")
     expect(profile.packageName).toBe("agentswarm-cli")
@@ -35,6 +36,7 @@ describe("AgencyProduct profile", () => {
     })
 
     expect(profile.custom).toBe(true)
+    expect(profile.customBranding).toBe(true)
     expect(profile.customStarter).toBe(true)
     expect(profile.name).toBe("Example Product")
     expect(profile.cmd).toBe("example")
@@ -55,12 +57,24 @@ describe("AgencyProduct profile", () => {
     })
 
     expect(profile.custom).toBe(true)
+    expect(profile.customBranding).toBe(false)
     expect(profile.customStarter).toBe(false)
     expect(profile.name).toBe("Agent Swarm")
     expect(profile.cmd).toBe("agentswarm")
     expect(profile.packageName).toBe("agentswarm-cli")
     expect(profile.launcherPackageName).toBe("@vrsen/agentswarm")
     expect(profile.agencyEntryFiles).toEqual(["main.py"])
+  })
+
+  test("custom command alone does not force text branding", () => {
+    const profile = AgencyProduct.resolve({
+      AGENTSWARM_PRODUCT_COMMAND: "example",
+    })
+
+    expect(profile.custom).toBe(true)
+    expect(profile.customBranding).toBe(false)
+    expect(profile.name).toBe("Agent Swarm")
+    expect(profile.cmd).toBe("example")
   })
 })
 

--- a/packages/opencode/test/cli/branding-help.test.ts
+++ b/packages/opencode/test/cli/branding-help.test.ts
@@ -78,6 +78,29 @@ describe("CLI branding help", () => {
     expect(plain).not.toContain("█▀▀█ █▀▀█ █▀▀█ █▀▀▄")
   })
 
+  test("uses text branding instead of the Agent Swarm wordmark for downstream product profiles", () => {
+    const profile = AgencyProduct.resolve({
+      AGENTSWARM_PRODUCT_DISPLAY_NAME: "Example Product",
+      AGENTSWARM_PRODUCT_COMMAND: "example",
+    })
+    const plain = UI.logo("  ", profile)
+    const row = `${glyphs.left[1]} ${glyphs.right[1]}`.trimEnd()
+
+    expect(plain).toBe("  Example Product")
+    expect(plain).not.toContain(row)
+  })
+
+  test("keeps the Agent Swarm wordmark when only the downstream command is customized", () => {
+    const profile = AgencyProduct.resolve({
+      AGENTSWARM_PRODUCT_COMMAND: "example",
+    })
+    const plain = UI.logo("  ", profile)
+    const row = `${glyphs.left[1]} ${glyphs.right[1]}`.trimEnd()
+
+    expect(plain).toContain(`  ${row}`)
+    expect(plain).not.toBe("  Agent Swarm")
+  })
+
   test("does not invent uninstall commands for unpublished package-manager channels", () => {
     expect(packageManagerUninstallCommand("npm")).toEqual([
       "npm",

--- a/packages/opencode/test/cli/tui/logo.test.tsx
+++ b/packages/opencode/test/cli/tui/logo.test.tsx
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { AgencyProduct } from "../../../src/agency-swarm/product"
+import { textLogo } from "../../../src/cli/cmd/tui/component/logo"
+
+test("keeps the glyph logo for the default Agent Swarm profile", () => {
+  expect(textLogo(AgencyProduct.resolve({}))).toBeUndefined()
+})
+
+test("uses text branding for downstream product profiles", () => {
+  const profile = AgencyProduct.resolve({
+    AGENTSWARM_PRODUCT_DISPLAY_NAME: "Example Product",
+  })
+
+  expect(textLogo(profile)).toBe("Example Product")
+})
+
+test("keeps the glyph logo when only the downstream command is customized", () => {
+  const profile = AgencyProduct.resolve({
+    AGENTSWARM_PRODUCT_COMMAND: "example",
+  })
+
+  expect(textLogo(profile)).toBeUndefined()
+})


### PR DESCRIPTION
### Issue for this PR

Closes #225

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Downstream product builds that set `AGENTSWARM_PRODUCT_DISPLAY_NAME` now render that product name instead of the Agent Swarm wordmark in CLI help and the TUI home logo. The default Agent Swarm profile still uses the existing glyph wordmark, and command-only overrides do not change branding.

### How did you verify your code works?

- `bun test test/agency-swarm/product.test.ts test/cli/branding-help.test.ts test/cli/tui/logo.test.tsx test/agency-swarm/build-version.test.ts test/agency-swarm/npx.test.ts --timeout 30000`
- `bun typecheck`
- `bun turbo test:ci`
- `git diff --check HEAD`
- `codex review --base vrsen/dev -c model="gpt-5.5" -c model_reasoning_effort="high"`
- Built a local OpenSwarm-profile binary with `AGENTSWARM_PRODUCT_DISPLAY_NAME=OpenSwarm`; its `--help` output starts with `OpenSwarm`, and `--version` returns `1.0.1-rc.3`.

### Screenshots / recordings

CLI output was checked locally. No screenshot is attached because this change is covered by text output and TUI logo unit coverage.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
