### PR TITLE
fix(build): use pkg.version fallback instead of upstream npm version

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -49,7 +49,7 @@ const productEnvNames = [
 const productDefines = Object.fromEntries(
   productEnvNames.map((name) => [name, process.env[name] ? JSON.stringify(process.env[name]) : "undefined"]),
 )
-const buildVersion = resolveBuildVersion(process.env, Script.version)
+const buildVersion = resolveBuildVersion(process.env, pkg.version)
 const versionValues = createReleaseVersionValues(buildVersion)
 const releaseRepo = resolveReleaseRepo(process.env)
 // Product package overrides are for compiled runtime copy and the user agent;


### PR DESCRIPTION
### Issue for this PR

Closes #241

### Type of change

- [x] Bug fix

### What does this PR do?

`resolveBuildVersion(process.env, Script.version)` in `build.ts` falls back to `Script.version` when neither `AGENTSWARM_PRODUCT_VERSION` nor `OPENCODE_VERSION` is set. `Script.version` either fetches and increments the upstream `opencode-ai` npm version or returns a `0.0.0-dev-…` timestamp — neither is the fork's actual package version. That value gets baked into the compiled binary as `OPENCODE_VERSION`, so the TUI footer shows the wrong version.

Fix: pass `pkg.version` from `packages/opencode/package.json` as the fallback. CI release builds that explicitly set `OPENCODE_VERSION` or `AGENTSWARM_PRODUCT_VERSION` are unaffected — those env vars still win.

### How did you verify your code works?

Traced the version display: TUI footer → `Installation.VERSION` → `OPENCODE_VERSION` global → `resolveBuildVersion` fallback → `Script.version`. Confirmed `pkg.version` is the correct stable fallback that reflects the fork's own version.

### Screenshots / recordings

_N/A — version string fix, no layout change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR