### PR TITLE
fix(provider): align OpenRouter reasoning settings

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -520,6 +520,14 @@ const OPENAI_GPT5_PRO_2_PLUS_EFFORTS = ["medium", "high", "xhigh"]
 const OPENAI_GPT5_CHAT_EFFORTS = ["medium"]
 const OPENAI_GPT5_CODEX_XHIGH_EFFORTS = [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 const OPENAI_GPT5_CODEX_3_PLUS_EFFORTS = ["none", ...OPENAI_GPT5_CODEX_XHIGH_EFFORTS]
+const OPENROUTER_GEMINI_REASONING_BUDGETS = {
+  none: { reasoning: { enabled: false } },
+  minimal: { reasoning: { max_tokens: 64 } },
+  low: { reasoning: { max_tokens: 256 } },
+  medium: { reasoning: { max_tokens: 512 } },
+  high: { reasoning: { max_tokens: 768 } },
+  xhigh: { reasoning: { max_tokens: 900 } },
+}
 
 // OpenAI rolled out the `none` reasoning_effort tier on this date (Responses API).
 // Models released before it 400 on `reasoning_effort: "none"`, so we only expose
@@ -617,6 +625,14 @@ function googleThinkingBudgetMax(apiId: string) {
   return 24_576
 }
 
+function isGemini25(id: string) {
+  return id.toLowerCase().includes("gemini-2.5")
+}
+
+function isGemini3(id: string) {
+  return id.toLowerCase().includes("gemini-3")
+}
+
 export function variants(model: Provider.Model): Record<string, Record<string, any>> {
   if (!model.capabilities.reasoning) return {}
 
@@ -663,7 +679,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
 
   switch (model.api.npm) {
     case "@openrouter/ai-sdk-provider":
-      if (!id.includes("gpt") && !id.includes("gemini-3") && !id.includes("claude")) return {}
+      if (!id.includes("gpt") && !id.includes("claude") && !isGemini25(id) && !isGemini3(id)) return {}
+      if (isGemini25(id)) return OPENROUTER_GEMINI_REASONING_BUDGETS
       return Object.fromEntries(
         (id.includes("gpt") ? openaiCompatibleReasoningEfforts(id) : OPENAI_EFFORTS).map((effort) => [
           effort,
@@ -1073,8 +1090,12 @@ export function options(input: {
     result["usage"] = {
       include: true,
     }
-    if (input.model.api.id.includes("gemini-3")) {
-      result["reasoning"] = { effort: "high" }
+    if (input.model.capabilities.reasoning) {
+      if (input.model.api.npm === "@openrouter/ai-sdk-provider" && isGemini25(input.model.api.id)) {
+        result["reasoning"] = OPENROUTER_GEMINI_REASONING_BUDGETS.high.reasoning
+      } else if (isGemini3(input.model.api.id)) {
+        result["reasoning"] = { effort: "high" }
+      }
     }
   }
 

--- a/packages/opencode/src/session/agency-swarm-client-config.ts
+++ b/packages/opencode/src/session/agency-swarm-client-config.ts
@@ -24,7 +24,8 @@ import { asRecord, asString } from "./agency-swarm-utils"
 const log = Log.create({ service: "session.agency-swarm" })
 const STRUCTURED_ATTACHMENT_MESSAGE_MIN_VERSION = "1.9.6"
 const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key"
-const OPENROUTER_FREE_TIER_MAX_TOKENS = 2500
+const OPENROUTER_FREE_TIER_MAX_TOKENS = 1000
+const OPENROUTER_ANTHROPIC_REASONING_FREE_TIER_MAX_TOKENS = 2500
 
 async function finalizeClientConfig(
   merged: Record<string, unknown> | undefined,
@@ -75,13 +76,22 @@ async function applyOpenRouterTokenPolicy(out: Record<string, unknown>) {
   const apiKey = asString(out["api_key"]) ?? asString(out["apiKey"])
   const freeTier = await isOpenRouterFreeTier(apiKey)
   if (freeTier) {
-    modelSettings["max_tokens"] = OPENROUTER_FREE_TIER_MAX_TOKENS
+    modelSettings["max_tokens"] = openRouterFreeTierMaxTokens(model, modelSettings)
   } else {
     delete modelSettings["max_tokens"]
   }
   if (Object.keys(modelSettings).length === 0) {
     delete out["model_settings_extra_args"]
   }
+}
+
+function openRouterFreeTierMaxTokens(model: string, settings: Record<string, unknown>) {
+  const id = model.toLowerCase()
+  const reasoning = asRecord(asRecord(settings["extra_body"])?.["reasoning"])
+  if (reasoning && reasoning["enabled"] !== false && (id.includes("anthropic/") || id.includes("claude"))) {
+    return OPENROUTER_ANTHROPIC_REASONING_FREE_TIER_MAX_TOKENS
+  }
+  return OPENROUTER_FREE_TIER_MAX_TOKENS
 }
 
 async function isOpenRouterFreeTier(apiKey: string | undefined): Promise<boolean> {

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -752,7 +752,12 @@ export namespace SessionAgencySwarm {
     const extraBodyReasoning = { ...(asRecord(extraBody["reasoning"]) ?? {}) }
     if (modelID.includes("anthropic/") || modelID.includes("claude")) {
       const maxTokens = reasoning["max_tokens"]
-      if (typeof maxTokens === "number" && Number.isFinite(maxTokens)) {
+      if (reasoning["enabled"] === false) {
+        extraBody["reasoning"] = {
+          ...extraBodyReasoning,
+          enabled: false,
+        }
+      } else if (typeof maxTokens === "number" && Number.isFinite(maxTokens)) {
         extraBody["reasoning"] = {
           ...extraBodyReasoning,
           max_tokens: Math.max(1, Math.floor(maxTokens)),

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -29,8 +29,28 @@ export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
 type Result = Awaited<ReturnType<typeof streamText>>
 
 // Avoid re-instantiating remeda's deep merge types in this hot LLM path; the runtime behavior is still mergeDeep.
-const mergeOptions = (target: Record<string, any>, source: Record<string, any> | undefined): Record<string, any> =>
-  mergeDeep(target, source ?? {}) as Record<string, any>
+const mergeOptions = (target: Record<string, any>, source: Record<string, any> | undefined): Record<string, any> => {
+  let sourceOptions = source ?? {}
+  if (isReasoningDisabled(target.reasoning) && source?.reasoning !== undefined) {
+    sourceOptions = { ...source }
+    delete sourceOptions.reasoning
+  }
+  const result = mergeDeep(target, sourceOptions) as Record<string, any>
+  const reasoning = source?.reasoning
+  if (isReasoningDisabled(reasoning)) {
+    result.reasoning = reasoning
+  }
+  return result
+}
+
+function isReasoningDisabled(value: unknown) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "enabled" in value &&
+    (value as Record<string, unknown>).enabled === false
+  )
+}
 
 export type StreamInput = {
   user: MessageV2.User

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -238,6 +238,105 @@ describe("ProviderTransform.options - google thinkingConfig gating", () => {
   })
 })
 
+describe("ProviderTransform.options - OpenRouter Gemini reasoning", () => {
+  const sessionID = "ses_test"
+  const createOpenRouterModel = (apiId: string) =>
+    ({
+      id: `openrouter/${apiId}`,
+      providerID: "openrouter",
+      api: {
+        id: apiId,
+        url: "https://openrouter.ai",
+        npm: "@openrouter/ai-sdk-provider",
+      },
+      name: apiId,
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
+      limit: { context: 128000, output: 8192 },
+      status: "active",
+      options: {},
+      headers: {},
+    }) as any
+
+  test("enables OpenRouter Gemini reasoning by default", () => {
+    const model = createOpenRouterModel("google/gemini-2.5-flash")
+
+    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
+      usage: { include: true },
+      prompt_cache_key: sessionID,
+      reasoning: { max_tokens: 768 },
+    })
+  })
+
+  test("keeps OpenRouter Gemini 3 reasoning effort by default", () => {
+    const model = createOpenRouterModel("google/gemini-3-pro-preview")
+
+    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
+      usage: { include: true },
+      prompt_cache_key: sessionID,
+      reasoning: { effort: "high" },
+    })
+  })
+
+  test("does not enable default reasoning for non-Gemini OpenRouter models", () => {
+    const model = createOpenRouterModel("anthropic/claude-haiku-4.5")
+
+    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
+      usage: { include: true },
+      prompt_cache_key: sessionID,
+    })
+  })
+
+  test("does not enable default reasoning for OpenRouter Gemini models without reasoning", () => {
+    const model = createOpenRouterModel("google/gemini-2.5-flash-nothinking")
+    model.capabilities.reasoning = false
+
+    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
+      usage: { include: true },
+      prompt_cache_key: sessionID,
+    })
+  })
+
+  test("keeps llmgateway Gemini defaults unchanged", () => {
+    const model = createOpenRouterModel("google/gemini-2.5-flash")
+    model.id = "llmgateway/google/gemini-2.5-flash"
+    model.providerID = "llmgateway"
+    model.api = {
+      id: "google/gemini-2.5-flash",
+      url: "https://llmgateway.ai",
+      npm: "@llmgateway/ai-sdk-provider",
+    }
+
+    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
+      usage: { include: true },
+    })
+  })
+
+  test("keeps llmgateway Gemini 3 reasoning effort by default", () => {
+    const model = createOpenRouterModel("google/gemini-3-pro-preview")
+    model.id = "llmgateway/google/gemini-3-pro-preview"
+    model.providerID = "llmgateway"
+    model.api = {
+      id: "google/gemini-3-pro-preview",
+      url: "https://llmgateway.ai",
+      npm: "@llmgateway/ai-sdk-provider",
+    }
+
+    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
+      usage: { include: true },
+      reasoning: { effort: "high" },
+    })
+  })
+})
+
 describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
   const sessionID = "test-session-123"
 
