### PR TITLE
feat: support standalone product Python environments

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -45,6 +45,7 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
   - Behavior: Agent Swarm defaults remain unchanged when no downstream product inputs are set.
   - Behavior: release builds can use `AGENTSWARM_PRODUCT_VERSION` so direct downstream binaries report the downstream package version.
   - Behavior: downstream profiles can set `AGENTSWARM_PRODUCT_SKIP_POST_AUTH_MODEL_SELECTION` to skip the model prompt after auth. `/models` stays available unless `AGENTSWARM_PRODUCT_HIDE_MODEL_SELECTION` explicitly hides it.
+  - Behavior: downstream profiles can set `AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT=standalone` so launcher-created or repaired project `.venv` environments use standalone Python instead of Conda-family Python. The Agent Swarm default remains `any`.
   - Implementation: `AgencyProduct` in `packages/opencode/src/agency-swarm/product.ts`, launcher detection in `packages/opencode/src/agency-swarm/npx.ts`, the FastAPI server launcher module argument, installation distribution metadata, and `packages/opencode/script/build.ts`.
 
 - **One-command launcher npm package**

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -37,7 +37,9 @@ For each failure scenario, capture the visible user result and cite the source p
 - **Happy-path proof:** The launcher detects configured entry files; the default Agent Swarm profile still detects only `agency.py`.
 - **Happy-path proof:** A missing local project creates the configured starter repository in the configured starter folder.
 - **Happy-path proof:** A release-built binary reports `AGENTSWARM_PRODUCT_VERSION` when it is set.
+- **Happy-path proof:** With `AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT=standalone`, launcher setup creates or repairs project `.venv` environments with standalone Python 3.12+ and rebuilds existing Conda-family `.venv` environments.
 - **Failure scenarios to test:** Missing custom product values fall back to Agent Swarm defaults instead of inventing a downstream product.
