### PR TITLE
Quiet uv install output

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -916,11 +916,7 @@ async function ensureProjectPython(
         "launcher refresh",
         profile,
       )
-      prompts.log.info(
-        refreshLogFile
-          ? `Refreshing project dependencies with local uv. Streaming output to stderr. Full log: ${refreshLogFile}`
-          : "Refreshing project dependencies with local uv. Streaming output to stderr.",
-      )
+      prompts.log.info("Refreshing project dependencies...")
       let localUv: string | undefined
       try {
         localUv = await ensureLocalUv(directory, venvPython, {
@@ -1023,11 +1019,7 @@ async function ensureProjectPython(
     "launcher rebuild",
     profile,
   )
-  prompts.log.info(
-    installLogFile
-      ? `Installing project dependencies. Streaming output to stderr. Full log: ${installLogFile}`
-      : "Installing project dependencies. Streaming output to stderr.",
-  )
+  prompts.log.info("Installing project dependencies...")
   const localUv = await ensureLocalUv(directory, venvPython, {
     forceInstall: true,
     logFile: installLogFile,
@@ -1038,11 +1030,7 @@ async function ensureProjectPython(
     timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
   })
   if (install.timedOut) {
-    throw new Error(
-      install.logFile
-        ? `Dependency install timed out after ${formatInstallDuration(REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${install.logFile}.`
-        : `Dependency install timed out after ${formatInstallDuration(REBUILD_INSTALL_TIMEOUT_MS)}.`,
-    )
+    throw new Error(formatCommandTimeout(install, "Dependency install", REBUILD_INSTALL_TIMEOUT_MS))
   }
   if (install.code !== 0) {
     throw new Error(formatCommandFailure(install, "Dependency install failed"))
@@ -1077,7 +1065,6 @@ async function installProjectDependencies(
       {
         cwd: directory,
         logFile: options.logFile,
-        streamOutputToStderr: true,
         timeoutMs: options.timeoutMs,
       },
     )
@@ -1089,7 +1076,6 @@ async function installProjectDependencies(
     const result = await runCommand([localUv, "pip", "install", "--python", venvPython, "--upgrade", "-e", "."], {
       cwd: directory,
       logFile: options.logFile,
-      streamOutputToStderr: true,
       timeoutMs: options.timeoutMs,
     })
     return { ...result, hadManifests: true }
@@ -1099,7 +1085,6 @@ async function installProjectDependencies(
     [localUv, "pip", "install", "--python", venvPython, FALLBACK_AGENCY_SWARM_REQUIREMENT],
     {
       logFile: options.logFile,
-      streamOutputToStderr: true,
       timeoutMs: options.timeoutMs,
     },
   )
@@ -1121,11 +1106,7 @@ async function refreshProjectDependencies(
 
   const result = await installProjectDependencies(directory, venvPython, localUv, options)
   if (result.timedOut) {
-    prompts.log.warn(
-      result.logFile
-        ? `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}. Check the log file at ${result.logFile}.`
-        : `Timed out while refreshing project dependencies after ${formatInstallDuration(options.timeoutMs)}.`,
-    )
+    prompts.log.warn(formatCommandTimeout(result, "Project dependency refresh", options.timeoutMs))
     return { installerFailed: false }
   }
   if (result.code !== 0) {
@@ -1227,16 +1208,17 @@ async function ensureLatestAgencySwarm(
       {
         cwd: directory,
         logFile: options?.logFile,
-        streamOutputToStderr: true,
         suppressPythonTracebackStderr: true,
         timeoutMs: options?.timeoutMs,
       },
     )
     if (result.timedOut) {
       prompts.log.warn(
-        result.logFile
-          ? `Timed out while refreshing launcher-managed agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}. Check the log file at ${result.logFile}.`
-          : `Timed out while refreshing launcher-managed agency-swarm after ${formatInstallDuration(options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS)}.`,
+        formatCommandTimeout(
+          result,
+          "Launcher-managed agency-swarm refresh",
+          options?.timeoutMs ?? REBUILD_INSTALL_TIMEOUT_MS,
+        ),
       )
       return { installerFailed: false }
     }
@@ -1272,14 +1254,11 @@ async function ensureLocalUv(
   const result = await runCommand([venvPython, "-m", "pip", "install", "--upgrade", "uv"], {
     cwd: directory,
     logFile: options.logFile,
-    streamOutputToStderr: true,
     timeoutMs: options.timeoutMs,
   })
   if (result.timedOut) {
     throw new Error(
-      result.logFile
-        ? `Project Python environment setup timed out while installing uv after ${formatInstallDuration(options.timeoutMs)}. Check the log file at ${result.logFile}.`
-        : `Project Python environment setup timed out while installing uv after ${formatInstallDuration(options.timeoutMs)}.`,
+      formatCommandTimeout(result, "Project Python environment setup while installing uv", options.timeoutMs),
     )
   }
   if (result.code !== 0) {
@@ -1343,14 +1322,16 @@ function summarizeCommandOutput(result: Pick<CommandResult, "stdout" | "stderr">
 }
 
 function formatCommandFailure(result: CommandResult, fallback: string) {
-  if (!result.logFile) {
-    const detail = result.stderr.trim() || result.stdout.trim()
-    return detail ? `${fallback}: ${detail}` : fallback
-  }
   const summary = summarizeCommandOutput(result)
-  const logHint = ` Check the log file at ${result.logFile}.`
-  if (summary) return `${fallback}: ${summary}.${logHint}`
-  return `${fallback}.${logHint}`.trim()
+  const logHint = result.logFile ? ` Check the log file at ${result.logFile}.` : ""
+  return summary ? `${fallback}: ${summary}.${logHint}` : `${fallback}.${logHint}`.trim()
+}
+
+function formatCommandTimeout(result: CommandResult, label: string, timeoutMs: number) {
+  const summary = summarizeCommandOutput(result)
+  const logHint = result.logFile ? ` Check the log file at ${result.logFile}.` : ""
+  const detail = summary ? ` Last output: ${summary}${/[.!?]$/.test(summary) ? "" : "."}` : ""
+  return `${label} timed out after ${formatInstallDuration(timeoutMs)}.${detail}${logHint}`
 }
 
 function formatInstallDuration(ms: number) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1439,23 +1439,21 @@ describe("agency-swarm npx onboarding", () => {
     expect(canaryCommands).toHaveLength(2)
   })
 
-  test("prepareProjectLaunch streams rebuild output to stderr", async () => {
+  test("prepareProjectLaunch keeps successful rebuild output compact and logged", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
+    const iso = "2026-04-23T02:15:00.000Z"
 
     spyOn(prompts, "confirm").mockResolvedValue(true as never)
     spyOn(prompts, "spinner").mockReturnValue({
       start() {},
       stop() {},
     } as never)
-    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+    spyOn(Date.prototype, "toISOString").mockReturnValue(iso)
     const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true as never)
-
-    let resolveInstall!: (code: number) => void
-    const installExited = new Promise<number>((resolve) => {
-      resolveInstall = resolve
-    })
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
 
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
@@ -1483,24 +1481,48 @@ describe("agency-swarm npx onboarding", () => {
       }
       if (isUvPipInstallCommand(cmd)) {
         return {
-          exited: installExited,
+          exited: Promise.resolve(0),
           stdout: "Resolving packages...\n",
           stderr: "Downloading wheels...\n",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        let resolveExit!: (code: number) => void
+        const exited = new Promise<number>((resolve) => {
+          resolveExit = resolve
+        })
+        return {
+          exited,
+          stderr: "",
+          kill() {
+            resolveExit(0)
+          },
         } as never
       }
       throw new Error(`Unexpected command: ${cmd.join(" ")}`)
     })
 
-    const launch = prepareProjectLaunch({
+    const launch = await prepareProjectLaunch({
       directory: dir.path,
       agencyFile: path.join(dir.path, "agency.py"),
       moduleName: "agency",
     })
 
-    resolveInstall(1)
-    await expect(launch).rejects.toThrow("Dependency install failed: Downloading wheels....")
-    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Resolving packages...\n")
-    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Downloading wheels...\n")
+    expect(info).toHaveBeenCalledWith("Installing project dependencies...")
+    expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain("Full log")
+    expect(stderrWrite.mock.calls.map((call) => call[0]).join("")).not.toContain("Resolving packages")
+    const logContent = await Bun.file(launcherLogFilePath(dir.path, "launcher-rebuild", iso)).text()
+    expect(logContent).toContain("Resolving packages...")
+    expect(logContent).toContain("Downloading wheels...")
+
+    await launch?.cleanup?.()
   })
 
   test("prepareProjectLaunch times out dependency rebuilds with a clear log path", async () => {
@@ -1583,7 +1605,9 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(error).toBeInstanceOf(Error)
     if (!error) throw new Error("Expected prepareProjectLaunch to fail")
-    expect(error.message).toMatch(/Dependency install timed out after 10 minutes\..*launcher-rebuild\.log/)
+    expect(error.message).toMatch(
+      /Dependency install timed out after 10 minutes\. Last output: still working\.\.\..*launcher-rebuild\.log/,
+    )
     expect(error.message).not.toContain(dir.path)
   })
 
@@ -1676,7 +1700,7 @@ describe("agency-swarm npx onboarding", () => {
     expect(outcome.message).toContain("Dependency install timed out after 10 minutes")
   })
 
-  test("prepareProjectLaunch preserves shutdown stderr emitted during timeout", async () => {
+  test("prepareProjectLaunch includes shutdown stderr in timeout summary without mirroring", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
 
@@ -1753,10 +1777,9 @@ describe("agency-swarm npx onboarding", () => {
         agencyFile: path.join(dir.path, "agency.py"),
         moduleName: "agency",
       }),
-    ).rejects.toThrow("Dependency install timed out after 10 minutes")
+    ).rejects.toThrow("Last output: still working... | term tail")
 
-    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("still working...\n")
-    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("term tail\n")
+    expect(stderrWrite).not.toHaveBeenCalled()
   })
 
   test("prepareProjectLaunch clears the install timeout as soon as the child exits", async () => {
@@ -1861,9 +1884,10 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
-  test("prepareProjectLaunch surfaces refresh stderr when agency-swarm upgrade fails", async () => {
+  test("prepareProjectLaunch keeps refresh failures compact and logged", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
+    const iso = "2026-04-23T02:20:00.000Z"
     await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
       recursive: true,
     })
@@ -1880,6 +1904,7 @@ describe("agency-swarm npx onboarding", () => {
     const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
     const stderrWrite = spyOn(process.stderr, "write").mockImplementation(() => true as never)
+    spyOn(Date.prototype, "toISOString").mockReturnValue(iso)
     spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
 
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
@@ -1943,16 +1968,15 @@ describe("agency-swarm npx onboarding", () => {
       moduleName: "agency",
     })
 
-    expect(info).toHaveBeenCalledWith(
-      expect.stringContaining("Refreshing project dependencies with local uv. Streaming output to stderr."),
-    )
-    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain("Collecting agency-swarm...\n")
-    expect(stderrWrite.mock.calls.map((call) => call[0])).toContain(
-      "ERROR: No matching distribution found for agency-swarm[fastapi,litellm]",
-    )
+    expect(info).toHaveBeenCalledWith("Refreshing project dependencies...")
+    expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain("Full log")
+    expect(stderrWrite.mock.calls.map((call) => call[0]).join("")).not.toContain("Collecting agency-swarm")
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("Installer output: ERROR: No matching distribution found"),
     )
+    const logContent = await Bun.file(launcherLogFilePath(dir.path, "launcher-refresh", iso)).text()
+    expect(logContent).toContain("Collecting agency-swarm...")
+    expect(logContent).toContain("ERROR: No matching distribution found for agency-swarm[fastapi,litellm]")
 
     await launch?.cleanup?.()
   })
@@ -2076,7 +2100,7 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
-  test("prepareProjectLaunch resumes stderr after a non-Error pip refresh traceback", async () => {
+  test("prepareProjectLaunch logs non-Error pip refresh tracebacks without mirroring stderr", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
     await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
@@ -2162,7 +2186,7 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     const mirroredOutput = stderrWrite.mock.calls.map((call) => call[0]).join("")
-    expect(mirroredOutput).toContain("later stderr after traceback")
+    expect(mirroredOutput).not.toContain("later stderr after traceback")
     expect(mirroredOutput).not.toContain("Traceback (most recent call last):")
     expect(mirroredOutput).not.toContain("pip._internal.cli.main")
     expect(mirroredOutput).not.toContain("Exception: pip bootstrap failed")
@@ -2899,7 +2923,7 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
-  test("prepareProjectLaunch ignores mirrored stderr pipe failures during rebuild installs", async () => {
+  test("prepareProjectLaunch does not mirror rebuild install output to stderr", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
 
@@ -2976,12 +3000,12 @@ describe("agency-swarm npx onboarding", () => {
       moduleName: "agency",
     })
 
-    expect(stderrWrite).toHaveBeenCalled()
+    expect(stderrWrite).not.toHaveBeenCalled()
 
     await launch?.cleanup?.()
   })
 
-  test("prepareProjectLaunch preserves full install stderr when log creation falls back", async () => {
+  test("prepareProjectLaunch keeps install failures bounded when log creation falls back", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
     const blockedLogDir = launcherLogDirectory(dir.path)
@@ -3035,7 +3059,9 @@ describe("agency-swarm npx onboarding", () => {
         agencyFile: path.join(dir.path, "agency.py"),
         moduleName: "agency",
       }),
-    ).rejects.toThrow(`Dependency install failed: ${installStderr}`)
+    ).rejects.toThrow(
+      "Dependency install failed: resolver detail 3 | resolver detail 4 | resolver detail 5 | resolver detail 6 | resolver detail 7.",
+    )
   })
 
   test("prepareProjectLaunch omits rebuild log hints when timeout logging never opens", async () => {
@@ -3124,7 +3150,7 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(error).toBeInstanceOf(Error)
     if (!error) throw new Error("Expected prepareProjectLaunch to fail")
-    expect(error.message).toBe("Dependency install timed out after 10 minutes.")
+    expect(error.message).toBe("Dependency install timed out after 10 minutes. Last output: still working...")
   })
 
   test("prepareProjectLaunch avoids manifest remediation after fallback install canary failures", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This keeps Agency Swarm install and refresh output concise by no longer mirroring full uv dependency output to stderr during normal runs.

Failure and timeout paths still show a short useful summary, and the full command output stays available in the launcher log when a log file exists.

### How did you verify your code works?

Focused Agency Swarm npx tests passed: 89 passed, 0 failed.

Package typecheck passed.

The pre-push hook also ran the repo typecheck successfully.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