@@ -2591,6 +2690,89 @@ describe("ProviderTransform.variants", () => {
       })
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+    })
+
+    test("gemini-2.5 returns fixed OpenRouter reasoning budgets", () => {
+      const model = createMockModel({
+        id: "openrouter/google/gemini-2.5-flash",
+        providerID: "openrouter",
+        api: {
+          id: "google/gemini-2.5-flash",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+      expect(result.high).toEqual({ reasoning: { max_tokens: 768 } })
+    })
+
+    test("does not expose reasoning variants for unsupported OpenRouter Gemini models", () => {
+      const model = createMockModel({
+        id: "openrouter/google/gemini-2.0-flash",
+        providerID: "openrouter",
+        api: {
+          id: "google/gemini-2.0-flash",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+
+      expect(ProviderTransform.variants(model)).toEqual({})
+    })
+
+    test.each([
+      "openrouter/google/gemini-2.5-flash",
+      "openrouter/google/gemini-3-5-pro",
+      "openrouter/anthropic/claude-haiku-4.5",
+      "openrouter/x-ai/grok-4.3",
+    ])(
+      "does not cap output tokens for OpenRouter reasoning model %s",
+      (id) => {
+        const model = createMockModel({
+          id,
+          providerID: "openrouter",
+          api: {
+            id: id.replace("openrouter/", ""),
+            url: "https://openrouter.ai",
+            npm: "@openrouter/ai-sdk-provider",
+          },
+          limit: { output: 64_000 },
+        })
+
+        expect(ProviderTransform.maxOutputTokens(model)).toBe(32_000)
+      },
+    )
+
+    test("does not cap OpenRouter GPT output tokens", () => {
+      const model = createMockModel({
+        id: "openrouter/openai/gpt-5.4-mini",
+        providerID: "openrouter",
+        api: {
+          id: "openai/gpt-5.4-mini",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+        limit: { output: 64_000 },
+      })
+
+      expect(ProviderTransform.maxOutputTokens(model)).toBe(32_000)
+    })
+
+    test("does not cap non-reasoning OpenRouter Grok output tokens", () => {
+      const model = createMockModel({
+        id: "openrouter/x-ai/grok-4",
+        providerID: "openrouter",
+        api: {
+          id: "x-ai/grok-4",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+        capabilities: { reasoning: false },
+        limit: { output: 64_000 },
+      })
+
+      expect(ProviderTransform.maxOutputTokens(model)).toBe(32_000)
     })
 
     test("grok-4 returns empty object", () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1409,6 +1409,65 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream keeps OpenRouter Claude disabled reasoning at the default free tier cap", async () => {
+    mockHistory()
+    globalThis.fetch = mock(async () => Response.json({ data: { is_free_tier: true } })) as unknown as typeof fetch
+    spyOn(Auth, "all").mockImplementation(async () => ({
+      openrouter: { type: "api", key: "stored-openrouter" } as any,
+    })) as typeof Auth.all
+    spyOn(Env, "all").mockImplementation(() => ({
+      OPENROUTER_API_KEY: "env-openrouter",
+    })) as typeof Env.all
+    spyOn(Provider, "list").mockImplementation(async () => ({
+      openrouter: {
+        id: "openrouter",
+        name: "OpenRouter",
+        source: "api",
+        env: ["OPENROUTER_API_KEY"],
+        options: {},
+        models: {},
+      },
+    })) as typeof Provider.list
+    AgencySwarmAdapter.getMetadata = (async () => ({
+      agency_swarm_version: "1.9.3",
+      metadata: { agents: ["AgentA"] },
+      nodes: [],
+    })) as typeof AgencySwarmAdapter.getMetadata
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "openrouter",
+      modelID: "anthropic/claude-sonnet-4.5",
+      variantOptions: {
+        reasoning: { enabled: false },
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "stored-openrouter",
+      model: "openrouter/anthropic/claude-sonnet-4.5",
+      model_settings_extra_args: {
+        extra_body: {
+          reasoning: {
+            enabled: false,
+          },
+        },
+        max_tokens: 1000,
+      },
+    })
+  })
+
   test("stream forwards OpenRouter reasoning effort for non-Claude models", async () => {
     mockHistory()
     globalThis.fetch = mock(async () => Response.json({ data: { is_free_tier: true } })) as unknown as typeof fetch
@@ -1463,7 +1522,7 @@ describe("session.agency-swarm", () => {
             effort: "high",
           },
         },
-        max_tokens: 2500,
+        max_tokens: 1000,
       },
     })
   })
@@ -1563,6 +1622,124 @@ describe("session.agency-swarm", () => {
       model_settings_extra_args: {
         thinking: { type: "adaptive" },
         reasoning_effort: "high",
+      },
+    })
+  })
+
+  test("stream forwards OpenRouter Gemini reasoning budget", async () => {
+    mockHistory()
+    globalThis.fetch = mock(async () => Response.json({ data: { is_free_tier: true } })) as unknown as typeof fetch
+    spyOn(Auth, "all").mockImplementation(async () => ({
+      openrouter: { type: "api", key: "stored-openrouter" } as any,
+    })) as typeof Auth.all
+    spyOn(Env, "all").mockImplementation(() => ({
+      OPENROUTER_API_KEY: "env-openrouter",
+    })) as typeof Env.all
+    spyOn(Provider, "list").mockImplementation(async () => ({
+      openrouter: {
+        id: "openrouter",
+        name: "OpenRouter",
+        source: "api",
+        env: ["OPENROUTER_API_KEY"],
+        options: {},
+        models: {},
+      },
+    })) as typeof Provider.list
+    AgencySwarmAdapter.getMetadata = (async () => ({
+      agency_swarm_version: "1.9.3",
+      metadata: { agents: ["AgentA"] },
+      nodes: [],
+    })) as typeof AgencySwarmAdapter.getMetadata
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "openrouter",
+      modelID: "google/gemini-2.5-flash",
+      variantOptions: {
+        reasoning: { max_tokens: 768 },
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "stored-openrouter",
+      model: "openrouter/google/gemini-2.5-flash",
+      model_settings_extra_args: {
+        extra_body: {
+          reasoning: {
+            max_tokens: 768,
+          },
+        },
+        max_tokens: 1000,
+      },
+    })
+  })
+
+  test("stream caps OpenRouter Gemini tokens when reasoning is disabled", async () => {
+    mockHistory()
+    globalThis.fetch = mock(async () => Response.json({ data: { is_free_tier: true } })) as unknown as typeof fetch
+    spyOn(Auth, "all").mockImplementation(async () => ({
+      openrouter: { type: "api", key: "stored-openrouter" } as any,
+    })) as typeof Auth.all
+    spyOn(Env, "all").mockImplementation(() => ({
+      OPENROUTER_API_KEY: "env-openrouter",
+    })) as typeof Env.all
+    spyOn(Provider, "list").mockImplementation(async () => ({
+      openrouter: {
+        id: "openrouter",
+        name: "OpenRouter",
+        source: "api",
+        env: ["OPENROUTER_API_KEY"],
+        options: {},
+        models: {},
+      },
+    })) as typeof Provider.list
+    AgencySwarmAdapter.getMetadata = (async () => ({
+      agency_swarm_version: "1.9.3",
+      metadata: { agents: ["AgentA"] },
+      nodes: [],
+    })) as typeof AgencySwarmAdapter.getMetadata
+
+    let captured: Record<string, unknown> | undefined
+    AgencySwarmAdapter.streamRun = async function* (input) {
+      captured = input.clientConfig
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    input.sessionModel = {
+      providerID: "openrouter",
+      modelID: "google/gemini-2.5-flash",
+      variantOptions: {
+        reasoning: { enabled: false },
+      },
+    }
+
+    const stream = await SessionAgencySwarm.stream(input)
+    for await (const _event of stream.fullStream) {
+      // consume
+    }
+
+    expect(captured).toEqual({
+      api_key: "stored-openrouter",
+      model: "openrouter/google/gemini-2.5-flash",
+      model_settings_extra_args: {
+        extra_body: {
+          reasoning: {
+            enabled: false,
+          },
+        },
+        max_tokens: 1000,
       },
     })
   })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -319,6 +319,164 @@ function createEventResponse(chunks: unknown[], includeDone = false) {
 }
 
 describe("session.llm.stream", () => {
+  test("OpenRouter Gemini 2.5 none variant replaces the default reasoning budget", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "openrouter"
+    const modelID = "google/gemini-2.5-flash"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-openrouter-gemini-none")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("msg_user-openrouter-gemini-none"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id, variant: "none" },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = await request
+        expect(capture.body.reasoning).toEqual({ enabled: false })
+      },
+    })
+  })
+
+  test("OpenRouter Gemini 2.5 disabled model reasoning overrides later variant budgets", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "openrouter"
+    const modelID = "google/gemini-2.5-flash"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-openrouter-gemini-disabled")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("msg_user-openrouter-gemini-disabled"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id, variant: "high" },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: {
+            ...resolved,
+            options: {
+              ...resolved.options,
+              reasoning: { enabled: false },
+            },
+          },
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = await request
+        expect(capture.body.reasoning).toEqual({ enabled: false })
+      },
+    })
+  })
+
   test("sends temperature, tokens, and reasoning options for openai-compatible models", async () => {
     const server = state.server
     if (!server) {


### PR DESCRIPTION
### Issue for this PR

Fixes #247

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes OpenRouter reasoning options so provider-specific settings are sent in the shape each model expects.

This keeps Gemini 3 on reasoning effort, sends Gemini 2.5 reasoning budgets as token limits, preserves `reasoning: { enabled: false }` for the `none` variant, and keeps free-tier token limits compatible with the affected OpenRouter models.

### How did you verify your code works?

Focused tests passed:
- `transform.test.ts`: 239 pass
- `agency-swarm.test.ts`: 119 pass
- `llm.test.ts`: 16 pass

Also ran direct OpenRouter smoke checks for OpenAI, xAI, and Gemini reasoning, plus Anthropic basic text.

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