+- **Failure scenarios to test:** With standalone Python required, a machine without standalone Python 3.12+ fails visibly instead of silently using Conda-family Python.
 - **Owner/source:** `packages/opencode/src/agency-swarm/product.ts`, `packages/opencode/src/agency-swarm/npx.ts`, `packages/opencode/src/agency-swarm/server-launcher.ts`, `packages/opencode/src/installation/distribution.ts`, and `packages/opencode/script/build.ts`.
 
 #### Detected local project, venv, and uv

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -43,6 +43,7 @@ const productEnvNames = [
   "AGENTSWARM_PRODUCT_TUI_LOGO_LEFT",
   "AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT",
   "AGENTSWARM_PRODUCT_WORDMARK_LINES",
+  "AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT",
 ] as const
 const productDefines = Object.fromEntries(
   productEnvNames.map((name) => [name, process.env[name] ? JSON.stringify(process.env[name]) : "undefined"]),

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -100,6 +100,8 @@ const SERVER_STDERR_COLLECT_TIMEOUT_MS = 1000
 const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
 const PROCESS_KILL_GRACE_MS = 5000
 const FALLBACK_AGENCY_SWARM_REQUIREMENT = "agency-swarm[fastapi,litellm]>=1.9.6"
+const CONDA_PATH_COMPONENT =
+  /(?:^|[/\\])(?:anaconda\d*|miniconda\d*|miniforge\d*|mambaforge|micromamba|conda\d*)(?:[/\\]|$)/i
 
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
@@ -1573,9 +1575,7 @@ async function inspectPython(
 }
 
 function isCondaPython(info: PythonInfo) {
-  return [info.executable, info.basePrefix].some((value) =>
-    value ? /(?:^|[/\\])(?:anaconda\d*|miniconda\d*|miniforge\d*|mambaforge|micromamba)(?:[/\\]|$)/i.test(value) : false,
-  )
+  return [info.executable, info.basePrefix].some((value) => (value ? CONDA_PATH_COMPONENT.test(value) : false))
 }
 
 function formatPython(info: PythonInfo | undefined, cmd: string[]) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -3,7 +3,7 @@ import net from "node:net"
 import os from "node:os"
 import path from "node:path"
 import { createWriteStream, existsSync, statSync } from "node:fs"
-import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
 import { AgencySwarmRunSession } from "./run-session"
 import { SERVER_LAUNCHER_SCRIPT } from "./server-launcher"
@@ -12,6 +12,16 @@ import { Filesystem } from "@/util/filesystem"
 import type { Session } from "@/session"
 import { SessionID } from "@/session/schema"
 import { AgencyProduct } from "./product"
+import {
+  collectUnixPythonCandidates,
+  findPythonExecutable,
+  formatPython,
+  inspectPython,
+  isCondaPython,
+  type PythonInfo,
+} from "./python-runtime"
+
+export { collectUnixPythonCandidates }
 
 export const LAUNCHER_ENTRY_ENV = "AGENTSWARM_LAUNCHER"
 export const STARTER_TEMPLATE_REPO = AgencyProduct.starterTemplateRepo
@@ -55,14 +65,6 @@ interface CommandResult {
   logFile?: string
 }
 
-interface PythonInfo {
-  cmd: string[]
-  executable: string
-  version: string
-  basePrefix?: string
-  condaMetadata?: boolean
-}
-
 interface VenvCanaryResult {
   healthy: boolean
   stderr: string
@@ -101,8 +103,6 @@ const SERVER_STDERR_COLLECT_TIMEOUT_MS = 1000
 const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
 const PROCESS_KILL_GRACE_MS = 5000
 const FALLBACK_AGENCY_SWARM_REQUIREMENT = "agency-swarm[fastapi,litellm]>=1.9.6"
-const CONDA_PATH_COMPONENT =
-  /(?:^|[/\\])(?:anaconda\d*|miniconda\d*|miniforge\d*|mambaforge|micromamba|conda\d*)(?:[/\\]|$)/i
 
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
@@ -777,7 +777,7 @@ async function ensureProjectPython(
     // the self-heal path rebuilds instead of the launcher aborting.
     let info: PythonInfo | undefined
     try {
-      info = await inspectPython([venvPython], undefined, {
+      info = await inspectPython(runCommand, [venvPython], undefined, {
         includeBasePrefix: profile.pythonEnvironment === "standalone",
       })
     } catch (error) {
@@ -836,7 +836,11 @@ async function ensureProjectPython(
     corruptedVenv = true
   }
 
-  const detected = await findPythonExecutable(corruptedVenv ? venvDir : undefined, profile.pythonEnvironment)
+  const detected = await findPythonExecutable(
+    runCommand,
+    corruptedVenv ? venvDir : undefined,
+    profile.pythonEnvironment,
+  )
   if (!detected) {
     if (corruptedVenv) {
       throw new Error(
@@ -1462,130 +1466,6 @@ async function hasGitHubTemplateFlow() {
   if (gh.code !== 0) return false
   const auth = await runCommand(["gh", "auth", "status"])
   return auth.code === 0
-}
-
-// Walk $PATH for python3.<minor> binaries before trying unqualified names. Some
-// installers leave `python3` pointed at an older system interpreter while exposing
-// supported versions only through their fully qualified names, such as python3.14.
-// Prefer the oldest supported version when several are installed.
-export async function collectUnixPythonCandidates(): Promise<string[][]> {
-  const found = new Map<string, { minor: number; order: number }>()
-  let order = 0
-  for (const dir of (process.env.PATH ?? "").split(":")) {
-    if (!dir) continue
-    let entries: string[]
-    try {
-      entries = await readdir(dir)
-    } catch {
-      continue
-    }
-    for (const entry of entries) {
-      const match = entry.match(/^python3\.(\d+)$/)
-      if (!match) continue
-      const minor = Number(match[1])
-      if (minor < 12) continue
-      const candidate = path.join(dir, entry)
-      if (!found.has(candidate)) found.set(candidate, { minor, order: order++ })
-    }
-  }
-  const versioned = [...found.entries()]
-    .sort(([, a], [, b]) => a.minor - b.minor || a.order - b.order)
-    .map(([name]) => [name])
-  return [...versioned, ["python3"], ["python"]]
-}
-
-async function findPythonExecutable(excludeUnder?: string, pythonEnvironment: AgencyProduct.PythonEnvironment = "any") {
-  const candidates: string[][] =
-    process.platform === "win32"
-      ? [["py", "-3.13"], ["py", "-3.12"], ["python"], ["python3"]]
-      : await collectUnixPythonCandidates()
-
-  const excludeRoot = excludeUnder ? path.resolve(excludeUnder) : undefined
-  const excludePrefix = excludeRoot ? excludeRoot + path.sep : undefined
-  const spawnEnv = excludeRoot ? stripVenvFromEnv(process.env, excludeRoot) : undefined
-
-  for (const candidate of candidates) {
-    const info = await inspectPython(candidate, spawnEnv, {
-      includeBasePrefix: pythonEnvironment === "standalone",
-    })
-    if (!info) continue
-    if (excludeRoot && excludePrefix) {
-      const resolved = path.resolve(info.executable)
-      if (resolved === excludeRoot || resolved.startsWith(excludePrefix)) continue
-    }
-    const match = info.version.match(/^(\d+)\.(\d+)/)
-    if (!match) continue
-    const major = Number(match[1])
-    const minor = Number(match[2])
-    if (pythonEnvironment === "standalone" && isCondaPython(info)) continue
-    if (major > 3 || (major === 3 && minor >= 12)) return info
-  }
-}
-
-function stripVenvFromEnv(env: NodeJS.ProcessEnv, venvRoot: string): NodeJS.ProcessEnv {
-  const venvBin = path.join(venvRoot, process.platform === "win32" ? "Scripts" : "bin")
-  const venvBinResolved = path.resolve(venvBin)
-  const pathKey = process.platform === "win32" ? "Path" : "PATH"
-  const rawPath = env[pathKey] ?? env.PATH ?? ""
-  const sep = process.platform === "win32" ? ";" : ":"
-  const filtered = rawPath
-    .split(sep)
-    .filter((entry) => {
-      if (!entry) return false
-      try {
-        const resolved = path.resolve(entry)
-        return resolved !== venvBinResolved && !resolved.startsWith(venvBinResolved + path.sep)
-      } catch {
-        return true
-      }
-    })
-    .join(sep)
-  const next = { ...env, [pathKey]: filtered }
-  delete next.VIRTUAL_ENV
-  // macOS's python3 honors __PYVENV_LAUNCHER__ when reporting sys.executable,
-  // so leaving it in would make a healthy system Python lie and report itself
-  // as the broken .venv interpreter, hiding the only valid recovery candidate.
-  delete next.__PYVENV_LAUNCHER__
-  return next
-}
-
-async function inspectPython(
-  cmd: string[],
-  env?: NodeJS.ProcessEnv,
-  options?: { includeBasePrefix?: boolean },
-): Promise<PythonInfo | undefined> {
-  const script = options?.includeBasePrefix
-    ? [
-        "import os, sys",
-        "print(sys.executable)",
-        "print(sys.version.split()[0])",
-        "base_prefix = getattr(sys, 'base_prefix', sys.prefix)",
-        "print(base_prefix)",
-        "prefixes = {sys.prefix, base_prefix}",
-        "print('1' if any(os.path.isdir(os.path.join(prefix, 'conda-meta')) for prefix in prefixes if prefix) else '0')",
-      ].join("; ")
-    : "import sys; print(sys.executable); print(sys.version.split()[0])"
-  const result = await runCommand([...cmd, "-c", script], env ? { env } : undefined)
-  if (result.code !== 0) return
-  const [executable, version, basePrefix, condaMetadata] = result.stdout.trim().split(/\r?\n/)
-  if (!executable || !version) return
-  return {
-    cmd,
-    executable,
-    version,
-    basePrefix,
-    condaMetadata: condaMetadata === "1",
-  }
-}
-
-function isCondaPython(info: PythonInfo) {
-  if (info.condaMetadata) return true
-  return [info.executable, info.basePrefix].some((value) => (value ? CONDA_PATH_COMPONENT.test(value) : false))
-}
-
-function formatPython(info: PythonInfo | undefined, cmd: string[]) {
-  if (!info) return cmd.join(" ")
-  return `${info.executable} (Python ${info.version})`
 }
 
 function getVenvPythonPath(directory: string) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -23,6 +23,7 @@ type ProductProfile = Pick<
   AgencyProduct.Profile,
   "custom" | "name" | "customStarter" | "starterTemplateRepo" | "starterProjectName" | "agencyEntryFiles"
 >
+type LaunchProfile = Pick<AgencyProduct.Profile, "name" | "launcherPackageName" | "pythonEnvironment">
 
 export function starterTemplateUrl(profile: Pick<AgencyProduct.Profile, "starterTemplateRepo"> = AgencyProduct) {
   return `https://github.com/${profile.starterTemplateRepo}.git`
@@ -58,6 +59,7 @@ interface PythonInfo {
   cmd: string[]
   executable: string
   version: string
+  basePrefix?: string
 }
 
 interface VenvCanaryResult {
@@ -423,6 +425,15 @@ export function validateStarterName(base: string, value?: string) {
   if (existsSync(path.join(base, name))) return "A folder with this name already exists"
 }
 
+function launchProfile(profile: ProductProfile): LaunchProfile {
+  const values = profile as ProductProfile & Partial<LaunchProfile>
+  return {
+    name: profile.name,
+    launcherPackageName: values.launcherPackageName ?? AgencyProduct.launcherPackageName,
+    pythonEnvironment: values.pythonEnvironment ?? AgencyProduct.pythonEnvironment,
+  }
+}
+
 export async function prepareNpxLaunch(
   directory: string,
   profile: ProductProfile = AgencyProduct,
@@ -439,7 +450,7 @@ export async function prepareNpxLaunch(
       return
     }
 
-    const launch = await prepareProjectLaunch(targetProject)
+    const launch = await prepareProjectLaunch(targetProject, launchProfile(profile))
     if (!launch) {
       prompts.outro("Cancelled")
       return
@@ -477,7 +488,7 @@ export async function prepareNpxLaunch(
     return
   }
 
-  const launch = await prepareProjectLaunch(targetProject)
+  const launch = await prepareProjectLaunch(targetProject, launchProfile(profile))
   if (!launch) {
     prompts.outro("Cancelled")
     return
@@ -722,13 +733,16 @@ async function createStarterProject(input: {
   return requireDetectedStarterProject(targetDirectory, starterProfile)
 }
 
-export async function prepareProjectLaunch(project: AgencyProject): Promise<PreparedNpxLaunch | undefined> {
-  prompts.log.info(`Starting the ${AgencyProduct.name} project.`)
+export async function prepareProjectLaunch(
+  project: AgencyProject,
+  profile: LaunchProfile = AgencyProduct,
+): Promise<PreparedNpxLaunch | undefined> {
+  prompts.log.info(`Starting the ${profile.name} project.`)
   prompts.log.info(
     "The launcher will reuse a project `.venv`, start a local FastAPI server, and connect the terminal UI to it.",
   )
 
-  const python = await ensureProjectPython(project.directory)
+  const python = await ensureProjectPython(project.directory, profile)
   if (!python) return
 
   prompts.log.info("Starting your agency project.")
@@ -744,7 +758,10 @@ export async function prepareProjectLaunch(project: AgencyProject): Promise<Prep
   }
 }
 
-async function ensureProjectPython(directory: string) {
+async function ensureProjectPython(
+  directory: string,
+  profile: Pick<LaunchProfile, "launcherPackageName" | "pythonEnvironment">,
+) {
   const venvPython = getVenvPythonPath(directory)
   const venvDir = path.resolve(path.join(directory, ".venv"))
   let selfHealing = false
@@ -757,11 +774,16 @@ async function ensureProjectPython(directory: string) {
     // the self-heal path rebuilds instead of the launcher aborting.
     let info: PythonInfo | undefined
     try {
-      info = await inspectPython([venvPython])
+      info = await inspectPython([venvPython], undefined, {
+        includeBasePrefix: profile.pythonEnvironment === "standalone",
+      })
     } catch (error) {
       prompts.log.warn(`Project Python could not be probed: ${error instanceof Error ? error.message : String(error)}`)
     }
     if (!info) {
+      corruptedVenv = true
+    } else if (profile.pythonEnvironment === "standalone" && isCondaPython(info)) {
+      prompts.log.warn("Project `.venv` uses a Conda-family Python. Rebuilding with a standalone Python...")
       corruptedVenv = true
     } else {
       prompts.log.info(`Using project Python: ${formatPython(info, [venvPython])}`)
@@ -811,7 +833,7 @@ async function ensureProjectPython(directory: string) {
     corruptedVenv = true
   }
 
-  const detected = await findPythonExecutable(corruptedVenv ? venvDir : undefined)
+  const detected = await findPythonExecutable(corruptedVenv ? venvDir : undefined, profile.pythonEnvironment)
   if (!detected) {
     if (corruptedVenv) {
       throw new Error(
@@ -819,7 +841,7 @@ async function ensureProjectPython(directory: string) {
       )
     }
     throw new Error(
-      `Python 3.12 or newer was not found. Install Python, then rerun \`npx ${AgencyProduct.launcherPackageName}\`.`,
+      `Python 3.12 or newer was not found. Install Python, then rerun \`npx ${profile.launcherPackageName}\`.`,
     )
   }
   // During self-heal, invoke the resolved interpreter by its absolute path. The alias
@@ -1444,7 +1466,8 @@ async function hasGitHubTemplateFlow() {
 // supported versions only through their fully qualified names, such as python3.14.
 // Prefer the oldest supported version when several are installed.
 export async function collectUnixPythonCandidates(): Promise<string[][]> {
-  const found = new Map<string, number>()
+  const found = new Map<string, { minor: number; order: number }>()
+  let order = 0
   for (const dir of (process.env.PATH ?? "").split(":")) {
     if (!dir) continue
     let entries: string[]
@@ -1458,14 +1481,20 @@ export async function collectUnixPythonCandidates(): Promise<string[][]> {
       if (!match) continue
       const minor = Number(match[1])
       if (minor < 12) continue
-      if (!found.has(entry)) found.set(entry, minor)
+      const candidate = path.join(dir, entry)
+      if (!found.has(candidate)) found.set(candidate, { minor, order: order++ })
     }
   }
-  const versioned = [...found.entries()].sort(([, a], [, b]) => a - b).map(([name]) => [name])
+  const versioned = [...found.entries()]
+    .sort(([, a], [, b]) => a.minor - b.minor || a.order - b.order)
+    .map(([name]) => [name])
   return [...versioned, ["python3"], ["python"]]
 }
 
-async function findPythonExecutable(excludeUnder?: string) {
+async function findPythonExecutable(
+  excludeUnder?: string,
+  pythonEnvironment: AgencyProduct.PythonEnvironment = "any",
+) {
   const candidates: string[][] =
     process.platform === "win32"
       ? [["py", "-3.13"], ["py", "-3.12"], ["python"], ["python3"]]
@@ -1476,7 +1505,9 @@ async function findPythonExecutable(excludeUnder?: string) {
   const spawnEnv = excludeRoot ? stripVenvFromEnv(process.env, excludeRoot) : undefined
 
   for (const candidate of candidates) {
-    const info = await inspectPython(candidate, spawnEnv)
+    const info = await inspectPython(candidate, spawnEnv, {
+      includeBasePrefix: pythonEnvironment === "standalone",
+    })
     if (!info) continue
     if (excludeRoot && excludePrefix) {
       const resolved = path.resolve(info.executable)
@@ -1486,6 +1517,7 @@ async function findPythonExecutable(excludeUnder?: string) {
     if (!match) continue
     const major = Number(match[1])
     const minor = Number(match[2])
+    if (pythonEnvironment === "standalone" && isCondaPython(info)) continue
     if (major > 3 || (major === 3 && minor >= 12)) return info
   }
 }
@@ -1517,19 +1549,33 @@ function stripVenvFromEnv(env: NodeJS.ProcessEnv, venvRoot: string): NodeJS.Proc
   return next
 }
 
-async function inspectPython(cmd: string[], env?: NodeJS.ProcessEnv): Promise<PythonInfo | undefined> {
+async function inspectPython(
+  cmd: string[],
+  env?: NodeJS.ProcessEnv,
+  options?: { includeBasePrefix?: boolean },
+): Promise<PythonInfo | undefined> {
+  const script = options?.includeBasePrefix
+    ? "import sys; print(sys.executable); print(sys.version.split()[0]); print(getattr(sys, 'base_prefix', sys.prefix))"
+    : "import sys; print(sys.executable); print(sys.version.split()[0])"
   const result = await runCommand(
-    [...cmd, "-c", "import sys; print(sys.executable); print(sys.version.split()[0])"],
+    [...cmd, "-c", script],
     env ? { env } : undefined,
   )
   if (result.code !== 0) return
-  const [executable, version] = result.stdout.trim().split(/\r?\n/)
+  const [executable, version, basePrefix] = result.stdout.trim().split(/\r?\n/)
   if (!executable || !version) return
   return {
     cmd,
     executable,
     version,
+    basePrefix,
   }
+}
+
+function isCondaPython(info: PythonInfo) {
+  return [info.executable, info.basePrefix].some((value) =>
+    value ? /(?:^|[/\\])(?:anaconda\d*|miniconda\d*|miniforge\d*|mambaforge|micromamba)(?:[/\\]|$)/i.test(value) : false,
+  )
 }
 
 function formatPython(info: PythonInfo | undefined, cmd: string[]) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -60,6 +60,7 @@ interface PythonInfo {
   executable: string
   version: string
   basePrefix?: string
+  condaMetadata?: boolean
 }
 
 interface VenvCanaryResult {
@@ -1493,10 +1494,7 @@ export async function collectUnixPythonCandidates(): Promise<string[][]> {
   return [...versioned, ["python3"], ["python"]]
 }
 
-async function findPythonExecutable(
-  excludeUnder?: string,
-  pythonEnvironment: AgencyProduct.PythonEnvironment = "any",
-) {
+async function findPythonExecutable(excludeUnder?: string, pythonEnvironment: AgencyProduct.PythonEnvironment = "any") {
   const candidates: string[][] =
     process.platform === "win32"
       ? [["py", "-3.13"], ["py", "-3.12"], ["python"], ["python3"]]
@@ -1557,24 +1555,31 @@ async function inspectPython(
   options?: { includeBasePrefix?: boolean },
 ): Promise<PythonInfo | undefined> {
   const script = options?.includeBasePrefix
-    ? "import sys; print(sys.executable); print(sys.version.split()[0]); print(getattr(sys, 'base_prefix', sys.prefix))"
+    ? [
+        "import os, sys",
+        "print(sys.executable)",
+        "print(sys.version.split()[0])",
+        "base_prefix = getattr(sys, 'base_prefix', sys.prefix)",
+        "print(base_prefix)",
+        "prefixes = {sys.prefix, base_prefix}",
+        "print('1' if any(os.path.isdir(os.path.join(prefix, 'conda-meta')) for prefix in prefixes if prefix) else '0')",
+      ].join("; ")
     : "import sys; print(sys.executable); print(sys.version.split()[0])"
-  const result = await runCommand(
-    [...cmd, "-c", script],
-    env ? { env } : undefined,
-  )
+  const result = await runCommand([...cmd, "-c", script], env ? { env } : undefined)
   if (result.code !== 0) return
-  const [executable, version, basePrefix] = result.stdout.trim().split(/\r?\n/)
+  const [executable, version, basePrefix, condaMetadata] = result.stdout.trim().split(/\r?\n/)
   if (!executable || !version) return
   return {
     cmd,
     executable,
     version,
     basePrefix,
+    condaMetadata: condaMetadata === "1",
   }
 }
 
 function isCondaPython(info: PythonInfo) {
+  if (info.condaMetadata) return true
   return [info.executable, info.basePrefix].some((value) => (value ? CONDA_PATH_COMPONENT.test(value) : false))
 }
 

--- a/packages/opencode/src/agency-swarm/product.ts
+++ b/packages/opencode/src/agency-swarm/product.ts
@@ -14,8 +14,11 @@ declare const AGENTSWARM_PRODUCT_HIDE_MODEL_SELECTION: string | undefined
 declare const AGENTSWARM_PRODUCT_TUI_LOGO_LEFT: string | undefined
 declare const AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: string | undefined
 declare const AGENTSWARM_PRODUCT_WORDMARK_LINES: string | undefined
+declare const AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: string | undefined
 
 export namespace AgencyProduct {
+  export type PythonEnvironment = "any" | "standalone"
+
   export interface Profile {
     custom: boolean
     customBranding: boolean
@@ -36,6 +39,7 @@ export namespace AgencyProduct {
     tuiLogoLeft?: string[]
     tuiLogoRight?: string[]
     wordmarkLines?: string[]
+    pythonEnvironment: PythonEnvironment
   }
 
   const defaults: Profile = {
@@ -55,6 +59,7 @@ export namespace AgencyProduct {
     starterTemplateRepo: "agency-ai-solutions/agency-starter-template",
     starterProjectName: "my-agency",
     agencyEntryFiles: ["agency.py"],
+    pythonEnvironment: "any",
   }
 
   const defineValues = {
@@ -96,6 +101,10 @@ export namespace AgencyProduct {
       typeof AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT === "undefined" ? undefined : AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT,
     AGENTSWARM_PRODUCT_WORDMARK_LINES:
       typeof AGENTSWARM_PRODUCT_WORDMARK_LINES === "undefined" ? undefined : AGENTSWARM_PRODUCT_WORDMARK_LINES,
+    AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT:
+      typeof AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT === "undefined"
+        ? undefined
+        : AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT,
   } satisfies Record<string, string | undefined>
 
   function clean(value: string | undefined) {
@@ -144,6 +153,13 @@ export namespace AgencyProduct {
     return undefined
   }
 
+  function readPythonEnvironment(value: string | undefined): PythonEnvironment | undefined {
+    const normalized = clean(value)?.toLowerCase()
+    if (!normalized) return undefined
+    if (normalized === "any" || normalized === "standalone") return normalized
+    return undefined
+  }
+
   export function resolve(env: Record<string, string | undefined> = process.env): Profile {
     const overrides = {
       name: readValue(env, "AGENTSWARM_PRODUCT_DISPLAY_NAME"),
@@ -162,6 +178,7 @@ export namespace AgencyProduct {
       tuiLogoLeft: readLines(readRawValue(env, "AGENTSWARM_PRODUCT_TUI_LOGO_LEFT")),
       tuiLogoRight: readLines(readRawValue(env, "AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT")),
       wordmarkLines: readLines(readRawValue(env, "AGENTSWARM_PRODUCT_WORDMARK_LINES")),
+      pythonEnvironment: readPythonEnvironment(readValue(env, "AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT")),
     }
     const custom = Object.values(overrides).some((value) => value !== undefined)
     const customBranding =
@@ -191,6 +208,7 @@ export namespace AgencyProduct {
       tuiLogoLeft: overrides.tuiLogoLeft,
       tuiLogoRight: overrides.tuiLogoRight,
       wordmarkLines: overrides.wordmarkLines,
+      pythonEnvironment: overrides.pythonEnvironment ?? defaults.pythonEnvironment,
     }
   }
 
@@ -215,6 +233,7 @@ export namespace AgencyProduct {
   export const tuiLogoLeft = current.tuiLogoLeft
   export const tuiLogoRight = current.tuiLogoRight
   export const wordmarkLines = current.wordmarkLines
+  export const pythonEnvironment = current.pythonEnvironment
   export const connect = "Authenticate providers"
   export const start = [
     "Authenticate providers and connect to a local agency-swarm server before sending prompts.",

--- a/packages/opencode/src/agency-swarm/python-runtime.ts
+++ b/packages/opencode/src/agency-swarm/python-runtime.ts
@@ -1,0 +1,150 @@
+import path from "node:path"
+import { readdir } from "node:fs/promises"
+import type { AgencyProduct } from "./product"
+
+export interface PythonInfo {
+  cmd: string[]
+  executable: string
+  version: string
+  basePrefix?: string
+  condaMetadata?: boolean
+}
+
+export interface PythonCommandResult {
+  code: number
+  stdout: string
+}
+
+export type PythonCommandRunner = (cmd: string[], options?: { env?: NodeJS.ProcessEnv }) => Promise<PythonCommandResult>
+
+const CONDA_PATH_COMPONENT =
+  /(?:^|[/\\])(?:anaconda\d*|miniconda\d*|miniforge\d*|mambaforge|micromamba|conda\d*)(?:[/\\]|$)/i
+
+// Walk $PATH for python3.<minor> binaries before trying unqualified names. Some
+// installers leave `python3` pointed at an older system interpreter while exposing
+// supported versions only through their fully qualified names, such as python3.14.
+// Prefer the oldest supported version when several are installed.
+export async function collectUnixPythonCandidates(): Promise<string[][]> {
+  const found = new Map<string, { minor: number; order: number }>()
+  let order = 0
+  for (const dir of (process.env.PATH ?? "").split(":")) {
+    if (!dir) continue
+    let entries: string[]
+    try {
+      entries = await readdir(dir)
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const match = entry.match(/^python3\.(\d+)$/)
+      if (!match) continue
+      const minor = Number(match[1])
+      if (minor < 12) continue
+      const candidate = path.join(dir, entry)
+      if (!found.has(candidate)) found.set(candidate, { minor, order: order++ })
+    }
+  }
+  const versioned = [...found.entries()]
+    .sort(([, a], [, b]) => a.minor - b.minor || a.order - b.order)
+    .map(([name]) => [name])
+  return [...versioned, ["python3"], ["python"]]
+}
+
+export async function findPythonExecutable(
+  run: PythonCommandRunner,
+  excludeUnder?: string,
+  environment: AgencyProduct.PythonEnvironment = "any",
+) {
+  const candidates: string[][] =
+    process.platform === "win32"
+      ? [["py", "-3.13"], ["py", "-3.12"], ["python"], ["python3"]]
+      : await collectUnixPythonCandidates()
+
+  const root = excludeUnder ? path.resolve(excludeUnder) : undefined
+  const prefix = root ? root + path.sep : undefined
+  const env = root ? stripVenvFromEnv(process.env, root) : undefined
+
+  for (const candidate of candidates) {
+    const info = await inspectPython(run, candidate, env, {
+      includeBasePrefix: environment === "standalone",
+    })
+    if (!info) continue
+    if (root && prefix) {
+      const resolved = path.resolve(info.executable)
+      if (resolved === root || resolved.startsWith(prefix)) continue
+    }
+    const match = info.version.match(/^(\d+)\.(\d+)/)
+    if (!match) continue
+    const major = Number(match[1])
+    const minor = Number(match[2])
+    if (environment === "standalone" && isCondaPython(info)) continue
+    if (major > 3 || (major === 3 && minor >= 12)) return info
+  }
+}
+
+export async function inspectPython(
+  run: PythonCommandRunner,
+  cmd: string[],
+  env?: NodeJS.ProcessEnv,
+  options?: { includeBasePrefix?: boolean },
+): Promise<PythonInfo | undefined> {
+  const script = options?.includeBasePrefix
+    ? [
+        "import os, sys",
+        "print(sys.executable)",
+        "print(sys.version.split()[0])",
+        "base_prefix = getattr(sys, 'base_prefix', sys.prefix)",
+        "print(base_prefix)",
+        "prefixes = {sys.prefix, base_prefix}",
+        "print('1' if any(os.path.isdir(os.path.join(prefix, 'conda-meta')) for prefix in prefixes if prefix) else '0')",
+      ].join("; ")
+    : "import sys; print(sys.executable); print(sys.version.split()[0])"
+  const result = await run([...cmd, "-c", script], env ? { env } : undefined)
+  if (result.code !== 0) return
+  const [executable, version, basePrefix, condaMetadata] = result.stdout.trim().split(/\r?\n/)
+  if (!executable || !version) return
+  return {
+    cmd,
+    executable,
+    version,
+    basePrefix,
+    condaMetadata: condaMetadata === "1",
+  }
+}
+
+export function formatPython(info: PythonInfo | undefined, cmd: string[]) {
+  if (!info) return cmd.join(" ")
+  return `${info.executable} (Python ${info.version})`
+}
+
+export function isCondaPython(info: PythonInfo) {
+  if (info.condaMetadata) return true
+  return info.basePrefix ? CONDA_PATH_COMPONENT.test(info.basePrefix) : false
+}
+
+function stripVenvFromEnv(env: NodeJS.ProcessEnv, root: string): NodeJS.ProcessEnv {
+  const bin = path.join(root, process.platform === "win32" ? "Scripts" : "bin")
+  const resolvedBin = path.resolve(bin)
+  const key = process.platform === "win32" ? "Path" : "PATH"
+  const raw = env[key] ?? env.PATH ?? ""
+  const sep = process.platform === "win32" ? ";" : ":"
+  const filtered = raw
+    .split(sep)
+    .filter((entry) => {
+      if (!entry) return false
+      try {
+        const resolved = path.resolve(entry)
+        return resolved !== resolvedBin && !resolved.startsWith(resolvedBin + path.sep)
+      } catch {
+        return true
+      }
+    })
+    .join(sep)
+  const next = { ...env, [key]: filtered }
+  delete next.VIRTUAL_ENV
+  // macOS's python3 honors __PYVENV_LAUNCHER__ when reporting sys.executable,
+  // so leaving it in would make a healthy system Python lie and report itself
+  // as the broken .venv interpreter, hiding the only valid recovery candidate.
+  delete next.__PYVENV_LAUNCHER__
+  return next
+}

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -974,7 +974,8 @@ describe("agency-swarm npx onboarding", () => {
       pythonEnvironment: "standalone" as const,
     }
     const commands: string[][] = []
-    const replacementPython = process.platform === "win32" ? "C:\\Python312\\python.exe" : "/opt/homebrew/bin/python3.12"
+    const replacementPython =
+      process.platform === "win32" ? "C:\\Python312\\python.exe" : "/opt/homebrew/bin/python3.12"
 
     spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
@@ -1009,7 +1010,12 @@ describe("agency-swarm npx onboarding", () => {
           } as never
         }
       }
-      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd) || isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+      if (
+        isPythonVenvCommand(cmd) ||
+        isPythonPipInstallUvCommand(cmd) ||
+        isUvPipInstallCommand(cmd) ||
+        isCanaryCommand(cmd)
+      ) {
         return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
       }
       if (cmd[1]?.endsWith("launch_agency.py")) {
@@ -1044,7 +1050,7 @@ describe("agency-swarm npx onboarding", () => {
   })
 
   test.skipIf(process.platform === "win32")(
-    "prepareProjectLaunch skips plain Conda candidates for standalone products",
+    "prepareProjectLaunch skips Conda metadata candidates for standalone products",
     async () => {
       await using dir = await tmpdir()
       await using conda = await tmpdir()
@@ -1082,14 +1088,14 @@ describe("agency-swarm npx onboarding", () => {
           if (target === path.join(conda.path, "python3.12")) {
             return {
               exited: Promise.resolve(0),
-              stdout: "/opt/conda/bin/python\n3.12.7\n/opt/conda\n",
+              stdout: "/opt/py312/bin/python\n3.12.7\n/opt/py312\n1\n",
               stderr: "",
             } as never
           }
           if (target === "python3") {
             return {
               exited: Promise.resolve(0),
-              stdout: "/usr/bin/python3.12\n3.12.7\n/usr\n",
+              stdout: "/usr/bin/python3.12\n3.12.7\n/usr\n0\n",
               stderr: "",
             } as never
           }
@@ -1128,6 +1134,9 @@ describe("agency-swarm npx onboarding", () => {
           profile,
         )
 
+        expect(commands.some((cmd) => isPythonProbeCommand(cmd) && (cmd.at(-1) ?? "").includes("conda-meta"))).toBe(
+          true,
+        )
         expect(commands.filter(isPythonVenvCommand)).toEqual([["python3", "-m", "venv", ".venv"]])
 
         await launch?.cleanup?.()

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -997,7 +997,7 @@ describe("agency-swarm npx onboarding", () => {
         if (target.endsWith(process.platform === "win32" ? "\\python.exe" : "/python")) {
           return {
             exited: Promise.resolve(0),
-            stdout: `${target}\n3.12.7\n/opt/anaconda3\n`,
+            stdout: `${target}\n3.12.7\n/opt/conda\n`,
             stderr: "",
           } as never
         }
@@ -1042,6 +1042,100 @@ describe("agency-swarm npx onboarding", () => {
 
     await launch?.cleanup?.()
   })
+
+  test.skipIf(process.platform === "win32")(
+    "prepareProjectLaunch skips plain Conda candidates for standalone products",
+    async () => {
+      await using dir = await tmpdir()
+      await using conda = await tmpdir()
+      await writeAgency(dir.path)
+      await Bun.write(path.join(conda.path, "python3.12"), "")
+
+      const profile = {
+        ...AgencyProduct.resolve({}),
+        name: "Example Product",
+        pythonEnvironment: "standalone" as const,
+      }
+      const commands: string[][] = []
+      const originalPath = process.env.PATH
+
+      process.env.PATH = conda.path
+      spyOn(prompts, "confirm").mockResolvedValue(true as never)
+      spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+      spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+      spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+      spyOn(prompts, "spinner").mockReturnValue({
+        start() {},
+        stop() {},
+      } as never)
+      spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+      spyOn(Bun, "spawn").mockImplementation((options: any) => {
+        const cmd = options?.cmd as string[] | undefined
+        if (!cmd) throw new Error("Missing command")
+        if (isUvVersionCommand(cmd)) {
+          return { exited: Promise.resolve(0), stdout: "uv 0.8.0\n", stderr: "" } as never
+        }
+        commands.push(cmd)
+        if (isPythonProbeCommand(cmd)) {
+          const target = cmd[0] ?? ""
+          if (target === path.join(conda.path, "python3.12")) {
+            return {
+              exited: Promise.resolve(0),
+              stdout: "/opt/conda/bin/python\n3.12.7\n/opt/conda\n",
+              stderr: "",
+            } as never
+          }
+          if (target === "python3") {
+            return {
+              exited: Promise.resolve(0),
+              stdout: "/usr/bin/python3.12\n3.12.7\n/usr\n",
+              stderr: "",
+            } as never
+          }
+        }
+        if (
+          isPythonVenvCommand(cmd) ||
+          isPythonPipInstallUvCommand(cmd) ||
+          isUvPipInstallCommand(cmd) ||
+          isCanaryCommand(cmd)
+        ) {
+          return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+        }
+        if (cmd[1]?.endsWith("launch_agency.py")) {
+          let resolveExit!: (code: number) => void
+          const exited = new Promise<number>((resolve) => {
+            resolveExit = resolve
+          })
+          return {
+            exited,
+            stderr: "",
+            kill() {
+              resolveExit(0)
+            },
+          } as never
+        }
+        throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+      })
+
+      try {
+        const launch = await prepareProjectLaunch(
+          {
+            directory: dir.path,
+            agencyFile: path.join(dir.path, "agency.py"),
+            moduleName: "agency",
+          },
+          profile,
+        )
+
+        expect(commands.filter(isPythonVenvCommand)).toEqual([["python3", "-m", "venv", ".venv"]])
+
+        await launch?.cleanup?.()
+      } finally {
+        process.env.PATH = originalPath
+      }
+    },
+  )
 
   test("prepareProjectLaunch recreates `.venv` when uv cannot refresh launcher-managed dependencies", async () => {
     await using dir = await tmpdir()

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1050,6 +1050,78 @@ describe("agency-swarm npx onboarding", () => {
   })
 
   test.skipIf(process.platform === "win32")(
+    "prepareProjectLaunch keeps standalone venvs when only the project path contains conda",
+    async () => {
+      await using root = await tmpdir()
+      const project = path.join(root.path, "work", "conda", "my-agency")
+      await mkdir(project, { recursive: true })
+      await writeAgency(project)
+      await writeVenvPython(project)
+
+      const profile = {
+        ...AgencyProduct.resolve({}),
+        name: "Example Product",
+        pythonEnvironment: "standalone" as const,
+      }
+      const commands: string[][] = []
+
+      spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+      spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+      spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+      spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+      spyOn(Bun, "spawn").mockImplementation((options: any) => {
+        const cmd = options?.cmd as string[] | undefined
+        if (!cmd) throw new Error("Missing command")
+        if (isUvVersionCommand(cmd)) {
+          return { exited: Promise.resolve(0), stdout: "uv 0.8.0\n", stderr: "" } as never
+        }
+        commands.push(cmd)
+        if (isPythonProbeCommand(cmd)) {
+          const target = cmd[0] ?? ""
+          return {
+            exited: Promise.resolve(0),
+            stdout: `${target}\n3.12.7\n/opt/homebrew/opt/python@3.12\n0\n`,
+            stderr: "",
+          } as never
+        }
+        if (isPythonPipInstallUvCommand(cmd) || isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+          return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+        }
+        if (cmd[1]?.endsWith("launch_agency.py")) {
+          let resolveExit!: (code: number) => void
+          const exited = new Promise<number>((resolve) => {
+            resolveExit = resolve
+          })
+          return {
+            exited,
+            stderr: "",
+            kill() {
+              resolveExit(0)
+            },
+          } as never
+        }
+        throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+      })
+
+      const launch = await prepareProjectLaunch(
+        {
+          directory: project,
+          agencyFile: path.join(project, "agency.py"),
+          moduleName: "agency",
+        },
+        profile,
+      )
+
+      expect(getTestVenvPython(project)).toContain(`${path.sep}conda${path.sep}`)
+      expect(commands.some((cmd) => isPythonProbeCommand(cmd) && (cmd.at(-1) ?? "").includes("conda-meta"))).toBe(true)
+      expect(commands.some(isPythonVenvCommand)).toBe(false)
+
+      await launch?.cleanup?.()
+    },
+  )
+
+  test.skipIf(process.platform === "win32")(
     "prepareProjectLaunch skips Conda metadata candidates for standalone products",
     async () => {
       await using dir = await tmpdir()

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -20,6 +20,7 @@ import {
   summarizeBridgeStderr,
   validateStarterName,
 } from "../../src/agency-swarm/npx"
+import { AgencyProduct } from "../../src/agency-swarm/product"
 import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
@@ -178,8 +179,12 @@ describe("agency-swarm npx onboarding", () => {
       process.env.PATH = [oldDir.path, newDir.path].join(":")
       try {
         const candidates = await collectUnixPythonCandidates()
-        const versioned = candidates.map(([name]) => name).filter((name) => /^python3\.\d+$/.test(name))
-        expect(versioned).toEqual(["python3.12", "python3.14", "python3.99"])
+        const versioned = candidates.map(([name]) => name).filter((name) => /^python3\.\d+$/.test(path.basename(name)))
+        expect(versioned).toEqual([
+          path.join(oldDir.path, "python3.12"),
+          path.join(newDir.path, "python3.14"),
+          path.join(newDir.path, "python3.99"),
+        ])
         expect(candidates.at(-2)).toEqual(["python3"])
         expect(candidates.at(-1)).toEqual(["python"])
       } finally {
@@ -199,7 +204,7 @@ describe("agency-swarm npx onboarding", () => {
       process.env.PATH = dir.path
       try {
         const candidates = await collectUnixPythonCandidates()
-        expect(candidates.map(([name]) => name)).toEqual(["python3.14", "python3", "python"])
+        expect(candidates.map(([name]) => name)).toEqual([path.join(dir.path, "python3.14"), "python3", "python"])
       } finally {
         process.env.PATH = originalPath
       }
@@ -220,8 +225,8 @@ describe("agency-swarm npx onboarding", () => {
       process.env.PATH = dir.path
       try {
         const candidates = await collectUnixPythonCandidates()
-        const versioned = candidates.map(([name]) => name).filter((name) => /^python3\.\d+$/.test(name))
-        expect(versioned).toEqual(["python3.13"])
+        const versioned = candidates.map(([name]) => name).filter((name) => /^python3\.\d+$/.test(path.basename(name)))
+        expect(versioned).toEqual([path.join(dir.path, "python3.13")])
       } finally {
         process.env.PATH = originalPath
       }
@@ -283,7 +288,9 @@ describe("agency-swarm npx onboarding", () => {
 
     const installCommand = commands.find(isUvPipInstallCommand)
 
-    expect(commands.filter(isPythonVenvCommand)).toEqual([["python3.12", "-m", "venv", ".venv"]])
+    const venvCommand = commands.find(isPythonVenvCommand)
+    expect(venvCommand?.slice(1)).toEqual(["-m", "venv", ".venv"])
+    expect(path.basename(venvCommand?.[0] ?? "")).toBe("python3.12")
     expect(installCommand).toEqual([
       getTestVenvUv(dir.path),
       "pip",
@@ -954,6 +961,86 @@ describe("agency-swarm npx onboarding", () => {
     expect(confirm).not.toHaveBeenCalled()
     expect(await Bun.file(staleFile).exists()).toBe(false)
     expect(commands.filter(isPythonVenvCommand)).toEqual([["/usr/bin/python3.12", "-m", "venv", ".venv"]])
+  })
+
+  test("prepareProjectLaunch rebuilds Conda-family venvs for standalone products", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await writeVenvPython(dir.path)
+
+    const profile = {
+      ...AgencyProduct.resolve({}),
+      name: "Example Product",
+      pythonEnvironment: "standalone" as const,
+    }
+    const commands: string[][] = []
+    const replacementPython = process.platform === "win32" ? "C:\\Python312\\python.exe" : "/opt/homebrew/bin/python3.12"
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+    spyOn(prompts, "spinner").mockReturnValue({
+      start() {},
+      stop() {},
+    } as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return { exited: Promise.resolve(0), stdout: "uv 0.8.0\n", stderr: "" } as never
+      }
+      commands.push(cmd)
+      if (isPythonProbeCommand(cmd)) {
+        const target = cmd[0] ?? ""
+        if (target.endsWith(process.platform === "win32" ? "\\python.exe" : "/python")) {
+          return {
+            exited: Promise.resolve(0),
+            stdout: `${target}\n3.12.7\n/opt/anaconda3\n`,
+            stderr: "",
+          } as never
+        }
+        if (isReplacementPythonProbe(cmd)) {
+          return {
+            exited: Promise.resolve(0),
+            stdout: `${replacementPython}\n3.12.7\n/opt/homebrew/opt/python@3.12\n`,
+            stderr: "",
+          } as never
+        }
+      }
+      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd) || isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch(
+      {
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+        moduleName: "agency",
+      },
+      profile,
+    )
+
+    expect(commands.some((cmd) => isPythonProbeCommand(cmd) && (cmd.at(-1) ?? "").includes("base_prefix"))).toBe(true)
+    expect(commands.filter(isPythonVenvCommand)).toEqual([[replacementPython, "-m", "venv", ".venv"]])
+
+    await launch?.cleanup?.()
   })
 
   test("prepareProjectLaunch recreates `.venv` when uv cannot refresh launcher-managed dependencies", async () => {
@@ -3997,7 +4084,13 @@ function isReplacementPythonProbe(cmd: string[]) {
     if (target === "py" && (cmd[1]?.startsWith("-3.") ?? false)) return true
     return target === "python" || target === "python3"
   }
-  return target === "python" || target === "python3" || /^python3\.\d+$/.test(target)
+  const base = path.basename(target)
+  return target === "python" || target === "python3" || /^python3\.\d+$/.test(base)
+}
+
+function isPythonProbeCommand(cmd: string[]) {
+  const script = cmd.at(-1) ?? ""
+  return cmd.includes("-c") && script.includes("print(sys.executable)") && script.includes("sys.version.split")
 }
 
 function isCanaryCommand(cmd: string[]) {

--- a/packages/opencode/test/agency-swarm/product.test.ts
+++ b/packages/opencode/test/agency-swarm/product.test.ts
@@ -25,6 +25,7 @@ describe("AgencyProduct profile", () => {
     expect(profile.tuiLogoLeft).toBeUndefined()
     expect(profile.tuiLogoRight).toBeUndefined()
     expect(profile.wordmarkLines).toBeUndefined()
+    expect(profile.pythonEnvironment).toBe("any")
     expect(AgencyProduct.tuiLogo(profile)).toBeUndefined()
   })
 
@@ -46,6 +47,7 @@ describe("AgencyProduct profile", () => {
       AGENTSWARM_PRODUCT_TUI_LOGO_LEFT: JSON.stringify([" LEFT", "LEFT2"]),
       AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: "RIGHT\\nRIGHT2",
       AGENTSWARM_PRODUCT_WORDMARK_LINES: "WORD\\n MARK",
+      AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: "standalone",
     })
 
     expect(profile.custom).toBe(true)
@@ -69,10 +71,20 @@ describe("AgencyProduct profile", () => {
     expect(profile.tuiLogoLeft).toEqual([" LEFT", "LEFT2"])
     expect(profile.tuiLogoRight).toEqual(["RIGHT", "RIGHT2"])
     expect(profile.wordmarkLines).toEqual(["WORD", " MARK"])
+    expect(profile.pythonEnvironment).toBe("standalone")
     expect(AgencyProduct.tuiLogo(profile)).toEqual({
       left: [" LEFT", "LEFT2"],
       right: ["RIGHT", "RIGHT2"],
     })
+  })
+
+  test("ignores invalid downstream Python environment values", () => {
+    const profile = AgencyProduct.resolve({
+      AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: "conda",
+    })
+
+    expect(profile.custom).toBe(false)
+    expect(profile.pythonEnvironment).toBe("any")
   })
 
   test("custom entry files alone do not force starter creation", () => {


### PR DESCRIPTION
### Issue for this PR

N/A - downstream product environment option.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a downstream product setting for Python environment selection. Products can keep the default behavior, or require a standalone Python runtime. When standalone mode is enabled, launcher setup rejects Conda-family interpreters and rebuilds Conda-backed project `.venv`s with a non-Conda Python.

This is needed by OpenSwarm because its agent set imports native-heavy Python packages. The failing QA run crashed inside an Anaconda Python process after loading mixed native libraries, leaving the TUI unable to reach the local backend.

### How did you verify your code works?

- `bun test test/agency-swarm/product.test.ts test/agency-swarm/npx.test.ts`
- `bun run typecheck`
- pre-push `bun turbo typecheck`
- built local darwin-arm64 binary and verified `--version`
- used by the OpenSwarm local QA build that passed `/agents`, `/models`, live prompt, and handoff follow-up smoke checks

### Screenshots / recordings

N/A.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
