### PR TITLE
refactor(opencode): make Agent Swarm command row assertion robust

### DIFF
--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -33,7 +33,7 @@ async function waitForConfiguredDemoRecipient(tui: TuiProcess) {
 }
 
 function hasCommand(screen: string, command: string) {
-  return screen.split("\n").some((line) => line.includes(command) && line.trimStart().startsWith("┃"))
+  return screen.split("\n").some((line) => new RegExp(`┃\\s+${command}\\b`).test(line))
 }
 
 afterEach(async () => {


### PR DESCRIPTION
### Issue for this PR

Not applicable; refactor/test-only release gate fix.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates the Agent Swarm TUI e2e command-row helper so it matches slash commands after the menu border even when another visual element appears to the left of the menu.

This fixes the failing release CI assertion without changing product code.

### How did you verify your code works?

Focused failing test passed locally. Full Agent Swarm e2e passed locally with 28 passing tests and 1 intended live-telemetry skip. Local Codex review found no actionable regression. Pre-push typecheck passed.

### Screenshots / recordings

Not applicable; this is a test-helper-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
