### PR TITLE
feat(opencode): support generic downstream add-ons

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -46,7 +46,7 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
   - Behavior: release builds can use `AGENTSWARM_PRODUCT_VERSION` so direct downstream binaries report the downstream package version.
   - Behavior: downstream profiles can set `AGENTSWARM_PRODUCT_SKIP_POST_AUTH_MODEL_SELECTION` to skip the model prompt after auth. `/models` stays available unless `AGENTSWARM_PRODUCT_HIDE_MODEL_SELECTION` explicitly hides it.
   - Behavior: downstream profiles can set `AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT=standalone` so launcher-created or repaired project `.venv` environments use standalone Python instead of Conda-family Python. The Agent Swarm default remains `any`.
-  - Behavior: downstream profiles can set `AGENTSWARM_PRODUCT_ENABLE_ADDONS=true` to expose the native `/addons` command and post-auth add-ons setup flow. The Agent Swarm default keeps `/addons` hidden.
+  - Behavior: downstream profiles can set `AGENTSWARM_PRODUCT_ADDONS` to a JSON add-ons list to expose the native `/addons` command and post-auth add-ons setup flow. The Agent Swarm default keeps `/addons` hidden.
   - Implementation: `AgencyProduct` in `packages/opencode/src/agency-swarm/product.ts`, launcher detection in `packages/opencode/src/agency-swarm/npx.ts`, the FastAPI server launcher module argument, installation distribution metadata, native TUI provider dialogs, and `packages/opencode/script/build.ts`.
 
 - **One-command launcher npm package**

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -47,7 +47,8 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
   - Behavior: downstream profiles can set `AGENTSWARM_PRODUCT_SKIP_POST_AUTH_MODEL_SELECTION` to skip the model prompt after auth. `/models` stays available unless `AGENTSWARM_PRODUCT_HIDE_MODEL_SELECTION` explicitly hides it.
   - Behavior: downstream profiles can set `AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT=standalone` so launcher-created or repaired project `.venv` environments use standalone Python instead of Conda-family Python. The Agent Swarm default remains `any`.
   - Behavior: downstream profiles can set `AGENTSWARM_PRODUCT_ADDONS` to a JSON add-ons list to expose the native `/addons` command and post-auth add-ons setup flow. The Agent Swarm default keeps `/addons` hidden.
-  - Implementation: `AgencyProduct` in `packages/opencode/src/agency-swarm/product.ts`, launcher detection in `packages/opencode/src/agency-swarm/npx.ts`, the FastAPI server launcher module argument, installation distribution metadata, native TUI provider dialogs, and `packages/opencode/script/build.ts`.
+  - Behavior: downstream profiles can set `AGENTSWARM_PRODUCT_STATE_ROOT` so the product project, launcher logs, and add-on `.env` reads and writes live under a fixed product state root. The Agent Swarm default still uses the caller project and temporary launcher logs.
+  - Implementation: `AgencyProduct` in `packages/opencode/src/agency-swarm/product.ts`, launcher detection in `packages/opencode/src/agency-swarm/npx.ts`, add-on env storage in `packages/opencode/src/cli/cmd/tui/util/env-file.ts`, the FastAPI server launcher module argument, installation distribution metadata, native TUI provider dialogs, and `packages/opencode/script/build.ts`.
 
 - **One-command launcher npm package**
   - Intent: let users start the fork through one npm package instead of setting up the Python side first.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -37,7 +37,7 @@ For each failure scenario, capture the visible user result and cite the source p
 - **Happy-path proof:** The launcher detects configured entry files; the default Agent Swarm profile still detects only `agency.py`.
 - **Happy-path proof:** A missing local project creates the configured starter repository in the configured starter folder.
 - **Happy-path proof:** A release-built binary reports `AGENTSWARM_PRODUCT_VERSION` when it is set.
-- **Happy-path proof:** A downstream profile can opt into `/addons`, while the default Agent Swarm profile keeps `/addons` hidden.
+- **Happy-path proof:** A downstream profile can provide `AGENTSWARM_PRODUCT_ADDONS` to expose `/addons`, while the default Agent Swarm profile keeps `/addons` hidden.
 - **Happy-path proof:** With `AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT=standalone`, launcher setup creates or repairs project `.venv` environments with standalone Python 3.12+ and rebuilds existing Conda-family `.venv` environments.
 - **Failure scenarios to test:** Missing custom product values fall back to Agent Swarm defaults instead of inventing a downstream product.
 - **Failure scenarios to test:** The default Agent Swarm profile does not expose `/addons`.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -39,10 +39,11 @@ For each failure scenario, capture the visible user result and cite the source p
 - **Happy-path proof:** A release-built binary reports `AGENTSWARM_PRODUCT_VERSION` when it is set.
 - **Happy-path proof:** A downstream profile can provide `AGENTSWARM_PRODUCT_ADDONS` to expose `/addons`, while the default Agent Swarm profile keeps `/addons` hidden.
 - **Happy-path proof:** With `AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT=standalone`, launcher setup creates or repairs project `.venv` environments with standalone Python 3.12+ and rebuilds existing Conda-family `.venv` environments.
+- **Happy-path proof:** With `AGENTSWARM_PRODUCT_STATE_ROOT`, the product project, launcher logs, and add-on `.env` reads and writes stay under the fixed product state root.
 - **Failure scenarios to test:** Missing custom product values fall back to Agent Swarm defaults instead of inventing a downstream product.
 - **Failure scenarios to test:** The default Agent Swarm profile does not expose `/addons`.
 - **Failure scenarios to test:** With standalone Python required, a machine without standalone Python 3.12+ fails visibly instead of silently using Conda-family Python.
-- **Owner/source:** `packages/opencode/src/agency-swarm/product.ts`, `packages/opencode/src/agency-swarm/npx.ts`, `packages/opencode/src/agency-swarm/server-launcher.ts`, `packages/opencode/src/installation/distribution.ts`, and `packages/opencode/script/build.ts`.
+- **Owner/source:** `packages/opencode/src/agency-swarm/product.ts`, `packages/opencode/src/agency-swarm/npx.ts`, `packages/opencode/src/cli/cmd/tui/util/env-file.ts`, `packages/opencode/src/agency-swarm/server-launcher.ts`, `packages/opencode/src/installation/distribution.ts`, and `packages/opencode/script/build.ts`.
 
 #### Detected local project, venv, and uv
 

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -40,6 +40,7 @@ For each failure scenario, capture the visible user result and cite the source p
 - **Happy-path proof:** A downstream profile can opt into `/addons`, while the default Agent Swarm profile keeps `/addons` hidden.
 - **Happy-path proof:** With `AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT=standalone`, launcher setup creates or repairs project `.venv` environments with standalone Python 3.12+ and rebuilds existing Conda-family `.venv` environments.
 - **Failure scenarios to test:** Missing custom product values fall back to Agent Swarm defaults instead of inventing a downstream product.
+- **Failure scenarios to test:** The default Agent Swarm profile does not expose `/addons`.
 - **Failure scenarios to test:** With standalone Python required, a machine without standalone Python 3.12+ fails visibly instead of silently using Conda-family Python.
 - **Owner/source:** `packages/opencode/src/agency-swarm/product.ts`, `packages/opencode/src/agency-swarm/npx.ts`, `packages/opencode/src/agency-swarm/server-launcher.ts`, `packages/opencode/src/installation/distribution.ts`, and `packages/opencode/script/build.ts`.
 

--- a/e2e/agent-swarm-tui/addons.test.ts
+++ b/e2e/agent-swarm-tui/addons.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  openAIProviderTestConfig,
+  startAgencyProtocolServer,
+  startTui,
+  type AgencyProtocolServer,
+  type TuiProcess,
+} from "./harness"
+
+let currentTui: TuiProcess | undefined
+let currentServer: AgencyProtocolServer | undefined
+const tuiReadyTimeoutMs = process.env.CI ? 120_000 : 30_000
+const tuiInteractionTimeoutMs = process.env.CI ? 60_000 : 45_000
+
+const productAddons = JSON.stringify([
+  { id: "search", title: "Search Add-on", keys: ["SEARCH_API_KEY"] },
+  { id: "team", title: "Team Workspace", keys: ["TEAM_API_KEY", "TEAM_USER_ID"] },
+  { id: "native-openai", title: "Native OpenAI Add-on", keys: ["NATIVE_OPENAI_KEY"], excludeProviders: ["openai"] },
+])
+
+afterEach(async () => {
+  await currentTui?.close()
+  currentTui = undefined
+  currentServer?.stop()
+  currentServer = undefined
+})
+
+describe("Agent Swarm downstream add-ons e2e", () => {
+  test("downstream product add-ons command opens the native add-ons dialog", async () => {
+    currentServer = await startAgencyProtocolServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      env: {
+        AGENTSWARM_PRODUCT_ADDONS: productAddons,
+      },
+      config: openAIProviderTestConfig,
+    })
+
+    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    currentTui.write("/add")
+    await currentTui.waitForText("/addons", tuiInteractionTimeoutMs)
+    currentTui.write("\r")
+    const screen = await currentTui.waitForText("Search Add-on", tuiInteractionTimeoutMs)
+
+    expect(screen).toContain("Search Add-on")
+    expect(screen).toContain("Team Workspace")
+    expect(screen).toContain("TEAM_API_KEY, TEAM_USER_ID")
+    expect(screen).not.toContain("Native OpenAI Add-on")
+    expect(screen).toContain("Continue")
+  })
+
+  test("downstream product /agents exact command is not shadowed by /addons", async () => {
+    currentServer = await startAgencyProtocolServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      env: {
+        AGENTSWARM_PRODUCT_ADDONS: productAddons,
+      },
+      config: openAIProviderTestConfig,
+    })
+
+    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    currentTui.write("/agents\r")
+    await currentTui.waitForText("Select swarm", tuiInteractionTimeoutMs)
+    const screen = await currentTui.waitForText("Live QA Agency", tuiInteractionTimeoutMs)
+
+    expect(screen).toContain("Live QA Agency")
+    expect(screen).not.toContain("Configure add-ons")
+  })
+
+  test("downstream product auth success opens add-ons before closing", async () => {
+    currentServer = await startAgencyProtocolServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      env: {
+        AGENTSWARM_PRODUCT_ADDONS: productAddons,
+      },
+    })
+
+    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
+    currentTui.write("/auth")
+    await currentTui.waitForText("/auth", tuiInteractionTimeoutMs)
+    currentTui.write("\r")
+    await currentTui.waitForText("OpenAI", tuiInteractionTimeoutMs)
+    currentTui.write("\r")
+    await currentTui.waitForText("Manually enter API Key", tuiInteractionTimeoutMs)
+    currentTui.write("\x1b[B\r")
+    await currentTui.waitFor(
+      () => currentTui!.screen().includes("API key") && currentTui!.screen().includes("enter submit"),
+      "API key prompt",
+      tuiInteractionTimeoutMs,
+    )
+    currentTui.write("test-openai-key\r")
+    const screen = await currentTui.waitForText("Search Add-on", tuiInteractionTimeoutMs)
+
+    expect(screen).toContain("Configure add-ons")
+    expect(screen).toContain("Team Workspace")
+    expect(screen).not.toContain("Native OpenAI Add-on")
+  })
+})

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -85,36 +85,10 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(screen).not.toContain("Configure add-ons")
   })
 
