### PR TITLE
fix(opencode): preserve Agent Swarm routing through metadata outage

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -95,14 +95,14 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
 
 - **Persist handed-off agent across turns**
   - Intent: keep Agency Swarm handoff control active until the user changes it.
-  - Behavior: a `transfer_to_*` handoff switches control to the handed-off agent for later turns. This is not delegation; control does not return to the original agent unless the user or swarm changes it.
+  - Behavior: a `transfer_to_*` handoff switches control to the handed-off agent for later turns. This is not delegation; control does not return to the original agent unless the user or swarm changes it. If metadata refresh is unavailable during a later turn, an explicit prompt recipient is still sent best-effort instead of dropping routing.
   - Implementation: `resolveSessionRecipient` in `packages/opencode/src/session/agency-swarm.ts`.
   - Added by: `708545a4`
 
 - **Preserve caller agent during history compaction**
   - Intent: keep agency caller context intact when long sessions are compacted.
-  - Behavior: compaction preserves the caller agent identity needed for later routing and display.
-  - Implementation: `compactHistory` and `extractCallerAgent` in `packages/opencode/src/session/agency-swarm.ts`.
+  - Behavior: compaction preserves the caller agent identity needed for later routing and display. Internal flat Agency metadata is not replayed as AI SDK provider metadata.
+  - Implementation: `compactHistory` and `extractCallerAgent` in `packages/opencode/src/session/agency-swarm.ts`, and Agency metadata replay filtering in `packages/opencode/src/session/message-v2.ts`.
   - Added by: `06ad1be4`
 
 - **Recover loopback history across Agency server URL or port changes**

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -213,14 +213,18 @@ For each failure scenario, capture the visible user result and cite the source p
 - **Happy-path proof:** Attached file and image context stays available across follow-up prompts without requiring reattachment.
 - **Happy-path proof:** Manual history replay may resend inline attachment content or references.
 - **Happy-path proof:** Handoff-selected recipient agents persist across turns.
+- **Happy-path proof:** Explicit current-prompt handoff recipients persist across metadata-refresh outages.
 - **Happy-path proof:** Ordinary `SendMessage` delegation does not change user control.
 - **Happy-path proof:** Caller agent identity survives history compaction.
+- **Happy-path proof:** History compaction ignores internal Agency metadata that is not valid model provider metadata.
 - **Happy-path proof:** Loopback history recovers across local server URL or port changes.
 - **Happy-path proof:** Agency tool-output metadata stays attached to the correct wrapper call.
 - **Failure scenarios to test:** Structured-capability mismatch uses the legacy payload instead of dropping attachments.
 - **Failure scenarios to test:** History compaction does not lose caller agent identity.
+- **Failure scenarios to test:** A metadata outage after an explicit current-prompt handoff recipient does not drop the next prompt back to the coordinator.
+- **Failure scenarios to test:** Flat Agency metadata on text, reasoning, or tool parts does not break compaction.
 - **Failure scenarios to test:** Local loopback URL or port changes do not strand prior history.
-- **Owner/source:** `packages/opencode/src/session/agency-swarm-utils.ts`, `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/agency-swarm/history.ts`.
+- **Owner/source:** `packages/opencode/src/session/agency-swarm-utils.ts`, `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/session/message-v2.ts`, `packages/opencode/src/agency-swarm/history.ts`.
 
 ### Sharing, PR Reopen, And Backend Management
 

