### PR TITLE
fix: target fork repo in stale issue workflow

### DIFF
--- a/script/github/close-issues.ts
+++ b/script/github/close-issues.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-const repo = "anomalyco/opencode"
+const repo = process.env.GITHUB_REPOSITORY ?? "VRSEN/agentswarm-cli"
 const days = 60
 const msg = `To stay organized issues are automatically closed after ${days} days of no activity. If the issue is still relevant please open a new one.`
 


### PR DESCRIPTION
### Issue for this PR

Closes #236

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The scheduled stale-issue workflow was running in the fork but targeting `anomalyco/opencode`.
That makes the fork token fail when the script tries to comment on or close upstream issues.

This changes the script to use `GITHUB_REPOSITORY` in GitHub Actions and keeps `VRSEN/agentswarm-cli` as the local fallback.

### How did you verify your code works?

- `GITHUB_REPOSITORY=VRSEN/agentswarm-cli bun script/github/close-issues.ts` exits at the existing missing-token guard
- `git diff --check`
- Claude CLI review with `claude-opus-4-7 --effort high`: No findings.

### Screenshots / recordings

Not applicable; this is a workflow script fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
