### PR TITLE
feat: Support for anthropic, google, xai and openrouter providers

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1574,7 +1574,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                         </TooltipKeybind>
                       </Show>
                     </div>
-                    <Show when={variants().length > 2}>
+                    <Show when={variants().length > 1}>
                       <div
                         data-component="prompt-variant-control"
                         style={providersShouldFadeIn() ? { animation: "fade-in 0.3s" } : undefined}

--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />

--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-/// <reference path="../../ui/src/custom-elements.d.ts" />
+../../ui/src/custom-elements.d.ts

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />

--- a/packages/opencode/src/agency-swarm/adapter.ts
+++ b/packages/opencode/src/agency-swarm/adapter.ts
@@ -519,6 +519,8 @@ export namespace AgencySwarmAdapter {
     const litellmKeys = asRecord(value["litellm_keys"]) ?? asRecord(value["litellmKeys"])
     const headers = readStringRecord(value["default_headers"]) ?? readStringRecord(value["defaultHeaders"])
     const model = asString(value["model"])
+    const modelSettingsExtraArgs =
+      asRecord(value["model_settings_extra_args"]) ?? asRecord(value["modelSettingsExtraArgs"])
 
     const payload: Record<string, unknown> = {}
     if (baseURL) payload["base_url"] = baseURL
@@ -526,6 +528,9 @@ export namespace AgencySwarmAdapter {
     if (litellmKeys && Object.keys(litellmKeys).length > 0) payload["litellm_keys"] = litellmKeys
     if (headers) payload["default_headers"] = headers
     if (model) payload["model"] = model
+    if (modelSettingsExtraArgs && Object.keys(modelSettingsExtraArgs).length > 0) {
+      payload["model_settings_extra_args"] = modelSettingsExtraArgs
+    }
 
     if (Object.keys(payload).length === 0) return undefined
     return sanitizeClientConfigForTransport(payload)

--- a/packages/opencode/src/agency-swarm/litellm-provider.ts
+++ b/packages/opencode/src/agency-swarm/litellm-provider.ts
@@ -91,7 +91,6 @@ const LITELLM_PROVIDER_IDS = new Set([
   "oobabooga",
   "openai",
   "openai_like",
-  "openrouter",
   "ovhcloud",
   "perplexity",
   "petals",
@@ -161,6 +160,8 @@ export function mapProviderIDToLiteLLMProvider(providerID: string): string | und
 const AGENCY_SWARM_PROVIDER_ID = "agency-swarm"
 
 const OPENAI_LITELLM_ID = "openai"
+const OPENROUTER_PROVIDER_ID = "openrouter"
+const OPENROUTER_MODEL_PREFIX = `${OPENROUTER_PROVIDER_ID}/`
 
 const LITELLM_OPENAI_PREFIX = "litellm/openai/"
 
@@ -190,6 +191,7 @@ function stripOpenAILiteLLMRoutePrefixes(t: string, providerID: string): string 
 export function normalizeExplicitClientConfigModel(raw: string): string {
   const t = raw.trim()
   if (!t) return t
+  if (t.startsWith(OPENROUTER_MODEL_PREFIX)) return t
   if (t.startsWith("litellm/")) {
     const afterLitellm = t.slice("litellm/".length)
     if (afterLitellm.startsWith(`${OPENAI_LITELLM_ID}/`)) return afterLitellm.slice(OPENAI_LITELLM_ID.length + 1)
@@ -202,6 +204,10 @@ export function normalizeExplicitClientConfigModel(raw: string): string {
   if (stripped !== t) return stripped
   if (slash !== -1) return `litellm/${t}`
   return t
+}
+
+export function isOpenRouterClientConfigModel(model: string | undefined): boolean {
+  return !!model?.trim().startsWith(OPENROUTER_MODEL_PREFIX)
 }
 
 // TODO(agency-swarm#629): remove after upstream scopes config.base_url per-provider.
@@ -226,7 +232,8 @@ export function isOpenAIBasedLitellmModel(sessionLitellmModel: string | undefine
 
 /**
  * Build `client_config.model` from the CLI session selection.
- * OpenAI models use the bare model id only (e.g. `gpt-4o`). Other providers use `litellm/<provider>/<model>`.
+ * OpenAI models use the bare model id only (e.g. `gpt-4o`). OpenRouter models use direct
+ * `openrouter/<model>` routing. Other providers use `litellm/<provider>/<model>`.
  * Skips when the session model is the agency-swarm placeholder (no LLM provider).
  * The caller-supplied `providerID` decides the route: for OpenRouter-style ids like
  * `openrouter/openai/gpt-5.2` (or bare `openai/gpt-5.2` with `providerID="openrouter"`),
@@ -236,6 +243,10 @@ export function buildLitellmModelForClientConfig(providerID: string, modelID: st
   if (providerID === AGENCY_SWARM_PROVIDER_ID) return undefined
   const t = modelID.trim()
   if (!t) return undefined
+  if (providerID === OPENROUTER_PROVIDER_ID) {
+    if (t.startsWith(OPENROUTER_MODEL_PREFIX)) return t
+    return `${OPENROUTER_MODEL_PREFIX}${t}`
+  }
   const stripped = stripOpenAILiteLLMRoutePrefixes(t, providerID)
   if (stripped !== t) return stripped
   if (t.startsWith("litellm/")) return t

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -671,8 +671,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       value: "variant.cycle",
       keybind: "variant_cycle",
       category: "Agent",
-      enabled: !frameworkMode(),
-      hidden: frameworkMode(),
+      enabled: local.model.variant.list().length > 0,
+      hidden: local.model.variant.list().length === 0,
       onSelect: () => {
         local.model.variant.cycle()
       },
@@ -682,8 +682,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       value: "variant.list",
       keybind: "variant_list",
       category: "Agent",
-      enabled: !frameworkMode(),
-      hidden: frameworkMode() || local.model.variant.list().length === 0,
+      enabled: local.model.variant.list().length > 0,
+      hidden: local.model.variant.list().length === 0,
       slash: {
         name: "variants",
       },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -35,9 +35,10 @@ import { Telemetry } from "@/telemetry/telemetry"
 const PROVIDER_PRIORITY: Record<string, number> = {
   openai: 0,
   anthropic: 1,
-  "github-copilot": 2,
-  google: 3,
-  "opencode-go": 4,
+  openrouter: 2,
+  "github-copilot": 3,
+  google: 4,
+  "opencode-go": 5,
   opencode: 100,
 }
 
@@ -118,6 +119,7 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
           return {
             opencode: "(Recommended)",
             anthropic: "(API key)",
+            openrouter: "(API key)",
             openai: "(Browser sign-in or API key)",
             "opencode-go": "Low cost subscription for everyone",
           }[provider.id]

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -6,7 +6,14 @@ import { Log } from "@/util"
 import { hasStoredProviderCredential } from "@tui/util/provider-auth"
 import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
 
-export const AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS = ["openai", "anthropic", "google", "gemini", "xai"] as const
+export const AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS = [
+  "openai",
+  "anthropic",
+  "google",
+  "gemini",
+  "xai",
+  "openrouter",
+] as const
 const log = Log.create({ service: "tui.session-error" })
 
 /**
@@ -156,6 +163,8 @@ function envNamesForPrimaryProvider(id: (typeof AGENCY_SWARM_PRIMARY_AUTH_PROVID
       return ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
     case "xai":
       return ["XAI_API_KEY"]
+    case "openrouter":
+      return ["OPENROUTER_API_KEY"]
   }
 }
 

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -6,12 +6,12 @@ import { Log } from "@/util"
 import { hasStoredProviderCredential } from "@tui/util/provider-auth"
 import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
 
-export const AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS = ["openai", "anthropic"] as const
+export const AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS = ["openai", "anthropic", "google", "gemini", "xai"] as const
 const log = Log.create({ service: "tui.session-error" })
 
 /**
  * True when a provider id is usable in Agent Swarm framework mode: either the
- * `agency-swarm` provider itself or one of the primary upstream auth providers
+ * `agency-swarm` provider itself or one of the supported upstream auth providers
  * (`AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS`) that `shouldBlockAgencyPromptSubmit`
  * actually accepts. Surfaces like `/models` use this to avoid dead-end selections
  * the send guard would immediately block.
@@ -89,7 +89,7 @@ function usesLocalAgencyProviderAuth(providers: Provider[]) {
 }
 
 /**
- * Forwarding upstream credentials means the agency-swarm call depends on locally stored OpenAI/Anthropic
+ * Forwarding upstream credentials means the agency-swarm call depends on locally stored upstream provider
  * credentials even against non-loopback base URLs (e.g. `host.docker.internal`, remote bridges).
  * Active when the env flag is set, the caller passes the override, or the agency-swarm provider opts in.
  */
@@ -131,7 +131,9 @@ function hasSupportedAgencyCredential(
   if (providerMatch) return true
   // Mirror the bridge's direct env reads (SessionAgencySwarm.buildAuthClientConfig): primary-provider env vars
   // are upstream creds even when the provider is filtered out of the enabled list.
-  return AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS.some((id) => isNonEmptyEnv(env[envNameForPrimaryProvider(id)]))
+  return AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS.some((id) =>
+    envNamesForPrimaryProvider(id).some((name) => isNonEmptyEnv(env[name])),
+  )
 }
 
 function hasEnvCredentialForProvider(provider: AuthProvider | Provider, env: Record<string, string | undefined>) {
@@ -142,8 +144,19 @@ function isNonEmptyEnv(value: string | undefined) {
   return typeof value === "string" && value.trim().length > 0
 }
 
-function envNameForPrimaryProvider(id: (typeof AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS)[number]) {
-  return id === "openai" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY"
+function envNamesForPrimaryProvider(id: (typeof AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS)[number]) {
+  switch (id) {
+    case "openai":
+      return ["OPENAI_API_KEY"]
+    case "anthropic":
+      return ["ANTHROPIC_API_KEY"]
+    case "google":
+      return ["GOOGLE_API_KEY", "GEMINI_API_KEY"]
+    case "gemini":
+      return ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+    case "xai":
+      return ["XAI_API_KEY"]
+  }
 }
 
 function hasExplicitAgencyClientConfig(provider: Provider | undefined) {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -421,6 +421,9 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
 
   const id = model.id.toLowerCase()
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
+  function isGrok43(id: string): boolean {
+    return id.includes("grok-4.3") || id.includes("grok-4-3")
+  }
   if (
     id.includes("deepseek-chat") ||
     id.includes("deepseek-reasoner") ||
@@ -447,6 +450,13 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       low: { reasoningEffort: "low" },
       high: { reasoningEffort: "high" },
     }
+  }
+  if (id.includes("grok") && isGrok43(id)) {
+    const efforts = ["none", ...WIDELY_SUPPORTED_EFFORTS]
+    if (model.api.npm === "@openrouter/ai-sdk-provider") {
+      return Object.fromEntries(efforts.map((effort) => [effort, { reasoning: { effort } }]))
+    }
+    return Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }]))
   }
   if (id.includes("grok")) return {}
 

--- a/packages/opencode/src/session/agency-swarm-client-config.ts
+++ b/packages/opencode/src/session/agency-swarm-client-config.ts
@@ -27,22 +27,35 @@ function finalizeClientConfig(
   merged: Record<string, unknown> | undefined,
   explicitForModel: Record<string, unknown> | undefined,
   sessionLitellmModel: string | undefined,
+  sessionModelSettingsExtraArgs: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
   const explicitModel = explicitForModel && asString(explicitForModel["model"])
-  if (merged && Object.keys(merged).length > 0) {
-    const out = { ...merged }
-    if (explicitModel) {
-      out["model"] = normalizeExplicitClientConfigModel(explicitModel)
-    } else if (sessionLitellmModel) {
-      out["model"] = sessionLitellmModel
+  const applySessionSettings = (out: Record<string, unknown>) => {
+    if (sessionModelSettingsExtraArgs && Object.keys(sessionModelSettingsExtraArgs).length > 0) {
+      out["model_settings_extra_args"] = {
+        ...(asRecord(out["model_settings_extra_args"]) ?? {}),
+        ...sessionModelSettingsExtraArgs,
+      }
     }
     return out
   }
+  if (merged && Object.keys(merged).length > 0) {
+    const out = { ...merged }
+    if (sessionLitellmModel) {
+      out["model"] = sessionLitellmModel
+    } else if (explicitModel) {
+      out["model"] = normalizeExplicitClientConfigModel(explicitModel)
+    }
+    return applySessionSettings(out)
+  }
   if (explicitModel) {
-    return { model: normalizeExplicitClientConfigModel(explicitModel) }
+    return applySessionSettings({ model: normalizeExplicitClientConfigModel(explicitModel) })
   }
   if (sessionLitellmModel) {
-    return { model: sessionLitellmModel }
+    return applySessionSettings({ model: sessionLitellmModel })
+  }
+  if (sessionModelSettingsExtraArgs && Object.keys(sessionModelSettingsExtraArgs).length > 0) {
+    return applySessionSettings({})
   }
   return undefined
 }
@@ -55,11 +68,13 @@ export async function resolveClientConfig(
   config: Record<string, unknown> | undefined,
   forwardUpstreamCredentials?: boolean,
   sessionLitellmModel?: string,
+  sessionModelSettingsExtraArgs?: Record<string, unknown>,
 ): Promise<Record<string, unknown> | undefined> {
   const explicit = asRecord(config)
   const explicitUpstreamBaseURL = readConfiguredBaseURL(explicit)
   const explicitModel = explicit && asString(explicit["model"])
-  const requestedModel = explicitModel ? normalizeExplicitClientConfigModel(explicitModel) : sessionLitellmModel
+  const requestedModel =
+    sessionLitellmModel ?? (explicitModel ? normalizeExplicitClientConfigModel(explicitModel) : undefined)
   const forwardGenerated =
     isLocalAgencyURL(baseURL) || Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS || forwardUpstreamCredentials === true
   const skipOpenAIApiKey = hasExplicitOpenAIApiKey(config) || !!readCredentialHeaders(config)
@@ -93,14 +108,14 @@ export async function resolveClientConfig(
         : rawGenerated
       : rawGenerated
   if (!config) {
-    return finalizeClientConfig(generated, undefined, sessionLitellmModel)
+    return finalizeClientConfig(generated, undefined, sessionLitellmModel, sessionModelSettingsExtraArgs)
   }
   if (!generated) {
-    return finalizeClientConfig(explicit, explicit, sessionLitellmModel)
+    return finalizeClientConfig(explicit, explicit, sessionLitellmModel, sessionModelSettingsExtraArgs)
   }
 
   if (!explicit) {
-    return finalizeClientConfig(generated, undefined, sessionLitellmModel)
+    return finalizeClientConfig(generated, undefined, sessionLitellmModel, sessionModelSettingsExtraArgs)
   }
 
   const merged: Record<string, unknown> = {
@@ -142,7 +157,7 @@ export async function resolveClientConfig(
   }
   delete merged["defaultHeaders"]
 
-  return finalizeClientConfig(merged, explicit, sessionLitellmModel)
+  return finalizeClientConfig(merged, explicit, sessionLitellmModel, sessionModelSettingsExtraArgs)
 }
 
 async function buildAuthClientConfig(

--- a/packages/opencode/src/session/agency-swarm-client-config.ts
+++ b/packages/opencode/src/session/agency-swarm-client-config.ts
@@ -7,6 +7,7 @@ import {
 } from "@/agency-swarm/client-config"
 import {
   isOpenAIBasedLitellmModel,
+  isOpenRouterClientConfigModel,
   mapProviderIDToLiteLLMProvider,
   normalizeExplicitClientConfigModel,
   OPENAI_BASED_LITELLM_PROVIDERS,
@@ -22,21 +23,24 @@ import { asRecord, asString } from "./agency-swarm-utils"
 
 const log = Log.create({ service: "session.agency-swarm" })
 const STRUCTURED_ATTACHMENT_MESSAGE_MIN_VERSION = "1.9.6"
+const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key"
+const OPENROUTER_FREE_TIER_MAX_TOKENS = 2500
 
-function finalizeClientConfig(
+async function finalizeClientConfig(
   merged: Record<string, unknown> | undefined,
   explicitForModel: Record<string, unknown> | undefined,
   sessionLitellmModel: string | undefined,
   sessionModelSettingsExtraArgs: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
+): Promise<Record<string, unknown> | undefined> {
   const explicitModel = explicitForModel && asString(explicitForModel["model"])
-  const applySessionSettings = (out: Record<string, unknown>) => {
+  const applySessionSettings = async (out: Record<string, unknown>) => {
     if (sessionModelSettingsExtraArgs && Object.keys(sessionModelSettingsExtraArgs).length > 0) {
       out["model_settings_extra_args"] = {
         ...(asRecord(out["model_settings_extra_args"]) ?? {}),
         ...sessionModelSettingsExtraArgs,
       }
     }
+    await applyOpenRouterTokenPolicy(out)
     return out
   }
   if (merged && Object.keys(merged).length > 0) {
@@ -60,6 +64,49 @@ function finalizeClientConfig(
   return undefined
 }
 
+async function applyOpenRouterTokenPolicy(out: Record<string, unknown>) {
+  const model = asString(out["model"])
+  if (!model || !isOpenRouterClientConfigModel(model)) return
+
+  const modelSettings = asRecord(out["model_settings_extra_args"])
+  if (!modelSettings || modelSettings["__openrouter_default_max_tokens"] !== true) return
+
+  delete modelSettings["__openrouter_default_max_tokens"]
+  const apiKey = asString(out["api_key"]) ?? asString(out["apiKey"])
+  const freeTier = await isOpenRouterFreeTier(apiKey)
+  if (freeTier) {
+    modelSettings["max_tokens"] = OPENROUTER_FREE_TIER_MAX_TOKENS
+  } else {
+    delete modelSettings["max_tokens"]
+  }
+  if (Object.keys(modelSettings).length === 0) {
+    delete out["model_settings_extra_args"]
+  }
+}
+
+async function isOpenRouterFreeTier(apiKey: string | undefined): Promise<boolean> {
+  if (!apiKey) return true
+  try {
+    const response = await fetch(OPENROUTER_KEY_URL, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal: AbortSignal.timeout(3000),
+    })
+    if (!response.ok) return true
+    const payload = asRecord(await response.json().catch(() => undefined))
+    const data = asRecord(payload?.["data"])
+    const isFreeTier = data?.["is_free_tier"]
+    return isFreeTier !== false
+  } catch (error) {
+    log.warn("failed to inspect OpenRouter key tier; using free-tier token cap", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return true
+  }
+}
+
 export async function resolveClientConfig(
   baseURL: string,
   agency: string,
@@ -77,12 +124,14 @@ export async function resolveClientConfig(
     sessionLitellmModel ?? (explicitModel ? normalizeExplicitClientConfigModel(explicitModel) : undefined)
   const forwardGenerated =
     isLocalAgencyURL(baseURL) || Flag.AGENTSWARM_FORWARD_UPSTREAM_CREDENTIALS || forwardUpstreamCredentials === true
-  const skipOpenAIApiKey = hasExplicitOpenAIApiKey(config) || !!readCredentialHeaders(config)
+  const targetOpenRouter = isOpenRouterClientConfigModel(requestedModel)
+  const skipOpenAIApiKey = hasExplicitOpenAIApiKey(config) || !!readCredentialHeaders(config) || targetOpenRouter
   const rawGenerated = forwardGenerated
     ? await buildAuthClientConfig(await Auth.all(), await listProvidersForEnvCheck(), await getEnvForClientConfig(), {
         skipOpenAIApiKeyInjection: skipOpenAIApiKey,
         skipOpenAIOAuthFromStored: hasExplicitOpenAIClientConfig(config),
         allowStoredOpenAIOAuth: !explicitUpstreamBaseURL || isCodexAPIBaseURL(explicitUpstreamBaseURL),
+        targetOpenRouter,
       })
     : undefined
   const generated =
@@ -108,14 +157,14 @@ export async function resolveClientConfig(
         : rawGenerated
       : rawGenerated
   if (!config) {
-    return finalizeClientConfig(generated, undefined, sessionLitellmModel, sessionModelSettingsExtraArgs)
+    return await finalizeClientConfig(generated, undefined, sessionLitellmModel, sessionModelSettingsExtraArgs)
   }
   if (!generated) {
-    return finalizeClientConfig(explicit, explicit, sessionLitellmModel, sessionModelSettingsExtraArgs)
+    return await finalizeClientConfig(explicit, explicit, sessionLitellmModel, sessionModelSettingsExtraArgs)
   }
 
   if (!explicit) {
-    return finalizeClientConfig(generated, undefined, sessionLitellmModel, sessionModelSettingsExtraArgs)
+    return await finalizeClientConfig(generated, undefined, sessionLitellmModel, sessionModelSettingsExtraArgs)
   }
 
   const merged: Record<string, unknown> = {
@@ -157,7 +206,7 @@ export async function resolveClientConfig(
   }
   delete merged["defaultHeaders"]
 
-  return finalizeClientConfig(merged, explicit, sessionLitellmModel, sessionModelSettingsExtraArgs)
+  return await finalizeClientConfig(merged, explicit, sessionLitellmModel, sessionModelSettingsExtraArgs)
 }
 
 async function buildAuthClientConfig(
@@ -168,6 +217,7 @@ async function buildAuthClientConfig(
     skipOpenAIApiKeyInjection: boolean
     skipOpenAIOAuthFromStored: boolean
     allowStoredOpenAIOAuth: boolean
+    targetOpenRouter: boolean
   },
 ): Promise<Record<string, unknown> | undefined> {
   const payload: Record<string, unknown> = {}
@@ -180,6 +230,11 @@ async function buildAuthClientConfig(
 
     if (providerID === "openai") {
       if (!options.skipOpenAIApiKeyInjection) payload["api_key"] = key
+      continue
+    }
+
+    if (providerID === "openrouter") {
+      if (options.targetOpenRouter) payload["api_key"] = key
       continue
     }
 
@@ -211,6 +266,11 @@ async function buildAuthClientConfig(
       continue
     }
 
+    if (providerID === "openrouter") {
+      if (options.targetOpenRouter) payload["api_key"] = auth.key
+      continue
+    }
+
     const litellmProvider = mapProviderIDToLiteLLMProvider(providerID)
     if (!litellmProvider) continue
     litellmKeys[litellmProvider] = auth.key
@@ -222,6 +282,14 @@ async function buildAuthClientConfig(
 
   if (!options.skipOpenAIApiKeyInjection && !payload["api_key"]) {
     const fromEnv = env["OPENAI_API_KEY"]
+    if (typeof fromEnv === "string") {
+      const trimmed = fromEnv.trim()
+      if (trimmed) payload["api_key"] = trimmed
+    }
+  }
+
+  if (options.targetOpenRouter && !payload["api_key"]) {
+    const fromEnv = env["OPENROUTER_API_KEY"]
     if (typeof fromEnv === "string") {
       const trimmed = fromEnv.trim()
       if (trimmed) payload["api_key"] = trimmed

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -58,6 +58,8 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const reasoningBuffer = new Map<string, string>()
   const reasoningOpen = new Set<string>()
   const reasoningByItem = new Map<string, Set<string>>()
+  const responseTextReplay = new Map<string, Set<string>>()
+  const responseReasoningReplay = new Map<string, Set<string>>()
 
   let usage: Usage | undefined
   let lastTextItemID: string | undefined
@@ -84,13 +86,39 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return current === text && !textOpen.has(key)
   }
 
-  const matchesBufferedContent = (buffers: Iterable<string>, text: string) => {
+  const replayTextKey = (text: string) => {
     const normalized = text.trim()
-    if (!normalized) return false
-    for (const buffer of buffers) {
-      if (buffer.trim() === normalized) return true
+    return normalized ? normalized : undefined
+  }
+
+  const providerResponseID = (item: Record<string, unknown> | undefined) => {
+    return asString(asRecord(item?.["provider_data"])?.["response_id"])
+  }
+
+  const rememberResponseReplay = (
+    store: Map<string, Set<string>>,
+    item: Record<string, unknown> | undefined,
+    text: string | undefined,
+  ) => {
+    const responseID = providerResponseID(item)
+    const key = text ? replayTextKey(text) : undefined
+    if (!responseID || !key) return
+    const existing = store.get(responseID)
+    if (existing) {
+      existing.add(key)
+    } else {
+      store.set(responseID, new Set([key]))
     }
-    return false
+  }
+
+  const hasResponseReplay = (
+    store: Map<string, Set<string>>,
+    item: Record<string, unknown> | undefined,
+    text: string,
+  ) => {
+    const responseID = providerResponseID(item)
+    const key = replayTextKey(text)
+    return !!responseID && !!key && store.get(responseID)?.has(key) === true
   }
 
   const agentUpdatedHandoffMetadata = (agent: string | undefined) => {
@@ -707,12 +735,18 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (itemType === "message") {
       const itemID = asString(item["id"]) || lastTextItemID
       if (!itemID) return []
+      rememberResponseReplay(responseTextReplay, item, extractMessageText(item))
       return finishText(itemID, textIndex.get(itemID) ?? 0, undefined, eventMeta, outputMeta(outputIndex))
     }
 
     if (itemType === "reasoning") {
       const itemID = asString(item["id"]) || lastReasoningItemID
       if (!itemID) return []
+      const summary = Array.isArray(item["summary"]) ? item["summary"] : []
+      for (const raw of summary) {
+        const record = asRecord(raw)
+        rememberResponseReplay(responseReasoningReplay, item, asString(record?.["text"]) || undefined)
+      }
       return Array.from(reasoningByItem.get(itemID) ?? [])
         .filter((value) => reasoningOpen.has(value))
         .flatMap((key) => {
@@ -810,7 +844,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       if (!itemID) return []
       const text = extractMessageText(rawItem)
       if (!text) return []
-      if (matchesBufferedContent(textBuffer.values(), text)) {
+      if (hasResponseReplay(responseTextReplay, rawItem, text)) {
         return []
       }
       const index = 0
@@ -837,7 +871,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return summary.flatMap((raw, index) => {
       const record = asRecord(raw)
       const text = asString(record?.["text"]) || undefined
-      if (text && matchesBufferedContent(reasoningBuffer.values(), text)) return []
+      if (text && hasResponseReplay(responseReasoningReplay, rawItem, text)) return []
       return finishReasoning(itemID, index, text, eventMeta, { source: "run_item_stream_event" })
     })
   }
@@ -1082,7 +1116,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       if (!itemID) continue
       const text = extractMessageText(message)
       if (!text) continue
-      if (matchesBufferedContent(textBuffer.values(), text)) continue
+      if (hasResponseReplay(responseTextReplay, message, text)) continue
       if (shouldSkipDuplicateAssistantText(itemID, 0, text)) continue
       parts.push(
         ...finishText(itemID, 0, text, messageMeta, {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -84,6 +84,15 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return current === text && !textOpen.has(key)
   }
 
+  const matchesBufferedContent = (buffers: Iterable<string>, text: string) => {
+    const normalized = text.trim()
+    if (!normalized) return false
+    for (const buffer of buffers) {
+      if (buffer.trim() === normalized) return true
+    }
+    return false
+  }
+
   const agentUpdatedHandoffMetadata = (agent: string | undefined) => {
     const handoffAgent = agent ?? input.assistantMessage.agent
     return handoffAgent && agentUpdatedHandoffAgents.has(handoffAgent)
@@ -801,6 +810,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       if (!itemID) return []
       const text = extractMessageText(rawItem)
       if (!text) return []
+      if (matchesBufferedContent(textBuffer.values(), text)) {
+        return []
+      }
       const index = 0
       if (shouldSkipDuplicateAssistantText(itemID, index, text)) {
         return []
@@ -825,6 +837,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return summary.flatMap((raw, index) => {
       const record = asRecord(raw)
       const text = asString(record?.["text"]) || undefined
+      if (text && matchesBufferedContent(reasoningBuffer.values(), text)) return []
       return finishReasoning(itemID, index, text, eventMeta, { source: "run_item_stream_event" })
     })
   }
@@ -1069,6 +1082,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       if (!itemID) continue
       const text = extractMessageText(message)
       if (!text) continue
+      if (matchesBufferedContent(textBuffer.values(), text)) continue
       if (shouldSkipDuplicateAssistantText(itemID, 0, text)) continue
       parts.push(
         ...finishText(itemID, 0, text, messageMeta, {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -75,7 +75,7 @@ export namespace SessionAgencySwarm {
     options: RuntimeOptions
     abort: AbortSignal
     /** Session UI model for this turn; forwarded as `client_config.model` (bare id for OpenAI, else `litellm/...`) for server-side override. */
-    sessionModel?: { providerID: string; modelID: string }
+    sessionModel?: { providerID: string; modelID: string; variantOptions?: Record<string, unknown> }
     recipientAgent?: string
   }
 
@@ -421,6 +421,7 @@ export namespace SessionAgencySwarm {
       const sessionLitellmModel =
         input.sessionModel &&
         buildLitellmModelForClientConfig(input.sessionModel.providerID, input.sessionModel.modelID)
+      const sessionModelSettingsExtraArgs = normalizeVariantOptionsForClientConfig(input.sessionModel)
       const clientConfig = await resolveClientConfig(
         input.options.baseURL,
         agency,
@@ -429,6 +430,7 @@ export namespace SessionAgencySwarm {
         input.options.clientConfig,
         input.options.forwardUpstreamCredentials,
         sessionLitellmModel,
+        sessionModelSettingsExtraArgs,
       )
 
       const hasCurrentFileAttachments = hasFileParts(input.userMessage)
@@ -698,6 +700,71 @@ export namespace SessionAgencySwarm {
 
   function asBoolean(value: unknown): boolean | undefined {
     return typeof value === "boolean" ? value : undefined
+  }
+
+  function normalizeVariantOptionsForClientConfig(
+    sessionModel: { providerID: string; modelID: string; variantOptions?: Record<string, unknown> } | undefined,
+  ): Record<string, unknown> | undefined {
+    const variantOptions = sessionModel?.variantOptions
+    if (!variantOptions || Object.keys(variantOptions).length === 0) return undefined
+    const out: Record<string, unknown> = { ...variantOptions }
+    if ("reasoningEffort" in out && !("reasoning_effort" in out)) {
+      out["reasoning_effort"] = out["reasoningEffort"]
+      delete out["reasoningEffort"]
+    }
+    if ("reasoningSummary" in out && !("reasoning_summary" in out)) {
+      out["reasoning_summary"] = out["reasoningSummary"]
+      delete out["reasoningSummary"]
+    }
+    const providerID = sessionModel.providerID.toLowerCase()
+    const modelID = sessionModel.modelID.toLowerCase()
+    if (providerID === "anthropic") {
+      if (typeof out["effort"] === "string" && !("reasoning_effort" in out)) {
+        out["reasoning_effort"] = out["effort"]
+      }
+      delete out["effort"]
+      delete out["reasoning_summary"]
+      delete out["include"]
+      normalizeThinkingBudget(out)
+    } else if (providerID === "google" || providerID === "gemini" || providerID === "google-vertex") {
+      normalizeGeminiThinkingConfig(out)
+      delete out["reasoning_summary"]
+      delete out["include"]
+    } else if (providerID === "xai" && modelID.includes("grok")) {
+      delete out["reasoning_effort"]
+      delete out["reasoning_summary"]
+      delete out["include"]
+      delete out["effort"]
+    }
+    return Object.keys(out).length > 0 ? out : undefined
+  }
+
+  function normalizeThinkingBudget(out: Record<string, unknown>) {
+    const thinking = asRecord(out["thinking"])
+    if (!thinking) return
+    const budgetTokens = thinking["budgetTokens"]
+    if (typeof budgetTokens === "number" && !("budget_tokens" in thinking)) {
+      out["thinking"] = { ...thinking, budget_tokens: budgetTokens }
+      delete (out["thinking"] as Record<string, unknown>)["budgetTokens"]
+    }
+  }
+
+  function normalizeGeminiThinkingConfig(out: Record<string, unknown>) {
+    const thinkingConfig = asRecord(out["thinkingConfig"])
+    const thinkingBudget = thinkingConfig?.["thinkingBudget"] ?? out["thinkingBudget"]
+    const thinkingLevel = thinkingConfig?.["thinkingLevel"] ?? out["thinkingLevel"]
+    if (typeof thinkingBudget === "number") {
+      out["thinking"] = { type: "enabled", budget_tokens: thinkingBudget }
+      if (!("reasoning_effort" in out)) {
+        out["reasoning_effort"] = thinkingBudget >= 16000 ? "high" : "medium"
+      }
+    } else if (typeof thinkingLevel === "string" && !("reasoning_effort" in out)) {
+      out["reasoning_effort"] = thinkingLevel
+    }
+    delete out["thinkingConfig"]
+    delete out["thinkingBudget"]
+    delete out["thinkingLevel"]
+    delete out["includeThoughts"]
   }
 
   async function resolveRecipientAgent(input: {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -735,8 +735,54 @@ export namespace SessionAgencySwarm {
       delete out["reasoning_summary"]
       delete out["include"]
       delete out["effort"]
+    } else if (providerID === "openrouter") {
+      normalizeOpenRouterReasoningConfig(out, modelID)
     }
     return Object.keys(out).length > 0 ? out : undefined
+  }
+
+  function normalizeOpenRouterReasoningConfig(out: Record<string, unknown>, modelID: string) {
+    const reasoning = asRecord(out["reasoning"])
+    if (!reasoning) return
+
+    const extraBody = { ...(asRecord(out["extra_body"]) ?? {}) }
+    const extraBodyReasoning = { ...(asRecord(extraBody["reasoning"]) ?? {}) }
+    if (modelID.includes("anthropic/") || modelID.includes("claude")) {
+      const maxTokens = reasoning["max_tokens"]
+      if (typeof maxTokens === "number" && Number.isFinite(maxTokens)) {
+        extraBody["reasoning"] = {
+          ...extraBodyReasoning,
+          max_tokens: Math.max(1, Math.floor(maxTokens)),
+        }
+      } else if (typeof reasoning["effort"] === "string") {
+        extraBody["reasoning"] = {
+          ...extraBodyReasoning,
+          effort: reasoning["effort"],
+        }
+      } else {
+        extraBody["reasoning"] = {
+          ...extraBodyReasoning,
+          enabled: true,
+        }
+      }
+      if (typeof out["max_tokens"] !== "number") {
+        out["__openrouter_default_max_tokens"] = true
+      }
+    } else {
+      extraBody["reasoning"] = {
+        ...reasoning,
+        ...extraBodyReasoning,
+      }
+    }
+    if (typeof out["max_tokens"] !== "number") {
+      out["__openrouter_default_max_tokens"] = true
+    }
+    if (Object.keys(extraBody).length > 0) {
+      out["extra_body"] = extraBody
+    } else {
+      delete out["extra_body"]
+    }
+    delete out["reasoning"]
   }
 
   function normalizeThinkingBudget(out: Record<string, unknown>) {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -730,11 +730,6 @@ export namespace SessionAgencySwarm {
       normalizeGeminiThinkingConfig(out)
       delete out["reasoning_summary"]
       delete out["include"]
-    } else if (providerID === "xai" && modelID.includes("grok")) {
-      delete out["reasoning_effort"]
-      delete out["reasoning_summary"]
-      delete out["include"]
-      delete out["effort"]
     } else if (providerID === "openrouter") {
       normalizeOpenRouterReasoningConfig(out, modelID)
     }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1469,6 +1469,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   sessionModel: {
                     providerID: lastUser.model.providerID,
                     modelID: lastUser.model.modelID,
+                    variantOptions:
+                      lastUser.model.variant && model.variants ? model.variants[lastUser.model.variant] : undefined,
                   },
                   recipientAgent:
                     lastUser.agencyRecipientAgent ??

--- a/packages/opencode/test/agency-swarm/adapter.test.ts
+++ b/packages/opencode/test/agency-swarm/adapter.test.ts
@@ -190,6 +190,11 @@ describe("agency-swarm.adapter", () => {
         litellmKeys: {
           anthropic: "ant-secret",
         },
+        modelSettingsExtraArgs: {
+          reasoning_effort: "high",
+          reasoning_summary: "auto",
+          include: ["reasoning.encrypted_content"],
+        },
       },
     })) {
       // consume stream
@@ -216,6 +221,11 @@ describe("agency-swarm.adapter", () => {
         },
         litellm_keys: {
           anthropic: "ant-secret",
+        },
+        model_settings_extra_args: {
+          reasoning_effort: "high",
+          reasoning_summary: "auto",
+          include: ["reasoning.encrypted_content"],
         },
       },
     })

--- a/packages/opencode/test/agency-swarm/client-config.test.ts
+++ b/packages/opencode/test/agency-swarm/client-config.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   buildLitellmModelForClientConfig,
   isOpenAIBasedLitellmModel,
+  isOpenRouterClientConfigModel,
   normalizeExplicitClientConfigModel,
 } from "../../src/agency-swarm/litellm-provider"
 
@@ -101,11 +102,14 @@ describe("agency-swarm client config credentials", () => {
 })
 
 describe("agency-swarm litellm model routing", () => {
-  test("buildLitellmModelForClientConfig keeps the caller provider for OpenRouter-namespaced ids", () => {
+  test("buildLitellmModelForClientConfig uses direct OpenRouter routing", () => {
     expect(buildLitellmModelForClientConfig("openrouter", "openrouter/openai/gpt-5.2")).toBe(
-      "litellm/openrouter/openai/gpt-5.2",
+      "openrouter/openai/gpt-5.2",
     )
-    expect(buildLitellmModelForClientConfig("openrouter", "openai/gpt-5.2")).toBe("litellm/openrouter/openai/gpt-5.2")
+    expect(buildLitellmModelForClientConfig("openrouter", "openai/gpt-5.2")).toBe("openrouter/openai/gpt-5.2")
+    expect(buildLitellmModelForClientConfig("openrouter", "anthropic/claude-sonnet-4.5")).toBe(
+      "openrouter/anthropic/claude-sonnet-4.5",
+    )
   })
 
   test("buildLitellmModelForClientConfig still strips openai/ prefixes when the provider is openai", () => {
@@ -120,7 +124,7 @@ describe("agency-swarm litellm model routing", () => {
   })
 
   test("normalizeExplicitClientConfigModel preserves non-OpenAI provider namespaces", () => {
-    expect(normalizeExplicitClientConfigModel("openrouter/openai/gpt-5.2")).toBe("litellm/openrouter/openai/gpt-5.2")
+    expect(normalizeExplicitClientConfigModel("openrouter/openai/gpt-5.2")).toBe("openrouter/openai/gpt-5.2")
     expect(normalizeExplicitClientConfigModel("litellm/openrouter/openai/gpt-5.2")).toBe(
       "litellm/openrouter/openai/gpt-5.2",
     )
@@ -139,5 +143,11 @@ describe("agency-swarm litellm model routing", () => {
     expect(isOpenAIBasedLitellmModel("litellm/anthropic/claude-sonnet-4-6")).toBe(false)
     expect(isOpenAIBasedLitellmModel("litellm/gemini/gemini-2.5-pro")).toBe(false)
     expect(isOpenAIBasedLitellmModel("anthropic/claude-sonnet-4-6")).toBe(false)
+  })
+
+  test("isOpenRouterClientConfigModel detects direct OpenRouter routes only", () => {
+    expect(isOpenRouterClientConfigModel("openrouter/openai/gpt-5.2")).toBe(true)
+    expect(isOpenRouterClientConfigModel("litellm/openrouter/openai/gpt-5.2")).toBe(false)
+    expect(isOpenRouterClientConfigModel("gpt-5")).toBe(false)
   })
 })

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -758,7 +758,7 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
-  test("framework mode still opens auth when only a non-primary provider is credentialed", () => {
+  test("framework mode accepts Google as an upstream provider credential", () => {
     expect(
       shouldOpenStartupAuthDialog({
         frameworkMode: true,
@@ -782,13 +782,15 @@ describe("agency session errors", () => {
           },
         ],
       }),
-    ).toBe(true)
+    ).toBe(false)
   })
 
-  test("framework auth only supports openai and anthropic", () => {
+  test("framework auth supports Agent Swarm upstream providers", () => {
     expect(isSupportedAgencyAuthProvider("openai")).toBe(true)
     expect(isSupportedAgencyAuthProvider("anthropic")).toBe(true)
-    expect(isSupportedAgencyAuthProvider("google")).toBe(false)
+    expect(isSupportedAgencyAuthProvider("google")).toBe(true)
+    expect(isSupportedAgencyAuthProvider("gemini")).toBe(true)
+    expect(isSupportedAgencyAuthProvider("xai")).toBe(true)
     expect(isSupportedAgencyAuthProvider("github-copilot")).toBe(false)
   })
 
@@ -1013,6 +1015,8 @@ describe("agency session errors", () => {
 describe("isAgencySupportedProvider (/models filter)", () => {
   const mixed: Provider[] = [
     { id: "gemini", name: "Gemini", source: "config", env: [], options: {}, models: {} },
+    { id: "google", name: "Google", source: "config", env: [], options: {}, models: {} },
+    { id: "xai", name: "xAI", source: "config", env: [], options: {}, models: {} },
     { id: "github-copilot", name: "GitHub Copilot", source: "config", env: [], options: {}, models: {} },
     { id: "openai", name: "OpenAI", source: "config", env: [], options: {}, models: {} },
     { id: "anthropic", name: "Anthropic", source: "config", env: [], options: {}, models: {} },
@@ -1024,13 +1028,22 @@ describe("isAgencySupportedProvider (/models filter)", () => {
     return frameworkMode ? providers.filter((provider) => isAgencySupportedProvider(provider.id)) : providers
   }
 
-  test("framework mode keeps only openai, anthropic, agency-swarm", () => {
-    expect(filterForDialog(mixed, true).map((provider) => provider.id)).toEqual(["openai", "anthropic", "agency-swarm"])
+  test("framework mode keeps supported Agent Swarm providers", () => {
+    expect(filterForDialog(mixed, true).map((provider) => provider.id)).toEqual([
+      "gemini",
+      "google",
+      "xai",
+      "openai",
+      "anthropic",
+      "agency-swarm",
+    ])
   })
 
   test("non-framework mode passes the full provider list through", () => {
     expect(filterForDialog(mixed, false).map((provider) => provider.id)).toEqual([
       "gemini",
+      "google",
+      "xai",
       "github-copilot",
       "openai",
       "anthropic",

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -297,6 +297,34 @@ describe("agency session errors", () => {
     ).toBe(false)
   })
 
+  test("framework mode skips auth when forwarding is active and OPENROUTER_API_KEY is set in env", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        forwardUpstreamCredentials: true,
+        env: { OPENROUTER_API_KEY: "sk-openrouter-env" },
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: { baseURL: "https://agency.example.com" },
+            models: {},
+          },
+          {
+            id: "openrouter",
+            name: "OpenRouter",
+            source: "config",
+            env: ["OPENROUTER_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
   test("framework mode skips auth from env even when the primary provider is filtered out", () => {
     // Mirrors SessionAgencySwarm.buildAuthClientConfig()'s direct OPENAI_API_KEY read:
     // the bridge can authenticate via env even when openai is not in the enabled provider list.
@@ -785,12 +813,40 @@ describe("agency session errors", () => {
     ).toBe(false)
   })
 
+  test("framework mode accepts OpenRouter as an upstream provider credential", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "openrouter",
+            name: "OpenRouter",
+            source: "api",
+            env: ["OPENROUTER_API_KEY"],
+            key: "openrouter-key",
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
   test("framework auth supports Agent Swarm upstream providers", () => {
     expect(isSupportedAgencyAuthProvider("openai")).toBe(true)
     expect(isSupportedAgencyAuthProvider("anthropic")).toBe(true)
     expect(isSupportedAgencyAuthProvider("google")).toBe(true)
     expect(isSupportedAgencyAuthProvider("gemini")).toBe(true)
     expect(isSupportedAgencyAuthProvider("xai")).toBe(true)
+    expect(isSupportedAgencyAuthProvider("openrouter")).toBe(true)
     expect(isSupportedAgencyAuthProvider("github-copilot")).toBe(false)
   })
 
@@ -1017,6 +1073,7 @@ describe("isAgencySupportedProvider (/models filter)", () => {
     { id: "gemini", name: "Gemini", source: "config", env: [], options: {}, models: {} },
     { id: "google", name: "Google", source: "config", env: [], options: {}, models: {} },
     { id: "xai", name: "xAI", source: "config", env: [], options: {}, models: {} },
+    { id: "openrouter", name: "OpenRouter", source: "config", env: [], options: {}, models: {} },
     { id: "github-copilot", name: "GitHub Copilot", source: "config", env: [], options: {}, models: {} },
     { id: "openai", name: "OpenAI", source: "config", env: [], options: {}, models: {} },
     { id: "anthropic", name: "Anthropic", source: "config", env: [], options: {}, models: {} },
@@ -1033,6 +1090,7 @@ describe("isAgencySupportedProvider (/models filter)", () => {
       "gemini",
       "google",
       "xai",
+      "openrouter",
       "openai",
       "anthropic",
       "agency-swarm",
@@ -1044,6 +1102,7 @@ describe("isAgencySupportedProvider (/models filter)", () => {
       "gemini",
       "google",
       "xai",
+      "openrouter",
       "github-copilot",
       "openai",
       "anthropic",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2234,6 +2234,37 @@ describe("ProviderTransform.variants", () => {
       expect(result.low).toEqual({ reasoning: { effort: "low" } })
       expect(result.high).toEqual({ reasoning: { effort: "high" } })
     })
+
+    test("grok-4.3 returns reasoning effort variants", () => {
+      const model = createMockModel({
+        id: "openrouter/grok-4.3",
+        providerID: "openrouter",
+        api: {
+          id: "grok-4.3",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
+      expect(result.none).toEqual({ reasoning: { effort: "none" } })
+      expect(result.high).toEqual({ reasoning: { effort: "high" } })
+    })
+
+    test("grok-4-3 returns reasoning effort variants", () => {
+      const model = createMockModel({
+        id: "openrouter/grok-4-3-20260430",
+        providerID: "openrouter",
+        api: {
+          id: "grok-4-3-20260430",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
+      expect(result.medium).toEqual({ reasoning: { effort: "medium" } })
+    })
   })
 
   describe("@ai-sdk/gateway", () => {
@@ -2570,6 +2601,37 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["low", "high"])
       expect(result.low).toEqual({ reasoningEffort: "low" })
       expect(result.high).toEqual({ reasoningEffort: "high" })
+    })
+
+    test("grok-4.3 returns reasoningEffort variants", () => {
+      const model = createMockModel({
+        id: "xai/grok-4.3",
+        providerID: "xai",
+        api: {
+          id: "grok-4.3",
+          url: "https://api.x.ai",
+          npm: "@ai-sdk/xai",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
+      expect(result.none).toEqual({ reasoningEffort: "none" })
+      expect(result.high).toEqual({ reasoningEffort: "high" })
+    })
+
+    test("grok-4-3 returns reasoningEffort variants", () => {
+      const model = createMockModel({
+        id: "xai/grok-4-3-20260430",
+        providerID: "xai",
+        api: {
+          id: "grok-4-3-20260430",
+          url: "https://api.x.ai",
+          npm: "@ai-sdk/xai",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
+      expect(result.medium).toEqual({ reasoningEffort: "medium" })
     })
   })
 

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -6878,6 +6878,178 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["The current time is 10:00 AM."])
   })
 
+  test("stream does not duplicate response-scoped message replay when LiteLLM changes item id", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: {
+              type: "message",
+              id: "call_as_message",
+              provider_data: { response_id: "response_same_message" },
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "call_as_message",
+            output_index: "0",
+            delta: "The current time is 07:29.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "call_as_message",
+            output_index: "0",
+            text: "The current time is 07:29.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: {
+              type: "message",
+              id: "call_as_message",
+              content: [{ type: "output_text", text: "The current time is 07:29." }],
+              provider_data: { response_id: "response_same_message" },
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "message_output_created",
+          item: {
+            raw_item: {
+              type: "message",
+              id: "msg_agent_run_changed_id",
+              content: [{ type: "output_text", text: "The current time is 07:29." }],
+              provider_data: { response_id: "response_same_message" },
+            },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "text-delta") {
+        deltas.push(event.text)
+      }
+    }
+
+    expect(deltas).toEqual(["The current time is 07:29."])
+  })
+
+  test("stream keeps repeated assistant text from a different provider response", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "message", id: "msg_first", provider_data: { response_id: "response_first" } },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_first",
+            output_index: "0",
+            delta: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_first",
+            output_index: "0",
+            text: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: {
+              type: "message",
+              id: "msg_first",
+              content: [{ type: "output_text", text: "OK" }],
+              provider_data: { response_id: "response_first" },
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "message_output_created",
+          item: {
+            raw_item: {
+              type: "message",
+              id: "msg_second",
+              content: [{ type: "output_text", text: "OK" }],
+              provider_data: { response_id: "response_second" },
+            },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "text-delta") {
+        deltas.push(event.text)
+      }
+    }
+
+    expect(deltas).toEqual(["OK", "OK"])
+  })
+
   test("stream keeps both distinct short assistant messages in the same run (no body-only dedupe)", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
@@ -7032,6 +7204,94 @@ describe("session.agency-swarm", () => {
     }
 
     expect(deltas).toEqual(["Find the right file first."])
+  })
+
+  test("stream does not duplicate response-scoped reasoning replay when LiteLLM changes item id", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: {
+              type: "reasoning",
+              id: "reasoning_raw",
+              provider_data: { response_id: "response_same_reasoning" },
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "reasoning_raw",
+            summary_index: "0",
+            output_index: "0",
+            delta: "The tool returned a timestamp.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "reasoning_raw",
+            summary_index: "0",
+            output_index: "0",
+            text: "The tool returned a timestamp.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: {
+              type: "reasoning",
+              id: "reasoning_raw",
+              summary: [{ text: "The tool returned a timestamp." }],
+              provider_data: { response_id: "response_same_reasoning" },
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "reasoning_item_created",
+          item: {
+            raw_item: {
+              type: "reasoning",
+              id: "reasoning_changed",
+              summary: [{ text: "The tool returned a timestamp." }],
+              provider_data: { response_id: "response_same_reasoning" },
+            },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["The tool returned a timestamp."])
   })
 
   test("stream does not duplicate tool input when tool_called follows output_item.added", async () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1489,6 +1489,37 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream forwards selected xAI Grok reasoning effort to agency client config", async () => {
+    mockHistory()
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "xai",
+      modelID: "grok-4.3",
+      variantOptions: {
+        reasoningEffort: "high",
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      model: "litellm/xai/grok-4.3",
+      model_settings_extra_args: {
+        reasoning_effort: "high",
+      },
+    })
+  })
+
   test("stream maps anthropic model variant effort to litellm reasoning effort", async () => {
     mockHistory()
 

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1224,6 +1224,141 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream forwards selected model variant settings to agency client config", async () => {
+    mockHistory()
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      variantOptions: {
+        reasoningEffort: "high",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      model: "gpt-5.4",
+      model_settings_extra_args: {
+        reasoning_effort: "high",
+        reasoning_summary: "auto",
+        include: ["reasoning.encrypted_content"],
+      },
+    })
+  })
+
+  test("stream maps anthropic model variant effort to litellm reasoning effort", async () => {
+    mockHistory()
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-6",
+      variantOptions: {
+        thinking: { type: "adaptive" },
+        effort: "high",
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      model: "litellm/anthropic/claude-sonnet-4-6",
+      model_settings_extra_args: {
+        thinking: { type: "adaptive" },
+        reasoning_effort: "high",
+      },
+    })
+  })
+
+  test("stream maps gemini thinking config to litellm thinking", async () => {
+    mockHistory()
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "google",
+      modelID: "gemini-2.5-pro",
+      variantOptions: {
+        thinkingConfig: {
+          includeThoughts: true,
+          thinkingBudget: 16000,
+        },
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      model: "litellm/gemini/gemini-2.5-pro",
+      model_settings_extra_args: {
+        thinking: { type: "enabled", budget_tokens: 16000 },
+        reasoning_effort: "high",
+      },
+    })
+  })
+
+  test("stream maps top-level gemini thinking level to litellm reasoning effort", async () => {
+    mockHistory()
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "google",
+      modelID: "gemini-3.5-flash",
+      variantOptions: {
+        includeThoughts: true,
+        thinkingLevel: "high",
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      model: "litellm/gemini/gemini-3.5-flash",
+      model_settings_extra_args: {
+        reasoning_effort: "high",
+      },
+    })
+  })
+
   test("stream forwards stored API auth to remote URL when forwardUpstreamCredentials is true", async () => {
     mockHistory()
     spyOn(Auth, "all").mockImplementation(async () => ({
@@ -2181,7 +2316,7 @@ describe("session.agency-swarm", () => {
     }
   })
 
-  test("explicit client_config.model overrides session-derived model", async () => {
+  test("session UI model overrides explicit client_config.model for the current turn", async () => {
     mockHistory()
     spyOn(Auth, "all").mockImplementation(async () => ({})) as typeof Auth.all
     spyOn(Env, "all").mockImplementation(() => ({})) as typeof Env.all
@@ -2239,7 +2374,7 @@ describe("session.agency-swarm", () => {
       }
 
       expect(body?.["client_config"]).toEqual({
-        model: "gpt-4o",
+        model: "litellm/anthropic/claude-sonnet-4-5",
       })
     } finally {
       await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
@@ -6414,6 +6549,72 @@ describe("session.agency-swarm", () => {
     }
 
     expect(deltas).toEqual(["Hi, there!"])
+  })
+
+  test("stream does not duplicate text when message_output_created replays open output_text", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "message", id: "msg_open_run_item_replay" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_open_run_item_replay",
+            output_index: "0",
+            delta: "The current time is 10:00 AM.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "message_output_created",
+          item: {
+            raw_item: {
+              type: "message",
+              id: "msg_open_run_item_replay",
+              content: [{ type: "output_text", text: "The current time is 10:00 AM." }],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "message", id: "msg_open_run_item_replay" },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "text-delta") {
+        deltas.push(event.text)
+      }
+    }
+
+    expect(deltas).toEqual(["The current time is 10:00 AM."])
   })
 
   test("stream keeps both distinct short assistant messages in the same run (no body-only dedupe)", async () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1224,6 +1224,236 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream forwards selected OpenRouter model and key through direct client config", async () => {
+    mockHistory()
+    spyOn(Auth, "all").mockImplementation(async () => ({
+      openai: { type: "api", key: "stored-openai" } as any,
+      openrouter: { type: "api", key: "stored-openrouter" } as any,
+    })) as typeof Auth.all
+    spyOn(Env, "all").mockImplementation(() => ({
+      OPENAI_API_KEY: "env-openai",
+      OPENROUTER_API_KEY: "env-openrouter",
+    })) as typeof Env.all
+    spyOn(Provider, "list").mockImplementation(async () => ({
+      openai: {
+        id: "openai",
+        name: "OpenAI",
+        source: "api",
+        env: ["OPENAI_API_KEY"],
+        options: {},
+        models: {},
+      },
+      openrouter: {
+        id: "openrouter",
+        name: "OpenRouter",
+        source: "api",
+        env: ["OPENROUTER_API_KEY"],
+        options: {},
+        models: {},
+      },
+    })) as typeof Provider.list
+    AgencySwarmAdapter.getMetadata = (async () => ({
+      agency_swarm_version: "1.9.3",
+      metadata: { agents: ["AgentA"] },
+      nodes: [],
+    })) as typeof AgencySwarmAdapter.getMetadata
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = { providerID: "openrouter", modelID: "anthropic/claude-sonnet-4.5" }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "env-openrouter",
+      model: "openrouter/anthropic/claude-sonnet-4.5",
+    })
+  })
+
+  test("stream caps OpenRouter Claude max tokens for free tier keys", async () => {
+    mockHistory()
+    globalThis.fetch = mock(async () => Response.json({ data: { is_free_tier: true } })) as unknown as typeof fetch
+    spyOn(Auth, "all").mockImplementation(async () => ({
+      openrouter: { type: "api", key: "stored-openrouter" } as any,
+    })) as typeof Auth.all
+    spyOn(Env, "all").mockImplementation(() => ({
+      OPENROUTER_API_KEY: "env-openrouter",
+    })) as typeof Env.all
+    spyOn(Provider, "list").mockImplementation(async () => ({
+      openrouter: {
+        id: "openrouter",
+        name: "OpenRouter",
+        source: "api",
+        env: ["OPENROUTER_API_KEY"],
+        options: {},
+        models: {},
+      },
+    })) as typeof Provider.list
+    AgencySwarmAdapter.getMetadata = (async () => ({
+      agency_swarm_version: "1.9.3",
+      metadata: { agents: ["AgentA"] },
+      nodes: [],
+    })) as typeof AgencySwarmAdapter.getMetadata
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "openrouter",
+      modelID: "anthropic/claude-sonnet-4.5",
+      variantOptions: {
+        reasoning: { effort: "high" },
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "env-openrouter",
+      model: "openrouter/anthropic/claude-sonnet-4.5",
+      model_settings_extra_args: {
+        extra_body: {
+          reasoning: {
+            effort: "high",
+          },
+        },
+        max_tokens: 2500,
+      },
+    })
+  })
+
+  test("stream leaves OpenRouter Claude max tokens unset for paid tier keys", async () => {
+    mockHistory()
+    globalThis.fetch = mock(async () => Response.json({ data: { is_free_tier: false } })) as unknown as typeof fetch
+    spyOn(Auth, "all").mockImplementation(async () => ({
+      openrouter: { type: "api", key: "stored-openrouter" } as any,
+    })) as typeof Auth.all
+    spyOn(Env, "all").mockImplementation(() => ({
+      OPENROUTER_API_KEY: "env-openrouter",
+    })) as typeof Env.all
+    spyOn(Provider, "list").mockImplementation(async () => ({
+      openrouter: {
+        id: "openrouter",
+        name: "OpenRouter",
+        source: "api",
+        env: ["OPENROUTER_API_KEY"],
+        options: {},
+        models: {},
+      },
+    })) as typeof Provider.list
+    AgencySwarmAdapter.getMetadata = (async () => ({
+      agency_swarm_version: "1.9.3",
+      metadata: { agents: ["AgentA"] },
+      nodes: [],
+    })) as typeof AgencySwarmAdapter.getMetadata
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "openrouter",
+      modelID: "anthropic/claude-sonnet-4.5",
+      variantOptions: {
+        reasoning: { effort: "high" },
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "env-openrouter",
+      model: "openrouter/anthropic/claude-sonnet-4.5",
+      model_settings_extra_args: {
+        extra_body: {
+          reasoning: {
+            effort: "high",
+          },
+        },
+      },
+    })
+  })
+
+  test("stream forwards OpenRouter reasoning effort for non-Claude models", async () => {
+    mockHistory()
+    globalThis.fetch = mock(async () => Response.json({ data: { is_free_tier: true } })) as unknown as typeof fetch
+    spyOn(Auth, "all").mockImplementation(async () => ({
+      openrouter: { type: "api", key: "stored-openrouter" } as any,
+    })) as typeof Auth.all
+    spyOn(Env, "all").mockImplementation(() => ({
+      OPENROUTER_API_KEY: "env-openrouter",
+    })) as typeof Env.all
+    spyOn(Provider, "list").mockImplementation(async () => ({
+      openrouter: {
+        id: "openrouter",
+        name: "OpenRouter",
+        source: "api",
+        env: ["OPENROUTER_API_KEY"],
+        options: {},
+        models: {},
+      },
+    })) as typeof Provider.list
+    AgencySwarmAdapter.getMetadata = (async () => ({
+      agency_swarm_version: "1.9.3",
+      metadata: { agents: ["AgentA"] },
+      nodes: [],
+    })) as typeof AgencySwarmAdapter.getMetadata
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "openrouter",
+      modelID: "openai/gpt-5.4",
+      variantOptions: {
+        reasoning: { effort: "high" },
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "env-openrouter",
+      model: "openrouter/openai/gpt-5.4",
+      model_settings_extra_args: {
+        extra_body: {
+          reasoning: {
+            effort: "high",
+          },
+        },
+        max_tokens: 2500,
+      },
+    })
+  })
+
   test("stream forwards selected model variant settings to agency client config", async () => {
     mockHistory()
 


### PR DESCRIPTION
### Issue for this PR

Closes #247

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes Agent Swarm framework mode not honoring the selected provider/model variant. The selected model variant is forwarded through `client_config.model_settings_extra_args`, provider-specific variant fields are normalized before sending, and framework mode no longer hides the variant controls.

This also fixes duplicated streamed text/reasoning after tool use by skipping same-item replayed content from later run-item events, and fixes Windows root typecheck failures from symlinked `custom-elements.d.ts` files.

Adds OpenRouter support for Agency Swarm TUI. OpenRouter models are routed as direct `openrouter/...` client-config models, OpenRouter credentials are forwarded from stored provider auth or `OPENROUTER_API_KEY`, and reasoning settings are sent through OpenRouter-compatible `extra_body.reasoning`.

Depends on companion Agency Swarm PRs:

- https://github.com/VRSEN/agency-swarm/pull/654
- https://github.com/VRSEN/agency-swarm/pull/655

### How did you verify your code works?

Manually tested and ran focused Agent Swarm provider, stream, TUI session-error, typecheck, and single-binary build checks.

### Screenshots / recordings

None

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