-  test("downstream product add-ons command opens the native add-ons dialog", async () => {
-    currentServer = await startAgencyProtocolServer()
-    currentTui = await startTui({
-      baseURL: currentServer.baseURL,
-      env: {
-        AGENTSWARM_PRODUCT_ENABLE_ADDONS: "true",
-      },
-      config: openAIProviderTestConfig,
-    })
-
-    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
-    currentTui.write("/add")
-    await currentTui.waitForText("/addons", tuiInteractionTimeoutMs)
-    currentTui.write("\r")
-    const screen = await currentTui.waitForText("Web Search", tuiInteractionTimeoutMs)
-
-    expect(screen).toContain("Web Search")
-    expect(screen).toContain("Composio")
-    expect(screen).toContain("Fal.ai")
-    expect(screen).toContain("Unsplash")
-    expect(screen).toContain("Continue")
-  })
-
   test("downstream product /auth keeps the Agent Swarm auth dialog available", async () => {
     currentServer = await startAgencyProtocolServer()
     currentTui = await startTui({
       baseURL: currentServer.baseURL,
-      env: {
-        AGENTSWARM_PRODUCT_ENABLE_ADDONS: "true",
-      },
       config: openAIProviderTestConfig,
     })
 
@@ -126,54 +100,6 @@ describe("Agent Swarm terminal TUI e2e", () => {
 
     expect(screen).toContain("OpenAI")
     expect(screen).not.toContain("Connect a provider")
-  })
-
-  test("downstream product /agents exact command is not shadowed by /addons", async () => {
-    currentServer = await startAgencyProtocolServer()
-    currentTui = await startTui({
-      baseURL: currentServer.baseURL,
-      env: {
-        AGENTSWARM_PRODUCT_ENABLE_ADDONS: "true",
-      },
-      config: openAIProviderTestConfig,
-    })
-
-    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
-    currentTui.write("/agents\r")
-    await currentTui.waitForText("Select swarm", tuiInteractionTimeoutMs)
-    const screen = await currentTui.waitForText("Live QA Agency", tuiInteractionTimeoutMs)
-
-    expect(screen).toContain("Live QA Agency")
-    expect(screen).not.toContain("Configure add-ons")
-  })
-
-  test("downstream product auth success opens add-ons before closing", async () => {
-    currentServer = await startAgencyProtocolServer()
-    currentTui = await startTui({
-      baseURL: currentServer.baseURL,
-      env: {
-        AGENTSWARM_PRODUCT_ENABLE_ADDONS: "true",
-      },
-    })
-
-    await currentTui.waitForText("Agency Swarm", tuiReadyTimeoutMs)
-    currentTui.write("/auth")
-    await currentTui.waitForText("/auth", tuiInteractionTimeoutMs)
-    currentTui.write("\r")
-    await currentTui.waitForText("OpenAI", tuiInteractionTimeoutMs)
-    currentTui.write("\r")
-    await currentTui.waitForText("Manually enter API Key", tuiInteractionTimeoutMs)
-    currentTui.write("\x1b[B\r")
-    await currentTui.waitFor(
-      () => currentTui!.screen().includes("API key") && currentTui!.screen().includes("enter submit"),
-      "API key prompt",
-      tuiInteractionTimeoutMs,
-    )
-    currentTui.write("test-openai-key\r")
-    const screen = await currentTui.waitForText("Web Search", tuiInteractionTimeoutMs)
-
-    expect(screen).toContain("Configure add-ons")
-    expect(screen).toContain("Composio")
   })
 
   test("run-mode /auth emits telemetry by default when PostHog config is present", async () => {

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -32,6 +32,10 @@ async function waitForConfiguredDemoRecipient(tui: TuiProcess) {
   )
 }
 
+function hasCommand(screen: string, command: string) {
+  return screen.split("\n").some((line) => line.includes(command) && line.trimStart().startsWith("┃"))
+}
+
 afterEach(async () => {
   await currentTui?.close()
   currentTui = undefined
@@ -73,11 +77,12 @@ describe("Agent Swarm terminal TUI e2e", () => {
     await currentTui.waitForText("/auth")
     const screen = await currentTui.waitForText("/connect")
 
-    expect(screen).toContain("/auth")
-    expect(screen).toContain("/connect")
-    expect(screen).toContain("/models")
-    expect(screen).toContain("/agents")
-    expect(screen).not.toContain("/addons")
+    expect(hasCommand(screen, "/auth")).toBe(true)
+    expect(hasCommand(screen, "/connect")).toBe(true)
+    expect(hasCommand(screen, "/models")).toBe(true)
+    expect(hasCommand(screen, "/agents")).toBe(true)
+    expect(hasCommand(screen, "/addons")).toBe(false)
+    expect(screen).not.toContain("Configure add-ons")
   })
 
   test("downstream product add-ons command opens the native add-ons dialog", async () => {

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -44,7 +44,7 @@ const productEnvNames = [
   "AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT",
   "AGENTSWARM_PRODUCT_WORDMARK_LINES",
   "AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT",
-  "AGENTSWARM_PRODUCT_ENABLE_ADDONS",
+  "AGENTSWARM_PRODUCT_ADDONS",
 ] as const
 const productDefines = Object.fromEntries(
   productEnvNames.map((name) => [name, process.env[name] ? JSON.stringify(process.env[name]) : "undefined"]),

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -45,6 +45,7 @@ const productEnvNames = [
   "AGENTSWARM_PRODUCT_WORDMARK_LINES",
   "AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT",
   "AGENTSWARM_PRODUCT_ADDONS",
+  "AGENTSWARM_PRODUCT_STATE_ROOT",
 ] as const
 const productDefines = Object.fromEntries(
   productEnvNames.map((name) => [name, process.env[name] ? JSON.stringify(process.env[name]) : "undefined"]),

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -24,7 +24,7 @@ import {
 export { collectUnixPythonCandidates }
 
 export const LAUNCHER_ENTRY_ENV = "AGENTSWARM_LAUNCHER"
-export const PRODUCT_STATE_ROOT_ENV = "AGENTSWARM_PRODUCT_STATE_ROOT"
+export const PRODUCT_STATE_ROOT_ENV = AgencySwarmRunSession.PRODUCT_STATE_ROOT_ENV
 export const STARTER_TEMPLATE_REPO = AgencyProduct.starterTemplateRepo
 export const LOCAL_AGENCY_ID = "local-agency"
 
@@ -77,9 +77,23 @@ export interface AgencyProject {
 export interface NpxCwdLaunch {
   directory: string
   cwdOnly: true
+  configContent?: string
 }
 
 export type NpxAutoProject = AgencyProject | NpxCwdLaunch
+
+export type InputRunSession =
+  | {
+      sessionID: string
+      mode?: "local-project"
+      directory: string
+    }
+  | {
+      sessionID: string
+      mode: "remote-config"
+      directory: string
+      config: AgencySwarmRunSession.RemoteConfig
+    }
 
 export function isNpxCwdLaunch(project: NpxAutoProject): project is NpxCwdLaunch {
   return "cwdOnly" in project
@@ -161,7 +175,7 @@ export async function resolveNpxAutoProject(input: {
   prompt?: string
   agent?: string
   sessions?: Iterable<Pick<Session.Info, "id" | "directory" | "parentID" | "time">>
-  runSessions?: Iterable<{ sessionID: string; directory: string }>
+  runSessions?: Iterable<InputRunSession>
   profile?: Pick<ProductProfile, "agencyEntryFiles" | "stateRoot">
 }): Promise<NpxAutoProject | undefined> {
   if (!isLauncher(input)) return
@@ -288,7 +302,7 @@ function isLauncher(input: { env: NodeJS.ProcessEnv; argv?: string[] }) {
 
 async function resolveRunProject(
   session: Pick<Session.Info, "id" | "directory">,
-  runSessions?: Iterable<{ sessionID: string; directory: string }>,
+  runSessions?: Iterable<InputRunSession>,
   profile: Pick<ProductProfile, "agencyEntryFiles" | "stateRoot"> = AgencyProduct,
 ): Promise<NpxAutoProject | undefined> {
   const directory = resolveProductProjectDirectory(profile)
@@ -296,9 +310,18 @@ async function resolveRunProject(
   if (directory && !scoped) return
 
   const run = runSessions
-    ? Array.from(runSessions).find((item) => item.sessionID === session.id)
+    ? resolveInputRunSession(session.id, runSessions)
     : await AgencySwarmRunSession.get(session.id)
   if (run) {
+    if (run.mode === "remote-config") {
+      if (!directory || !scoped) return
+      if (path.resolve(run.directory) !== path.resolve(session.directory)) return
+      return {
+        directory: run.directory,
+        cwdOnly: true,
+        configContent: buildAgencyConfig(run.config),
+      }
+    }
     if (path.resolve(run.directory) !== path.resolve(session.directory)) return
     return detectAgencyProject(run.directory, profile)
   }
@@ -308,6 +331,25 @@ async function resolveRunProject(
     return project
   }
   if (scoped) return { directory, cwdOnly: true }
+}
+
+function resolveInputRunSession(
+  sessionID: string,
+  runSessions: Iterable<InputRunSession>,
+): AgencySwarmRunSession.Info | undefined {
+  const match = Array.from(runSessions).find((item) => item.sessionID === sessionID)
+  if (!match) return
+  if (match.mode === "remote-config") {
+    return {
+      mode: "remote-config",
+      directory: match.directory,
+      config: match.config,
+    }
+  }
+  return {
+    mode: "local-project",
+    directory: match.directory,
+  }
 }
 
 async function isLegacyAgencySwarmRunSession(sessionID: Session.Info["id"]) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -24,6 +24,7 @@ import {
 export { collectUnixPythonCandidates }
 
 export const LAUNCHER_ENTRY_ENV = "AGENTSWARM_LAUNCHER"
+export const PRODUCT_STATE_ROOT_ENV = "AGENTSWARM_PRODUCT_STATE_ROOT"
 export const STARTER_TEMPLATE_REPO = AgencyProduct.starterTemplateRepo
 export const LOCAL_AGENCY_ID = "local-agency"
 
@@ -42,12 +43,19 @@ export function starterTemplateUrl(profile: Pick<AgencyProduct.Profile, "starter
 export const STARTER_TEMPLATE_URL = starterTemplateUrl()
 
 export function resolveProductStateRoot(profile: Pick<AgencyProduct.Profile, "stateRoot"> = AgencyProduct) {
-  return profile.stateRoot ? path.resolve(profile.stateRoot) : undefined
+  const root = profile.stateRoot?.trim()
+  return root ? path.resolve(root) : undefined
 }
 
 export function resolveProductProjectDirectory(profile: Pick<AgencyProduct.Profile, "stateRoot"> = AgencyProduct) {
   const root = resolveProductStateRoot(profile)
   return root ? path.join(root, "project") : undefined
+}
+
+function normalizeProductStateRootEnv(profile: Pick<AgencyProduct.Profile, "stateRoot"> = AgencyProduct) {
+  const root = resolveProductStateRoot(profile)
+  if (root) process.env[PRODUCT_STATE_ROOT_ENV] = root
+  return root
 }
 
 type LaunchChoice = "project" | "starter" | "connect"
@@ -148,7 +156,8 @@ export async function resolveNpxAutoProject(input: {
   if (!isLauncher(input)) return
   if (input.model && input.model.split("/")[0] !== AgencySwarmAdapter.PROVIDER_ID) return
   const profile = input.profile ?? AgencyProduct
-  const directory = resolveProductProjectDirectory(profile) ?? input.directory
+  const stateRoot = normalizeProductStateRootEnv(profile)
+  const directory = stateRoot ? path.join(stateRoot, "project") : input.directory
 
   if (input.session) {
     const session = await getResumeSession(input.session, input.sessions)
@@ -459,7 +468,8 @@ export async function prepareNpxLaunch(
   profile: ProductProfile = AgencyProduct,
 ): Promise<PreparedNpxLaunch | undefined> {
   prompts.intro(profile.name)
-  const projectDirectory = resolveProductProjectDirectory(profile)
+  const stateRoot = normalizeProductStateRootEnv(profile)
+  const projectDirectory = stateRoot ? path.join(stateRoot, "project") : undefined
   const launchDirectory = projectDirectory ?? directory
 
   if (profile.customStarter) {
@@ -503,7 +513,7 @@ export async function prepareNpxLaunch(
   }
 
   const targetProject =
-    choice === "project"
+    choice === "project" || (choice === "starter" && projectDirectory && project)
       ? project
       : projectDirectory
         ? await createProductStateRootProject({ directory: projectDirectory, profile })
@@ -527,7 +537,7 @@ export async function prepareNpxLaunch(
 
 async function chooseLaunchChoice(
   project: AgencyProject | undefined,
-  profile: Pick<ProductProfile, "custom" | "name"> = AgencyProduct,
+  profile: Pick<ProductProfile, "custom" | "name" | "stateRoot"> = AgencyProduct,
 ) {
   prompts.log.info("1. Choose how to start the terminal UI.")
   prompts.log.info(
@@ -545,11 +555,15 @@ async function chooseLaunchChoice(
             },
           ]
         : []),
-      {
-        value: "starter" as const,
-        label: "Create a new starter project",
-        hint: "recommended for a fresh setup",
-      },
+      ...(project && resolveProductStateRoot(profile)
+        ? []
+        : [
+            {
+              value: "starter" as const,
+              label: "Create a new starter project",
+              hint: "recommended for a fresh setup",
+            },
+          ]),
       {
         value: "connect" as const,
         label: "Connect to an existing agency",

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -74,6 +74,17 @@ export interface AgencyProject {
   moduleName: string
 }
 
+export interface NpxCwdLaunch {
+  directory: string
+  cwdOnly: true
+}
+
+export type NpxAutoProject = AgencyProject | NpxCwdLaunch
+
+export function isNpxCwdLaunch(project: NpxAutoProject): project is NpxCwdLaunch {
+  return "cwdOnly" in project
+}
+
 interface CommandResult {
   code: number
   stdout: string
@@ -152,7 +163,7 @@ export async function resolveNpxAutoProject(input: {
   sessions?: Iterable<Pick<Session.Info, "id" | "directory" | "parentID" | "time">>
   runSessions?: Iterable<{ sessionID: string; directory: string }>
   profile?: Pick<ProductProfile, "agencyEntryFiles" | "stateRoot">
-}) {
+}): Promise<NpxAutoProject | undefined> {
   if (!isLauncher(input)) return
   if (input.model && input.model.split("/")[0] !== AgencySwarmAdapter.PROVIDER_ID) return
   const profile = input.profile ?? AgencyProduct
@@ -279,9 +290,10 @@ async function resolveRunProject(
   session: Pick<Session.Info, "id" | "directory">,
   runSessions?: Iterable<{ sessionID: string; directory: string }>,
   profile: Pick<ProductProfile, "agencyEntryFiles" | "stateRoot"> = AgencyProduct,
-) {
+): Promise<NpxAutoProject | undefined> {
   const directory = resolveProductProjectDirectory(profile)
-  if (directory && path.resolve(session.directory) !== directory) return
+  const scoped = directory !== undefined && path.resolve(session.directory) === directory
+  if (directory && !scoped) return
 
   const run = runSessions
     ? Array.from(runSessions).find((item) => item.sessionID === session.id)
@@ -292,10 +304,10 @@ async function resolveRunProject(
   }
 
   const project = await detectAgencyProject(session.directory, profile)
-  if (!project) return
-  if (!(await isLegacyAgencySwarmRunSession(session.id))) return
-  if (!(await hasLegacyLocalAgencyHistory(session.id))) return
-  return project
+  if (project && (await isLegacyAgencySwarmRunSession(session.id)) && (await hasLegacyLocalAgencyHistory(session.id))) {
+    return project
+  }
+  if (scoped) return { directory, cwdOnly: true }
 }
 
 async function isLegacyAgencySwarmRunSession(sessionID: Session.Info["id"]) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -505,10 +505,12 @@ export async function prepareNpxLaunch(
   const targetProject =
     choice === "project"
       ? project
-      : await createStarterProject({
-          baseDirectory: launchDirectory,
-          profile,
-        })
+      : projectDirectory
+        ? await createProductStateRootProject({ directory: projectDirectory, profile })
+        : await createStarterProject({
+            baseDirectory: launchDirectory,
+            profile,
+          })
   if (!targetProject) {
     prompts.outro("Cancelled")
     return
@@ -766,6 +768,8 @@ async function createProductStateRootProject(input: {
   prompts.log.info("2. Create the product state project.")
   prompts.log.info(`   This keeps ${input.profile.name} launcher state in one user folder.`)
 
+  const starterProfile = input.profile.customStarter ? input.profile : AgencyProduct
+
   await mkdir(path.dirname(input.directory), { recursive: true })
   prompts.log.step(`Creating starter project in \`${input.directory}\``)
   const clone = await runCommand(["git", "clone", "--depth=1", starterTemplateUrl(input.profile), input.directory])
@@ -777,7 +781,7 @@ async function createProductStateRootProject(input: {
     force: true,
   }).catch(() => undefined)
   await runCommand(["git", "init", "-b", "main"], { cwd: input.directory })
-  return requireDetectedStarterProject(input.directory, input.profile)
+  return requireDetectedStarterProject(input.directory, starterProfile)
 }
 
 export async function prepareProjectLaunch(

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -459,7 +459,6 @@ export async function prepareNpxLaunch(
   profile: ProductProfile = AgencyProduct,
 ): Promise<PreparedNpxLaunch | undefined> {
   prompts.intro(profile.name)
-  const stateRoot = resolveProductStateRoot(profile)
   const projectDirectory = resolveProductProjectDirectory(profile)
   const launchDirectory = projectDirectory ?? directory
 
@@ -491,9 +490,9 @@ export async function prepareNpxLaunch(
     prompts.outro("Cancelled")
     return
   }
+  if (projectDirectory) await mkdir(projectDirectory, { recursive: true })
 
   if (choice === "connect") {
-    if (stateRoot) await mkdir(stateRoot, { recursive: true })
     const launch = await prepareRemoteLaunch(launchDirectory)
     if (!launch) {
       prompts.outro("Cancelled")

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -31,15 +31,24 @@ const nativeSetTimeout = globalThis.setTimeout.bind(globalThis)
 
 type ProductProfile = Pick<
   AgencyProduct.Profile,
-  "custom" | "name" | "customStarter" | "starterTemplateRepo" | "starterProjectName" | "agencyEntryFiles"
+  "custom" | "name" | "customStarter" | "starterTemplateRepo" | "starterProjectName" | "agencyEntryFiles" | "stateRoot"
 >
-type LaunchProfile = Pick<AgencyProduct.Profile, "name" | "launcherPackageName" | "pythonEnvironment">
+type LaunchProfile = Pick<AgencyProduct.Profile, "name" | "launcherPackageName" | "pythonEnvironment" | "stateRoot">
 
 export function starterTemplateUrl(profile: Pick<AgencyProduct.Profile, "starterTemplateRepo"> = AgencyProduct) {
   return `https://github.com/${profile.starterTemplateRepo}.git`
 }
 
 export const STARTER_TEMPLATE_URL = starterTemplateUrl()
+
+export function resolveProductStateRoot(profile: Pick<AgencyProduct.Profile, "stateRoot"> = AgencyProduct) {
+  return profile.stateRoot ? path.resolve(profile.stateRoot) : undefined
+}
+
+export function resolveProductProjectDirectory(profile: Pick<AgencyProduct.Profile, "stateRoot"> = AgencyProduct) {
+  const root = resolveProductStateRoot(profile)
+  return root ? path.join(root, "project") : undefined
+}
 
 type LaunchChoice = "project" | "starter" | "connect"
 type StarterMode = "github" | "local"
@@ -134,27 +143,30 @@ export async function resolveNpxAutoProject(input: {
   agent?: string
   sessions?: Iterable<Pick<Session.Info, "id" | "directory" | "parentID" | "time">>
   runSessions?: Iterable<{ sessionID: string; directory: string }>
+  profile?: Pick<ProductProfile, "agencyEntryFiles" | "stateRoot">
 }) {
   if (!isLauncher(input)) return
   if (input.model && input.model.split("/")[0] !== AgencySwarmAdapter.PROVIDER_ID) return
+  const profile = input.profile ?? AgencyProduct
+  const directory = resolveProductProjectDirectory(profile) ?? input.directory
 
   if (input.session) {
     const session = await getResumeSession(input.session, input.sessions)
-    return session ? resolveRunProject(session, input.runSessions) : undefined
+    return session ? resolveRunProject(session, input.runSessions, profile) : undefined
   }
 
   if (input.continue) {
-    const sessions = input.sessions ? Array.from(input.sessions) : await listResumeSessions(input.directory)
+    const sessions = input.sessions ? Array.from(input.sessions) : await listResumeSessions(directory)
     const session = sessions
-      .filter((item) => item.directory === input.directory && !item.parentID)
+      .filter((item) => item.directory === directory && !item.parentID)
       .toSorted((a, b) => b.time.updated - a.time.updated)[0]
-    if (session) return resolveRunProject(session, input.runSessions)
+    if (session) return resolveRunProject(session, input.runSessions, profile)
     if (input.fork) return
-    return detectAgencyProject(input.directory)
+    return detectAgencyProject(directory, profile)
   }
 
   if (input.prompt || input.agent || input.model) {
-    return detectAgencyProject(input.directory)
+    return detectAgencyProject(directory, profile)
   }
 }
 
@@ -257,16 +269,20 @@ function isLauncher(input: { env: NodeJS.ProcessEnv; argv?: string[] }) {
 async function resolveRunProject(
   session: Pick<Session.Info, "id" | "directory">,
   runSessions?: Iterable<{ sessionID: string; directory: string }>,
+  profile: Pick<ProductProfile, "agencyEntryFiles" | "stateRoot"> = AgencyProduct,
 ) {
+  const directory = resolveProductProjectDirectory(profile)
+  if (directory && path.resolve(session.directory) !== directory) return
+
   const run = runSessions
     ? Array.from(runSessions).find((item) => item.sessionID === session.id)
     : await AgencySwarmRunSession.get(session.id)
   if (run) {
     if (path.resolve(run.directory) !== path.resolve(session.directory)) return
-    return detectAgencyProject(run.directory)
+    return detectAgencyProject(run.directory, profile)
   }
 
-  const project = await detectAgencyProject(session.directory)
+  const project = await detectAgencyProject(session.directory, profile)
   if (!project) return
   if (!(await isLegacyAgencySwarmRunSession(session.id))) return
   if (!(await hasLegacyLocalAgencyHistory(session.id))) return
@@ -434,6 +450,7 @@ function launchProfile(profile: ProductProfile): LaunchProfile {
     name: profile.name,
     launcherPackageName: values.launcherPackageName ?? AgencyProduct.launcherPackageName,
     pythonEnvironment: values.pythonEnvironment ?? AgencyProduct.pythonEnvironment,
+    stateRoot: profile.stateRoot,
   }
 }
 
@@ -442,12 +459,18 @@ export async function prepareNpxLaunch(
   profile: ProductProfile = AgencyProduct,
 ): Promise<PreparedNpxLaunch | undefined> {
   prompts.intro(profile.name)
+  const stateRoot = resolveProductStateRoot(profile)
+  const projectDirectory = resolveProductProjectDirectory(profile)
+  const launchDirectory = projectDirectory ?? directory
 
   if (profile.customStarter) {
     const targetProject =
-      (await detectAgencyProject(directory, profile)) ??
-      (await detectAgencyProject(path.join(directory, profile.starterProjectName), profile)) ??
-      (await createStarterProject({ baseDirectory: directory, profile }))
+      projectDirectory !== undefined
+        ? ((await detectAgencyProject(projectDirectory, profile)) ??
+          (await createProductStateRootProject({ directory: projectDirectory, profile })))
+        : ((await detectAgencyProject(directory, profile)) ??
+          (await detectAgencyProject(path.join(directory, profile.starterProjectName), profile)) ??
+          (await createStarterProject({ baseDirectory: directory, profile })))
     if (!targetProject) {
       prompts.outro("Cancelled")
       return
@@ -462,7 +485,7 @@ export async function prepareNpxLaunch(
     return launch
   }
 
-  const project = await detectAgencyProject(directory, profile)
+  const project = await detectAgencyProject(launchDirectory, profile)
   const choice = await chooseLaunchChoice(project, profile)
   if (!choice) {
     prompts.outro("Cancelled")
@@ -470,7 +493,8 @@ export async function prepareNpxLaunch(
   }
 
   if (choice === "connect") {
-    const launch = await prepareRemoteLaunch(directory)
+    if (stateRoot) await mkdir(stateRoot, { recursive: true })
+    const launch = await prepareRemoteLaunch(launchDirectory)
     if (!launch) {
       prompts.outro("Cancelled")
       return
@@ -483,7 +507,7 @@ export async function prepareNpxLaunch(
     choice === "project"
       ? project
       : await createStarterProject({
-          baseDirectory: directory,
+          baseDirectory: launchDirectory,
           profile,
         })
   if (!targetProject) {
@@ -736,6 +760,27 @@ async function createStarterProject(input: {
   return requireDetectedStarterProject(targetDirectory, starterProfile)
 }
 
+async function createProductStateRootProject(input: {
+  directory: string
+  profile: ProductProfile
+}): Promise<AgencyProject | undefined> {
+  prompts.log.info("2. Create the product state project.")
+  prompts.log.info(`   This keeps ${input.profile.name} launcher state in one user folder.`)
+
+  await mkdir(path.dirname(input.directory), { recursive: true })
+  prompts.log.step(`Creating starter project in \`${input.directory}\``)
+  const clone = await runCommand(["git", "clone", "--depth=1", starterTemplateUrl(input.profile), input.directory])
+  if (clone.code !== 0) {
+    throw new Error(clone.stderr.trim() || clone.stdout.trim() || "Starter template clone failed")
+  }
+  await rm(path.join(input.directory, ".git"), {
+    recursive: true,
+    force: true,
+  }).catch(() => undefined)
+  await runCommand(["git", "init", "-b", "main"], { cwd: input.directory })
+  return requireDetectedStarterProject(input.directory, input.profile)
+}
+
 export async function prepareProjectLaunch(
   project: AgencyProject,
   profile: LaunchProfile = AgencyProduct,
@@ -763,7 +808,7 @@ export async function prepareProjectLaunch(
 
 async function ensureProjectPython(
   directory: string,
-  profile: Pick<LaunchProfile, "launcherPackageName" | "pythonEnvironment">,
+  profile: Pick<LaunchProfile, "launcherPackageName" | "pythonEnvironment" | "stateRoot">,
 ) {
   const venvPython = getVenvPythonPath(directory)
   const venvDir = path.resolve(path.join(directory, ".venv"))
@@ -790,7 +835,12 @@ async function ensureProjectPython(
       corruptedVenv = true
     } else {
       prompts.log.info(`Using project Python: ${formatPython(info, [venvPython])}`)
-      const refreshLogFile = await tryCreateProjectCommandLogFile(directory, "launcher-refresh", "launcher refresh")
+      const refreshLogFile = await tryCreateProjectCommandLogFile(
+        directory,
+        "launcher-refresh",
+        "launcher refresh",
+        profile,
+      )
       prompts.log.info(
         refreshLogFile
           ? `Refreshing project dependencies with local uv. Streaming output to stderr. Full log: ${refreshLogFile}`
@@ -892,7 +942,12 @@ async function ensureProjectPython(
   }
 
   prompts.log.step("`.venv` created")
-  const installLogFile = await tryCreateProjectCommandLogFile(directory, "launcher-rebuild", "launcher rebuild")
+  const installLogFile = await tryCreateProjectCommandLogFile(
+    directory,
+    "launcher-rebuild",
+    "launcher rebuild",
+    profile,
+  )
   prompts.log.info(
     installLogFile
       ? `Installing project dependencies. Streaming output to stderr. Full log: ${installLogFile}`
@@ -1179,16 +1234,28 @@ async function hasDependencyManifest(directory: string) {
   )
 }
 
-async function createProjectCommandLogFile(directory: string, stem: string) {
+async function createProjectCommandLogFile(
+  directory: string,
+  stem: string,
+  profile: Pick<AgencyProduct.Profile, "stateRoot"> = AgencyProduct,
+) {
   const projectID = `${path.basename(path.resolve(directory)) || "project"}-${Bun.hash(path.resolve(directory)).toString(16)}`
-  const logDirectory = path.join(os.tmpdir(), "agentswarm-cli-logs", projectID)
+  const stateRoot = resolveProductStateRoot(profile)
+  const logDirectory = stateRoot
+    ? path.join(stateRoot, "logs", projectID)
+    : path.join(os.tmpdir(), "agentswarm-cli-logs", projectID)
   await mkdir(logDirectory, { recursive: true })
   return path.join(logDirectory, `${new Date().toISOString().replaceAll(":", "").replaceAll(".", "")}-${stem}.log`)
 }
 
-async function tryCreateProjectCommandLogFile(directory: string, stem: string, label: string) {
+async function tryCreateProjectCommandLogFile(
+  directory: string,
+  stem: string,
+  label: string,
+  profile: Pick<AgencyProduct.Profile, "stateRoot"> = AgencyProduct,
+) {
   try {
-    return await createProjectCommandLogFile(directory, stem)
+    return await createProjectCommandLogFile(directory, stem, profile)
   } catch (error) {
     prompts.log.warn(
       `Could not create ${label} log file. Continuing without a saved log: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -44,7 +44,7 @@ export const STARTER_TEMPLATE_URL = starterTemplateUrl()
 
 export function resolveProductStateRoot(profile: Pick<AgencyProduct.Profile, "stateRoot"> = AgencyProduct) {
   const root = profile.stateRoot?.trim()
-  return root ? path.resolve(root) : undefined
+  return root ? Filesystem.resolve(root) : undefined
 }
 
 export function resolveProductProjectDirectory(profile: Pick<AgencyProduct.Profile, "stateRoot"> = AgencyProduct) {
@@ -192,7 +192,9 @@ export async function resolveNpxAutoProject(input: {
   if (input.continue) {
     const sessions = input.sessions ? Array.from(input.sessions) : await listResumeSessions(directory)
     const session = sessions
-      .filter((item) => item.directory === directory && !item.parentID)
+      .filter(
+        (item) => (stateRoot ? Filesystem.resolve(item.directory) : item.directory) === directory && !item.parentID,
+      )
       .toSorted((a, b) => b.time.updated - a.time.updated)[0]
     if (session) return resolveRunProject(session, input.runSessions, profile)
     if (input.fork) return
@@ -306,23 +308,25 @@ async function resolveRunProject(
   profile: Pick<ProductProfile, "agencyEntryFiles" | "stateRoot"> = AgencyProduct,
 ): Promise<NpxAutoProject | undefined> {
   const directory = resolveProductProjectDirectory(profile)
-  const scoped = directory !== undefined && path.resolve(session.directory) === directory
+  const sessionDirectory = directory ? Filesystem.resolve(session.directory) : path.resolve(session.directory)
+  const scoped = directory !== undefined && sessionDirectory === directory
   if (directory && !scoped) return
 
   const run = runSessions
     ? resolveInputRunSession(session.id, runSessions)
     : await AgencySwarmRunSession.get(session.id)
   if (run) {
+    const runDirectory = directory ? Filesystem.resolve(run.directory) : path.resolve(run.directory)
     if (run.mode === "remote-config") {
       if (!directory || !scoped) return
-      if (path.resolve(run.directory) !== path.resolve(session.directory)) return
+      if (runDirectory !== sessionDirectory) return
       return {
         directory: run.directory,
         cwdOnly: true,
         configContent: buildAgencyConfig(run.config),
       }
     }
-    if (path.resolve(run.directory) !== path.resolve(session.directory)) return
+    if (runDirectory !== sessionDirectory) return
     return detectAgencyProject(run.directory, profile)
   }
 

--- a/packages/opencode/src/agency-swarm/product.ts
+++ b/packages/opencode/src/agency-swarm/product.ts
@@ -15,10 +15,17 @@ declare const AGENTSWARM_PRODUCT_TUI_LOGO_LEFT: string | undefined
 declare const AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: string | undefined
 declare const AGENTSWARM_PRODUCT_WORDMARK_LINES: string | undefined
 declare const AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: string | undefined
-declare const AGENTSWARM_PRODUCT_ENABLE_ADDONS: string | undefined
+declare const AGENTSWARM_PRODUCT_ADDONS: string | undefined
 
 export namespace AgencyProduct {
   export type PythonEnvironment = "any" | "standalone"
+
+  export interface Addon {
+    id: string
+    title: string
+    keys: string[]
+    excludeProviders?: string[]
+  }
 
   export interface Profile {
     custom: boolean
@@ -26,7 +33,7 @@ export namespace AgencyProduct {
     customStarter: boolean
     skipPostAuthModelSelection: boolean
     hideModelSelection: boolean
-    enableAddons: boolean
+    addons: Addon[]
     name: string
     cmd: string
     packageName: string
@@ -50,7 +57,7 @@ export namespace AgencyProduct {
     customStarter: false,
     skipPostAuthModelSelection: false,
     hideModelSelection: false,
-    enableAddons: false,
+    addons: [],
     name: "Agent Swarm",
     cmd: "agentswarm",
     packageName: "agentswarm-cli",
@@ -106,8 +113,8 @@ export namespace AgencyProduct {
       typeof AGENTSWARM_PRODUCT_WORDMARK_LINES === "undefined" ? undefined : AGENTSWARM_PRODUCT_WORDMARK_LINES,
     AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT:
       typeof AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT === "undefined" ? undefined : AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT,
-    AGENTSWARM_PRODUCT_ENABLE_ADDONS:
-      typeof AGENTSWARM_PRODUCT_ENABLE_ADDONS === "undefined" ? undefined : AGENTSWARM_PRODUCT_ENABLE_ADDONS,
+    AGENTSWARM_PRODUCT_ADDONS:
+      typeof AGENTSWARM_PRODUCT_ADDONS === "undefined" ? undefined : AGENTSWARM_PRODUCT_ADDONS,
   } satisfies Record<string, string | undefined>
 
   function clean(value: string | undefined) {
@@ -163,6 +170,54 @@ export namespace AgencyProduct {
     return undefined
   }
 
+  function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+  }
+
+  function readStringList(value: unknown) {
+    return Array.isArray(value) && value.every((item) => typeof item === "string") && value.length > 0
+      ? value
+      : undefined
+  }
+
+  function readOptionalStringList(value: unknown) {
+    return Array.isArray(value) && value.every((item) => typeof item === "string") ? value : undefined
+  }
+
+  function isEnvKey(value: string) {
+    return /^[A-Z_][A-Z0-9_]*$/.test(value)
+  }
+
+  function readAddon(value: unknown): Addon | undefined {
+    if (!isRecord(value)) return undefined
+    if (typeof value.id !== "string" || typeof value.title !== "string") return undefined
+    const keys = readStringList(value.keys)
+    if (!keys || keys.some((key) => !isEnvKey(key))) return undefined
+    const hasExclusions = Object.hasOwn(value, "excludeProviders")
+    const excludeProviders = hasExclusions ? readOptionalStringList(value.excludeProviders) : undefined
+    if (hasExclusions && !excludeProviders) return undefined
+    const addon = {
+      id: value.id,
+      title: value.title,
+      keys,
+    }
+    return excludeProviders ? { ...addon, excludeProviders } : addon
+  }
+
+  function readAddons(value: string | undefined) {
+    if (value === undefined || value.trim() === "") return undefined
+    try {
+      const parsed: unknown = JSON.parse(value)
+      if (!Array.isArray(parsed)) return undefined
+      const addons = parsed.map(readAddon).filter((item): item is Addon => item !== undefined)
+      if (addons.length !== parsed.length) return undefined
+      if (new Set(addons.map((addon) => addon.id)).size !== addons.length) return undefined
+      return addons
+    } catch {
+      return undefined
+    }
+  }
+
   export function resolve(env: Record<string, string | undefined> = process.env): Profile {
     const overrides = {
       name: readValue(env, "AGENTSWARM_PRODUCT_DISPLAY_NAME"),
@@ -182,7 +237,7 @@ export namespace AgencyProduct {
       tuiLogoRight: readLines(readRawValue(env, "AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT")),
       wordmarkLines: readLines(readRawValue(env, "AGENTSWARM_PRODUCT_WORDMARK_LINES")),
       pythonEnvironment: readPythonEnvironment(readValue(env, "AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT")),
-      enableAddons: readBoolean(readValue(env, "AGENTSWARM_PRODUCT_ENABLE_ADDONS")),
+      addons: readAddons(readRawValue(env, "AGENTSWARM_PRODUCT_ADDONS")),
     }
     const custom = Object.values(overrides).some((value) => value !== undefined)
     const customBranding =
@@ -198,7 +253,7 @@ export namespace AgencyProduct {
       customStarter,
       skipPostAuthModelSelection: overrides.skipPostAuthModelSelection ?? defaults.skipPostAuthModelSelection,
       hideModelSelection: overrides.hideModelSelection ?? defaults.hideModelSelection,
-      enableAddons: overrides.enableAddons ?? defaults.enableAddons,
+      addons: overrides.addons ?? defaults.addons,
       name: overrides.name ?? defaults.name,
       cmd: overrides.cmd ?? defaults.cmd,
       packageName: overrides.packageName ?? defaults.packageName,
@@ -224,7 +279,7 @@ export namespace AgencyProduct {
   export const customStarter = current.customStarter
   export const skipPostAuthModelSelection = current.skipPostAuthModelSelection
   export const hideModelSelection = current.hideModelSelection
-  export const enableAddons = current.enableAddons
+  export const addons = current.addons
   export const name = current.name
   export const packageName = current.packageName
   export const launcherPackageName = current.launcherPackageName
@@ -254,8 +309,8 @@ export namespace AgencyProduct {
     return !profile.hideModelSelection
   }
 
-  export function shouldShowAddons(profile: Pick<Profile, "enableAddons"> = current) {
-    return profile.enableAddons
+  export function shouldShowAddons(profile: Pick<Profile, "addons"> = current) {
+    return profile.addons.length > 0
   }
 
   export function modelSwitchCommandState(profile: Pick<Profile, "hideModelSelection"> = current) {

--- a/packages/opencode/src/agency-swarm/product.ts
+++ b/packages/opencode/src/agency-swarm/product.ts
@@ -1,3 +1,5 @@
+import path from "node:path"
+
 declare const AGENTSWARM_PRODUCT_DISPLAY_NAME: string | undefined
 declare const AGENTSWARM_PRODUCT_COMMAND: string | undefined
 declare const AGENTSWARM_PRODUCT_PACKAGE_NAME: string | undefined
@@ -129,6 +131,11 @@ export namespace AgencyProduct {
     return clean(env[name]) ?? clean(defineValues[name])
   }
 
+  function readStateRoot(env: Record<string, string | undefined>) {
+    const root = readValue(env, "AGENTSWARM_PRODUCT_STATE_ROOT")
+    return root ? path.resolve(root) : undefined
+  }
+
   function readRawValue(env: Record<string, string | undefined>, name: keyof typeof defineValues) {
     return env[name] ?? defineValues[name]
   }
@@ -241,7 +248,7 @@ export namespace AgencyProduct {
       wordmarkLines: readLines(readRawValue(env, "AGENTSWARM_PRODUCT_WORDMARK_LINES")),
       pythonEnvironment: readPythonEnvironment(readValue(env, "AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT")),
       addons: readAddons(readRawValue(env, "AGENTSWARM_PRODUCT_ADDONS")),
-      stateRoot: readValue(env, "AGENTSWARM_PRODUCT_STATE_ROOT"),
+      stateRoot: readStateRoot(env),
     }
     const custom = Object.values(overrides).some((value) => value !== undefined)
     const customBranding =

--- a/packages/opencode/src/agency-swarm/product.ts
+++ b/packages/opencode/src/agency-swarm/product.ts
@@ -247,7 +247,7 @@ export namespace AgencyProduct {
       tuiLogoRight: readLines(readRawValue(env, "AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT")),
       wordmarkLines: readLines(readRawValue(env, "AGENTSWARM_PRODUCT_WORDMARK_LINES")),
       pythonEnvironment: readPythonEnvironment(readValue(env, "AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT")),
-      addons: readAddons(readRawValue(env, "AGENTSWARM_PRODUCT_ADDONS")),
+      addons: readAddons(readValue(env, "AGENTSWARM_PRODUCT_ADDONS")),
       stateRoot: readStateRoot(env),
     }
     const custom = Object.values(overrides).some((value) => value !== undefined)

--- a/packages/opencode/src/agency-swarm/product.ts
+++ b/packages/opencode/src/agency-swarm/product.ts
@@ -16,6 +16,7 @@ declare const AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: string | undefined
 declare const AGENTSWARM_PRODUCT_WORDMARK_LINES: string | undefined
 declare const AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: string | undefined
 declare const AGENTSWARM_PRODUCT_ADDONS: string | undefined
+declare const AGENTSWARM_PRODUCT_STATE_ROOT: string | undefined
 
 export namespace AgencyProduct {
   export type PythonEnvironment = "any" | "standalone"
@@ -49,6 +50,7 @@ export namespace AgencyProduct {
     tuiLogoRight?: string[]
     wordmarkLines?: string[]
     pythonEnvironment: PythonEnvironment
+    stateRoot?: string
   }
 
   const defaults: Profile = {
@@ -113,8 +115,9 @@ export namespace AgencyProduct {
       typeof AGENTSWARM_PRODUCT_WORDMARK_LINES === "undefined" ? undefined : AGENTSWARM_PRODUCT_WORDMARK_LINES,
     AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT:
       typeof AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT === "undefined" ? undefined : AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT,
-    AGENTSWARM_PRODUCT_ADDONS:
-      typeof AGENTSWARM_PRODUCT_ADDONS === "undefined" ? undefined : AGENTSWARM_PRODUCT_ADDONS,
+    AGENTSWARM_PRODUCT_ADDONS: typeof AGENTSWARM_PRODUCT_ADDONS === "undefined" ? undefined : AGENTSWARM_PRODUCT_ADDONS,
+    AGENTSWARM_PRODUCT_STATE_ROOT:
+      typeof AGENTSWARM_PRODUCT_STATE_ROOT === "undefined" ? undefined : AGENTSWARM_PRODUCT_STATE_ROOT,
   } satisfies Record<string, string | undefined>
 
   function clean(value: string | undefined) {
@@ -238,6 +241,7 @@ export namespace AgencyProduct {
       wordmarkLines: readLines(readRawValue(env, "AGENTSWARM_PRODUCT_WORDMARK_LINES")),
       pythonEnvironment: readPythonEnvironment(readValue(env, "AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT")),
       addons: readAddons(readRawValue(env, "AGENTSWARM_PRODUCT_ADDONS")),
+      stateRoot: readValue(env, "AGENTSWARM_PRODUCT_STATE_ROOT"),
     }
     const custom = Object.values(overrides).some((value) => value !== undefined)
     const customBranding =
@@ -269,6 +273,7 @@ export namespace AgencyProduct {
       tuiLogoRight: overrides.tuiLogoRight,
       wordmarkLines: overrides.wordmarkLines,
       pythonEnvironment: overrides.pythonEnvironment ?? defaults.pythonEnvironment,
+      stateRoot: overrides.stateRoot,
     }
   }
 
@@ -295,6 +300,7 @@ export namespace AgencyProduct {
   export const tuiLogoRight = current.tuiLogoRight
   export const wordmarkLines = current.wordmarkLines
   export const pythonEnvironment = current.pythonEnvironment
+  export const stateRoot = current.stateRoot
   export const connect = "Authenticate providers"
   export const start = [
     "Authenticate providers and connect to a local agency-swarm server before sending prompts.",

--- a/packages/opencode/src/agency-swarm/run-session.ts
+++ b/packages/opencode/src/agency-swarm/run-session.ts
@@ -85,7 +85,7 @@ export namespace AgencySwarmRunSession {
     const env = input.env ?? process.env
     const root = env[PRODUCT_STATE_ROOT_ENV]?.trim()
     if (!root) return
-    if (path.resolve(input.directory) !== path.join(path.resolve(root), "project")) return
+    if (Filesystem.resolve(input.directory) !== path.join(Filesystem.resolve(root), "project")) return
     return remoteConfigFromContent(env.OPENCODE_CONFIG_CONTENT)
   }
 

--- a/packages/opencode/src/agency-swarm/run-session.ts
+++ b/packages/opencode/src/agency-swarm/run-session.ts
@@ -1,4 +1,5 @@
 import path from "node:path"
+import { chmod } from "node:fs/promises"
 import { Global } from "@opencode-ai/core/global"
 import { Log } from "@/util"
 import { Filesystem } from "@/util/filesystem"
@@ -52,6 +53,14 @@ export namespace AgencySwarmRunSession {
     const data = await read()
     if (!(sessionID in data)) return
     delete data[sessionID]
+    await write(data)
+  }
+
+  export async function copy(input: { sourceID: string; targetID: string }) {
+    const data = await read()
+    const info = data[input.sourceID]
+    if (!info) return
+    data[input.targetID] = structuredClone(info)
     await write(data)
   }
 
@@ -113,7 +122,13 @@ export namespace AgencySwarmRunSession {
   }
 
   async function write(data: Record<string, Info>) {
-    await Filesystem.writeJson(file, data)
+    await Filesystem.writeJson(file, data, 0o600)
+    if (process.platform !== "win32") {
+      await chmod(file, 0o600).catch((error) => {
+        if (isEnoent(error)) return
+        throw error
+      })
+    }
   }
 
   function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -122,5 +137,9 @@ export namespace AgencySwarmRunSession {
 
   function readString(value: unknown) {
     return typeof value === "string" && value.trim().length > 0 ? value : undefined
+  }
+
+  function isEnoent(error: unknown) {
+    return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"
   }
 }

--- a/packages/opencode/src/agency-swarm/run-session.ts
+++ b/packages/opencode/src/agency-swarm/run-session.ts
@@ -2,16 +2,30 @@ import path from "node:path"
 import { Global } from "@opencode-ai/core/global"
 import { Log } from "@/util"
 import { Filesystem } from "@/util/filesystem"
+import { AgencySwarmAdapter } from "./adapter"
 
 export namespace AgencySwarmRunSession {
   const log = Log.create({ service: "agency-swarm.run-session" })
   export const LOCAL_PROJECT_ENV = "AGENTSWARM_RUN_PROJECT"
+  export const PRODUCT_STATE_ROOT_ENV = "AGENTSWARM_PRODUCT_STATE_ROOT"
   const PROVIDER_ID = "agency-swarm"
 
-  type Info = {
-    mode: "local-project"
-    directory: string
+  export type RemoteConfig = {
+    baseURL: string
+    agency: string
+    token?: string
   }
+
+  export type Info =
+    | {
+        mode: "local-project"
+        directory: string
+      }
+    | {
+        mode: "remote-config"
+        directory: string
+        config: RemoteConfig
+      }
 
   const file = path.join(Global.Path.state, "agency-swarm-run-sessions.json")
 
@@ -24,6 +38,16 @@ export namespace AgencySwarmRunSession {
     await write(data)
   }
 
+  export async function markRemote(input: { sessionID: string; directory: string; config: RemoteConfig }) {
+    const data = await read()
+    data[input.sessionID] = {
+      mode: "remote-config",
+      directory: path.resolve(input.directory),
+      config: input.config,
+    }
+    await write(data)
+  }
+
   export async function clear(sessionID: string) {
     const data = await read()
     if (!(sessionID in data)) return
@@ -32,15 +56,49 @@ export namespace AgencySwarmRunSession {
   }
 
   export async function sync(input: { sessionID: string; providerID: string; directory?: string }) {
-    if (input.providerID !== PROVIDER_ID || !input.directory) {
+    if (input.providerID !== PROVIDER_ID) {
       await clear(input.sessionID)
       return
     }
-    await mark({ sessionID: input.sessionID, directory: input.directory })
+    if (input.directory) {
+      await mark({ sessionID: input.sessionID, directory: input.directory })
+      return
+    }
+    if ((await get(input.sessionID))?.mode === "remote-config") return
+    await clear(input.sessionID)
   }
 
   export async function get(sessionID: string): Promise<Info | undefined> {
     return (await read())[sessionID]
+  }
+
+  export function remoteConfigFromEnv(input: { directory: string; env?: NodeJS.ProcessEnv }) {
+    const env = input.env ?? process.env
+    const root = env[PRODUCT_STATE_ROOT_ENV]?.trim()
+    if (!root) return
+    if (path.resolve(input.directory) !== path.join(path.resolve(root), "project")) return
+    return remoteConfigFromContent(env.OPENCODE_CONFIG_CONTENT)
+  }
+
+  export function remoteConfigFromContent(content: string | undefined): RemoteConfig | undefined {
+    if (!content) return
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(content)
+    } catch {
+      return
+    }
+    const provider = asRecord(asRecord(parsed)?.["provider"])?.[PROVIDER_ID]
+    const options = asRecord(asRecord(provider)?.["options"])
+    const baseURL = readString(options?.["baseURL"]) ?? readString(options?.["base_url"])
+    const agency = readString(options?.["agency"])
+    if (!baseURL || !agency) return
+    const token = readString(asRecord(provider)?.["key"]) ?? readString(options?.["token"])
+    return {
+      baseURL: AgencySwarmAdapter.normalizeBaseURL(baseURL),
+      agency,
+      ...(token ? { token } : {}),
+    }
   }
 
   async function read(): Promise<Record<string, Info>> {
@@ -56,5 +114,13 @@ export namespace AgencySwarmRunSession {
 
   async function write(data: Record<string, Info>) {
     await Filesystem.writeJson(file, data)
+  }
+
+  function asRecord(value: unknown): Record<string, unknown> | undefined {
+    return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined
+  }
+
+  function readString(value: unknown) {
+    return typeof value === "string" && value.trim().length > 0 ? value : undefined
   }
 }

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-addons.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-addons.tsx
@@ -3,7 +3,8 @@ import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
 import { useTheme } from "../context/theme"
 import { DialogPrompt } from "../ui/dialog-prompt"
-import { readEnvKey, writeEnvKey } from "../util/env-file"
+import { readEnvKey, writeEnvKeys } from "../util/env-file"
+import { errorMessage as toErrorMessage } from "@/util/error"
 
 type Addon = {
   id: string
@@ -27,11 +28,12 @@ function keys(addons: Addon[]) {
   return addons.flatMap((addon) => addon.keys)
 }
 
-export function DialogAddons(props: { providerID: string; onDone: () => void }) {
+export function DialogAddons(props: { providerID: string; onDone: () => void; error?: string }) {
   const dialog = useDialog()
   const { theme } = useTheme()
   const [selected, setSelected] = createSignal(new Set<string>())
   const [version, setVersion] = createSignal(0)
+  const [error, setError] = createSignal(props.error)
   const available = createMemo(() =>
     ADDONS.filter((addon) => !(addon.excludeProviders ?? []).includes(props.providerID)),
   )
@@ -41,6 +43,7 @@ export function DialogAddons(props: { providerID: string; onDone: () => void }) 
   })
 
   function toggle(addon: Addon) {
+    setError(undefined)
     setSelected((current) => {
       const next = new Set(current)
       if (next.has(addon.id)) next.delete(addon.id)
@@ -60,6 +63,7 @@ export function DialogAddons(props: { providerID: string; onDone: () => void }) 
       props.onDone()
       return
     }
+    const values: [string, string][] = []
     for (const key of keys(picked)) {
       const value = await DialogPrompt.show(dialog, key, {
         placeholder: key,
@@ -74,13 +78,34 @@ export function DialogAddons(props: { providerID: string; onDone: () => void }) 
         dialog.replace(() => <DialogAddons providerID={props.providerID} onDone={props.onDone} />)
         return
       }
-      writeEnvKey(key, clean)
+      values.push([key, clean])
+    }
+    try {
+      writeEnvKeys(values)
+    } catch (err) {
+      dialog.replace(() => (
+        <DialogAddons
+          providerID={props.providerID}
+          onDone={props.onDone}
+          error={`Could not save add-ons: ${toErrorMessage(err)}`}
+        />
+      ))
+      return
     }
     setVersion((value) => value + 1)
     props.onDone()
   }
 
   const options = createMemo<DialogSelectOption<string>[]>(() => [
+    ...(error()
+      ? [
+          {
+            title: "Add-ons were not saved",
+            value: "error",
+            description: error(),
+          },
+        ]
+      : []),
     ...available().map((addon) => ({
       title: addon.title,
       value: addon.id,

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-addons.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-addons.tsx
@@ -5,26 +5,9 @@ import { useTheme } from "../context/theme"
 import { DialogPrompt } from "../ui/dialog-prompt"
 import { readEnvKey, writeEnvKeys } from "../util/env-file"
 import { errorMessage as toErrorMessage } from "@/util/error"
+import { AgencyProduct } from "@/agency-swarm/product"
 
-type Addon = {
-  id: string
-  title: string
-  keys: string[]
-  excludeProviders?: string[]
-}
-
-const ADDONS: Addon[] = [
-  { id: "search", title: "Web Search", keys: ["SEARCH_API_KEY"] },
-  { id: "anthropic", title: "Anthropic Claude", keys: ["ANTHROPIC_API_KEY"], excludeProviders: ["anthropic"] },
-  { id: "composio", title: "Composio", keys: ["COMPOSIO_API_KEY", "COMPOSIO_USER_ID"] },
-  { id: "google", title: "Google Gemini", keys: ["GOOGLE_API_KEY"], excludeProviders: ["google"] },
-  { id: "fal", title: "Fal.ai", keys: ["FAL_KEY"] },
-  { id: "pexels", title: "Pexels", keys: ["PEXELS_API_KEY"] },
-  { id: "pixabay", title: "Pixabay", keys: ["PIXABAY_API_KEY"] },
-  { id: "unsplash", title: "Unsplash", keys: ["UNSPLASH_ACCESS_KEY"] },
-]
-
-function keys(addons: Addon[]) {
+function keys(addons: AgencyProduct.Addon[]) {
   return addons.flatMap((addon) => addon.keys)
 }
 
@@ -35,14 +18,14 @@ export function DialogAddons(props: { providerID: string; onDone: () => void; er
   const [version, setVersion] = createSignal(0)
   const [error, setError] = createSignal(props.error)
   const available = createMemo(() =>
-    ADDONS.filter((addon) => !(addon.excludeProviders ?? []).includes(props.providerID)),
+    AgencyProduct.addons.filter((addon) => !(addon.excludeProviders ?? []).includes(props.providerID)),
   )
 
   onMount(() => {
     if (available().length === 0) props.onDone()
   })
 
-  function toggle(addon: Addon) {
+  function toggle(addon: AgencyProduct.Addon) {
     setError(undefined)
     setSelected((current) => {
       const next = new Set(current)
@@ -52,7 +35,7 @@ export function DialogAddons(props: { providerID: string; onDone: () => void; er
     })
   }
 
-  function configured(addon: Addon) {
+  function configured(addon: AgencyProduct.Addon) {
     version()
     return addon.keys.every((key) => readEnvKey(key))
   }

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-addons.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-addons.tsx
@@ -8,7 +8,7 @@ import { errorMessage as toErrorMessage } from "@/util/error"
 import { AgencyProduct } from "@/agency-swarm/product"
 
 function keys(addons: AgencyProduct.Addon[]) {
-  return addons.flatMap((addon) => addon.keys)
+  return [...new Set(addons.flatMap((addon) => addon.keys))]
 }
 
 export function DialogAddons(props: { providerID: string; onDone: () => void; error?: string }) {

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -18,6 +18,7 @@ import { Instance } from "@/project/instance"
 import { writeHeapSnapshot } from "v8"
 import { AgencyProduct } from "@/agency-swarm/product"
 import {
+  isNpxCwdLaunch,
   prepareNpxLaunch,
   prepareProjectLaunch,
   resolveNpxAutoProject,
@@ -158,12 +159,16 @@ export const TuiThreadCommand = cmd({
             prompt: args.prompt,
             agent: args.agent,
           })
+      const localProject = project && !isNpxCwdLaunch(project) ? project : undefined
+      const cwdProject = project && isNpxCwdLaunch(project) ? project : undefined
       const prepared = shouldBootstrap
         ? await prepareNpxLaunch(selectedProject)
-        : project
-          ? await prepareProjectLaunch(project)
+        : localProject
+          ? await prepareProjectLaunch(localProject)
+          : cwdProject
+            ? { directory: cwdProject.directory }
           : undefined
-      if ((shouldBootstrap || project) && !prepared) {
+      if ((shouldBootstrap || localProject) && !prepared) {
         return
       }
       cleanup = prepared?.cleanup

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -166,8 +166,8 @@ export const TuiThreadCommand = cmd({
         : localProject
           ? await prepareProjectLaunch(localProject)
           : cwdProject
-            ? { directory: cwdProject.directory }
-          : undefined
+            ? { directory: cwdProject.directory, configContent: cwdProject.configContent }
+            : undefined
       if ((shouldBootstrap || localProject) && !prepared) {
         return
       }

--- a/packages/opencode/src/cli/cmd/tui/util/env-file.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/env-file.ts
@@ -83,11 +83,11 @@ export function writeEnvKeys(values: [string, string][], dir = process.cwd()) {
   let lines = current.split(/\r\n|\n/)
   const pending = new Map(unique)
   for (const [key, value] of unique) {
-    const match = new RegExp(`^(\\s*(?:export\\s+)?)${key}(\\s*=)`)
+    const match = new RegExp(`^(\\s*(?:export\\s+)?)${key}(\\s*=).*$`)
     lines = lines.map((line) => {
       if (!match.test(line)) return line
       pending.delete(key)
-      return line.replace(match, `$1${key}$2`).replace(/=.*/, `=${formatValue(value)}`)
+      return line.replace(match, (_, prefix: string, equals: string) => `${prefix}${key}${equals}${formatValue(value)}`)
     })
   }
   const remaining = [...pending].map(([key, value]) => `${key}=${formatValue(value)}`)

--- a/packages/opencode/src/cli/cmd/tui/util/env-file.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/env-file.ts
@@ -1,12 +1,14 @@
 import { spawnSync } from "node:child_process"
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import path from "node:path"
+import { AgencyProduct } from "@/agency-swarm/product"
 
 const keyPattern = /^[A-Z_][A-Z0-9_]*$/
 const productStateRootEnv = "AGENTSWARM_PRODUCT_STATE_ROOT"
 
 function envDir(dir?: string) {
-  const root = process.env[productStateRootEnv]?.trim()
+  const env = process.env[productStateRootEnv]?.trim()
+  const root = env || AgencyProduct.stateRoot?.trim()
   return dir ?? (root ? path.resolve(root) : process.cwd())
 }
 

--- a/packages/opencode/src/cli/cmd/tui/util/env-file.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/env-file.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import { spawnSync } from "node:child_process"
+import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs"
 import path from "node:path"
 
 const keyPattern = /^[A-Z_][A-Z0-9_]*$/
@@ -10,7 +11,14 @@ function envPath(dir = process.cwd()) {
 function parseValue(value: string) {
   const trimmed = value.trim()
   if (!trimmed) return ""
-  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(trimmed)
+      if (typeof parsed === "string") return parsed
+    } catch {}
+    return trimmed.slice(1, -1)
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
     return trimmed.slice(1, -1)
   }
   return trimmed
@@ -22,6 +30,23 @@ function formatValue(value: string) {
 
 function assertKey(key: string) {
   if (!keyPattern.test(key)) throw new Error(`Invalid env key: ${key}`)
+}
+
+function isTracked(dir: string) {
+  const result = spawnSync("git", ["ls-files", "--error-unmatch", "--", ".env"], {
+    cwd: dir,
+    stdio: "ignore",
+  })
+  return result.status === 0
+}
+
+function writeProtected(file: string, content: string) {
+  writeFileSync(file, content, { mode: 0o600 })
+  chmodSync(file, 0o600)
+}
+
+function eol(content: string) {
+  return content.includes("\r\n") ? "\r\n" : "\n"
 }
 
 export function readEnvKey(key: string, dir = process.cwd()) {
@@ -37,24 +62,39 @@ export function readEnvKey(key: string, dir = process.cwd()) {
 }
 
 export function writeEnvKey(key: string, value: string, dir = process.cwd()) {
-  assertKey(key)
+  writeEnvKeys([[key, value]], dir)
+}
+
+export function writeEnvKeys(values: [string, string][], dir = process.cwd()) {
+  if (values.length === 0) return
+  for (const [key] of values) assertKey(key)
+  if (isTracked(dir)) throw new Error("Refusing to write add-on secrets to a git-tracked .env file.")
+
   const file = envPath(dir)
-  const next = `${key}=${formatValue(value)}`
+  const next = values.map(([key, value]) => `${key}=${formatValue(value)}`)
   if (!existsSync(file)) {
-    writeFileSync(file, `${next}\n`)
+    writeProtected(file, `${next.join("\n")}\n`)
     return
   }
 
-  const lines = readFileSync(file, "utf8").split(/\r?\n/)
-  const match = new RegExp(`^(\\s*(?:export\\s+)?)${key}(\\s*=)`)
-  let updated = false
-  const content = lines
-    .map((line) => {
+  const current = readFileSync(file, "utf8")
+  const lineEnd = eol(current)
+  let lines = current.split(/\r\n|\n/)
+  const pending = new Map(values)
+  for (const [key, value] of values) {
+    const match = new RegExp(`^(\\s*(?:export\\s+)?)${key}(\\s*=)`)
+    lines = lines.map((line) => {
       if (!match.test(line)) return line
-      updated = true
+      pending.delete(key)
       return line.replace(match, `$1${key}$2`).replace(/=.*/, `=${formatValue(value)}`)
     })
-    .join("\n")
+  }
+  const remaining = [...pending].map(([key, value]) => `${key}=${formatValue(value)}`)
+  let content = lines.join(lineEnd)
+  if (remaining.length > 0) {
+    content = content.length === 0 ? "" : content.replace(/(?:\r?\n)*$/, lineEnd)
+    content += `${remaining.join(lineEnd)}${lineEnd}`
+  }
 
-  writeFileSync(file, updated ? content : `${content.replace(/\n*$/, "\n")}${next}\n`)
+  writeProtected(file, content)
 }

--- a/packages/opencode/src/cli/cmd/tui/util/env-file.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/env-file.ts
@@ -68,10 +68,11 @@ export function writeEnvKey(key: string, value: string, dir = process.cwd()) {
 export function writeEnvKeys(values: [string, string][], dir = process.cwd()) {
   if (values.length === 0) return
   for (const [key] of values) assertKey(key)
+  const unique = [...new Map(values)]
   if (isTracked(dir)) throw new Error("Refusing to write add-on secrets to a git-tracked .env file.")
 
   const file = envPath(dir)
-  const next = values.map(([key, value]) => `${key}=${formatValue(value)}`)
+  const next = unique.map(([key, value]) => `${key}=${formatValue(value)}`)
   if (!existsSync(file)) {
     writeProtected(file, `${next.join("\n")}\n`)
     return
@@ -80,8 +81,8 @@ export function writeEnvKeys(values: [string, string][], dir = process.cwd()) {
   const current = readFileSync(file, "utf8")
   const lineEnd = eol(current)
   let lines = current.split(/\r\n|\n/)
-  const pending = new Map(values)
-  for (const [key, value] of values) {
+  const pending = new Map(unique)
+  for (const [key, value] of unique) {
     const match = new RegExp(`^(\\s*(?:export\\s+)?)${key}(\\s*=)`)
     lines = lines.map((line) => {
       if (!match.test(line)) return line

--- a/packages/opencode/src/cli/cmd/tui/util/env-file.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/env-file.ts
@@ -1,11 +1,17 @@
 import { spawnSync } from "node:child_process"
-import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import path from "node:path"
 
 const keyPattern = /^[A-Z_][A-Z0-9_]*$/
+const productStateRootEnv = "AGENTSWARM_PRODUCT_STATE_ROOT"
 
-function envPath(dir = process.cwd()) {
-  return path.join(dir, ".env")
+function envDir(dir?: string) {
+  const root = process.env[productStateRootEnv]?.trim()
+  return dir ?? (root ? path.resolve(root) : process.cwd())
+}
+
+function envPath(dir?: string) {
+  return path.join(envDir(dir), ".env")
 }
 
 function parseValue(value: string) {
@@ -49,7 +55,7 @@ function eol(content: string) {
   return content.includes("\r\n") ? "\r\n" : "\n"
 }
 
-export function readEnvKey(key: string, dir = process.cwd()) {
+export function readEnvKey(key: string, dir?: string) {
   assertKey(key)
   const file = envPath(dir)
   if (!existsSync(file)) return undefined
@@ -61,17 +67,19 @@ export function readEnvKey(key: string, dir = process.cwd()) {
   return parseValue(line.slice(line.indexOf("=") + 1))
 }
 
-export function writeEnvKey(key: string, value: string, dir = process.cwd()) {
+export function writeEnvKey(key: string, value: string, dir?: string) {
   writeEnvKeys([[key, value]], dir)
 }
 
-export function writeEnvKeys(values: [string, string][], dir = process.cwd()) {
+export function writeEnvKeys(values: [string, string][], dir?: string) {
   if (values.length === 0) return
   for (const [key] of values) assertKey(key)
   const unique = [...new Map(values)]
-  if (isTracked(dir)) throw new Error("Refusing to write add-on secrets to a git-tracked .env file.")
+  const root = envDir(dir)
+  mkdirSync(root, { recursive: true })
+  if (isTracked(root)) throw new Error("Refusing to write add-on secrets to a git-tracked .env file.")
 
-  const file = envPath(dir)
+  const file = envPath(root)
   const next = unique.map(([key, value]) => `${key}=${formatValue(value)}`)
   if (!existsSync(file)) {
     writeProtected(file, `${next.join("\n")}\n`)

--- a/packages/opencode/src/cli/cmd/tui/util/env-file.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/env-file.ts
@@ -6,9 +6,16 @@ import { AgencyProduct } from "@/agency-swarm/product"
 const keyPattern = /^[A-Z_][A-Z0-9_]*$/
 const productStateRootEnv = "AGENTSWARM_PRODUCT_STATE_ROOT"
 
+function envProductStateRoot() {
+  const root = process.env[productStateRootEnv]?.trim()
+  if (!root) return
+  const resolved = path.resolve(root)
+  if (resolved !== root) process.env[productStateRootEnv] = resolved
+  return resolved
+}
+
 function envDir(dir?: string) {
-  const env = process.env[productStateRootEnv]?.trim()
-  const root = env || AgencyProduct.stateRoot?.trim()
+  const root = envProductStateRoot() ?? AgencyProduct.stateRoot?.trim()
   return dir ?? (root ? path.resolve(root) : process.cwd())
 }
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -494,6 +494,8 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
           yield* remove(child.id)
         }
 
+        yield* Effect.promise(() => AgencySwarmRunSession.clear(sessionID).catch((e) => log.error(e)))
+
         // `remove` needs to work in all cases, such as a broken
         // sessions that run cleanup. In certain cases these will
         // run without any instance state, so we need to turn off

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -616,6 +616,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
           })
         }
       }
+      yield* Effect.promise(() => AgencySwarmRunSession.copy({ sourceID: original.id, targetID: session.id }))
       return session
     })
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -571,6 +571,13 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
       const runProject = process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
       if (runProject) {
         yield* Effect.promise(() => AgencySwarmRunSession.mark({ sessionID: result.id, directory: runProject }))
+      } else {
+        const remoteConfig = AgencySwarmRunSession.remoteConfigFromEnv({ directory })
+        if (remoteConfig) {
+          yield* Effect.promise(() =>
+            AgencySwarmRunSession.markRemote({ sessionID: result.id, directory, config: remoteConfig }),
+          )
+        }
       }
       return result
     })

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -4277,6 +4277,95 @@ describe("agency-swarm npx onboarding", () => {
     expect(project).toEqual({ directory: projectDir, cwdOnly: true })
   })
 
+  test("resolveNpxAutoProject preserves remote config for product state resumes", async () => {
+    await using caller = await tmpdir()
+    await using root = await tmpdir()
+    const projectDir = path.join(root.path, "project")
+    const sessionID = SessionID.descending("ses_remote")
+    await mkdir(projectDir, { recursive: true })
+
+    const project = await resolveNpxAutoProject({
+      directory: caller.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: sessionID,
+      profile: {
+        ...downstreamProfile,
+        stateRoot: root.path,
+      },
+      sessions: [
+        {
+          id: sessionID,
+          directory: projectDir,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [
+        {
+          sessionID,
+          mode: "remote-config",
+          directory: projectDir,
+          config: {
+            baseURL: "https://remote.example",
+            agency: "remote-agency",
+            token: "server-token",
+          },
+        },
+      ],
+    })
+    if (!project || !("cwdOnly" in project)) throw new Error("Expected cwd-only project")
+    const config = JSON.parse(project.configContent ?? "{}")
+
+    expect(project.directory).toBe(projectDir)
+    expect(project.cwdOnly).toBe(true)
+    expect(config.provider["agency-swarm"].options).toEqual({
+      baseURL: "https://remote.example",
+      agency: "remote-agency",
+      discoveryTimeoutMs: 2000,
+      timeout: false,
+      token: "server-token",
+    })
+  })
+
+  test("resolveNpxAutoProject ignores remote run metadata without a product state root", async () => {
+    await using dir = await tmpdir()
+    const sessionID = SessionID.descending("ses_remote")
+
+    const project = await resolveNpxAutoProject({
+      directory: dir.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: sessionID,
+      sessions: [
+        {
+          id: sessionID,
+          directory: dir.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [
+        {
+          sessionID,
+          mode: "remote-config",
+          directory: dir.path,
+          config: {
+            baseURL: "https://remote.example",
+            agency: "remote-agency",
+            token: "server-token",
+          },
+        },
+      ],
+    })
+
+    expect(project).toBeUndefined()
+  })
+
   test("resolveNpxAutoProject uses legacy local-agency history for continue", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -3341,6 +3341,101 @@ describe("agency-swarm npx onboarding", () => {
     expect(launch?.directory).toBe(project)
   })
 
+  test("prepareNpxLaunch creates default starters at the state-root project path", async () => {
+    await using caller = await tmpdir()
+    await using root = await tmpdir()
+    const profile = AgencyProduct.resolve({
+      AGENTSWARM_PRODUCT_STATE_ROOT: root.path,
+    })
+    const project = path.join(root.path, "project")
+    const nested = path.join(project, profile.starterProjectName)
+    const calls: { cmd: string[]; cwd?: string }[] = []
+    const text = spyOn(prompts, "text").mockResolvedValue(profile.starterProjectName as never)
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+    spyOn(prompts, "outro").mockImplementation(() => undefined as never)
+    spyOn(prompts, "select").mockResolvedValue("starter" as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      calls.push({ cmd, cwd: options.cwd })
+
+      if (cmd[0] === "gh") {
+        return { exited: Promise.resolve(1), stdout: "", stderr: "gh unavailable" } as never
+      }
+
+      if (cmd[0] === "git" && cmd[1] === "clone") {
+        const target = cmd.at(-1)
+        if (!target) throw new Error("Missing clone target")
+        mkdirSync(path.join(target, ".venv", process.platform === "win32" ? "Scripts" : "bin"), { recursive: true })
+        writeFileSync(
+          path.join(target, "agency.py"),
+          "from agency_swarm import Agency\n\ndef create_agency():\n    return Agency()\n",
+        )
+        writeFileSync(getTestVenvPython(target), "")
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (cmd[0] === "git" && cmd[1] === "init") {
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (isUvVersionCommand(cmd)) {
+        return { exited: Promise.resolve(0), stdout: "uv 0.8.0\n", stderr: "" } as never
+      }
+
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return { exited: Promise.resolve(0), stdout: `${cmd[0]}\n3.12.7\n`, stderr: "" } as never
+      }
+
+      if (
+        isPythonVenvCommand(cmd) ||
+        isPythonPipInstallUvCommand(cmd) ||
+        isUvPipInstallCommand(cmd) ||
+        isCanaryCommand(cmd)
+      ) {
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareNpxLaunch(caller.path, profile)
+    const detected = await resolveNpxAutoProject({
+      directory: caller.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      prompt: "hello",
+      profile,
+    })
+
+    expect(profile.customStarter).toBe(false)
+    expect(text).not.toHaveBeenCalled()
+    expect(calls).toContainEqual({ cmd: ["git", "clone", "--depth=1", starterTemplateUrl(profile), project] })
+    expect(launch?.directory).toBe(project)
+    expect(launch?.runProjectDirectory).toBe(project)
+    expect(detected?.directory).toBe(project)
+    expect(existsSync(nested)).toBe(false)
+
+    await launch?.cleanup?.()
+  })
+
   test("prepareNpxLaunch clones the configured starter folder and launches the configured entry file", async () => {
     await using dir = await tmpdir()
     const target = path.join(dir.path, downstreamProfile.starterProjectName)

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { existsSync, mkdirSync, writeFileSync } from "node:fs"
-import { mkdir } from "node:fs/promises"
+import { mkdir, symlink } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import * as prompts from "@clack/prompts"
@@ -4328,6 +4328,77 @@ describe("agency-swarm npx onboarding", () => {
       timeout: false,
       token: "server-token",
     })
+  })
+
+  test("resolveNpxAutoProject resumes product state sessions through symlinked state roots", async () => {
+    await using caller = await tmpdir()
+    await using root = await tmpdir()
+    await using links = await tmpdir()
+    const stateRoot = path.join(links.path, "state-root")
+    const projectDir = path.join(root.path, "project")
+    const sessionID = SessionID.descending("ses_remote")
+    const config = {
+      baseURL: "https://remote.example",
+      agency: "remote-agency",
+      token: "server-token",
+    }
+    const profile = {
+      ...downstreamProfile,
+      stateRoot,
+    }
+    const sessions = [
+      {
+        id: sessionID,
+        directory: projectDir,
+        parentID: undefined,
+        time: {
+          created: 1,
+          updated: 1,
+        },
+      },
+    ]
+    const runSessions = [
+      {
+        sessionID,
+        mode: "remote-config" as const,
+        directory: projectDir,
+        config,
+      },
+    ]
+
+    await mkdir(projectDir, { recursive: true })
+    await symlink(root.path, stateRoot, process.platform === "win32" ? "junction" : "dir")
+
+    const bySession = await resolveNpxAutoProject({
+      directory: caller.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: sessionID,
+      profile,
+      sessions,
+      runSessions,
+    })
+    const byContinue = await resolveNpxAutoProject({
+      directory: caller.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      profile,
+      sessions,
+      runSessions,
+    })
+
+    expect(resolveProductProjectDirectory(profile)).toBe(projectDir)
+    for (const project of [bySession, byContinue]) {
+      if (!project || !("cwdOnly" in project)) throw new Error("Expected cwd-only project")
+      expect(project.directory).toBe(projectDir)
+      expect(project.cwdOnly).toBe(true)
+      expect(JSON.parse(project.configContent ?? "{}").provider["agency-swarm"].options).toEqual({
+        baseURL: "https://remote.example",
+        agency: "remote-agency",
+        discoveryTimeoutMs: 2000,
+        timeout: false,
+        token: "server-token",
+      })
+    }
   })
 
   test("resolveNpxAutoProject ignores remote run metadata without a product state root", async () => {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -27,6 +27,7 @@ import { AgencyProduct } from "../../src/agency-swarm/product"
 import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
+import { SessionID } from "../../src/session/schema"
 import { Storage } from "../../src/storage/storage"
 import { tmpdir } from "../fixture/fixture"
 
@@ -4242,6 +4243,38 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(project).toBeUndefined()
+  })
+
+  test("resolveNpxAutoProject preserves product state cwd for remote continue sessions", async () => {
+    await using caller = await tmpdir()
+    await using root = await tmpdir()
+    const projectDir = path.join(root.path, "project")
+    const sessionID = SessionID.descending("ses_remote")
+    await mkdir(projectDir, { recursive: true })
+
+    const project = await resolveNpxAutoProject({
+      directory: caller.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      continue: true,
+      profile: {
+        ...downstreamProfile,
+        stateRoot: root.path,
+      },
+      sessions: [
+        {
+          id: sessionID,
+          directory: projectDir,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [],
+    })
+
+    expect(project).toEqual({ directory: projectDir, cwdOnly: true })
   })
 
   test("resolveNpxAutoProject uses legacy local-agency history for continue", async () => {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -3302,6 +3302,45 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
+  test("prepareNpxLaunch creates the state-root project directory before remote connect launch", async () => {
+    await using caller = await tmpdir()
+    await using root = await tmpdir()
+    const project = path.join(root.path, "project")
+    const profile = {
+      ...AgencyProduct.resolve({}),
+      stateRoot: root.path,
+    }
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    spyOn(prompts, "outro").mockImplementation(() => undefined as never)
+    spyOn(prompts, "select").mockResolvedValue("connect" as never)
+    spyOn(prompts, "text").mockResolvedValue("http://127.0.0.1:8123" as never)
+    spyOn(prompts, "confirm").mockResolvedValue(false as never)
+    const rawFetch = globalThis.fetch
+    spyOn(globalThis, "fetch").mockImplementation(
+      Object.assign(
+        async (input: URL | RequestInfo) => {
+          const url = String(input)
+          const body = url.endsWith("/openapi.json")
+            ? { paths: { "/local-agency/get_metadata": { get: {} } } }
+            : { name: "Local Agency" }
+          return Response.json(body)
+        },
+        {
+          preconnect: rawFetch.preconnect?.bind(rawFetch),
+        },
+      ) as typeof globalThis.fetch,
+    )
+
+    expect(existsSync(project)).toBe(false)
+
+    const launch = await prepareNpxLaunch(caller.path, profile)
+
+    expect(existsSync(project)).toBe(true)
+    expect(launch?.directory).toBe(project)
+  })
+
   test("prepareNpxLaunch clones the configured starter folder and launches the configured entry file", async () => {
     await using dir = await tmpdir()
     const target = path.join(dir.path, downstreamProfile.starterProjectName)

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
-import { mkdirSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { mkdir } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
@@ -15,6 +15,8 @@ import {
   prepareNpxLaunch,
   resolveLauncherCommand,
   resolveNpxAutoProject,
+  resolveProductProjectDirectory,
+  resolveProductStateRoot,
   shouldRunNpxOnboarding,
   starterTemplateUrl,
   summarizeBridgeStderr,
@@ -3211,6 +3213,95 @@ describe("agency-swarm npx onboarding", () => {
     expect(project).toBeUndefined()
   })
 
+  test("product state root is the launcher project and state directory", async () => {
+    await using caller = await tmpdir()
+    await using root = await tmpdir()
+    const project = path.join(root.path, "project")
+    writeFileSync(path.join(root.path, ".env"), 'SEARCH_API_KEY="existing"\n')
+    const profile = {
+      ...downstreamProfile,
+      stateRoot: root.path,
+    }
+    const calls: { cmd: string[]; cwd?: string; logFile?: string }[] = []
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+    spyOn(prompts, "outro").mockImplementation(() => undefined as never)
+    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      calls.push({ cmd, cwd: options.cwd, logFile: options.logFile })
+
+      if (cmd[0] === "git" && cmd[1] === "clone") {
+        mkdirSync(project, { recursive: true })
+        writeFileSync(
+          path.join(project, "main.py"),
+          "from agency_swarm import Agency\n\ndef create_agency():\n    return Agency()\n",
+        )
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (cmd[0] === "git" && cmd[1] === "init") {
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (isUvVersionCommand(cmd)) {
+        return { exited: Promise.resolve(0), stdout: "uv 0.8.0\n", stderr: "" } as never
+      }
+
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return { exited: Promise.resolve(0), stdout: "/usr/bin/python3.12\n3.12.7\n", stderr: "" } as never
+      }
+
+      if (
+        isPythonVenvCommand(cmd) ||
+        isPythonPipInstallUvCommand(cmd) ||
+        isUvPipInstallCommand(cmd) ||
+        isCanaryCommand(cmd)
+      ) {
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareNpxLaunch(caller.path, profile)
+    const venv = calls.find((call) => isPythonVenvCommand(call.cmd))
+    const installs = calls.filter((call) => isUvPipInstallCommand(call.cmd) || isPythonPipInstallUvCommand(call.cmd))
+    const logs = await Array.fromAsync(new Bun.Glob("logs/**/*.log").scan(root.path))
+
+    expect(resolveProductStateRoot(profile)).toBe(root.path)
+    expect(resolveProductProjectDirectory(profile)).toBe(project)
+    expect(calls).toContainEqual({ cmd: ["git", "clone", "--depth=1", starterTemplateUrl(profile), project] })
+    expect(launch?.directory).toBe(project)
+    expect(launch?.runProjectDirectory).toBe(project)
+    expect(venv?.cwd).toBe(project)
+    expect(installs.flatMap((call) => call.cmd).every((item) => !item.includes(caller.path))).toBe(true)
+    expect(installs.flatMap((call) => call.cmd).some((item) => item.includes(path.join(project, ".venv")))).toBe(true)
+    expect(logs.some((file) => file.endsWith("launcher-rebuild.log"))).toBe(true)
+    expect(existsSync(path.join(root.path, ".env"))).toBe(true)
+    expect(existsSync(path.join(caller.path, ".venv"))).toBe(false)
+
+    await launch?.cleanup?.()
+  })
+
   test("prepareNpxLaunch clones the configured starter folder and launches the configured entry file", async () => {
     await using dir = await tmpdir()
     const target = path.join(dir.path, downstreamProfile.starterProjectName)
@@ -3551,6 +3642,40 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject rejects explicit sessions outside product state project directory", async () => {
+    await using caller = await tmpdir()
+    await using root = await tmpdir()
+    await using stale = await tmpdir()
+    const project = path.join(root.path, "project")
+    await mkdir(project, { recursive: true })
+    await writeAgency(project)
+    await writeAgency(stale.path)
+
+    const resolved = await resolveNpxAutoProject({
+      directory: caller.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      session: "ses_123",
+      profile: {
+        ...downstreamProfile,
+        stateRoot: root.path,
+      },
+      sessions: [
+        {
+          id: "ses_123" as any,
+          directory: stale.path,
+          parentID: undefined,
+          time: {
+            created: 1,
+            updated: 1,
+          },
+        },
+      ],
+      runSessions: [{ sessionID: "ses_123", directory: stale.path }],
+    })
+
+    expect(resolved).toBeUndefined()
   })
 
   test("resolveNpxAutoProject does not auto-start explicit sessions without run metadata", async () => {
@@ -3987,6 +4112,33 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(project?.directory).toBe(dir.path)
+  })
+
+  test("resolveNpxAutoProject uses product state root for prompt launch", async () => {
+    await using caller = await tmpdir()
+    await using root = await tmpdir()
+    const projectDir = path.join(root.path, "project")
+    await mkdir(projectDir, { recursive: true })
+    await Bun.write(
+      path.join(projectDir, "main.py"),
+      "from agency_swarm import Agency\n\ndef create_agency(load_threads_callback=None):\n    return Agency()\n",
+    )
+    await Bun.write(
+      path.join(caller.path, "main.py"),
+      "from agency_swarm import Agency\n\ndef create_agency(load_threads_callback=None):\n    return Agency()\n",
+    )
+
+    const project = await resolveNpxAutoProject({
+      directory: caller.path,
+      env: { [LAUNCHER_ENTRY_ENV]: "1" },
+      prompt: "hello",
+      profile: {
+        ...downstreamProfile,
+        stateRoot: root.path,
+      },
+    })
+
+    expect(project?.directory).toBe(path.join(root.path, "project"))
   })
 
   test("resolveNpxAutoProject starts current project for agent launch", async () => {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -13,6 +13,7 @@ import {
   LAUNCHER_ENTRY_ENV,
   prepareProjectLaunch,
   prepareNpxLaunch,
+  PRODUCT_STATE_ROOT_ENV,
   resolveLauncherCommand,
   resolveNpxAutoProject,
   resolveProductProjectDirectory,
@@ -31,6 +32,7 @@ import { tmpdir } from "../fixture/fixture"
 
 describe("agency-swarm npx onboarding", () => {
   const originalEnv = process.env[LAUNCHER_ENTRY_ENV]
+  const originalProductStateRootEnv = process.env[PRODUCT_STATE_ROOT_ENV]
   const downstreamProfile = {
     custom: true,
     name: "Example Product",
@@ -44,6 +46,8 @@ describe("agency-swarm npx onboarding", () => {
     mock.restore()
     if (originalEnv === undefined) delete process.env[LAUNCHER_ENTRY_ENV]
     else process.env[LAUNCHER_ENTRY_ENV] = originalEnv
+    if (originalProductStateRootEnv === undefined) delete process.env[PRODUCT_STATE_ROOT_ENV]
+    else process.env[PRODUCT_STATE_ROOT_ENV] = originalProductStateRootEnv
   })
 
   test("wrapper env enables onboarding for the default launch only", () => {
@@ -3341,6 +3345,95 @@ describe("agency-swarm npx onboarding", () => {
     expect(launch?.directory).toBe(project)
   })
 
+  test("prepareNpxLaunch exports a relative state root as absolute before launch", async () => {
+    await using caller = await tmpdir()
+    const cwd = process.cwd()
+    const previous = process.env[PRODUCT_STATE_ROOT_ENV]
+    const calls: { cmd: string[]; cwd?: string }[] = []
+    try {
+      process.chdir(caller.path)
+      process.env[PRODUCT_STATE_ROOT_ENV] = "state-root"
+      const profile = AgencyProduct.resolve({
+        [PRODUCT_STATE_ROOT_ENV]: process.env[PRODUCT_STATE_ROOT_ENV],
+      })
+      const root = path.join(caller.path, "state-root")
+      const project = path.join(root, "project")
+
+      spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+      spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
+      spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+      spyOn(prompts, "outro").mockImplementation(() => undefined as never)
+      spyOn(prompts, "select").mockResolvedValue("starter" as never)
+      spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+      spyOn(Bun, "spawn").mockImplementation((options: any) => {
+        const cmd = options?.cmd as string[] | undefined
+        if (!cmd) throw new Error("Missing command")
+        calls.push({ cmd, cwd: options.cwd })
+
+        if (cmd[0] === "git" && cmd[1] === "clone") {
+          const target = cmd.at(-1)
+          if (!target) throw new Error("Missing clone target")
+          mkdirSync(path.join(target, ".venv", process.platform === "win32" ? "Scripts" : "bin"), { recursive: true })
+          writeFileSync(
+            path.join(target, "agency.py"),
+            "from agency_swarm import Agency\n\ndef create_agency():\n    return Agency()\n",
+          )
+          writeFileSync(getTestVenvPython(target), "")
+          return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+        }
+
+        if (cmd[0] === "git" && cmd[1] === "init") {
+          return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+        }
+
+        if (isUvVersionCommand(cmd)) {
+          return { exited: Promise.resolve(0), stdout: "uv 0.8.0\n", stderr: "" } as never
+        }
+
+        if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+          return { exited: Promise.resolve(0), stdout: `${cmd[0]}\n3.12.7\n`, stderr: "" } as never
+        }
+
+        if (
+          isPythonVenvCommand(cmd) ||
+          isPythonPipInstallUvCommand(cmd) ||
+          isUvPipInstallCommand(cmd) ||
+          isCanaryCommand(cmd)
+        ) {
+          return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+        }
+
+        if (cmd[1]?.endsWith("launch_agency.py")) {
+          let resolveExit!: (code: number) => void
+          const exited = new Promise<number>((resolve) => {
+            resolveExit = resolve
+          })
+          return {
+            exited,
+            stderr: "",
+            kill() {
+              resolveExit(0)
+            },
+          } as never
+        }
+
+        throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+      })
+
+      const launch = await prepareNpxLaunch(caller.path, profile)
+
+      expect(process.env[PRODUCT_STATE_ROOT_ENV]).toBe(root)
+      expect(calls).toContainEqual({ cmd: ["git", "clone", "--depth=1", starterTemplateUrl(profile), project] })
+      expect(launch?.directory).toBe(project)
+
+      await launch?.cleanup?.()
+    } finally {
+      process.chdir(cwd)
+      if (previous === undefined) delete process.env[PRODUCT_STATE_ROOT_ENV]
+      else process.env[PRODUCT_STATE_ROOT_ENV] = previous
+    }
+  })
+
   test("prepareNpxLaunch creates default starters at the state-root project path", async () => {
     await using caller = await tmpdir()
     await using root = await tmpdir()
@@ -3432,6 +3525,69 @@ describe("agency-swarm npx onboarding", () => {
     expect(launch?.runProjectDirectory).toBe(project)
     expect(detected?.directory).toBe(project)
     expect(existsSync(nested)).toBe(false)
+
+    await launch?.cleanup?.()
+  })
+
+  test("prepareNpxLaunch hides starter creation when a fixed state-root project exists", async () => {
+    await using root = await tmpdir()
+    const project = path.join(root.path, "project")
+    const profile = AgencyProduct.resolve({
+      [PRODUCT_STATE_ROOT_ENV]: root.path,
+    })
+    const choices: string[] = []
+    const calls: { cmd: string[]; cwd?: string }[] = []
+    await mkdir(project, { recursive: true })
+    await writeAgency(project)
+    await writeVenvPython(project)
+
+    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
+    spyOn(prompts, "outro").mockImplementation(() => undefined as never)
+    spyOn(prompts, "select").mockImplementation((input) => {
+      choices.push(...input.options.map((option) => String(option.value)))
+      return Promise.resolve("project" as never)
+    })
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+    spyOn(Bun, "spawn").mockImplementation((options: any) => {
+      const cmd = options?.cmd as string[] | undefined
+      if (!cmd) throw new Error("Missing command")
+      calls.push({ cmd, cwd: options.cwd })
+
+      if (isUvVersionCommand(cmd)) {
+        return { exited: Promise.resolve(0), stdout: "uv 0.8.0\n", stderr: "" } as never
+      }
+
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        return { exited: Promise.resolve(0), stdout: `${cmd[0]}\n3.12.7\n`, stderr: "" } as never
+      }
+
+      if (isUvPipInstallCommand(cmd) || isCanaryCommand(cmd)) {
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
+      }
+
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
+        } as never
+      }
+
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareNpxLaunch(root.path, profile)
+
+    expect(choices).toEqual(["project", "connect"])
+    expect(calls.some((call) => call.cmd[0] === "git" && call.cmd[1] === "clone")).toBe(false)
+    expect(launch?.directory).toBe(project)
 
     await launch?.cleanup?.()
   })

--- a/packages/opencode/test/agency-swarm/product.test.ts
+++ b/packages/opencode/test/agency-swarm/product.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import path from "node:path"
 import { AgencyProduct } from "../../src/agency-swarm/product"
 
 describe("AgencyProduct profile", () => {
@@ -30,6 +31,14 @@ describe("AgencyProduct profile", () => {
     expect(profile.pythonEnvironment).toBe("any")
     expect(profile.stateRoot).toBeUndefined()
     expect(AgencyProduct.tuiLogo(profile)).toBeUndefined()
+  })
+
+  test("normalizes relative product state roots once", () => {
+    const profile = AgencyProduct.resolve({
+      AGENTSWARM_PRODUCT_STATE_ROOT: "example-product",
+    })
+
+    expect(profile.stateRoot).toBe(path.resolve("example-product"))
   })
 
   test("selects a generic downstream profile from product env", () => {

--- a/packages/opencode/test/agency-swarm/product.test.ts
+++ b/packages/opencode/test/agency-swarm/product.test.ts
@@ -9,7 +9,7 @@ describe("AgencyProduct profile", () => {
     expect(profile.customBranding).toBe(false)
     expect(profile.skipPostAuthModelSelection).toBe(false)
     expect(profile.hideModelSelection).toBe(false)
-    expect(profile.enableAddons).toBe(false)
+    expect(profile.addons).toEqual([])
     expect(AgencyProduct.shouldShowPostAuthModelSelection(profile)).toBe(true)
     expect(AgencyProduct.shouldShowModelSelection(profile)).toBe(true)
     expect(AgencyProduct.shouldShowAddons(profile)).toBe(false)
@@ -50,7 +50,15 @@ describe("AgencyProduct profile", () => {
       AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: "RIGHT\\nRIGHT2",
       AGENTSWARM_PRODUCT_WORDMARK_LINES: "WORD\\n MARK",
       AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: "standalone",
-      AGENTSWARM_PRODUCT_ENABLE_ADDONS: "true",
+      AGENTSWARM_PRODUCT_ADDONS: JSON.stringify([
+        { id: "search", title: "Search", keys: ["SEARCH_API_KEY"] },
+        {
+          id: "anthropic",
+          title: "Anthropic",
+          keys: ["ANTHROPIC_API_KEY"],
+          excludeProviders: ["anthropic"],
+        },
+      ]),
     })
 
     expect(profile.custom).toBe(true)
@@ -58,7 +66,15 @@ describe("AgencyProduct profile", () => {
     expect(profile.customStarter).toBe(true)
     expect(profile.skipPostAuthModelSelection).toBe(true)
     expect(profile.hideModelSelection).toBe(true)
-    expect(profile.enableAddons).toBe(true)
+    expect(profile.addons).toEqual([
+      { id: "search", title: "Search", keys: ["SEARCH_API_KEY"] },
+      {
+        id: "anthropic",
+        title: "Anthropic",
+        keys: ["ANTHROPIC_API_KEY"],
+        excludeProviders: ["anthropic"],
+      },
+    ])
     expect(AgencyProduct.shouldShowPostAuthModelSelection(profile)).toBe(false)
     expect(AgencyProduct.shouldShowModelSelection(profile)).toBe(false)
     expect(AgencyProduct.shouldShowAddons(profile)).toBe(true)
@@ -83,14 +99,53 @@ describe("AgencyProduct profile", () => {
     })
   })
 
-  test("ignores invalid add-ons flag values", () => {
+  test("ignores invalid add-ons config values", () => {
     const profile = AgencyProduct.resolve({
-      AGENTSWARM_PRODUCT_ENABLE_ADDONS: "maybe",
+      AGENTSWARM_PRODUCT_ADDONS: JSON.stringify([{ id: "search", title: "Search", keys: [] }]),
     })
 
     expect(profile.custom).toBe(false)
-    expect(profile.enableAddons).toBe(false)
+    expect(profile.addons).toEqual([])
     expect(AgencyProduct.shouldShowAddons(profile)).toBe(false)
+  })
+
+  test("ignores add-ons config with invalid env keys", () => {
+    for (const key of ["", "bad", "BAD-KEY"]) {
+      const profile = AgencyProduct.resolve({
+        AGENTSWARM_PRODUCT_ADDONS: JSON.stringify([{ id: "search", title: "Search", keys: [key] }]),
+      })
+
+      expect(profile.custom).toBe(false)
+      expect(profile.addons).toEqual([])
+      expect(AgencyProduct.shouldShowAddons(profile)).toBe(false)
+    }
+  })
+
+  test("ignores add-ons config with duplicate ids", () => {
+    const profile = AgencyProduct.resolve({
+      AGENTSWARM_PRODUCT_ADDONS: JSON.stringify([
+        { id: "search", title: "Search", keys: ["SEARCH_API_KEY"] },
+        { id: "search", title: "Other Search", keys: ["OTHER_SEARCH_API_KEY"] },
+      ]),
+    })
+
+    expect(profile.custom).toBe(false)
+    expect(profile.addons).toEqual([])
+    expect(AgencyProduct.shouldShowAddons(profile)).toBe(false)
+  })
+
+  test("ignores add-ons config with malformed provider exclusions", () => {
+    for (const excludeProviders of ["anthropic", [1], [null], {}]) {
+      const profile = AgencyProduct.resolve({
+        AGENTSWARM_PRODUCT_ADDONS: JSON.stringify([
+          { id: "search", title: "Search", keys: ["SEARCH_API_KEY"], excludeProviders },
+        ]),
+      })
+
+      expect(profile.custom).toBe(false)
+      expect(profile.addons).toEqual([])
+      expect(AgencyProduct.shouldShowAddons(profile)).toBe(false)
+    }
   })
 
   test("ignores invalid downstream Python environment values", () => {

--- a/packages/opencode/test/agency-swarm/product.test.ts
+++ b/packages/opencode/test/agency-swarm/product.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
 import path from "node:path"
 import { AgencyProduct } from "../../src/agency-swarm/product"
 
@@ -109,6 +111,64 @@ describe("AgencyProduct profile", () => {
       left: [" LEFT", "LEFT2"],
       right: ["RIGHT", "RIGHT2"],
     })
+  })
+
+  test("preserves compiled add-ons when runtime add-ons env is blank", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "agentswarm-product-"))
+    try {
+      const addons = [{ id: "search", title: "Search", keys: ["SEARCH_API_KEY"] }]
+      const root = path.resolve(import.meta.dir, "../..")
+      const entry = path.join(dir, "entry.ts")
+      const outdir = path.join(dir, "out")
+      await writeFile(
+        entry,
+        [
+          `import { AgencyProduct } from ${JSON.stringify(path.join(root, "src/agency-swarm/product.ts"))}`,
+          "console.log(JSON.stringify({",
+          "  addons: AgencyProduct.resolve(process.env).addons,",
+          "  currentAddons: AgencyProduct.addons,",
+          "  show: AgencyProduct.shouldShowAddons(),",
+          "}))",
+        ].join("\n"),
+      )
+
+      const result = await Bun.build({
+        entrypoints: [entry],
+        outdir,
+        format: "esm",
+        target: "bun",
+        define: {
+          AGENTSWARM_PRODUCT_ADDONS: JSON.stringify(JSON.stringify(addons)),
+        },
+      })
+      if (!result.success) {
+        throw new Error(result.logs.map((log) => log.message).join("\n"))
+      }
+
+      const proc = Bun.spawn([process.execPath, path.join(outdir, "entry.js")], {
+        cwd: root,
+        env: {
+          AGENTSWARM_PRODUCT_ADDONS: "",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      const [stdout, stderr, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+
+      expect(stderr).toBe("")
+      expect(code).toBe(0)
+      expect(JSON.parse(stdout)).toEqual({
+        addons,
+        currentAddons: addons,
+        show: true,
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 
   test("ignores invalid add-ons config values", () => {

--- a/packages/opencode/test/agency-swarm/product.test.ts
+++ b/packages/opencode/test/agency-swarm/product.test.ts
@@ -28,6 +28,7 @@ describe("AgencyProduct profile", () => {
     expect(profile.tuiLogoRight).toBeUndefined()
     expect(profile.wordmarkLines).toBeUndefined()
     expect(profile.pythonEnvironment).toBe("any")
+    expect(profile.stateRoot).toBeUndefined()
     expect(AgencyProduct.tuiLogo(profile)).toBeUndefined()
   })
 
@@ -50,6 +51,7 @@ describe("AgencyProduct profile", () => {
       AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: "RIGHT\\nRIGHT2",
       AGENTSWARM_PRODUCT_WORDMARK_LINES: "WORD\\n MARK",
       AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: "standalone",
+      AGENTSWARM_PRODUCT_STATE_ROOT: "/tmp/example-product",
       AGENTSWARM_PRODUCT_ADDONS: JSON.stringify([
         { id: "search", title: "Search", keys: ["SEARCH_API_KEY"] },
         {
@@ -93,6 +95,7 @@ describe("AgencyProduct profile", () => {
     expect(profile.tuiLogoRight).toEqual(["RIGHT", "RIGHT2"])
     expect(profile.wordmarkLines).toEqual(["WORD", " MARK"])
     expect(profile.pythonEnvironment).toBe("standalone")
+    expect(profile.stateRoot).toBe("/tmp/example-product")
     expect(AgencyProduct.tuiLogo(profile)).toEqual({
       left: [" LEFT", "LEFT2"],
       right: ["RIGHT", "RIGHT2"],

--- a/packages/opencode/test/agency-swarm/run-session.test.ts
+++ b/packages/opencode/test/agency-swarm/run-session.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { mkdir, symlink } from "node:fs/promises"
 import path from "node:path"
 import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
 import { Filesystem } from "../../src/util/filesystem"
+import { tmpdir } from "../fixture/fixture"
 
 describe("agency-swarm run session state", () => {
   afterEach(() => {
@@ -139,6 +141,40 @@ describe("agency-swarm run session state", () => {
       directory: path.join(root, "project"),
       env: {
         [AgencySwarmRunSession.PRODUCT_STATE_ROOT_ENV]: root,
+        OPENCODE_CONFIG_CONTENT: JSON.stringify({
+          provider: {
+            "agency-swarm": {
+              options: {
+                baseURL: "https://remote.example/",
+                agency: "remote-agency",
+                token: "server-token",
+              },
+            },
+          },
+        }),
+      },
+    })
+
+    expect(config).toEqual({
+      baseURL: "https://remote.example",
+      agency: "remote-agency",
+      token: "server-token",
+    })
+  })
+
+  test("remoteConfigFromEnv reads config when the state root is symlinked and directory is canonical", async () => {
+    await using root = await tmpdir()
+    await using links = await tmpdir()
+    const stateRoot = path.join(links.path, "state-root")
+    const projectDir = path.join(root.path, "project")
+
+    await mkdir(projectDir, { recursive: true })
+    await symlink(root.path, stateRoot, process.platform === "win32" ? "junction" : "dir")
+
+    const config = AgencySwarmRunSession.remoteConfigFromEnv({
+      directory: projectDir,
+      env: {
+        [AgencySwarmRunSession.PRODUCT_STATE_ROOT_ENV]: stateRoot,
         OPENCODE_CONFIG_CONTENT: JSON.stringify({
           provider: {
             "agency-swarm": {

--- a/packages/opencode/test/agency-swarm/run-session.test.ts
+++ b/packages/opencode/test/agency-swarm/run-session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import path from "node:path"
 import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
 import { Filesystem } from "../../src/util/filesystem"
 
@@ -44,5 +45,72 @@ describe("agency-swarm run session state", () => {
 
     expect(writeJson).toHaveBeenCalledTimes(1)
     expect(writeJson.mock.calls[0]?.[1]).toEqual({})
+  })
+
+  test("sync preserves remote metadata when agency sessions have no local project directory", async () => {
+    spyOn(Filesystem, "readJson").mockResolvedValue({
+      ses_123: {
+        mode: "remote-config",
+        directory: "/tmp/product/project",
+        config: {
+          baseURL: "https://remote.example",
+          agency: "remote-agency",
+          token: "server-token",
+        },
+      },
+    } as never)
+    const writeJson = spyOn(Filesystem, "writeJson").mockResolvedValue(undefined as never)
+
+    await AgencySwarmRunSession.sync({
+      sessionID: "ses_123",
+      providerID: "agency-swarm",
+    })
+
+    expect(writeJson).not.toHaveBeenCalled()
+  })
+
+  test("sync clears stale local-project metadata when the local project env is absent", async () => {
+    spyOn(Filesystem, "readJson").mockResolvedValue({
+      ses_123: {
+        mode: "local-project",
+        directory: "/tmp/project",
+      },
+    } as never)
+    const writeJson = spyOn(Filesystem, "writeJson").mockResolvedValue(undefined as never)
+
+    await AgencySwarmRunSession.sync({
+      sessionID: "ses_123",
+      providerID: "agency-swarm",
+    })
+
+    expect(writeJson).toHaveBeenCalledTimes(1)
+    expect(writeJson.mock.calls[0]?.[1]).toEqual({})
+  })
+
+  test("remoteConfigFromEnv reads state-root launch config for the product project directory", () => {
+    const root = path.join("/tmp", "product-state")
+    const config = AgencySwarmRunSession.remoteConfigFromEnv({
+      directory: path.join(root, "project"),
+      env: {
+        [AgencySwarmRunSession.PRODUCT_STATE_ROOT_ENV]: root,
+        OPENCODE_CONFIG_CONTENT: JSON.stringify({
+          provider: {
+            "agency-swarm": {
+              options: {
+                baseURL: "https://remote.example/",
+                agency: "remote-agency",
+                token: "server-token",
+              },
+            },
+          },
+        }),
+      },
+    })
+
+    expect(config).toEqual({
+      baseURL: "https://remote.example",
+      agency: "remote-agency",
+      token: "server-token",
+    })
   })
 })

--- a/packages/opencode/test/agency-swarm/run-session.test.ts
+++ b/packages/opencode/test/agency-swarm/run-session.test.ts
@@ -26,6 +26,7 @@ describe("agency-swarm run session state", () => {
         directory: "/tmp/project",
       },
     })
+    expect(writeJson.mock.calls[0]?.[2]).toBe(0o600)
   })
 
   test("sync clears stale local-project metadata for non-agency sessions", async () => {
@@ -45,6 +46,7 @@ describe("agency-swarm run session state", () => {
 
     expect(writeJson).toHaveBeenCalledTimes(1)
     expect(writeJson.mock.calls[0]?.[1]).toEqual({})
+    expect(writeJson.mock.calls[0]?.[2]).toBe(0o600)
   })
 
   test("sync preserves remote metadata when agency sessions have no local project directory", async () => {
@@ -85,6 +87,50 @@ describe("agency-swarm run session state", () => {
 
     expect(writeJson).toHaveBeenCalledTimes(1)
     expect(writeJson.mock.calls[0]?.[1]).toEqual({})
+    expect(writeJson.mock.calls[0]?.[2]).toBe(0o600)
+  })
+
+  test("copy preserves remote metadata under a new session id", async () => {
+    spyOn(Filesystem, "readJson").mockResolvedValue({
+      ses_parent: {
+        mode: "remote-config",
+        directory: "/tmp/product/project",
+        config: {
+          baseURL: "https://remote.example",
+          agency: "remote-agency",
+          token: "server-token",
+        },
+      },
+    } as never)
+    const writeJson = spyOn(Filesystem, "writeJson").mockResolvedValue(undefined as never)
+
+    await AgencySwarmRunSession.copy({
+      sourceID: "ses_parent",
+      targetID: "ses_child",
+    })
+
+    expect(writeJson).toHaveBeenCalledTimes(1)
+    expect(writeJson.mock.calls[0]?.[1]).toEqual({
+      ses_parent: {
+        mode: "remote-config",
+        directory: "/tmp/product/project",
+        config: {
+          baseURL: "https://remote.example",
+          agency: "remote-agency",
+          token: "server-token",
+        },
+      },
+      ses_child: {
+        mode: "remote-config",
+        directory: "/tmp/product/project",
+        config: {
+          baseURL: "https://remote.example",
+          agency: "remote-agency",
+          token: "server-token",
+        },
+      },
+    })
+    expect(writeJson.mock.calls[0]?.[2]).toBe(0o600)
   })
 
   test("remoteConfigFromEnv reads state-root launch config for the product project directory", () => {

--- a/packages/opencode/test/cli/tui/env-file.test.ts
+++ b/packages/opencode/test/cli/tui/env-file.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { spawnSync } from "node:child_process"
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { readEnvKey, writeEnvKey } from "../../../src/cli/cmd/tui/util/env-file"
+import { readEnvKey, writeEnvKey, writeEnvKeys } from "../../../src/cli/cmd/tui/util/env-file"
 
 async function tempdir() {
   return mkdtemp(path.join(os.tmpdir(), "agentswarm-env-file-"))
@@ -14,8 +15,12 @@ describe("env-file", () => {
     try {
       writeEnvKey("SEARCH_API_KEY", "search-key", dir)
 
-      expect(await readFile(path.join(dir, ".env"), "utf8")).toBe('SEARCH_API_KEY="search-key"\n')
+      const file = path.join(dir, ".env")
+      expect(await readFile(file, "utf8")).toContain("SEARCH_API_KEY=")
       expect(readEnvKey("SEARCH_API_KEY", dir)).toBe("search-key")
+      if (process.platform !== "win32") {
+        expect((await stat(file)).mode & 0o777).toBe(0o600)
+      }
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
@@ -28,7 +33,10 @@ describe("env-file", () => {
 
       writeEnvKey("SEARCH_API_KEY", "new", dir)
 
-      expect(await readFile(path.join(dir, ".env"), "utf8")).toBe('A=1\nexport SEARCH_API_KEY="new"\nB=2\n')
+      const content = await readFile(path.join(dir, ".env"), "utf8")
+      expect(content).toContain("A=1\n")
+      expect(content).toContain('export SEARCH_API_KEY="new"\n')
+      expect(content).toContain("B=2\n")
       expect(readEnvKey("SEARCH_API_KEY", dir)).toBe("new")
     } finally {
       await rm(dir, { recursive: true, force: true })
@@ -42,7 +50,65 @@ describe("env-file", () => {
 
       writeEnvKey("UNSPLASH_ACCESS_KEY", "photo-key", dir)
 
-      expect(await readFile(path.join(dir, ".env"), "utf8")).toBe('A=1\nUNSPLASH_ACCESS_KEY="photo-key"\n')
+      expect(readEnvKey("UNSPLASH_ACCESS_KEY", dir)).toBe("photo-key")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("round trips quoted values with escapes", async () => {
+    const dir = await tempdir()
+    try {
+      const value = 'quote" slash\\ newline\nend'
+
+      writeEnvKey("SEARCH_API_KEY", value, dir)
+
+      expect(readEnvKey("SEARCH_API_KEY", dir)).toBe(value)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("writes multiple keys together", async () => {
+    const dir = await tempdir()
+    try {
+      writeEnvKeys(
+        [
+          ["SEARCH_API_KEY", "search"],
+          ["COMPOSIO_API_KEY", "composio"],
+        ],
+        dir,
+      )
+
+      expect(readEnvKey("SEARCH_API_KEY", dir)).toBe("search")
+      expect(readEnvKey("COMPOSIO_API_KEY", dir)).toBe("composio")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("preserves CRLF line endings", async () => {
+    const dir = await tempdir()
+    try {
+      await writeFile(path.join(dir, ".env"), "A=1\r\nSEARCH_API_KEY=old\r\nB=2\r\n")
+
+      writeEnvKey("SEARCH_API_KEY", "new", dir)
+
+      expect(await readFile(path.join(dir, ".env"), "utf8")).toBe('A=1\r\nSEARCH_API_KEY="new"\r\nB=2\r\n')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("does not write secrets to a tracked .env file", async () => {
+    const dir = await tempdir()
+    try {
+      await writeFile(path.join(dir, ".env"), "SEARCH_API_KEY=old\n")
+      spawnSync("git", ["init"], { cwd: dir, stdio: "ignore" })
+      spawnSync("git", ["add", ".env"], { cwd: dir, stdio: "ignore" })
+
+      expect(() => writeEnvKey("SEARCH_API_KEY", "new", dir)).toThrow("git-tracked .env")
+      expect(readEnvKey("SEARCH_API_KEY", dir)).toBe("old")
     } finally {
       await rm(dir, { recursive: true, force: true })
     }

--- a/packages/opencode/test/cli/tui/env-file.test.ts
+++ b/packages/opencode/test/cli/tui/env-file.test.ts
@@ -43,6 +43,19 @@ describe("env-file", () => {
     }
   })
 
+  test("updates values containing replacement tokens", async () => {
+    const dir = await tempdir()
+    try {
+      await writeFile(path.join(dir, ".env"), "SEARCH_API_KEY=old\n")
+
+      writeEnvKey("SEARCH_API_KEY", "foo$&bar$$baz", dir)
+
+      expect(readEnvKey("SEARCH_API_KEY", dir)).toBe("foo$&bar$$baz")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   test("appends a missing key", async () => {
     const dir = await tempdir()
     try {

--- a/packages/opencode/test/cli/tui/env-file.test.ts
+++ b/packages/opencode/test/cli/tui/env-file.test.ts
@@ -87,6 +87,27 @@ describe("env-file", () => {
     }
   })
 
+  test("deduplicates keys before writing", async () => {
+    const dir = await tempdir()
+    try {
+      writeEnvKeys(
+        [
+          ["SEARCH_API_KEY", "old"],
+          ["COMPOSIO_API_KEY", "composio"],
+          ["SEARCH_API_KEY", "new"],
+        ],
+        dir,
+      )
+
+      const content = await readFile(path.join(dir, ".env"), "utf8")
+      expect(content.match(/SEARCH_API_KEY/g)?.length).toBe(1)
+      expect(readEnvKey("SEARCH_API_KEY", dir)).toBe("new")
+      expect(readEnvKey("COMPOSIO_API_KEY", dir)).toBe("composio")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   test("preserves CRLF line endings", async () => {
     const dir = await tempdir()
     try {

--- a/packages/opencode/test/cli/tui/env-file.test.ts
+++ b/packages/opencode/test/cli/tui/env-file.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process"
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
+import { AgencyProduct } from "../../../src/agency-swarm/product"
 import { readEnvKey, writeEnvKey, writeEnvKeys } from "../../../src/cli/cmd/tui/util/env-file"
 
 async function tempdir() {
@@ -48,6 +49,60 @@ describe("env-file", () => {
       process.chdir(cwd)
       if (previous === undefined) delete process.env.AGENTSWARM_PRODUCT_STATE_ROOT
       else process.env.AGENTSWARM_PRODUCT_STATE_ROOT = previous
+      await rm(caller, { recursive: true, force: true })
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("uses compiled product state root when the env var is absent", async () => {
+    const caller = await tempdir()
+    const root = await tempdir()
+    const cwd = process.cwd()
+    const previousEnv = process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+    const product = AgencyProduct as unknown as { stateRoot: string | undefined }
+    const previousRoot = product.stateRoot
+    try {
+      delete process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+      product.stateRoot = root
+      process.chdir(caller)
+
+      writeEnvKey("SEARCH_API_KEY", "search-key")
+
+      expect(readEnvKey("SEARCH_API_KEY")).toBe("search-key")
+      expect(await readFile(path.join(root, ".env"), "utf8")).toContain("SEARCH_API_KEY=")
+      await expect(readFile(path.join(caller, ".env"), "utf8")).rejects.toThrow()
+    } finally {
+      process.chdir(cwd)
+      product.stateRoot = previousRoot
+      if (previousEnv === undefined) delete process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+      else process.env.AGENTSWARM_PRODUCT_STATE_ROOT = previousEnv
+      await rm(caller, { recursive: true, force: true })
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("uses compiled product state root when the env var is blank", async () => {
+    const caller = await tempdir()
+    const root = await tempdir()
+    const cwd = process.cwd()
+    const previousEnv = process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+    const product = AgencyProduct as unknown as { stateRoot: string | undefined }
+    const previousRoot = product.stateRoot
+    try {
+      process.env.AGENTSWARM_PRODUCT_STATE_ROOT = "   "
+      product.stateRoot = root
+      process.chdir(caller)
+
+      writeEnvKey("SEARCH_API_KEY", "search-key")
+
+      expect(readEnvKey("SEARCH_API_KEY")).toBe("search-key")
+      expect(await readFile(path.join(root, ".env"), "utf8")).toContain("SEARCH_API_KEY=")
+      await expect(readFile(path.join(caller, ".env"), "utf8")).rejects.toThrow()
+    } finally {
+      process.chdir(cwd)
+      product.stateRoot = previousRoot
+      if (previousEnv === undefined) delete process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+      else process.env.AGENTSWARM_PRODUCT_STATE_ROOT = previousEnv
       await rm(caller, { recursive: true, force: true })
       await rm(root, { recursive: true, force: true })
     }

--- a/packages/opencode/test/cli/tui/env-file.test.ts
+++ b/packages/opencode/test/cli/tui/env-file.test.ts
@@ -10,6 +10,49 @@ async function tempdir() {
 }
 
 describe("env-file", () => {
+  test("defaults to the caller cwd when no product state root is set", async () => {
+    const dir = await tempdir()
+    const cwd = process.cwd()
+    const root = process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+    try {
+      delete process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+      process.chdir(dir)
+
+      writeEnvKey("SEARCH_API_KEY", "search-key")
+
+      expect(await readFile(path.join(dir, ".env"), "utf8")).toContain("SEARCH_API_KEY=")
+      expect(readEnvKey("SEARCH_API_KEY")).toBe("search-key")
+    } finally {
+      process.chdir(cwd)
+      if (root === undefined) delete process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+      else process.env.AGENTSWARM_PRODUCT_STATE_ROOT = root
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("uses product state root for default env reads and writes", async () => {
+    const caller = await tempdir()
+    const root = await tempdir()
+    const cwd = process.cwd()
+    const previous = process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+    try {
+      process.env.AGENTSWARM_PRODUCT_STATE_ROOT = root
+      process.chdir(caller)
+
+      writeEnvKey("SEARCH_API_KEY", "search-key")
+
+      expect(readEnvKey("SEARCH_API_KEY")).toBe("search-key")
+      expect(await readFile(path.join(root, ".env"), "utf8")).toContain("SEARCH_API_KEY=")
+      await expect(readFile(path.join(caller, ".env"), "utf8")).rejects.toThrow()
+    } finally {
+      process.chdir(cwd)
+      if (previous === undefined) delete process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+      else process.env.AGENTSWARM_PRODUCT_STATE_ROOT = previous
+      await rm(caller, { recursive: true, force: true })
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test("writes a new project .env file", async () => {
     const dir = await tempdir()
     try {

--- a/packages/opencode/test/cli/tui/env-file.test.ts
+++ b/packages/opencode/test/cli/tui/env-file.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { AgencyProduct } from "../../../src/agency-swarm/product"
@@ -51,6 +51,34 @@ describe("env-file", () => {
       else process.env.AGENTSWARM_PRODUCT_STATE_ROOT = previous
       await rm(caller, { recursive: true, force: true })
       await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("keeps a relative product state root stable after cwd changes", async () => {
+    const caller = await tempdir()
+    const cwd = process.cwd()
+    const previous = process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+    try {
+      process.env.AGENTSWARM_PRODUCT_STATE_ROOT = "state"
+      process.chdir(caller)
+      const root = path.resolve("state")
+      const project = path.join(root, "project")
+
+      writeEnvKey("SEARCH_API_KEY", "search-key")
+      await mkdir(project, { recursive: true })
+      process.chdir(project)
+      writeEnvKey("COMPOSIO_API_KEY", "composio-key")
+
+      expect(process.env.AGENTSWARM_PRODUCT_STATE_ROOT).toBe(root)
+      expect(readEnvKey("SEARCH_API_KEY")).toBe("search-key")
+      expect(readEnvKey("COMPOSIO_API_KEY")).toBe("composio-key")
+      expect(await readFile(path.join(root, ".env"), "utf8")).toContain("COMPOSIO_API_KEY=")
+      await expect(readFile(path.join(project, "state", ".env"), "utf8")).rejects.toThrow()
+    } finally {
+      process.chdir(cwd)
+      if (previous === undefined) delete process.env.AGENTSWARM_PRODUCT_STATE_ROOT
+      else process.env.AGENTSWARM_PRODUCT_STATE_ROOT = previous
+      await rm(caller, { recursive: true, force: true })
     }
   })
 

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -11,6 +11,7 @@ import * as Win32 from "../../../src/cli/cmd/tui/win32"
 import { TuiConfig } from "../../../src/cli/cmd/tui/config/tui"
 import { AgencyProduct } from "../../../src/agency-swarm/product"
 import * as Npx from "../../../src/agency-swarm/npx"
+import { AgencySwarmRunSession } from "../../../src/agency-swarm/run-session"
 
 const stop = new Error("stop")
 const seen = {
@@ -163,6 +164,139 @@ describe("tui thread", () => {
       process.chdir(cwd)
       if (pwd === undefined) delete process.env.PWD
       else process.env.PWD = pwd
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+      globalThis.Worker = worker
+    }
+  })
+
+  test("uses cwd-only remote config content for state-root resumes", async () => {
+    setup()
+    await using caller = await tmpdir({ git: true })
+    await using root = await tmpdir()
+    const project = path.join(root.path, "project")
+    const cwd = process.cwd()
+    const pwd = process.env.PWD
+    const configContent = Npx.buildAgencyConfig({
+      baseURL: "https://remote.example",
+      agency: "remote-agency",
+      token: "server-token",
+    })
+    const configContentEnv = process.env.OPENCODE_CONFIG_CONTENT
+    const localProjectEnv = process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
+    const worker = globalThis.Worker
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+    let workerEnv: Record<string, string> | undefined
+    seen.tui.length = 0
+    await fs.mkdir(project, { recursive: true })
+    const prepare = spyOn(Npx, "prepareProjectLaunch").mockImplementation(async () => {
+      throw new Error("prepareProjectLaunch should not run for cwd-only launches")
+    })
+    spyOn(Npx, "resolveNpxAutoProject").mockResolvedValue({
+      directory: project,
+      cwdOnly: true,
+      configContent,
+    })
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+    globalThis.Worker = class extends EventTarget {
+      onerror = null
+      onmessage = null
+      onmessageerror = null
+      constructor(_file: string | URL, options?: { env?: Record<string, string> }) {
+        super()
+        workerEnv = options?.env
+      }
+      postMessage() {}
+      terminate() {}
+    } as unknown as typeof Worker
+
+    try {
+      process.chdir(caller.path)
+      process.env.PWD = caller.path
+      await expect(call(undefined, { continue: true, prompt: undefined })).rejects.toBe(stop)
+      expect(prepare).not.toHaveBeenCalled()
+      expect(seen.tui[0]).toBe(project)
+      expect(workerEnv?.OPENCODE_CONFIG_CONTENT).toBe(configContent)
+    } finally {
+      process.chdir(cwd)
+      if (pwd === undefined) delete process.env.PWD
+      else process.env.PWD = pwd
+      if (configContentEnv === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+      else process.env.OPENCODE_CONFIG_CONTENT = configContentEnv
+      if (localProjectEnv === undefined) delete process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
+      else process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV] = localProjectEnv
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+      globalThis.Worker = worker
+    }
+  })
+
+  test("prepares local npx projects instead of reusing cwd-only config", async () => {
+    setup()
+    await using caller = await tmpdir({ git: true })
+    await using root = await tmpdir()
+    const project = path.join(root.path, "project")
+    const agency = {
+      directory: project,
+      agencyFile: path.join(project, "main.py"),
+      moduleName: "main",
+    }
+    const cwd = process.cwd()
+    const pwd = process.env.PWD
+    const configContent = Npx.buildAgencyConfig({
+      baseURL: "http://127.0.0.1:8123",
+      agency: "local-agency",
+    })
+    const configContentEnv = process.env.OPENCODE_CONFIG_CONTENT
+    const localProjectEnv = process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
+    const worker = globalThis.Worker
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+    let workerEnv: Record<string, string> | undefined
+    seen.tui.length = 0
+    await fs.mkdir(project, { recursive: true })
+    spyOn(Npx, "resolveNpxAutoProject").mockResolvedValue(agency)
+    const prepare = spyOn(Npx, "prepareProjectLaunch").mockResolvedValue({
+      directory: project,
+      runProjectDirectory: project,
+      configContent,
+    })
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+    globalThis.Worker = class extends EventTarget {
+      onerror = null
+      onmessage = null
+      onmessageerror = null
+      constructor(_file: string | URL, options?: { env?: Record<string, string> }) {
+        super()
+        workerEnv = options?.env
+      }
+      postMessage() {}
+      terminate() {}
+    } as unknown as typeof Worker
+
+    try {
+      process.chdir(caller.path)
+      process.env.PWD = caller.path
+      await expect(call(undefined, { continue: true, prompt: undefined })).rejects.toBe(stop)
+      expect(prepare).toHaveBeenCalledWith(agency)
+      expect(seen.tui[0]).toBe(project)
+      expect(workerEnv?.OPENCODE_CONFIG_CONTENT).toBe(configContent)
+      expect(workerEnv?.[AgencySwarmRunSession.LOCAL_PROJECT_ENV]).toBe(project)
+    } finally {
+      process.chdir(cwd)
+      if (pwd === undefined) delete process.env.PWD
+      else process.env.PWD = pwd
+      if (configContentEnv === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+      else process.env.OPENCODE_CONFIG_CONTENT = configContentEnv
+      if (localProjectEnv === undefined) delete process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV]
+      else process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV] = localProjectEnv
       if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
       else delete (process.stdin as { isTTY?: boolean }).isTTY
       globalThis.Worker = worker

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -10,10 +10,16 @@ import * as Network from "../../../src/cli/network"
 import * as Win32 from "../../../src/cli/cmd/tui/win32"
 import { TuiConfig } from "../../../src/cli/cmd/tui/config/tui"
 import { AgencyProduct } from "../../../src/agency-swarm/product"
+import * as Npx from "../../../src/agency-swarm/npx"
 
 const stop = new Error("stop")
 const seen = {
   tui: [] as string[],
+}
+
+type CallOverrides = {
+  continue?: boolean
+  prompt?: string
 }
 
 function setup() {
@@ -48,7 +54,7 @@ describe("tui thread", () => {
     mock.restore()
   })
 
-  async function call(project?: string) {
+  async function call(project?: string, overrides: CallOverrides = {}) {
     const { TuiThreadCommand } = await import("../../../src/cli/cmd/tui/thread")
     const args: Parameters<NonNullable<typeof TuiThreadCommand.handler>>[0] = {
       _: [],
@@ -66,6 +72,7 @@ describe("tui thread", () => {
       "mdns-domain": AgencyProduct.mdnsDomain,
       mdnsDomain: AgencyProduct.mdnsDomain,
       cors: [],
+      ...overrides,
     }
     return TuiThreadCommand.handler(args)
   }
@@ -116,5 +123,49 @@ describe("tui thread", () => {
 
   test("uses the real cwd after resolving a relative project from PWD", async () => {
     await check(".")
+  })
+
+  test("uses cwd-only npx launches without preparing local projects", async () => {
+    setup()
+    await using caller = await tmpdir({ git: true })
+    await using root = await tmpdir()
+    const project = path.join(root.path, "project")
+    const cwd = process.cwd()
+    const pwd = process.env.PWD
+    const worker = globalThis.Worker
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+    seen.tui.length = 0
+    await fs.mkdir(project, { recursive: true })
+    const prepare = spyOn(Npx, "prepareProjectLaunch").mockImplementation(async () => {
+      throw new Error("prepareProjectLaunch should not run for cwd-only launches")
+    })
+    spyOn(Npx, "resolveNpxAutoProject").mockResolvedValue({ directory: project, cwdOnly: true })
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+    globalThis.Worker = class extends EventTarget {
+      onerror = null
+      onmessage = null
+      onmessageerror = null
+      postMessage() {}
+      terminate() {}
+    } as unknown as typeof Worker
+
+    try {
+      process.chdir(caller.path)
+      process.env.PWD = caller.path
+      await expect(call(undefined, { continue: true, prompt: undefined })).rejects.toBe(stop)
+      expect(prepare).not.toHaveBeenCalled()
+      expect(seen.tui[0]).toBe(project)
+    } finally {
+      process.chdir(cwd)
+      if (pwd === undefined) delete process.env.PWD
+      else process.env.PWD = pwd
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+      globalThis.Worker = worker
+    }
   })
 })

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -207,6 +207,77 @@ describe("Session", () => {
     })
   })
 
+  test("remove clears Agency Swarm run-session metadata", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const info = await create({ title: "remote run-session delete" })
+        const config = {
+          baseURL: "https://remote.example",
+          agency: "remote-agency",
+          token: "server-token",
+        }
+
+        try {
+          await AgencySwarmRunSession.markRemote({
+            sessionID: info.id,
+            directory: tmp.path,
+            config,
+          })
+
+          await remove(info.id)
+
+          expect(await AgencySwarmRunSession.get(info.id)).toBeUndefined()
+        } finally {
+          await AgencySwarmRunSession.clear(info.id)
+          await remove(info.id).catch(() => undefined)
+        }
+      },
+    })
+  })
+
+  test("remove clears child Agency Swarm run-session metadata", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const parent = await create({ title: "remote run-session parent delete" })
+        const child = await create({ parentID: parent.id, title: "remote run-session child delete" })
+        const config = {
+          baseURL: "https://remote.example",
+          agency: "remote-agency",
+          token: "server-token",
+        }
+
+        try {
+          await AgencySwarmRunSession.markRemote({
+            sessionID: parent.id,
+            directory: tmp.path,
+            config,
+          })
+          await AgencySwarmRunSession.markRemote({
+            sessionID: child.id,
+            directory: tmp.path,
+            config,
+          })
+
+          await remove(parent.id)
+
+          expect(await AgencySwarmRunSession.get(parent.id)).toBeUndefined()
+          expect(await AgencySwarmRunSession.get(child.id)).toBeUndefined()
+        } finally {
+          await AgencySwarmRunSession.clear(parent.id)
+          await AgencySwarmRunSession.clear(child.id)
+          await remove(child.id).catch(() => undefined)
+          await remove(parent.id).catch(() => undefined)
+        }
+      },
+    })
+  })
+
   test("remove works without an instance", async () => {
     await using tmp = await tmpdir({ git: true })
 

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -8,6 +8,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { tmpdir } from "../fixture/fixture"
+import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
 
 const projectRoot = path.join(__dirname, "../..")
 void Log.init({ print: false })
@@ -22,6 +23,10 @@ function get(id: SessionID) {
 
 function remove(id: SessionID) {
   return AppRuntime.runPromise(SessionNs.Service.use((svc) => svc.remove(id)))
+}
+
+function fork(input: { sessionID: SessionID; messageID?: MessageID }) {
+  return AppRuntime.runPromise(SessionNs.Service.use((svc) => svc.fork(input)))
 }
 
 function updateMessage<T extends MessageV2.Info>(msg: T) {
@@ -162,6 +167,46 @@ describe("step-finish token propagation via Bus event", () => {
 })
 
 describe("Session", () => {
+  test("fork preserves Agency Swarm run-session metadata", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const parent = await create({ title: "remote run-session parent" })
+        let child: SessionNs.Info | undefined
+        const config = {
+          baseURL: "https://remote.example",
+          agency: "remote-agency",
+          token: "server-token",
+        }
+
+        try {
+          await AgencySwarmRunSession.markRemote({
+            sessionID: parent.id,
+            directory: tmp.path,
+            config,
+          })
+
+          child = await fork({ sessionID: parent.id })
+
+          expect(await AgencySwarmRunSession.get(child.id)).toEqual({
+            mode: "remote-config",
+            directory: tmp.path,
+            config,
+          })
+        } finally {
+          await AgencySwarmRunSession.clear(parent.id)
+          if (child) {
+            await AgencySwarmRunSession.clear(child.id)
+            await remove(child.id).catch(() => undefined)
+          }
+          await remove(parent.id).catch(() => undefined)
+        }
+      },
+    })
+  })
+
   test("remove works without an instance", async () => {
     await using tmp = await tmpdir({ git: true })
 


### PR DESCRIPTION
### Issue for this PR

Closes #234

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds validated generic product configuration for downstream builds:

- downstream product add-ons are configured with `AGENTSWARM_PRODUCT_ADDONS`
- selected add-on keys write through the shared `.env` utility
- downstream products can set `AGENTSWARM_PRODUCT_STATE_ROOT` so product state is rooted outside the caller cwd
- generic AgentSwarm keeps the existing cwd `.env` behavior when no product state root is set

OpenSwarm uses this in VRSEN/OpenSwarm#50 for its concrete add-ons list and fixed user state root.

### How did you verify your code works?

- `bun test test/agency-swarm/product.test.ts test/cli/tui/env-file.test.ts --timeout 30000`
- `bun test ../../e2e/agent-swarm-tui/addons.test.ts --timeout 180000 --max-concurrency=1`
- `bun test ../../e2e/agent-swarm-tui/addons.test.ts ../../e2e/agent-swarm-tui/terminal-tui.test.ts --timeout 180000 --max-concurrency=1`
- `bun typecheck`
- `git diff --check`
- pre-push `bun turbo typecheck`
- local Codex review against `vrsen/dev`: no actionable correctness issues on final commit
- GitHub PR checks: unit, E2E, Agent Swarm E2E, typecheck, nix-eval, and compliance/standards passed
- cross-repo package proof with VRSEN/OpenSwarm#50: local OpenSwarm `1.0.1-rc.8` package used this PR's built binary and passed `npm install`, `npm exec`, `npx`, `/agents`, and `/models`
- cross-repo live proof with VRSEN/OpenSwarm#50: local OpenSwarm `1.0.1-rc.8` package passed prompt and handoff smokes with Anthropic auth from the fixed OpenSwarm state root

### Screenshots / recordings

Not included. This is a terminal dialog flow covered by the Agent Swarm terminal E2E harness.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