--- a/e2e/agent-swarm-tui/metadata-outage-recipient.test.ts
+++ b/e2e/agent-swarm-tui/metadata-outage-recipient.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { startTui, type TuiProcess } from "./harness"
+
+let currentTui: TuiProcess | undefined
+let currentServer: Awaited<ReturnType<typeof startMetadataOutageAgencyServer>> | undefined
+const tuiReadyTimeoutMs = process.env.CI ? 120_000 : 30_000
+const tuiInteractionTimeoutMs = process.env.CI ? 60_000 : 45_000
+
+afterEach(async () => {
+  await currentTui?.close()
+  currentTui = undefined
+  currentServer?.stop()
+  currentServer = undefined
+})
+
+describe("Agent Swarm metadata outage recipient e2e", () => {
+  test("post-handoff prompt keeps recipient when metadata is unavailable", async () => {
+    currentServer = await startMetadataOutageAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "metadata-outage-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+    })
+
+    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    await currentTui.waitFor(
+      () => currentTui!.screen().includes("UserSupportAgent"),
+      "configured recipient",
+      tuiInteractionTimeoutMs,
+    )
+    currentTui.write("please live handoff this calculation\r")
+    await currentTui.waitForText("Live agent update moved control to MathAgent.", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => currentTui!.screen().includes("MathAgent · Agency Swarm"),
+      "live handoff routed prompt",
+      tuiInteractionTimeoutMs,
+    )
+    currentServer.setMetadataAvailable(false)
+
+    currentTui.write("continue after metadata outage\r")
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 2,
+      "post-handoff metadata outage request",
+      tuiInteractionTimeoutMs,
+    )
+
+    const nextBody = currentServer.requests[1]?.body
+    expect(nextBody?.message).toContain("continue after metadata outage")
+    expect(nextBody).toMatchObject({
+      recipient_agent: "MathAgent",
+    })
+  })
+})
+
+async function startMetadataOutageAgencyServer() {
+  const requests: Array<{ path: string; body: Record<string, unknown> }> = []
+  let metadataAvailable = true
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: async (request) => {
+      const url = new URL(request.url)
+      if (url.pathname === "/openapi.json") {
+        return Response.json({
+          openapi: "3.1.0",
+          paths: {
+            "/metadata-outage-agency/get_metadata": { get: {} },
+            "/metadata-outage-agency/get_response_stream": { post: {} },
+            "/metadata-outage-agency/cancel_response_stream": { post: {} },
+          },
+        })
+      }
+      if (url.pathname === "/metadata-outage-agency/get_metadata") {
+        if (!metadataAvailable) return new Response("metadata unavailable", { status: 503 })
+        return Response.json(metadata)
+      }
+      if (url.pathname === "/metadata-outage-agency/get_response_stream") {
+        const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+        requests.push({ path: url.pathname, body })
+        return new Response(stream(body, requests.length), {
+          headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+          },
+        })
+      }
+      if (url.pathname === "/metadata-outage-agency/cancel_response_stream") {
+        return Response.json({ cancelled: true })
+      }
+      return new Response("not found", { status: 404 })
+    },
+  })
+
+  return {
+    baseURL: `http://${server.hostname}:${server.port}`,
+    requests,
+    setMetadataAvailable(available: boolean) {
+      metadataAvailable = available
+    },
+    stop() {
+      server.stop(true)
+    },
+  }
+}
+
+const metadata = {
+  agency_swarm_version: "1.9.6",
+  metadata: {
+    agencyName: "MetadataOutageAgency",
+    agents: ["UserSupportAgent", "MathAgent"],
+    entryPoints: ["UserSupportAgent"],
+  },
+  nodes: [
+    agentNode("UserSupportAgent", true),
+    agentNode("MathAgent", false),
+  ],
+}
+
+function agentNode(id: string, isEntryPoint: boolean) {
+  return {
+    id,
+    type: "agent",
+    data: {
+      label: id,
+      description: `${id} test agent`,
+      isEntryPoint,
+      model: "gpt-5.4-mini",
+    },
+  }
+}
+
+function stream(body: Record<string, unknown>, count: number) {
+  const message = typeof body.message === "string" ? body.message.toLowerCase() : ""
+  if (message.includes("live handoff")) {
+    return sse([
+      ["meta", { run_id: `run_metadata_outage_${count}` }],
+      [
+        "data",
+        {
+          type: "agent_updated_stream_event",
+          agent: "MathAgent",
+          new_agent: {
+            id: "MathAgent",
+            name: "MathAgent",
+          },
+        },
+      ],
+      [
+        "messages",
+        {
+          new_messages: [
+            {
+              id: `msg_live_handoff_${count}`,
+              type: "message",
+              role: "assistant",
+              agent: "MathAgent",
+              content: [{ type: "output_text", text: "Live agent update moved control to MathAgent." }],
+            },
+          ],
+        },
+      ],
+      ["end", {}],
+    ])
+  }
+
+  return sse([
+    ["meta", { run_id: `run_metadata_outage_${count}` }],
+    [
+      "messages",
+      {
+        new_messages: [
+          {
+            id: `msg_metadata_outage_${count}`,
+            type: "message",
+            role: "assistant",
+            agent: body.recipient_agent || "UserSupportAgent",
+            content: [{ type: "output_text", text: "Metadata outage response complete." }],
+          },
+        ],
+      },
+    ],
+    ["end", {}],
+  ])
+}
+
+function sse(events: Array<[event: string, data: Record<string, unknown>]>) {
+  return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("")
+}

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -130,7 +130,8 @@ describe("Agent Swarm terminal TUI e2e", () => {
 
     await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
     currentTui.write("/agents\r")
-    const screen = await currentTui.waitForText("Select swarm", tuiInteractionTimeoutMs)
+    await currentTui.waitForText("Select swarm", tuiInteractionTimeoutMs)
+    const screen = await currentTui.waitForText("Live QA Agency", tuiInteractionTimeoutMs)
 
     expect(screen).toContain("Live QA Agency")
     expect(screen).not.toContain("Configure add-ons")

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1685,7 +1685,8 @@ export namespace SessionAgencySwarm {
         timeoutMs: input.options.discoveryTimeoutMs,
         mentionedRecipient,
         promptRecipient: input.recipientAgent,
-        historyRecipient: resolveHandoffRecipientFromHistory(chatHistory),
+        historyRecipient:
+          resolveHandoffRecipientFromHistory(chatHistory) ?? resolveHandoffRecipientFromHistory(history.chat_history),
         configuredRecipient: input.options.recipientAgent,
         configuredRecipientSelectedAt: input.options.recipientAgentSelectedAt,
       })
@@ -2235,6 +2236,17 @@ export namespace SessionAgencySwarm {
         timeoutMs: input.timeoutMs,
       })
     } catch (error) {
+      const explicit = candidates.find((candidate) => candidate.source === "message" || candidate.source === "prompt")
+      if (explicit) {
+        log.info("using explicit recipient without metadata validation because agency metadata refresh failed", {
+          sessionID: input.sessionID,
+          agency: input.agency,
+          recipientAgent: explicit.value.agent,
+          source: explicit.source,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return explicit.value.agent
+      }
       log.warn("unable to refresh agency metadata; skipping recipient override", {
         sessionID: input.sessionID,
         agency: input.agency,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -706,7 +706,13 @@ function hydrate(rows: (typeof MessageTable.$inferSelect)[]) {
 
 function providerMeta(metadata: Record<string, any> | undefined) {
   if (!metadata) return undefined
-  const { providerExecuted: _, ...rest } = metadata
+  // AI SDK provider metadata is keyed by provider name, so flat Agency fields
+  // cannot be replayed as top-level provider options.
+  const rest = Object.fromEntries(
+    Object.entries(metadata).filter(
+      ([key, value]) => key !== "providerExecuted" && typeof value === "object" && value !== null && !Array.isArray(value),
+    ),
+  )
   return Object.keys(rest).length > 0 ? rest : undefined
 }
 
@@ -843,7 +849,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           assistantMessage.parts.push({
             type: "text",
             text: part.text,
-            ...(differentModel ? {} : { providerMetadata: part.metadata }),
+            ...(differentModel ? {} : { providerMetadata: providerMeta(part.metadata) }),
           })
         if (part.type === "step-start")
           assistantMessage.parts.push({
@@ -925,7 +931,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           assistantMessage.parts.push({
             type: "reasoning",
             text: part.text,
-            ...(differentModel ? {} : { providerMetadata: part.metadata }),
+            ...(differentModel ? {} : { providerMetadata: providerMeta(part.metadata) }),
           })
         }
       }

--- a/packages/opencode/test/session/agency-swarm-recipient.test.ts
+++ b/packages/opencode/test/session/agency-swarm-recipient.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
+import { AgencySwarmHistory } from "../../src/agency-swarm/history"
+import { SessionAgencySwarm } from "../../src/session/agency-swarm"
+
+describe("session.agency-swarm recipient recovery", () => {
+  const originalGetMetadata = AgencySwarmAdapter.getMetadata
+  const originalStreamRun = AgencySwarmAdapter.streamRun
+  const originalLoad = AgencySwarmHistory.load
+  const originalAppendMessages = AgencySwarmHistory.appendMessages
+  const originalSetLastRunID = AgencySwarmHistory.setLastRunID
+
+  afterEach(() => {
+    mock.restore()
+    AgencySwarmAdapter.getMetadata = originalGetMetadata
+    AgencySwarmAdapter.streamRun = originalStreamRun
+    AgencySwarmHistory.load = originalLoad
+    AgencySwarmHistory.appendMessages = originalAppendMessages
+    AgencySwarmHistory.setLastRunID = originalSetLastRunID
+  })
+
+  test("stream preserves prompt recipient when metadata refresh is unavailable", async () => {
+    mockHistory()
+    let sentRecipient: string | undefined
+    AgencySwarmAdapter.getMetadata = (async () => {
+      throw new Error("The operation timed out.")
+    }) as typeof AgencySwarmAdapter.getMetadata
+    AgencySwarmAdapter.streamRun = async function* (args) {
+      sentRecipient = args.recipientAgent ?? undefined
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const input = helper()
+    input.recipientAgent = "Slides Agent"
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _ of stream.fullStream) {
+    }
+
+    expect(sentRecipient).toBe("Slides Agent")
+  })
+
+  const helper = () =>
+    ({
+      sessionID: "session_1",
+      assistantMessage: {
+        id: "message_assistant_1",
+        parentID: "message_user_1",
+        role: "assistant",
+        mode: "Default",
+        agent: "Default",
+        path: {
+          cwd: "/",
+          root: "/",
+        },
+        cost: 0,
+        tokens: {
+          total: 0,
+          input: 0,
+          output: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: "default",
+        providerID: "agency-swarm",
+        time: {
+          created: Date.now(),
+        },
+        sessionID: "session_1",
+      },
+      userMessage: {
+        info: {
+          id: "message_user_1",
+          role: "user",
+        },
+        parts: [
+          {
+            type: "text",
+            text: "hello",
+            ignored: false,
+          },
+        ],
+      },
+      options: {
+        baseURL: "http://127.0.0.1:8000",
+        agency: "builder",
+        discoveryTimeoutMs: 5000,
+      },
+      abort: new AbortController().signal,
+    }) as Parameters<typeof SessionAgencySwarm.stream>[0]
+
+  function mockHistory() {
+    AgencySwarmHistory.load = (async () => ({
+      scope: "http://127.0.0.1:8000|builder|session_1",
+      chat_history: [],
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.load
+    AgencySwarmHistory.appendMessages = (async () => ({
+      scope: "scope",
+      chat_history: [],
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.appendMessages
+    AgencySwarmHistory.setLastRunID = (async (_scope, runID) => ({
+      scope: "scope",
+      chat_history: [],
+      last_run_id: runID,
+      updated_at: Date.now(),
+    })) as typeof AgencySwarmHistory.setLastRunID
+  }
+})

--- a/packages/opencode/test/session/message-v2-agency-metadata.test.ts
+++ b/packages/opencode/test/session/message-v2-agency-metadata.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test"
+import { MessageV2 } from "../../src/session/message-v2"
+import type { Provider } from "../../src/provider"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+
+const sessionID = SessionID.make("session")
+const providerID = ProviderID.make("test")
+const model: Provider.Model = {
+  id: ModelID.make("test-model"),
+  providerID,
+  api: {
+    id: "test-model",
+    url: "https://example.com",
+    npm: "@ai-sdk/openai",
+  },
+  name: "Test Model",
+  capabilities: {
+    temperature: true,
+    reasoning: false,
+    attachment: false,
+    toolcall: true,
+    input: {
+      text: true,
+      audio: false,
+      image: false,
+      video: false,
+      pdf: false,
+    },
+    output: {
+      text: true,
+      audio: false,
+      image: false,
+      video: false,
+      pdf: false,
+    },
+    interleaved: false,
+  },
+  cost: {
+    input: 0,
+    output: 0,
+    cache: {
+      read: 0,
+      write: 0,
+    },
+  },
+  limit: {
+    context: 0,
+    input: 0,
+    output: 0,
+  },
+  status: "active",
+  options: {},
+  headers: {},
+  release_date: "2026-01-01",
+}
+
+describe("session.message-v2 Agency metadata", () => {
+  test("drops flat assistant metadata before model prompt conversion", async () => {
+    const assistantID = "m-assistant"
+    const input: MessageV2.WithParts[] = [
+      {
+        info: assistantInfo(assistantID),
+        parts: [
+          {
+            ...basePart(assistantID, "r1"),
+            type: "reasoning",
+            text: "thinking",
+            time: { start: 0 },
+            metadata: {
+              agent: "Slides Agent",
+              callerAgent: "Orchestrator",
+              agent_run_id: "agent_run_123",
+              item_id: "rs_flat",
+              summary_index: 0,
+              output_index: 0,
+              encrypted_content: "encrypted",
+              openai: {
+                itemId: "rs_123",
+              },
+            },
+          },
+          {
+            ...basePart(assistantID, "t1"),
+            type: "text",
+            text: "answer",
+            metadata: {
+              agent: "Slides Agent",
+              callerAgent: null,
+            },
+          },
+          {
+            ...basePart(assistantID, "t2"),
+            type: "text",
+            text: "flat only",
+            metadata: {
+              item_id: "msg_flat",
+              summary_index: 1,
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "thinking",
+            providerOptions: {
+              openai: {
+                itemId: "rs_123",
+              },
+            },
+          },
+          { type: "text", text: "answer" },
+          { type: "text", text: "flat only" },
+        ],
+      },
+    ])
+  })
+
+  test("drops flat Agency tool metadata before model prompt conversion", async () => {
+    const assistantID = "m-tool-assistant"
+    const input: MessageV2.WithParts[] = [
+      {
+        info: assistantInfo(assistantID),
+        parts: [
+          {
+            ...basePart(assistantID, "tool-1"),
+            type: "tool",
+            callID: "call_1",
+            tool: "send_message",
+            state: {
+              status: "completed",
+              input: { message: "continue" },
+              output: "done",
+              title: "send_message",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+            metadata: {
+              parent_run_id: "run_parent",
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "send_message",
+            input: { message: "continue" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "send_message",
+            output: { type: "text", value: "done" },
+          },
+        ],
+      },
+    ])
+  })
+})
+
+function assistantInfo(id: string): MessageV2.Assistant {
+  return {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: 0 },
+    parentID: "m-parent",
+    modelID: model.api.id,
+    providerID,
+    mode: "",
+    agent: "agent",
+    path: { cwd: "/", root: "/" },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  } as unknown as MessageV2.Assistant
+}
+
+function basePart(messageID: string, id: string) {
+  return {
+    id: PartID.make(id),
+    sessionID,
+    messageID: MessageID.make(messageID),
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #230

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two Agent Swarm run-mode failures seen around a backend interruption.

First, if a prompt has an explicit handed-off recipient and metadata refresh is unavailable, that recipient is still sent to the Agency server instead of being dropped. Stored handoff history remains available as recipient evidence, while fresher local chat history can still be rebuilt for the request body.

Second, compaction now filters replayed Agency metadata so flat Agency fields such as `agent`, `callerAgent`, `agent_run_id`, and `parent_run_id` stay out of AI SDK `providerOptions`. Provider-keyed metadata remains preserved.

The root-cause evidence is narrow: logs showed metadata refresh timing out while the candidate recipient was `Slides Agent`; the local session DB still had that prompt marked for `Slides Agent`; and the stored Agency history then showed the coordinator calling `send_message` to Slides. This supports metadata refresh failure dropping the recipient override, not a broader claim that reconnect alone caused the routing change.

### How did you verify your code works?

- `bun test test/session/message-v2-agency-metadata.test.ts test/session/agency-swarm-recipient.test.ts test/session/message-v2.test.ts test/session/agency-swarm.test.ts`
- `bun test --timeout 180000 --max-concurrency=1 ../../e2e/agent-swarm-tui/metadata-outage-recipient.test.ts ../../e2e/agent-swarm-tui/terminal-tui.test.ts`
- `bun test --timeout 180000 --max-concurrency=1 ../../e2e/agent-swarm-tui`
- `bun run typecheck`
- `bun turbo typecheck` from the push hook
- `git diff --check`
- Local independent diff reviews on the final diff: no actionable findings
- Current PR head: `9be5f76e0399c6dfd14a684cc4efbda3b22544a3`

### Screenshots / recordings

Not applicable; this is routing and compaction behavior covered by automated TUI tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
