### PR TITLE
fix: harden Agent Swarm release blockers

### DIFF
--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -139,4 +139,26 @@ describe("createChildStoreManager", () => {
       dispose()
     })
   })
+
+  test("treats unfinished assistant messages as working before status loads", () => {
+    queries = [{ isLoading: false }, { isLoading: false }, { isLoading: false }, { isLoading: false }]
+
+    createRoot((dispose) => {
+      const owner = getOwner()
+      if (!owner) throw new Error("owner required")
+
+      const store = manager(owner)
+      const [state, setState] = store.ensureChild("/repo")
+      setState("message", "ses_1", [
+        {
+          role: "assistant",
+          time: {},
+        } as unknown as State["message"][string][number],
+      ])
+
+      expect(state.session_working("ses_1")).toBe(true)
+
+      dispose()
+    })
+  })
 })

--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -161,4 +161,27 @@ describe("createChildStoreManager", () => {
       dispose()
     })
   })
+
+  test("does not use unfinished assistant messages after idle status loads", () => {
+    queries = [{ isLoading: false }, { isLoading: false }, { isLoading: false }, { isLoading: false }]
+
+    createRoot((dispose) => {
+      const owner = getOwner()
+      if (!owner) throw new Error("owner required")
+
+      const store = manager(owner)
+      const [state, setState] = store.ensureChild("/repo")
+      setState("session_status", "ses_1", { type: "idle" })
+      setState("message", "ses_1", [
+        {
+          role: "assistant",
+          time: {},
+        } as unknown as State["message"][string][number],
+      ])
+
+      expect(state.session_working("ses_1")).toBe(false)
+
+      dispose()
+    })
+  })
 })

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -211,7 +211,10 @@ export function createChildStoreManager(input: {
             session_status: {},
             session_working(id: string) {
               const type = this.session_status[id]?.type
-              return (type ?? "idle") !== "idle"
+              if ((type ?? "idle") !== "idle") return true
+              return (this.message[id] ?? []).some(
+                (item) => item.role === "assistant" && typeof item.time.completed !== "number",
+              )
             },
             session_diff: {},
             todo: {},

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -210,8 +210,8 @@ export function createChildStoreManager(input: {
             sessionTotal: 0,
             session_status: {},
             session_working(id: string) {
-              const type = this.session_status[id]?.type
-              if ((type ?? "idle") !== "idle") return true
+              const status = this.session_status[id]
+              if (status) return status.type !== "idle"
               return (this.message[id] ?? []).some(
                 (item) => item.role === "assistant" && typeof item.time.completed !== "number",
               )

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -123,7 +123,6 @@ const readHashAuthToken = () => {
 const readStartupAuthToken = () => {
   const hash = readHashAuthToken()
   if (hash) return hash
-  if (location.hostname.includes("opencode.ai")) return null
   return new URLSearchParams(location.search).get(AUTH_TOKEN_PARAM)
 }
 

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -112,11 +112,34 @@ const getDefaultUrl = () => {
   return getCurrentUrl()
 }
 
+const AUTH_TOKEN_PARAM = "auth_token"
+
+const readHashAuthToken = () => {
+  if (!location.hash) return null
+  const params = new URLSearchParams(location.hash.slice(1))
+  return params.get(AUTH_TOKEN_PARAM)
+}
+
+const readStartupAuthToken = () => {
+  const hash = readHashAuthToken()
+  if (hash) return hash
+  if (location.hostname.includes("opencode.ai")) return null
+  return new URLSearchParams(location.search).get(AUTH_TOKEN_PARAM)
+}
+
 const clearAuthToken = () => {
   const params = new URLSearchParams(location.search)
-  if (!params.has("auth_token")) return
-  params.delete("auth_token")
-  history.replaceState(null, "", location.pathname + (params.size ? `?${params}` : "") + location.hash)
+  const hadSearch = params.has(AUTH_TOKEN_PARAM)
+  params.delete(AUTH_TOKEN_PARAM)
+
+  const hashParams = new URLSearchParams(location.hash.slice(1))
+  const hadHash = hashParams.has(AUTH_TOKEN_PARAM)
+  hashParams.delete(AUTH_TOKEN_PARAM)
+
+  if (!hadSearch && !hadHash) return
+  const search = params.size ? `?${params}` : ""
+  const hash = hadHash ? (hashParams.size ? `#${hashParams}` : "") : location.hash
+  history.replaceState(null, "", location.pathname + search + hash)
 }
 
 const platform: Platform = {
@@ -147,14 +170,15 @@ if (import.meta.env.VITE_SENTRY_DSN) {
     integrations: (integrations) => {
       return integrations.filter(
         (i) =>
-          i.name !== "Breadcrumbs" && !(import.meta.env.OPENCODE_CHANNEL === "prod" && i.name === "GlobalHandlers"),
+          i.name !== "Breadcrumbs" &&
+          !(import.meta.env.VITE_OPENCODE_CHANNEL === "prod" && i.name === "GlobalHandlers"),
       )
     },
   })
 }
 
 if (root instanceof HTMLElement) {
-  const auth = authFromToken(new URLSearchParams(location.search).get("auth_token"))
+  const auth = authFromToken(readStartupAuthToken())
   clearAuthToken()
   const server: ServerConnection.Http = {
     type: "http",

--- a/packages/console/app/src/routes/workspace/[id]/usage/graph-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/usage/graph-section.tsx
@@ -41,36 +41,41 @@ async function getCosts(workspaceID: string, year: number, month: number, timezo
       })
     }
 
-    const usageData = await Database.use(async (tx) => {
-      const all = []
-      for (const window of windows) {
-        const rows = await tx
-          .select({
-            date: sql<string>`${window.date}`,
-            model: UsageTable.model,
-            totalCost: sql<number>`coalesce(sum(${UsageTable.cost}), 0)`,
-            keyId: UsageTable.keyID,
-            plan: planExpr,
-          })
-          .from(UsageTable)
-          .where(
-            and(
-              eq(UsageTable.workspaceID, workspaceID),
-              gte(UsageTable.timeCreated, window.start),
-              lt(UsageTable.timeCreated, window.end),
-            ),
-          )
-          .groupBy(UsageTable.model, UsageTable.keyID, planExpr)
-        all.push(
-          ...rows.map((r) => ({
+    const first = windows[0]!
+    const last = windows[windows.length - 1]!
+    const dateExpr = sql<string>`case ${sql.join(
+      windows.map(
+        (window) =>
+          sql`when ${UsageTable.timeCreated} >= ${window.start} and ${UsageTable.timeCreated} < ${window.end} then ${window.date}`,
+      ),
+      sql` `,
+    )} end`
+    const usageData = await Database.use((tx) =>
+      tx
+        .select({
+          date: dateExpr,
+          model: UsageTable.model,
+          totalCost: sql<number>`coalesce(sum(${UsageTable.cost}), 0)`,
+          keyId: UsageTable.keyID,
+          plan: planExpr,
+        })
+        .from(UsageTable)
+        .where(
+          and(
+            eq(UsageTable.workspaceID, workspaceID),
+            gte(UsageTable.timeCreated, first.start),
+            lt(UsageTable.timeCreated, last.end),
+          ),
+        )
+        .groupBy(dateExpr, UsageTable.model, UsageTable.keyID, planExpr)
+        .then((rows) =>
+          rows.map((r) => ({
             ...r,
             totalCost: Number(r.totalCost ?? 0),
             plan: r.plan as "sub" | "lite" | "byok" | null,
           })),
-        )
-      }
-      return all
-    })
+        ),
+    )
 
     // Get unique key IDs from usage
     const usageKeyIds = new Set(usageData.map((r) => r.keyId).filter((id) => id !== null))

--- a/packages/console/app/src/routes/workspace/[id]/usage/graph-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/usage/graph-section.tsx
@@ -1,4 +1,4 @@
-import { and, Database, eq, gte, inArray, isNull, lt, or, sql, sum } from "@opencode-ai/console-core/drizzle/index.js"
+import { and, Database, eq, gte, inArray, isNull, lt, or, sql } from "@opencode-ai/console-core/drizzle/index.js"
 import { UsageTable } from "@opencode-ai/console-core/schema/billing.sql.js"
 import { KeyTable } from "@opencode-ai/console-core/schema/key.sql.js"
 import { UserTable } from "@opencode-ai/console-core/schema/user.sql.js"
@@ -10,6 +10,7 @@ import { withActor } from "~/context/auth.withActor"
 import { Dropdown } from "~/component/dropdown"
 import { IconChevronLeft, IconChevronRight } from "~/component/icon"
 import styles from "./graph-section.module.css"
+import { localDateLabel, localDateUTC } from "./usage-time"
 import {
   Chart,
   BarController,
@@ -24,45 +25,52 @@ import { useI18n } from "~/context/i18n"
 
 Chart.register(BarController, BarElement, CategoryScale, LinearScale, Tooltip, Legend)
 
-async function getCosts(workspaceID: string, year: number, month: number, tzOffset: string) {
+async function getCosts(workspaceID: string, year: number, month: number, timezone: string) {
   "use server"
   return withActor(async () => {
-    const timezoneOffset = (() => {
-      const m = /^([+-])(\d{2}):(\d{2})$/.exec(tzOffset)
-      if (!m) return 0
-      const sign = m[1] === "-" ? -1 : 1
-      return sign * (Number(m[2]) * 60 + Number(m[3])) * 60_000
-    })()
+    const monthEnd = localDateLabel(year, month + 1, 1)
+    const planExpr = sql<string | null>`JSON_EXTRACT(${UsageTable.enrichment}, '$.plan')`
+    const windows: Array<{ date: string; start: Date; end: Date }> = []
+    for (let day = 1; ; day++) {
+      const date = localDateLabel(year, month, day)
+      if (date >= monthEnd) break
+      windows.push({
+        date,
+        start: localDateUTC(timezone, year, month, day),
+        end: localDateUTC(timezone, year, month, day + 1),
+      })
+    }
 
-    const monthStartUTC = new Date(Date.UTC(year, month, 1, 0, 0, 0) - timezoneOffset)
-    const monthEndUTC = new Date(Date.UTC(year, month + 1, 1, 0, 0, 0) - timezoneOffset)
-    const dateExpr = sql<string>`DATE(CONVERT_TZ(${UsageTable.timeCreated}, '+00:00', ${tzOffset}))`
-    const usageData = await Database.use((tx) =>
-      tx
-        .select({
-          date: dateExpr,
-          model: UsageTable.model,
-          totalCost: sum(UsageTable.cost),
-          keyId: UsageTable.keyID,
-          plan: sql<string | null>`JSON_EXTRACT(${UsageTable.enrichment}, '$.plan')`,
-        })
-        .from(UsageTable)
-        .where(
-          and(
-            eq(UsageTable.workspaceID, workspaceID),
-            gte(UsageTable.timeCreated, monthStartUTC),
-            lt(UsageTable.timeCreated, monthEndUTC),
-          ),
-        )
-        .groupBy(dateExpr, UsageTable.model, UsageTable.keyID, sql`JSON_EXTRACT(${UsageTable.enrichment}, '$.plan')`)
-        .then((x) =>
-          x.map((r) => ({
+    const usageData = await Database.use(async (tx) => {
+      const all = []
+      for (const window of windows) {
+        const rows = await tx
+          .select({
+            date: sql<string>`${window.date}`,
+            model: UsageTable.model,
+            totalCost: sql<number>`coalesce(sum(${UsageTable.cost}), 0)`,
+            keyId: UsageTable.keyID,
+            plan: planExpr,
+          })
+          .from(UsageTable)
+          .where(
+            and(
+              eq(UsageTable.workspaceID, workspaceID),
+              gte(UsageTable.timeCreated, window.start),
+              lt(UsageTable.timeCreated, window.end),
+            ),
+          )
+          .groupBy(UsageTable.model, UsageTable.keyID, planExpr)
+        all.push(
+          ...rows.map((r) => ({
             ...r,
-            totalCost: r.totalCost ? parseInt(r.totalCost) : 0,
+            totalCost: Number(r.totalCost ?? 0),
             plan: r.plan as "sub" | "lite" | "byok" | null,
           })),
-        ),
-    )
+        )
+      }
+      return all
+    })
 
     // Get unique key IDs from usage
     const usageKeyIds = new Set(usageData.map((r) => r.keyId).filter((id) => id !== null))
@@ -131,42 +139,6 @@ function formatDateLabel(dateStr: string): string {
   const [, m, d] = dateStr.split("-").map(Number)
   const month = new Date(2000, m - 1, 1).toLocaleDateString(undefined, { month: "short" })
   return `${month} ${d.toString().padStart(2, "0")}`
-}
-
-// Compute the UTC offset (in MySQL CONVERT_TZ format like "+05:30") for the
-// given IANA timezone at the given instant. Honors DST.
-function getTimezoneOffset(timezone: string, at: Date): string {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    hourCycle: "h23",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  })
-    .formatToParts(at)
-    .reduce<Record<string, string>>((acc, p) => {
-      if (p.type !== "literal") acc[p.type] = p.value
-      return acc
-    }, {})
-  const asUTC = Date.UTC(
-    Number(parts.year),
-    Number(parts.month) - 1,
-    Number(parts.day),
-    Number(parts.hour),
-    Number(parts.minute),
-    Number(parts.second),
-  )
-  const diffMinutes = Math.round((asUTC - at.getTime()) / 60_000)
-  const sign = diffMinutes < 0 ? "-" : "+"
-  const abs = Math.abs(diffMinutes)
-  const hh = Math.floor(abs / 60)
-    .toString()
-    .padStart(2, "0")
-  const mm = (abs % 60).toString().padStart(2, "0")
-  return `${sign}${hh}:${mm}`
 }
 
 function addOpacityToColor(color: string, opacity: number): string {
@@ -452,11 +424,7 @@ export function GraphSection() {
   })
 
   createEffect(async () => {
-    // Compute the offset for mid-month so DST transitions don't bias to the
-    // wrong side.
-    const midMonth = new Date(Date.UTC(store.year, store.month, 15, 12, 0, 0))
-    const tzOffset = getTimezoneOffset(timezone, midMonth)
-    const data = await getCosts(params.id!, store.year, store.month, tzOffset)
+    const data = await getCosts(params.id!, store.year, store.month, timezone)
     setStore({ data })
   })
 

--- a/packages/console/app/src/routes/workspace/[id]/usage/usage-time.ts
+++ b/packages/console/app/src/routes/workspace/[id]/usage/usage-time.ts
@@ -1,0 +1,46 @@
+const HOUR = 60 * 60 * 1000
+
+export function localDateLabel(year: number, month: number, day: number): string {
+  const date = new Date(Date.UTC(year, month, day))
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`
+}
+
+export function localDateUTC(timezone: string, year: number, month: number, day: number): Date {
+  const target = localDateLabel(year, month, day)
+  const format = createLocalDateFormatter(timezone)
+  const noon = Date.UTC(year, month, day, 12)
+  const rangeStart = noon - 48 * HOUR
+  const rangeEnd = noon + 48 * HOUR
+
+  for (let time = rangeStart; time <= rangeEnd; time += HOUR) {
+    if (format(new Date(time)) !== target) continue
+
+    let low = time - HOUR
+    let high = time
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2)
+      if (format(new Date(mid)) < target) low = mid + 1
+      else high = mid
+    }
+    return new Date(low)
+  }
+
+  throw new Error(`Could not find local date ${target} in ${timezone}`)
+}
+
+function createLocalDateFormatter(timezone: string) {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
+  return (at: Date) => {
+    const parts = formatter.formatToParts(at).reduce<Record<string, string>>((acc, p) => {
+      if (p.type !== "literal") acc[p.type] = p.value
+      return acc
+    }, {})
+    return `${parts.year}-${parts.month}-${parts.day}`
+  }
+}

--- a/packages/console/app/test/usage-time.test.ts
+++ b/packages/console/app/test/usage-time.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import { localDateLabel, localDateUTC } from "../src/routes/workspace/[id]/usage/usage-time"
+
+function localDate(timezone: string, at: Date): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
+    .formatToParts(at)
+    .reduce<Record<string, string>>((acc, p) => {
+      if (p.type !== "literal") acc[p.type] = p.value
+      return acc
+    }, {})
+  return `${parts.year}-${parts.month}-${parts.day}`
+}
+
+describe("localDateLabel", () => {
+  test("normalizes month overflow", () => {
+    expect(localDateLabel(2026, 12, 1)).toBe("2027-01-01")
+  })
+})
+
+describe("localDateUTC", () => {
+  test("finds the first instant of a normal local day", () => {
+    const start = localDateUTC("America/New_York", 2026, 0, 15)
+
+    expect(start.toISOString()).toBe("2026-01-15T05:00:00.000Z")
+    expect(localDate("America/New_York", new Date(start.getTime() - 1))).toBe("2026-01-14")
+    expect(localDate("America/New_York", start)).toBe("2026-01-15")
+  })
+
+  test("finds the first instant when DST skips local midnight", () => {
+    const start = localDateUTC("Africa/Cairo", 2024, 3, 26)
+
+    expect(start.toISOString()).toBe("2024-04-25T22:00:00.000Z")
+    expect(localDate("Africa/Cairo", new Date(start.getTime() - 1))).toBe("2024-04-25")
+    expect(localDate("Africa/Cairo", start)).toBe("2024-04-26")
+  })
+})

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -251,7 +251,7 @@ const main = Effect.gen(function* () {
 
     const xdg = process.env.XDG_DATA_HOME
     const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "share")
-    return !existsSync(join(base, "opencode", "opencode.db"))
+    return !existsSync(join(base, "agentswarm", "opencode.db"))
   })()
   let overlay: BrowserWindow | null = null
 
@@ -337,7 +337,7 @@ const main = Effect.gen(function* () {
     }
   }
 
-  yield* Fiber.await(loadingTask)
+  yield* Fiber.join(loadingTask)
   setInitStep({ phase: "done" })
 
   if (overlay) yield* Deferred.await(loadingComplete)

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -337,7 +337,7 @@ const main = Effect.gen(function* () {
     }
   }
 
-  yield* Fiber.join(loadingTask)
+  yield* Fiber.await(loadingTask)
   setInitStep({ phase: "done" })
 
   if (overlay) yield* Deferred.await(loadingComplete)

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -45,7 +45,7 @@ if (import.meta.env.VITE_SENTRY_DSN) {
         (i) =>
           i.name !== "Breadcrumbs" &&
           !(
-            import.meta.env.OPENCODE_CHANNEL === "prod" &&
+            import.meta.env.VITE_OPENCODE_CHANNEL === "prod" &&
             (i.name === "GlobalHandlers" || i.name === "BrowserApiErrors")
           ),
       )

--- a/packages/opencode/src/cli/cmd/tui/context/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/event.ts
@@ -15,8 +15,26 @@ export function useEvent() {
       if (event.payload.type === "sync") {
         return
       }
+      if (event.payload.type === "server.heartbeat") {
+        return
+      }
 
-      if (event.directory === "global" || event.project === project.project()) {
+      if (event.directory === "global") {
+        handler(event.payload, { workspace: event.workspace })
+        return
+      }
+      if (event.project && event.project !== project.project()) {
+        return
+      }
+
+      if (project.workspace.current()) {
+        if (event.workspace === project.workspace.current()) {
+          handler(event.payload, { workspace: event.workspace })
+        }
+        return
+      }
+
+      if (event.directory === project.instance.directory()) {
         handler(event.payload, { workspace: event.workspace })
       }
     })

--- a/packages/opencode/src/cli/cmd/tui/context/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/event.ts
@@ -27,14 +27,12 @@ export function useEvent() {
         return
       }
 
-      if (project.workspace.current()) {
-        if (event.workspace === project.workspace.current()) {
-          handler(event.payload, { workspace: event.workspace })
-        }
+      const current = project.workspace.current()
+      if (current && event.workspace && event.workspace !== current) {
         return
       }
 
-      if (event.directory === project.instance.directory()) {
+      if (event.project === project.project() || event.directory === project.instance.directory()) {
         handler(event.payload, { workspace: event.workspace })
       }
     })

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,6 +1,7 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { hasClientConfigCredential } from "@/agency-swarm/client-config"
 import { isAgencySwarmRunMode, type AgencySwarmRunModeInput } from "@/agency-swarm/run-mode"
+import { isLocalAgencyURL } from "@/session/agency-swarm-client-config"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Log } from "@opencode-ai/core/util/log"
 import { hasStoredProviderCredential } from "@tui/util/provider-auth"
@@ -69,30 +70,11 @@ function hasConfiguredAPIStyleCredential(provider: AuthProvider | undefined) {
   )
 }
 
-function isLoopbackBaseURL(baseURL: string) {
-  try {
-    const parsed = new URL(baseURL)
-    return (
-      parsed.hostname === "127.0.0.1" ||
-      parsed.hostname === "0.0.0.0" ||
-      parsed.hostname === "localhost" ||
-      parsed.hostname === "::1" ||
-      parsed.hostname === "[::1]"
-    )
-  } catch (error) {
-    log.error("failed to parse agency-swarm base URL while checking local-provider auth policy", {
-      baseURL,
-      error: error instanceof Error ? error.message : String(error),
-    })
-    return false
-  }
-}
-
 function usesLocalAgencyProviderAuth(providers: Provider[]) {
   const agencyProvider = providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
   const rawBaseURL = agencyProvider?.options?.["baseURL"] ?? agencyProvider?.options?.["base_url"]
   const baseURL = typeof rawBaseURL === "string" && rawBaseURL.trim() ? rawBaseURL : AgencySwarmAdapter.DEFAULT_BASE_URL
-  return isLoopbackBaseURL(baseURL)
+  return isLocalAgencyURL(baseURL)
 }
 
 /**

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -459,7 +459,7 @@ export const layer = Layer.effect(
                 const event = evt as { directory?: string; project?: string; payload: unknown }
                 GlobalBus.emit("event", {
                   directory: event.directory,
-                  project: event.project,
+                  project: space.projectID,
                   workspace: space.id,
                   payload: event.payload,
                 })
@@ -620,8 +620,8 @@ export const layer = Layer.effect(
         )
 
         const previous = current?.workspaceID ? yield* get(current.workspaceID) : undefined
-        const claimPreviousSession = (ownerID: string | undefined) =>
-          previous && ownerID ? sync.claim(input.sessionID, ownerID) : Effect.void
+        const claimSessionOwner = (ownerID: string | undefined) =>
+          ownerID ? sync.claim(input.sessionID, ownerID) : Effect.void
 
         if (previous) {
           const adapter = getAdapter(previous.projectID, previous.type)
@@ -686,7 +686,7 @@ export const layer = Layer.effect(
               workspaceID: null,
             },
           })
-          yield* claimPreviousSession(previous?.projectID)
+          yield* claimSessionOwner(previous?.projectID)
 
           log.info("session warp complete", {
             workspaceID: input.workspaceID,
@@ -714,7 +714,7 @@ export const layer = Layer.effect(
               workspaceID: input.workspaceID,
             },
           })
-          yield* claimPreviousSession(input.workspaceID)
+          yield* claimSessionOwner(input.workspaceID)
 
           log.info("session warp complete", {
             workspaceID: input.workspaceID,
@@ -723,8 +723,6 @@ export const layer = Layer.effect(
           })
           return
         }
-
-        yield* claimPreviousSession(input.workspaceID)
 
         const rows = yield* db((db) =>
           db
@@ -759,72 +757,76 @@ export const layer = Layer.effect(
           last: rows.at(-1)?.seq,
         })
 
-        yield* Effect.forEach(
-          batches,
-          (events, i) =>
-            Effect.gen(function* () {
-              const response = yield* http.execute(
-                HttpClientRequest.post(route(target.url, "/sync/replay"), {
-                  headers: new Headers(target.headers),
-                  body: HttpBody.jsonUnsafe({
-                    directory: space.directory ?? "",
-                    events,
+        const previousOwnerID = previous?.id ?? space.projectID
+        yield* claimSessionOwner(input.workspaceID)
+        yield* Effect.gen(function* () {
+          yield* Effect.forEach(
+            batches,
+            (events, i) =>
+              Effect.gen(function* () {
+                const response = yield* http.execute(
+                  HttpClientRequest.post(route(target.url, "/sync/replay"), {
+                    headers: new Headers(target.headers),
+                    body: HttpBody.jsonUnsafe({
+                      directory: space.directory ?? "",
+                      events,
+                    }),
                   }),
-                }),
-              )
+                )
 
-              if (response.status < 200 || response.status >= 300) {
-                const body = yield* response.text
-                log.error("session warp batch failed", {
+                if (response.status < 200 || response.status >= 300) {
+                  const body = yield* response.text
+                  log.error("session warp batch failed", {
+                    workspaceID: input.workspaceID,
+                    sessionID: input.sessionID,
+                    step: i + 1,
+                    total,
+                    status: response.status,
+                    body,
+                  })
+                  return yield* new SessionWarpHttpError({
+                    message: `Failed to warp session ${input.sessionID} into workspace ${workspaceID}: HTTP ${response.status} ${body}`,
+                    workspaceID,
+                    sessionID: input.sessionID,
+                    status: response.status,
+                    body,
+                  })
+                }
+
+                log.info("session warp batch posted", {
                   workspaceID: input.workspaceID,
                   sessionID: input.sessionID,
                   step: i + 1,
                   total,
                   status: response.status,
-                  body,
                 })
-                return yield* new SessionWarpHttpError({
-                  message: `Failed to warp session ${input.sessionID} into workspace ${workspaceID}: HTTP ${response.status} ${body}`,
-                  workspaceID,
-                  sessionID: input.sessionID,
-                  status: response.status,
-                  body,
-                })
-              }
+              }),
+            { discard: true },
+          )
 
-              log.info("session warp batch posted", {
-                workspaceID: input.workspaceID,
-                sessionID: input.sessionID,
-                step: i + 1,
-                total,
-                status: response.status,
-              })
+          const response = yield* http.execute(
+            HttpClientRequest.post(route(target.url, "/sync/steal"), {
+              headers: new Headers(target.headers),
+              body: HttpBody.jsonUnsafe({ sessionID: input.sessionID }),
             }),
-          { discard: true },
-        )
-
-        const response = yield* http.execute(
-          HttpClientRequest.post(route(target.url, "/sync/steal"), {
-            headers: new Headers(target.headers),
-            body: HttpBody.jsonUnsafe({ sessionID: input.sessionID }),
-          }),
-        )
-        if (response.status < 200 || response.status >= 300) {
-          const body = yield* response.text
-          log.error("session warp steal failed", {
-            workspaceID: input.workspaceID,
-            sessionID: input.sessionID,
-            status: response.status,
-            body,
-          })
-          return yield* new SessionWarpHttpError({
-            message: `Failed to steal session ${input.sessionID} into workspace ${workspaceID}: HTTP ${response.status} ${body}`,
-            workspaceID,
-            sessionID: input.sessionID,
-            status: response.status,
-            body,
-          })
-        }
+          )
+          if (response.status < 200 || response.status >= 300) {
+            const body = yield* response.text
+            log.error("session warp steal failed", {
+              workspaceID: input.workspaceID,
+              sessionID: input.sessionID,
+              status: response.status,
+              body,
+            })
+            return yield* new SessionWarpHttpError({
+              message: `Failed to steal session ${input.sessionID} into workspace ${workspaceID}: HTTP ${response.status} ${body}`,
+              workspaceID,
+              sessionID: input.sessionID,
+              status: response.status,
+              body,
+            })
+          }
+        }).pipe(Effect.tapError(() => claimSessionOwner(previousOwnerID)))
 
         log.info("session warp complete", {
           workspaceID: input.workspaceID,

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -724,42 +724,42 @@ export const layer = Layer.effect(
           return
         }
 
-        const rows = yield* db((db) =>
-          db
-            .select({
-              id: EventTable.id,
-              aggregateID: EventTable.aggregate_id,
-              seq: EventTable.seq,
-              type: EventTable.type,
-              data: EventTable.data,
-            })
-            .from(EventTable)
-            .where(eq(EventTable.aggregate_id, input.sessionID))
-            .orderBy(asc(EventTable.seq))
-            .all(),
-        )
-        if (rows.length === 0)
-          return yield* new SessionEventsNotFoundError({
-            message: `No events found for session: ${input.sessionID}`,
-            sessionID: input.sessionID,
-          })
-
-        const batches = Iterable.chunksOf(rows, 10)
-        const total = Iterable.size(batches)
-
-        log.info("session warp prepared", {
-          workspaceID: input.workspaceID,
-          sessionID: input.sessionID,
-          target: String(route(target.url, "/sync/replay")),
-          events: rows.length,
-          batches: total,
-          first: rows[0]?.seq,
-          last: rows.at(-1)?.seq,
-        })
-
         const previousOwnerID = previous?.id ?? space.projectID
         yield* claimSessionOwner(input.workspaceID)
         yield* Effect.gen(function* () {
+          const rows = yield* db((db) =>
+            db
+              .select({
+                id: EventTable.id,
+                aggregateID: EventTable.aggregate_id,
+                seq: EventTable.seq,
+                type: EventTable.type,
+                data: EventTable.data,
+              })
+              .from(EventTable)
+              .where(eq(EventTable.aggregate_id, input.sessionID))
+              .orderBy(asc(EventTable.seq))
+              .all(),
+          )
+          if (rows.length === 0)
+            return yield* new SessionEventsNotFoundError({
+              message: `No events found for session: ${input.sessionID}`,
+              sessionID: input.sessionID,
+            })
+
+          const batches = Iterable.chunksOf(rows, 10)
+          const total = Iterable.size(batches)
+
+          log.info("session warp prepared", {
+            workspaceID: input.workspaceID,
+            sessionID: input.sessionID,
+            target: String(route(target.url, "/sync/replay")),
+            events: rows.length,
+            batches: total,
+            first: rows[0]?.seq,
+            last: rows.at(-1)?.seq,
+          })
+
           yield* Effect.forEach(
             batches,
             (events, i) =>
@@ -826,13 +826,13 @@ export const layer = Layer.effect(
               body,
             })
           }
-        }).pipe(Effect.tapError(() => claimSessionOwner(previousOwnerID)))
 
-        log.info("session warp complete", {
-          workspaceID: input.workspaceID,
-          sessionID: input.sessionID,
-          batches: total,
-        })
+          log.info("session warp complete", {
+            workspaceID: input.workspaceID,
+            sessionID: input.sessionID,
+            batches: total,
+          })
+        }).pipe(Effect.tapError(() => claimSessionOwner(previousOwnerID)))
       }).pipe(
         Effect.tapError((err) =>
           Effect.sync(() =>

--- a/packages/opencode/src/server/routes/instance/httpapi/api.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/api.ts
@@ -26,7 +26,12 @@ import { SchemaErrorMiddleware } from "./middleware/schema-error"
 
 // SSE event schemas built from the BusEvent/SyncEvent registries.
 initProjectors()
-const EventSchema = Schema.Union(BusEvent.effectPayloads()).annotate({ identifier: "Event" })
+const ServerHeartbeat = Schema.Struct({
+  id: Schema.String,
+  type: Schema.Literal("server.heartbeat"),
+  properties: Schema.Struct({}),
+}).annotate({ identifier: "EventServerHeartbeat" })
+const EventSchema = Schema.Union([...BusEvent.effectPayloads(), ServerHeartbeat]).annotate({ identifier: "Event" })
 const SyncEventSchemas = SyncEvent.effectPayloads()
 
 export const RootHttpApi = HttpApi.make("opencode-root")

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/global.ts
@@ -14,11 +14,17 @@ const GlobalHealth = Schema.Struct({
 
 initProjectors()
 
+const GlobalServerHeartbeat = Schema.Struct({
+  id: Schema.String,
+  type: Schema.Literal("server.heartbeat"),
+  properties: Schema.Struct({}),
+})
+
 const GlobalEventSchema = Schema.Struct({
-  directory: Schema.String,
+  directory: Schema.optional(Schema.String),
   project: Schema.optional(Schema.String),
   workspace: Schema.optional(Schema.String),
-  payload: Schema.Union([...BusEvent.effectPayloads(), ...SyncEvent.effectPayloads()]),
+  payload: Schema.Union([...BusEvent.effectPayloads(), ...SyncEvent.effectPayloads(), GlobalServerHeartbeat]),
 }).annotate({ identifier: "GlobalEvent" })
 
 export const GlobalUpgradeInput = Schema.Struct({

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/v2/instance.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/v2/instance.ts
@@ -7,6 +7,8 @@ import { HttpServerRequest } from "effect/unstable/http"
 import { HttpApiMiddleware, OpenApi } from "effect/unstable/httpapi"
 
 export const InstanceQuery = Schema.Struct({
+  directory: Schema.optional(Schema.String),
+  workspace: Schema.optional(Schema.String),
   instance: Schema.optional(
     Schema.Struct({
       directory: Schema.optional(Schema.String),
@@ -39,9 +41,20 @@ export class V2InstanceMiddleware extends HttpApiMiddleware.Service<
 
 function ref(request: HttpServerRequest.HttpServerRequest): Instance.Ref {
   const query = new URL(request.url, "http://localhost").searchParams
+  const directory =
+    query.get("instance[directory]") || query.get("directory") || decodeHeader(request.headers["x-opencode-directory"])
   return {
-    directory: query.get("instance[directory]") || request.headers["x-opencode-directory"] || process.cwd(),
-    workspaceID: query.get("instance[workspace]") || request.headers["x-opencode-workspace"],
+    directory: directory || process.cwd(),
+    workspaceID: query.get("instance[workspace]") || query.get("workspace") || request.headers["x-opencode-workspace"],
+  }
+}
+
+function decodeHeader(header: string | undefined): string | undefined {
+  if (!header) return
+  try {
+    return decodeURIComponent(header)
+  } catch {
+    return header
   }
 }
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/mcp.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/mcp.ts
@@ -14,9 +14,11 @@ export const mcpHandlers = HttpApiBuilder.group(InstanceHttpApi, "mcp", (handler
 
     const add = Effect.fn("McpHttpApi.add")(function* (ctx: { payload: typeof AddPayload.Type }) {
       const result = (yield* mcp.add(ctx.payload.name, ctx.payload.config)).status
-      return yield* Schema.decodeUnknownEffect(StatusMap)(
-        "status" in result ? { [ctx.payload.name]: result } : result,
-      ).pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+      return yield* Schema.decodeUnknownEffect(MCP.Status)(result).pipe(
+        Effect.map((status) => ({ [ctx.payload.name]: status })),
+        Effect.catch(() => Schema.decodeUnknownEffect(StatusMap)(result)),
+        Effect.mapError(() => new HttpApiError.BadRequest({})),
+      )
     })
 
     const authStart = Effect.fn("McpHttpApi.authStart")(function* (ctx: { params: { name: string } }) {

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
@@ -12,14 +12,6 @@ export class InstanceContextMiddleware extends HttpApiMiddleware.Service<
   }
 >()("@opencode/ExperimentalHttpApiInstanceContext") {}
 
-function decode(input: string): string {
-  try {
-    return decodeURIComponent(input)
-  } catch {
-    return input
-  }
-}
-
 function provideInstanceContext<E>(
   effect: Effect.Effect<HttpServerResponse.HttpServerResponse, E>,
   store: InstanceStore.Interface,
@@ -27,7 +19,7 @@ function provideInstanceContext<E>(
   return Effect.gen(function* () {
     const route = yield* WorkspaceRouteContext
     return yield* store.provide(
-      { directory: decode(route.directory) },
+      { directory: route.directory },
       effect.pipe(Effect.provideService(WorkspaceRef, route.workspaceID)),
     )
   })

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -70,7 +70,18 @@ function selectedWorkspaceID(url: URL, sessionWorkspaceID?: WorkspaceID): Worksp
 }
 
 function defaultDirectory(request: HttpServerRequest.HttpServerRequest, url: URL): string {
-  return url.searchParams.get("directory") || request.headers["x-opencode-directory"] || process.cwd()
+  const query = url.searchParams.get("directory")
+  if (query) return query
+  const header = request.headers["x-opencode-directory"]
+  return header ? decodeDirectoryHeader(header) : process.cwd()
+}
+
+function decodeDirectoryHeader(header: string): string {
+  try {
+    return decodeURIComponent(header)
+  } catch {
+    return header
+  }
 }
 
 function shouldStayOnControlPlane(request: HttpServerRequest.HttpServerRequest, url: URL): boolean {
@@ -87,7 +98,7 @@ function resolveWorkspace(
 
 function missingWorkspaceResponse(id: WorkspaceID): HttpServerResponse.HttpServerResponse {
   return HttpServerResponse.text(`Workspace not found: ${id}`, {
-    status: 500,
+    status: 404,
     contentType: "text/plain; charset=utf-8",
   })
 }

--- a/packages/opencode/src/server/shared/public-ui.ts
+++ b/packages/opencode/src/server/shared/public-ui.ts
@@ -1,6 +1,6 @@
 // Static UI assets the browser fetches without app-managed credentials, e.g.
 // the manifest link in <head>. These bypass auth so the page can install/render
-// the manifest icons even when a server password is configured.
+// the manifest icons and boot chunks even when a server password is configured.
 export const PUBLIC_UI_PATHS = new Set<string>([
   "/site.webmanifest",
   "/web-app-manifest-192x192.png",
@@ -8,5 +8,5 @@ export const PUBLIC_UI_PATHS = new Set<string>([
 ])
 
 export function isPublicUIPath(method: string, pathname: string) {
-  return method === "GET" && PUBLIC_UI_PATHS.has(pathname)
+  return method === "GET" && (PUBLIC_UI_PATHS.has(pathname) || pathname.startsWith("/assets/"))
 }

--- a/packages/opencode/src/session/agency-swarm-history-transport.ts
+++ b/packages/opencode/src/session/agency-swarm-history-transport.ts
@@ -297,7 +297,7 @@ export function isCodexClientConfig(config: Record<string, unknown> | undefined)
 
 export function sanitizeAgencyHistoryForTransport(
   history: Array<Record<string, unknown>>,
-  options: { codexTransport?: boolean } = {},
+  options: { allowLocalFilePaths?: boolean; codexTransport?: boolean } = { allowLocalFilePaths: true },
 ) {
   return history.flatMap((item) => {
     const type = asString(item["type"])
@@ -305,6 +305,7 @@ export function sanitizeAgencyHistoryForTransport(
     if (type === "message" && asString(item["role"]) === "assistant" && !hasReplayableMessageContent(item["content"])) {
       return []
     }
+    if (options.allowLocalFilePaths === false) assertRemoteSafeHistoryItem(item)
     const transportItem =
       options.codexTransport && isHostedToolPreservationSystemMessage(item) ? { ...item, role: "developer" } : item
     return [normalizeAgencyHistoryItem(stripOpenAIResponseItemID(transportItem), "transport")]
@@ -408,8 +409,9 @@ export function truncateLargeText(value: string, maxChars: number, label: string
 export function replayStoredAttachmentsInOutgoingMessage(
   message: AgencyMessageInput,
   history: Array<Record<string, unknown>>,
+  options: { allowLocalFilePaths?: boolean } = { allowLocalFilePaths: true },
 ): { message: AgencyMessageInput; replayedAttachmentKeys: Set<string> } {
-  const replayedAttachments = collectReplayableAttachmentContent(history)
+  const replayedAttachments = collectReplayableAttachmentContent(history, options)
   if (replayedAttachments.length === 0) {
     return {
       message,
@@ -463,7 +465,10 @@ export function replayStoredAttachmentsInOutgoingMessage(
   }
 }
 
-function collectReplayableAttachmentContent(history: Array<Record<string, unknown>>) {
+function collectReplayableAttachmentContent(
+  history: Array<Record<string, unknown>>,
+  options: { allowLocalFilePaths?: boolean } = { allowLocalFilePaths: true },
+) {
   const result: Array<Record<string, unknown>> = []
   const seen = new Set<string>()
   for (const item of history) {
@@ -473,6 +478,7 @@ function collectReplayableAttachmentContent(history: Array<Record<string, unknow
     for (const rawPart of content) {
       const part = asRecord(rawPart)
       if (!part || !isReplayableAttachmentPart(part)) continue
+      if (options.allowLocalFilePaths === false) assertRemoteSafeAttachmentPart(part)
       const key = replayableAttachmentKey(part)
       if (seen.has(key)) continue
       seen.add(key)
@@ -480,6 +486,28 @@ function collectReplayableAttachmentContent(history: Array<Record<string, unknow
     }
   }
   return result
+}
+
+function assertRemoteSafeHistoryItem(item: Record<string, unknown>) {
+  const content = item["content"]
+  if (!Array.isArray(content)) return
+  for (const rawPart of content) {
+    const part = asRecord(rawPart)
+    if (!part || !isReplayableAttachmentPart(part)) continue
+    assertRemoteSafeAttachmentPart(part)
+  }
+}
+
+function assertRemoteSafeAttachmentPart(part: Record<string, unknown>) {
+  const fileData = asString(part["file_data"])
+  const fileURL = asString(part["file_url"])
+  const imageURL = asString(part["image_url"])
+  if (!fileData && !fileURL?.startsWith("file://") && !imageURL?.startsWith("file://") && !imageURL?.startsWith("data:")) {
+    return
+  }
+  throw new Error(
+    "Agent Swarm Run mode cannot send local file attachments to a remote Agency server. Use an http(s) URL or run against a local Agency server.",
+  )
 }
 
 export function stripReplayedAttachmentsFromMessages(messages: unknown[], replayedKeys: Set<string>) {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -735,8 +735,13 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (itemType === "message") {
       const itemID = asString(item["id"]) || lastTextItemID
       if (!itemID) return []
-      rememberResponseReplay(responseTextReplay, item, extractMessageText(item))
-      return finishText(itemID, textIndex.get(itemID) ?? 0, undefined, eventMeta, outputMeta(outputIndex))
+      const text = extractMessageText(item)
+      const index = textIndex.get(itemID) ?? 0
+      const parts = finishText(itemID, index, text, eventMeta, outputMeta(outputIndex))
+      if (text && textBuffer.get(textKey(itemID, index)) === text) {
+        rememberResponseReplay(responseTextReplay, item, text)
+      }
+      return parts
     }
 
     if (itemType === "reasoning") {

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -296,6 +296,11 @@ export function asRecord(value: unknown): Record<string, unknown> | undefined {
 
 function normalizeFileURL(part: MessageV2.FilePart, options: CollectFileURLOptions): string | undefined {
   if (part.url.startsWith("file://")) {
+    if (!options.allowLocalFilePaths) {
+      throw new Error(
+        "Agent Swarm Run mode cannot send local file attachments to a remote Agency server. Use an http(s) URL or run against a local Agency server.",
+      )
+    }
     try {
       return fileURLToPath(part.url)
     } catch {

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -187,13 +187,16 @@ export function buildOutgoingMessage(message: MessageV2.WithParts): string {
   return textParts.join("\n\n")
 }
 
-export function buildStructuredOutgoingMessage(message: MessageV2.WithParts): AgencyMessageInput {
+export function buildStructuredOutgoingMessage(
+  message: MessageV2.WithParts,
+  options: { allowLocalFilePaths?: boolean } = { allowLocalFilePaths: true },
+): AgencyMessageInput {
   const files = message.parts.filter((part): part is MessageV2.FilePart => part.type === "file")
   const text = buildOutgoingMessage(message)
   if (files.length === 0) return text
 
   const hasSyntheticText = message.parts.some((part) => part.type === "text" && !part.ignored && part.synthetic)
-  const content = files.flatMap((part) => structuredFileContent(part, { hasSyntheticText }))
+  const content = files.flatMap((part) => structuredFileContent(part, { ...options, hasSyntheticText }))
   if (text) content.push({ type: "input_text", text })
   return [
     {
@@ -217,13 +220,13 @@ function visibleOutgoingText(part: MessageV2.TextPart): string {
 
 function structuredFileContent(
   part: MessageV2.FilePart,
-  options: { hasSyntheticText?: boolean } = {},
+  options: { allowLocalFilePaths?: boolean; hasSyntheticText?: boolean } = {},
 ): Array<Record<string, unknown>> {
   if (part.mime === "application/x-directory") return []
   if (isExpandedLocalTextFile(part, options)) return []
 
   const filename = part.filename || path.basename(part.source?.type === "file" ? part.source.path : "") || "attachment"
-  const url = normalizeStructuredFileURL(part)
+  const url = normalizeStructuredFileURL(part, options)
   if (!url) return []
   if (part.mime.startsWith("image/")) {
     return [
@@ -256,9 +259,17 @@ function isExpandedLocalTextFile(part: MessageV2.FilePart, options: { hasSynthet
   return !!options.hasSyntheticText && part.source?.type === "file" && !!part.source.text && part.mime === "text/plain"
 }
 
-function normalizeStructuredFileURL(part: MessageV2.FilePart): string | undefined {
+function normalizeStructuredFileURL(
+  part: MessageV2.FilePart,
+  options: { allowLocalFilePaths?: boolean } = {},
+): string | undefined {
   if (part.url.startsWith("data:") || part.url.startsWith("http://") || part.url.startsWith("https://")) return part.url
   if (!part.url.startsWith("file://")) return undefined
+  if (!options.allowLocalFilePaths) {
+    throw new Error(
+      "Agent Swarm Run mode cannot send local file attachments to a remote Agency server. Use an http(s) URL or run against a local Agency server.",
+    )
+  }
   let filepath: string | undefined
   try {
     filepath = fileURLToPath(part.url)

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -444,8 +444,11 @@ export namespace SessionAgencySwarm {
         !!sessionMessages &&
         hasPriorFileParts(sessionMessages, input.userMessage.info.id)
       const codexTransport = isCodexClientConfig(clientConfig)
+      const allowLocalFilePaths = isLocalAgencyURL(input.options.baseURL)
       const sanitizedChatHistory = sanitizeAgencyHistoryForTransport(chatHistory, { codexTransport })
-      const replayOnlyOutgoing = replayStoredAttachmentsInOutgoingMessage(outgoingMessage, sanitizedChatHistory)
+      const replayOnlyOutgoing = allowLocalFilePaths
+        ? replayStoredAttachmentsInOutgoingMessage(outgoingMessage, sanitizedChatHistory)
+        : { message: outgoingMessage, replayedAttachmentKeys: new Set<string>() }
       const attachmentMessage =
         hasCurrentFileAttachments ||
         hasRebuildableFileAttachments ||
@@ -487,27 +490,34 @@ export namespace SessionAgencySwarm {
       if (persistRebuiltHistoryFromMessages && rebuiltHistoryFromMessages) {
         await AgencySwarmHistory.appendMessages(scope, normalizeAgencyHistoryForStorage(rebuiltHistoryFromMessages))
       }
-      const transportChatHistory = sanitizeAgencyHistoryForTransport(effectiveChatHistory, { codexTransport })
       let requestMessage: AgencyMessageInput = outgoingMessage
       let fileURLs: Record<string, string> | undefined
-      if (structuredAttachmentsSupported) {
-        const outgoing = replayStoredAttachmentsInOutgoingMessage(
-          buildStructuredOutgoingMessage(input.userMessage),
-          transportChatHistory,
-        )
-        requestMessage = outgoing.message
-        replayedAttachmentKeys = outgoing.replayedAttachmentKeys
-      } else {
-        replayedAttachmentKeys = new Set()
-        if (hasCurrentFileAttachments) {
-          fileURLs = collectFileURLs(input.userMessage, {
-            allowLocalFilePaths: isLocalAgencyURL(input.options.baseURL),
-            materializedFilePaths,
-          })
-        }
-      }
 
       try {
+        const transportChatHistory = sanitizeAgencyHistoryForTransport(effectiveChatHistory, {
+          allowLocalFilePaths,
+          codexTransport,
+        })
+        if (structuredAttachmentsSupported) {
+          const outgoing = replayStoredAttachmentsInOutgoingMessage(
+            buildStructuredOutgoingMessage(input.userMessage, {
+              allowLocalFilePaths,
+            }),
+            transportChatHistory,
+            { allowLocalFilePaths },
+          )
+          requestMessage = outgoing.message
+          replayedAttachmentKeys = outgoing.replayedAttachmentKeys
+        } else {
+          replayedAttachmentKeys = new Set()
+          if (hasCurrentFileAttachments) {
+            fileURLs = collectFileURLs(input.userMessage, {
+              allowLocalFilePaths,
+              materializedFilePaths,
+            })
+          }
+        }
+
         for await (const frame of AgencySwarmAdapter.streamRun({
           baseURL: input.options.baseURL,
           agency,

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -391,6 +391,15 @@ export const layer: Layer.Layer<
       }
       const userMessage = parent.info
       const compactionPart = parent.parts.find((part): part is MessageV2.CompactionPart => part.type === "compaction")
+      const endCompaction = (text: string, include?: MessageID) =>
+        flags.experimentalEventSystem
+          ? sync.run(SessionEvent.Compaction.Ended.Sync, {
+              sessionID: input.sessionID,
+              timestamp: DateTime.makeUnsafe(Date.now()),
+              text,
+              include,
+            })
+          : Effect.void
 
       let messages = input.messages
       let replay:
@@ -454,6 +463,7 @@ export const layer: Layer.Layer<
             isRetryable: false,
           }).toObject(),
         })
+        yield* endCompaction("")
         return "stop"
       }
       const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
@@ -534,6 +544,7 @@ export const layer: Layer.Layer<
         }).toObject()
         processor.message.finish = "error"
         yield* session.updateMessage(processor.message)
+        yield* endCompaction("", selected.tail_start_id)
         return "stop"
       }
 
@@ -628,24 +639,20 @@ export const layer: Layer.Layer<
         }
       }
 
+      const summary =
+        result === "continue"
+          ? summaryText(
+              (yield* session.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)).find(
+                (item) => item.info.id === msg.id,
+              ) ?? {
+                info: msg,
+                parts: [],
+              },
+            )
+          : undefined
+      yield* endCompaction(summary ?? "", selected.tail_start_id)
       if (processor.message.error) return "stop"
       if (result === "continue") {
-        const summary = summaryText(
-          (yield* session.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)).find(
-            (item) => item.info.id === msg.id,
-          ) ?? {
-            info: msg,
-            parts: [],
-          },
-        )
-        if (flags.experimentalEventSystem) {
-          yield* sync.run(SessionEvent.Compaction.Ended.Sync, {
-            sessionID: input.sessionID,
-            timestamp: DateTime.makeUnsafe(Date.now()),
-            text: summary ?? "",
-            include: selected.tail_start_id,
-          })
-        }
         yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
       }
       return result

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -463,7 +463,6 @@ export const layer: Layer.Layer<
             isRetryable: false,
           }).toObject(),
         })
-        yield* endCompaction("")
         return "stop"
       }
       const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
@@ -544,7 +543,6 @@ export const layer: Layer.Layer<
         }).toObject()
         processor.message.finish = "error"
         yield* session.updateMessage(processor.message)
-        yield* endCompaction("", selected.tail_start_id)
         return "stop"
       }
 
@@ -650,9 +648,9 @@ export const layer: Layer.Layer<
               },
             )
           : undefined
-      yield* endCompaction(summary ?? "", selected.tail_start_id)
       if (processor.message.error) return "stop"
       if (result === "continue") {
+        yield* endCompaction(summary ?? "", selected.tail_start_id)
         yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
       }
       return result

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -173,6 +173,34 @@ describe("agency session errors", () => {
     ).toBe(false)
   })
 
+  test("framework mode opens auth for docker-local agency-swarm backends", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {
+              baseURL: "http://host.docker.internal:8000",
+            },
+            models: {},
+          },
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: ["OPENAI_API_KEY"],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
   test("framework mode opens auth for non-loopback base URL when forwardUpstreamCredentials is on", () => {
     expect(
       shouldOpenStartupAuthDialog({

--- a/packages/opencode/test/cli/tui/use-event.test.tsx
+++ b/packages/opencode/test/cli/tui/use-event.test.tsx
@@ -125,7 +125,7 @@ describe("useEvent", () => {
     const { app, emit, seen, workspaces } = await mount()
 
     try {
-      emit(event(vcs("main"), { directory: "/tmp/other", project: projectID, workspace: "ws_a" }))
+      emit(event(vcs("main"), { directory: "/tmp/root", project: projectID, workspace: "ws_a" }))
 
       await wait(() => seen.length === 1)
 
@@ -149,12 +149,26 @@ describe("useEvent", () => {
     }
   })
 
-  test("delivers current project events regardless of active workspace", async () => {
+  test("ignores other workspace events when a workspace is active", async () => {
     const { app, emit, project, seen } = await mount()
 
     try {
       project.workspace.set("ws_a")
       emit(event(vcs("ws"), { directory: "/tmp/other", project: projectID, workspace: "ws_b" }))
+      await Bun.sleep(30)
+
+      expect(seen).toHaveLength(0)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("delivers active workspace events", async () => {
+    const { app, emit, project, seen } = await mount()
+
+    try {
+      project.workspace.set("ws_a")
+      emit(event(vcs("ws"), { directory: "/tmp/other", project: projectID, workspace: "ws_a" }))
 
       await wait(() => seen.length === 1)
 

--- a/packages/opencode/test/cli/tui/use-event.test.tsx
+++ b/packages/opencode/test/cli/tui/use-event.test.tsx
@@ -178,6 +178,21 @@ describe("useEvent", () => {
     }
   })
 
+  test("delivers project events without workspace when a workspace is active", async () => {
+    const { app, emit, project, seen } = await mount()
+
+    try {
+      project.workspace.set("ws_a")
+      emit(event(vcs("main"), { directory: "/tmp/root", project: projectID }))
+
+      await wait(() => seen.length === 1)
+
+      expect(seen).toEqual([vcs("main")])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
   test("delivers truly global events even when a workspace is active", async () => {
     const { app, emit, project, seen } = await mount()
 

--- a/packages/opencode/test/control-plane/workspace.test.ts
+++ b/packages/opencode/test/control-plane/workspace.test.ts
@@ -990,7 +990,7 @@ describe("workspace CRUD", () => {
     })
   })
 
-  it.live("sessionWarp claims the target owner before target replay fails", () => {
+  it.live("sessionWarp keeps the previous owner when target replay fails", () => {
     return Effect.gen(function* () {
       yield* HttpServer.serveEffect()(
         Effect.gen(function* () {
@@ -1023,6 +1023,104 @@ describe("workspace CRUD", () => {
               Effect.map((exit) => expect(exit._tag).toBe("Failure")),
             )
 
+            expect(sessionSequenceOwner(session.id)).toBe(previous.id)
+          }),
+        { git: true },
+      )
+    })
+  })
+
+  it.live("sessionWarp restores the previous owner when target steal fails", () => {
+    return Effect.gen(function* () {
+      yield* HttpServer.serveEffect()(
+        Effect.gen(function* () {
+          const req = yield* HttpServerRequest.HttpServerRequest
+          const pathname = new URL(req.url, "http://localhost").pathname
+          if (pathname === "/warp-target/sync/replay") return yield* HttpServerResponse.json({ sessionID: "ok" })
+          if (pathname === "/warp-target/sync/steal") return HttpServerResponse.text("steal failed", { status: 500 })
+          return HttpServerResponse.text("unexpected", { status: 500 })
+        }),
+      )
+      const url = yield* serverUrl()
+      yield* provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const workspace = yield* Workspace.Service
+            const sessionSvc = yield* SessionNs.Service
+            const previousType = unique("warp-steal-failed-prev")
+            const targetType = unique("warp-steal-failed-target")
+            const previous = workspaceInfo(Instance.project.id, previousType)
+            const target = workspaceInfo(Instance.project.id, targetType, { directory: "remote-target-dir" })
+            insertWorkspace(previous)
+            insertWorkspace(target)
+            registerAdapter(Instance.project.id, previousType, localAdapter("/unused").adapter)
+            registerAdapter(Instance.project.id, targetType, remoteAdapter(`${url}/warp-target`).adapter)
+            const session = yield* sessionSvc.create({})
+            attachSessionToWorkspace(session.id, previous.id)
+            claimSessionOwner(session.id, previous.id)
+
+            yield* Effect.exit(workspace.sessionWarp({ workspaceID: target.id, sessionID: session.id })).pipe(
+              Effect.map((exit) => expect(exit._tag).toBe("Failure")),
+            )
+
+            expect(sessionSequenceOwner(session.id)).toBe(previous.id)
+          }),
+        { git: true },
+      )
+    })
+  })
+
+  it.live("sessionWarp claims remote target owner from a local project source", () => {
+    const calls: FetchCall[] = []
+    return Effect.gen(function* () {
+      yield* HttpServer.serveEffect()(
+        Effect.gen(function* () {
+          const req = yield* HttpServerRequest.HttpServerRequest
+          const bodyText = yield* req.text
+          const call = {
+            url: new URL(req.url, "http://localhost"),
+            method: req.method,
+            headers: new Headers(req.headers),
+            bodyText,
+            json: bodyText ? JSON.parse(bodyText) : undefined,
+          }
+          calls.push(call)
+          if (call.url.pathname === "/warp-target/sync/replay")
+            return yield* HttpServerResponse.json({ sessionID: "ok" })
+          if (call.url.pathname === "/warp-target/sync/steal")
+            return yield* HttpServerResponse.json({ sessionID: "ok" })
+          return HttpServerResponse.text("unexpected", { status: 500 })
+        }),
+      )
+      const url = yield* serverUrl()
+      yield* provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const workspace = yield* Workspace.Service
+            const sessionSvc = yield* SessionNs.Service
+            const targetType = unique("warp-local-to-remote-target")
+            const target = workspaceInfo(Instance.project.id, targetType, { directory: "remote-target-dir" })
+            insertWorkspace(target)
+            registerAdapter(Instance.project.id, targetType, remoteAdapter(`${url}/warp-target`).adapter)
+            const session = yield* sessionSvc.create({})
+
+            yield* workspace.sessionWarp({ workspaceID: target.id, sessionID: session.id })
+
+            expect(calls.map((call) => `${call.method} ${call.url.pathname}`)).toEqual([
+              "POST /warp-target/sync/replay",
+              "POST /warp-target/sync/steal",
+            ])
+            expect(calls[0].json).toMatchObject({
+              directory: "remote-target-dir",
+              events: [
+                {
+                  aggregateID: session.id,
+                  seq: 0,
+                  type: SyncEvent.versionedType(SessionNs.Event.Created.type, SessionNs.Event.Created.version),
+                },
+              ],
+            })
+            expect(calls[1].json).toEqual({ sessionID: session.id })
             expect(sessionSequenceOwner(session.id)).toBe(target.id)
           }),
         { git: true },
@@ -1583,7 +1681,7 @@ describe("workspace sync state", () => {
                 captured.events.find((event) => event.workspace === info.id && event.payload.type === "custom.remote"),
               ).toMatchObject({
                 directory: "remote-dir",
-                project: "remote-project",
+                project: Instance.project.id,
                 payload: { properties: { ok: true } },
               })
               yield* workspace.remove(info.id)

--- a/packages/opencode/test/server/httpapi-instance-context.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-context.test.ts
@@ -197,6 +197,28 @@ describe("HttpApi instance context middleware", () => {
     }),
   )
 
+  it.live("preserves percent escapes in local workspace target directories", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const project = yield* Project.use.fromDirectory(dir)
+      const workspaceDir = path.join(dir, "acme%20demo")
+      const workspace = yield* createLocalWorkspace({
+        projectID: project.project.id,
+        type: "instance-context-percent-workspace",
+        directory: workspaceDir,
+      })
+      yield* serveProbe()
+
+      const response = yield* HttpClient.get(`/probe?workspace=${workspace.id}`)
+
+      expect(response.status).toBe(200)
+      expect(yield* response.json).toMatchObject({
+        directory: workspaceDir,
+        workspaceID: workspace.id,
+      })
+    }),
+  )
+
   it.live("uses configured workspace id instead of routing to the requested workspace", () =>
     Effect.gen(function* () {
       const fixedWorkspaceID = WorkspaceID.ascending()

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -92,6 +92,21 @@ describe("instance HttpApi", () => {
     }),
   )
 
+  it.live("decodes SDK directory headers for mutations", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const response = yield* HttpClientRequest.post(SessionPaths.create).pipe(
+        directoryHeader(encodeURIComponent(dir)),
+        HttpClientRequest.bodyJson({ title: "encoded directory" }),
+        Effect.flatMap(HttpClient.execute),
+      )
+
+      expect(response.status).toBe(200)
+      const body = (yield* response.json) as { directory: string }
+      expect(body.directory).toBe(dir)
+    }),
+  )
+
   it.live("does not emit sync fence headers for fixed-workspace reads or no-op mutations", () =>
     Effect.gen(function* () {
       const originalWorkspaceID = Flag.OPENCODE_WORKSPACE_ID

--- a/packages/opencode/test/server/httpapi-mcp.test.ts
+++ b/packages/opencode/test/server/httpapi-mcp.test.ts
@@ -109,6 +109,21 @@ describe("mcp HttpApi", () => {
         expect(added.status).toBe(200)
         expect(yield* json(added)).toMatchObject({ added: { status: "disabled" } })
 
+        const statusNamed = yield* request(handler, McpPaths.status, tmp.directory, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            name: "status",
+            config: {
+              type: "local",
+              command: ["echo", "status"],
+              enabled: false,
+            },
+          }),
+        })
+        expect(statusNamed.status).toBe(200)
+        expect(yield* json(statusNamed)).toMatchObject({ status: { status: "disabled" } })
+
         const connected = yield* request(handler, "/mcp/demo/connect", tmp.directory, { method: "POST" })
         expect(connected.status).toBe(200)
         expect(yield* json(connected)).toBe(true)

--- a/packages/opencode/test/server/httpapi-provider.test.ts
+++ b/packages/opencode/test/server/httpapi-provider.test.ts
@@ -72,6 +72,14 @@ function hasProviderMutationMarker(input: unknown, key: "all" | "providers", id:
   return isRecord(provider.options) && provider.options.mutatedByPlugin === true
 }
 
+function hasProviderListMutationMarker(input: unknown, id: string) {
+  if (!Array.isArray(input)) return false
+  const provider = input.find((item) => isRecord(item) && item.id === id)
+  if (!isRecord(provider)) return false
+  if (provider.name === "mutated-provider") return true
+  return isRecord(provider.options) && provider.options.mutatedByPlugin === true
+}
+
 function requestAuthorize(input: {
   providerID: string
   method: number
@@ -380,6 +388,19 @@ describe("provider HttpApi", () => {
       expect(hasProviderMutationMarker(providerBody, "all", "google")).toBe(false)
       expect(hasProviderMutationMarker(configBody, "providers", "google")).toBe(false)
       expect(hasNonZeroModelCost(providerBody, "all", "google")).toBe(true)
+    }),
+    { ...projectOptions, init: writeProviderModelsMutationPlugin },
+  )
+
+  it.instance(
+    "serves v2 provider lists from the directory query",
+    Effect.gen(function* () {
+      const directory = (yield* TestInstance).directory
+
+      const response = yield* request(`/api/provider?directory=${encodeURIComponent(directory)}`)
+
+      expect(response.status).toBe(200)
+      expect(hasProviderListMutationMarker(yield* response.json, "google")).toBe(false)
     }),
     { ...projectOptions, init: writeProviderModelsMutationPlugin },
   )

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -407,13 +407,18 @@ describe("HttpApi UI fallback", () => {
   )
 
   // Regression for #25698 (Ope): the browser fetches the PWA manifest and
-  // its icons via flows that don't carry app-managed credentials (the
+  // its icons and boot chunks via flows that don't carry app-managed credentials (the
   // `<link rel="manifest">` request is not under page-auth control), so the
   // server returning 401 breaks PWA install. These specific public assets
   // should bypass auth.
-  it.live("serves the PWA manifest without auth even when a server password is set", () =>
+  it.live("serves public UI assets without auth even when a server password is set", () =>
     Effect.gen(function* () {
-      for (const path of ["/site.webmanifest", "/web-app-manifest-192x192.png", "/web-app-manifest-512x512.png"]) {
+      for (const path of [
+        "/site.webmanifest",
+        "/web-app-manifest-192x192.png",
+        "/web-app-manifest-512x512.png",
+        "/assets/app.js",
+      ]) {
         const response = yield* uiApp({
           password: "secret",
           username: "opencode",

--- a/packages/opencode/test/server/httpapi-workspace-routing.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace-routing.test.ts
@@ -423,7 +423,7 @@ describe("HttpApi workspace routing middleware", () => {
 
       const response = yield* HttpClient.get(`/probe?workspace=${workspaceID}`)
 
-      expect(response.status).toBe(500)
+      expect(response.status).toBe(404)
       expect(yield* response.text).toBe(`Workspace not found: ${workspaceID}`)
     }),
   )
@@ -502,11 +502,17 @@ describe("HttpApi workspace routing middleware", () => {
         HttpClientRequest.setHeader("x-opencode-directory", headerDir),
         HttpClient.execute,
       )
+      const encodedHeaderResponse = yield* HttpClientRequest.get("/probe").pipe(
+        HttpClientRequest.setHeader("x-opencode-directory", encodeURIComponent(headerDir)),
+        HttpClient.execute,
+      )
 
       expect(queryResponse.status).toBe(200)
       expect(yield* queryResponse.json).toEqual({ directory: queryDir })
       expect(headerResponse.status).toBe(200)
       expect(yield* headerResponse.json).toEqual({ directory: headerDir })
+      expect(encodedHeaderResponse.status).toBe(200)
+      expect(yield* encodedHeaderResponse.json).toEqual({ directory: headerDir })
     }),
   )
 

--- a/packages/opencode/test/session/agency-swarm-utils.test.ts
+++ b/packages/opencode/test/session/agency-swarm-utils.test.ts
@@ -219,6 +219,24 @@ describe("session.agency-swarm-utils", () => {
     ).toThrow("Agent Swarm Run mode cannot send local image files to a remote Agency server")
   })
 
+  test("collectFileURLs blocks file URL attachments for remote Agency servers", () => {
+    expect(() =>
+      collectFileURLs(
+        msg([
+          file("part-1", {
+            type: "file",
+            mime: "text/plain",
+            url: pathToFileURL(path.join(os.tmpdir(), "remote.txt")).toString(),
+            filename: "remote.txt",
+          }),
+        ]),
+        {
+          allowLocalFilePaths: false,
+        },
+      ),
+    ).toThrow("Agent Swarm Run mode cannot send local file attachments to a remote Agency server")
+  })
+
   test("collectFileURLs materializes clipboard images for local Agency servers", async () => {
     const content = Buffer.from("clipboard image")
     const result = collectFileURLs(

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -6883,10 +6883,8 @@ describe("session.agency-swarm", () => {
       }
     }) as typeof AgencySwarmAdapter.cancel
     AgencySwarmAdapter.streamRun = async function* (args) {
+      expect(args.abort?.aborted).toBeTrue()
       yield { type: "meta", runID: "run_cancel" }
-      if (args.abort?.aborted) {
-        throw new DOMException("Aborted", "AbortError")
-      }
       yield { type: "end" }
     } as typeof AgencySwarmAdapter.streamRun
 
@@ -6906,6 +6904,7 @@ describe("session.agency-swarm", () => {
   test("stream treats external abort as cancelled without error event", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* (args) {
+      expect(args.abort?.aborted).toBeTrue()
       await new Promise<void>((resolve, reject) => {
         if (args.abort?.aborted) {
           reject(new DOMException("Aborted", "AbortError"))
@@ -7001,6 +7000,55 @@ describe("session.agency-swarm", () => {
     }
 
     expect(deltas).toEqual(["Hi, there!"])
+  })
+
+  test("stream preserves text when output_item.done is the first text event", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: {
+              type: "message",
+              id: "msg_done_only",
+              content: [{ type: "output_text", text: "Done only." }],
+              provider_data: { response_id: "response_done_only" },
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "message_output_created",
+          item: {
+            raw_item: {
+              type: "message",
+              id: "msg_done_only_replay",
+              content: [{ type: "output_text", text: "Done only." }],
+              provider_data: { response_id: "response_done_only" },
+            },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "text-delta") {
+        deltas.push(event.text)
+      }
+    }
+
+    expect(deltas).toEqual(["Done only."])
   })
 
   test("stream does not duplicate text when message_output_created replays open output_text", async () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -375,6 +375,96 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream reports remote legacy file attachments as handled errors", async () => {
+    mockHistory()
+    mockAgencyVersion("1.9.4")
+    let called = false
+    AgencySwarmAdapter.streamRun = async function* () {
+      called = true
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.baseURL = "https://agency.example.com"
+    input.userMessage.parts = [
+      {
+        type: "text",
+        text: "[PDF 1] Inspect this.",
+        ignored: false,
+      },
+      {
+        type: "file",
+        mime: "application/pdf",
+        filename: "proof.pdf",
+        url: "file:///tmp/proof.pdf",
+        source: {
+          type: "file",
+          path: "/tmp/proof.pdf",
+          text: {
+            value: "[PDF 1]",
+            start: 0,
+            end: 7,
+          },
+        },
+      },
+    ] as any
+
+    const stream = await SessionAgencySwarm.stream(input)
+    let message = ""
+    for await (const event of stream.fullStream) {
+      if (event.type !== "error") continue
+      message = String(event.error?.message ?? event.error ?? "")
+    }
+
+    expect(called).toBeFalse()
+    expect(message).toContain("Agent Swarm Run mode cannot send local file attachments to a remote Agency server")
+  })
+
+  test("stream reports remote structured file attachments as handled errors", async () => {
+    mockHistory()
+    mockAgencyVersion("1.9.6")
+    let called = false
+    AgencySwarmAdapter.streamRun = async function* () {
+      called = true
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.baseURL = "https://agency.example.com"
+    input.userMessage.parts = [
+      {
+        type: "text",
+        text: "[PDF 1] Inspect this.",
+        ignored: false,
+      },
+      {
+        type: "file",
+        mime: "application/pdf",
+        filename: "proof.pdf",
+        url: "file:///tmp/proof.pdf",
+        source: {
+          type: "file",
+          path: "/tmp/proof.pdf",
+          text: {
+            value: "[PDF 1]",
+            start: 0,
+            end: 7,
+          },
+        },
+      },
+    ] as any
+
+    const stream = await SessionAgencySwarm.stream(input)
+    let message = ""
+    for await (const event of stream.fullStream) {
+      if (event.type !== "error") continue
+      message = String(event.error?.message ?? event.error ?? "")
+    }
+
+    expect(called).toBeFalse()
+    expect(message).toContain("Agent Swarm Run mode cannot send local file attachments to a remote Agency server")
+  })
+
   test("stream skips directory file data on structured transport and sends expanded text", async () => {
     await using tmp = await tmpdir()
     mockHistory()
@@ -688,6 +778,57 @@ describe("session.agency-swarm", () => {
         },
       ],
     })
+  })
+
+  test("stream reports replayed local attachment content as handled errors for remote Agency", async () => {
+    mockAgencyVersion("1.9.6")
+    const filePart = {
+      type: "input_file",
+      file_data: `data:application/pdf;base64,${Buffer.from("Attachment proof phrase one: cobalt lantern.").toString("base64")}`,
+      filename: "proof.pdf",
+    }
+    const priorUser = {
+      type: "message",
+      role: "user",
+      content: [
+        filePart,
+        {
+          type: "input_text",
+          text: "[PDF 1] In the attached PDF, what is the exact value of phrase one?",
+        },
+      ],
+    }
+    const priorAssistant = {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "cobalt lantern" }],
+    }
+    mockHistory(undefined, [priorUser, priorAssistant])
+    let called = false
+    AgencySwarmAdapter.streamRun = async function* () {
+      called = true
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.options.baseURL = "https://agency.example.com"
+    input.userMessage.parts = [
+      {
+        type: "text",
+        text: "Without re-attaching the file, what is the exact value of phrase one?",
+        ignored: false,
+      },
+    ] as any
+
+    const stream = await SessionAgencySwarm.stream(input)
+    let message = ""
+    for await (const event of stream.fullStream) {
+      if (event.type !== "error") continue
+      message = String(event.error?.message ?? event.error ?? "")
+    }
+
+    expect(called).toBeFalse()
+    expect(message).toContain("Agent Swarm Run mode cannot send local file attachments to a remote Agency server")
   })
 
   test("stream replays stored attachment content when the follow-up has a new attachment", async () => {

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -30,6 +30,7 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { TestConfig } from "../fixture/config"
 import { SyncEvent } from "@/sync"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { SessionEvent } from "@/v2/session-event"
 
 void Log.init({ print: false })
 
@@ -1028,10 +1029,17 @@ describe("session.compaction.process", () => {
   itCompaction.instance(
     "marks summary message as errored on compact result",
     Effect.gen(function* () {
+      const bus = yield* Bus.Service
       const ssn = yield* SessionNs.Service
       const session = yield* ssn.create({})
       const msg = yield* createUserMessage(session.id, "hello")
       const msgs = yield* ssn.messages({ sessionID: session.id })
+      let ended = false
+      const unsub = yield* bus.subscribeCallback(SessionEvent.Compaction.Ended.Sync, (evt) => {
+        if (evt.properties.sessionID !== session.id) return
+        ended = true
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(unsub))
 
       const result = yield* SessionCompaction.use.process({
         parentID: msg.id,
@@ -1045,6 +1053,7 @@ describe("session.compaction.process", () => {
       )
 
       expect(result).toBe("stop")
+      expect(ended).toBe(false)
       expect(summary?.info.role).toBe("assistant")
       if (summary?.info.role === "assistant") {
         expect(summary.info.finish).toBe("error")

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -252,10 +252,15 @@ it.live("tool execution produces non-empty session diff (snapshot race)", () =>
       expect(fileExists).toBe(true)
 
       // Verify the tool call completed (in the first assistant message)
-      const allMsgs = yield* MessageV2.filterCompactedEffect(session.id)
-      const tool = allMsgs
-        .flatMap((m) => m.parts)
-        .find((p): p is MessageV2.ToolPart => p.type === "tool" && p.tool === "bash")
+      let tool: MessageV2.ToolPart | undefined
+      for (let i = 0; i < 50; i++) {
+        const allMsgs = yield* MessageV2.filterCompactedEffect(session.id)
+        tool = allMsgs
+          .flatMap((m) => m.parts)
+          .find((p): p is MessageV2.ToolPart => p.type === "tool" && p.tool === "bash")
+        if (tool?.state.status === "completed") break
+        yield* Effect.sleep("100 millis")
+      }
       expect(tool?.state.status).toBe("completed")
 
       // Poll for diff — summarize() is fire-and-forget

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -4396,6 +4396,8 @@ export class Model extends HeyApiClient {
    */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
+      directory?: string
+      workspace?: string
       instance?: {
         directory?: string
         workspace?: string
@@ -4403,7 +4405,18 @@ export class Model extends HeyApiClient {
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "instance" }] }])
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "instance" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).get<V2ModelListResponses, unknown, ThrowOnError>({
       url: "/api/model",
       ...options,
@@ -4420,6 +4433,8 @@ export class Provider2 extends HeyApiClient {
    */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
+      directory?: string
+      workspace?: string
       instance?: {
         directory?: string
         workspace?: string
@@ -4427,7 +4442,18 @@ export class Provider2 extends HeyApiClient {
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "instance" }] }])
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "instance" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).get<V2ProviderListResponses, unknown, ThrowOnError>({
       url: "/api/provider",
       ...options,
@@ -4443,6 +4469,8 @@ export class Provider2 extends HeyApiClient {
   public get<ThrowOnError extends boolean = false>(
     parameters: {
       providerID: string
+      directory?: string
+      workspace?: string
       instance?: {
         directory?: string
         workspace?: string
@@ -4456,6 +4484,8 @@ export class Provider2 extends HeyApiClient {
         {
           args: [
             { in: "path", key: "providerID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
             { in: "query", key: "instance" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -77,6 +77,7 @@ export type Event =
   | EventSessionNextCompactionStarted
   | EventSessionNextCompactionDelta
   | EventSessionNextCompactionEnded
+  | EventServerHeartbeat
 
 export type OAuth = {
   type: "oauth"
@@ -786,7 +787,7 @@ export type Prompt = {
 }
 
 export type GlobalEvent = {
-  directory: string
+  directory?: string
   project?: string
   workspace?: string
   payload:
@@ -895,6 +896,13 @@ export type GlobalEvent = {
     | SyncEventSessionNextCompactionStarted
     | SyncEventSessionNextCompactionDelta
     | SyncEventSessionNextCompactionEnded
+    | {
+        id: string
+        type: "server.heartbeat"
+        properties: {
+          [key: string]: unknown
+        }
+      }
 }
 
 /**
@@ -1871,6 +1879,14 @@ export type WorkspaceWarpError = {
   name: "WorkspaceWarpError"
   data: {
     message: string
+  }
+}
+
+export type EventServerHeartbeat = {
+  id: string
+  type: "server.heartbeat"
+  properties: {
+    [key: string]: unknown
   }
 }
 
@@ -6708,6 +6724,8 @@ export type V2ModelListData = {
   body?: never
   path?: never
   query?: {
+    directory?: string
+    workspace?: string
     instance?: {
       directory?: string
       workspace?: string
@@ -6729,6 +6747,8 @@ export type V2ProviderListData = {
   body?: never
   path?: never
   query?: {
+    directory?: string
+    workspace?: string
     instance?: {
       directory?: string
       workspace?: string
@@ -6752,6 +6772,8 @@ export type V2ProviderGetData = {
     providerID: string
   }
   query?: {
+    directory?: string
+    workspace?: string
     instance?: {
       directory?: string
       workspace?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9302,6 +9302,9 @@
           },
           {
             "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
+          },
+          {
+            "$ref": "#/components/schemas/EventServerHeartbeat"
           }
         ]
       },
@@ -11703,11 +11706,29 @@
               },
               {
                 "$ref": "#/components/schemas/SyncEventSessionNextCompactionEnded"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": ["server.heartbeat"]
+                  },
+                  "properties": {
+                    "type": "object",
+                    "properties": {}
+                  }
+                },
+                "required": ["id", "type", "properties"],
+                "additionalProperties": false
               }
             ]
           }
         },
-        "required": ["directory", "payload"],
+        "required": ["payload"],
         "additionalProperties": false
       },
       "LogLevel": {
@@ -13035,17 +13056,6 @@
         "required": ["_tag"],
         "additionalProperties": false
       },
-      "effect_HttpApiError_NotImplemented": {
-        "type": "object",
-        "properties": {
-          "_tag": {
-            "type": "string",
-            "enum": ["NotImplemented"]
-          }
-        },
-        "required": ["_tag"],
-        "additionalProperties": false
-      },
       "ToolListItem": {
         "type": "object",
         "properties": {
@@ -14203,6 +14213,17 @@
         "required": ["items", "cursor"],
         "additionalProperties": false
       },
+      "effect_HttpApiError_NotImplemented": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": ["NotImplemented"]
+          }
+        },
+        "required": ["_tag"],
+        "additionalProperties": false
+      },
       "V2SessionMessagesResponse": {
         "type": "object",
         "properties": {
@@ -14440,6 +14461,24 @@
           }
         },
         "required": ["name", "data"],
+        "additionalProperties": false
+      },
+      "EventServerHeartbeat": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["server.heartbeat"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
       "SyncEventMessageUpdated": {


### PR DESCRIPTION
### Issue for this PR

Closes #227

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Hardens the Agent Swarm CLI v1.5.0 release candidate after the OpenCode v1.14.51 sync in #248.

It fixes release blockers in Agency Swarm run-mode, remote workspace routing, hosted web auth, embedded UI asset serving, desktop startup, session state, compaction events, launcher uv output, and usage graph day grouping. It also stabilizes the Windows snapshot race regression test.

### How did you verify your code works?

Focused runtime tests passed. Package type checks passed for opencode, app, console app, and desktop. Full opencode unit CI passed with 3238 passing tests, 12 skipped, and 1 todo. Agent Swarm TUI e2e passed with 28 passing tests and 1 skipped.

The release build for `OPENCODE_VERSION=1.5.0` passed, and the built CLI reports `1.5.0`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
