### PR TITLE
feat: add Ollama local model support

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -29,6 +29,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 - Agency session resume and bridge recovery: `packages/opencode/src/agency-swarm/run-session.ts`, `packages/opencode/src/agency-swarm/npx.ts`, `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/cli/cmd/tui/session-error.ts`, `packages/opencode/src/cli/cmd/tui/context/agency-swarm-connection.tsx`.
 - Connection, auth, and provider dialogs: `packages/opencode/src/cli/cmd/tui/app.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx`, `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`, `packages/opencode/src/cli/cmd/tui/session-error.ts`.
 - Run-mode routing, add-ons, models, and attachments: `packages/opencode/src/agency-swarm/adapter.ts`, `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx`, `packages/opencode/src/cli/cmd/tui/context/local.tsx`, `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`.
+- Run-mode local models: `packages/opencode/src/agency-swarm/ollama.ts`, `packages/opencode/src/agency-swarm/litellm-provider.ts`, `packages/opencode/src/agency-swarm/client-config.ts`, `packages/opencode/src/provider/provider.ts`, `packages/opencode/src/cli/cmd/tui/component/download-ollama-model.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx`, `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`, `packages/opencode/src/cli/cmd/tui/session-error.ts`.
 - Builder and Plan preservation: `packages/opencode/src/session/agent-builder.ts`, `packages/opencode/src/session/agent-planner.ts`, `packages/opencode/src/session/prompt/agent-builder.txt`, `packages/opencode/src/session/prompt/agent-planner.txt`.
 - History, handoff, compaction, and message metadata: `packages/opencode/src/session/agency-swarm-utils.ts`, `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/session/message-v2.ts`, `packages/opencode/src/session/compaction.ts`, `packages/opencode/src/agency-swarm/history.ts`.
 - Sharing, PR reopen, and backend management: `packages/opencode/src/share/share-next.ts`, `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`, `packages/opencode/src/cli/cmd/pr.ts`, `packages/opencode/src/cli/cmd/agency.ts`, `README.md`.
@@ -145,6 +146,13 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Behavior: LiteLLM agency runs keep Codex OAuth only when the target model is OpenAI-based.
   - Implementation: `shouldStripCodexOAuth` and `stripCodexOAuthForNonOpenAI` in `packages/opencode/src/session/agency-swarm.ts`.
   - Added by: `6e36ccac`
+
+- **Run-mode Ollama local models**
+  - Intent: let Agent Swarm users run local open-source models through Ollama without leaving Run mode or adding upstream provider credentials.
+  - Behavior: `/models` exposes an Ollama provider in Agent Swarm Run mode and routes selections to Agency Swarm as LiteLLM `ollama_chat` models.
+  - Behavior: startup and prompt auth gates treat selected Ollama models as local and do not require OpenAI, Anthropic, OpenRouter, or other upstream credentials.
+  - Behavior: when a selected Ollama model is missing, the TUI can prompt to download it through Ollama and stale download completion must not close a newer dialog.
+  - Implementation: `AgencySwarmOllama` in `packages/opencode/src/agency-swarm/ollama.ts`, LiteLLM routing helpers, the built-in Ollama provider in `packages/opencode/src/provider/provider.ts`, auth gating in `packages/opencode/src/cli/cmd/tui/session-error.ts`, and model-selection/download flows in the TUI prompt and model dialogs.
 
 - **Tool outputs preserve wrapper call metadata**
   - Intent: keep Agency Swarm tool results attached to the correct wrapped call and preserve the extra metadata needed for tracing.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -176,6 +176,9 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** Compatible configured provider credentials pass through the credential bridge.
 - **Happy-path proof:** Provider auth stays a credential flow and does not act as a Run-mode switch.
 - **Happy-path proof:** `/models` selects the LLM config passed to Agency Swarm and does not act as a product mode switch.
+- **Happy-path proof:** Selecting an Ollama local model in `/models` routes the run through Agency Swarm as a LiteLLM `ollama_chat` model.
+- **Happy-path proof:** Selected Ollama local models skip upstream provider auth gates.
+- **Happy-path proof:** Missing selected Ollama models offer an Ollama download flow, and a dismissed download cannot later close a newer dialog.
 - **Happy-path proof:** In-flight Agency runs cancel through the bridge.
 - **Happy-path proof:** Codex OAuth is stripped from non-OpenAI LiteLLM agency runs.
 - **Happy-path proof:** Run mode hides Builder, Plan, `/editor`, `/variants`, `/init`, `/review`, and other disabled upstream-native surfaces.
@@ -188,6 +191,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Failure scenarios to test:** Server reachability or authorization failure opens `/connect`.
 - **Failure scenarios to test:** Provider credential failure opens `/auth`.
 - **Failure scenarios to test:** Non-OpenAI LiteLLM agency runs do not receive Codex OAuth credentials while OpenAI-based LiteLLM runs still keep them.
+- **Failure scenarios to test:** Missing or unreachable Ollama fails visibly without switching out of Run mode.
 
 #### Builder and Plan instruction preservation
 

--- a/packages/opencode/src/agency-swarm/litellm-provider.ts
+++ b/packages/opencode/src/agency-swarm/litellm-provider.ts
@@ -142,6 +142,7 @@ const PROVIDER_ALIASES: Record<string, string> = {
   "google-vertex": "vertex_ai",
   lmstudio: "lm_studio",
   nova: "amazon_nova",
+  ollama: "ollama_chat",
   "sap-ai-core": "sap",
   togetherai: "together_ai",
   vercel: "vercel_ai_gateway",

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1671,26 +1671,26 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
     const outputAbort = new AbortController()
     let timeout: ReturnType<typeof setTimeout> | undefined
     const exitPromise = proc.exited.finally(() => {
-      if (timeout) clearTimeout(timeout)
+      if (timeout) globalThis.clearTimeout(timeout)
     })
     const exitResult = exitPromise.then((code) => ({ code, timedOut: false as const }))
     const timeoutResult =
       options?.timeoutMs === undefined
         ? undefined
         : new Promise<{ code: number; timedOut: true }>((resolve) => {
-            timeout = setTimeout(() => {
+            timeout = globalThis.setTimeout(() => {
               resolve({ code: -1, timedOut: true })
               void (async () => {
                 try {
                   proc.kill()
                 } catch {}
-                const forceKill = setTimeout(() => {
+                const forceKill = globalThis.setTimeout(() => {
                   try {
                     proc.kill("SIGKILL")
                   } catch {}
                 }, PROCESS_KILL_GRACE_MS)
                 await exitPromise.catch(() => undefined)
-                clearTimeout(forceKill)
+                globalThis.clearTimeout(forceKill)
                 outputAbort.abort()
               })()
             }, options.timeoutMs)

--- a/packages/opencode/src/agency-swarm/ollama.ts
+++ b/packages/opencode/src/agency-swarm/ollama.ts
@@ -1,0 +1,243 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process"
+import { Log } from "@/util"
+
+const log = Log.create({ service: "agency-swarm.ollama" })
+const tagsURL = "http://127.0.0.1:11434/api/tags"
+const pullURL = "http://127.0.0.1:11434/api/pull"
+const started = new Set<ChildProcess>()
+let handlers = false
+
+export const PROVIDER_ID = "ollama"
+export const LITELLM_PROVIDER_ID = "ollama_chat"
+
+export class MissingModelError extends Error {
+  constructor(readonly modelID: string) {
+    super(`Ollama model ${modelID} is not installed.`)
+    this.name = "MissingModelError"
+  }
+}
+
+export type PullProgress = {
+  status: string
+  completed?: number
+  total?: number
+  percent?: number
+}
+
+export function isModel(input: { providerID: string; modelID: string } | undefined) {
+  return input?.providerID === PROVIDER_ID
+}
+
+export function isMissingModelError(error: unknown): error is MissingModelError {
+  return error instanceof MissingModelError
+}
+
+export function isModelListed(modelID: string, data: { models?: Array<{ name?: string; model?: string }> }) {
+  return (data.models ?? []).some((model) => model.name === modelID || model.model === modelID)
+}
+
+export function formatMissingModelInstallHint(modelID: string) {
+  return `Ollama model ${modelID} is not installed. Run \`ollama pull ${modelID}\` and try again.`
+}
+
+export function formatProgressBar(percent: number | undefined) {
+  if (percent === undefined) return "[--------------------] --%"
+  const width = 20
+  const filled = Math.round((percent / 100) * width)
+  return `[${"#".repeat(filled)}${"-".repeat(width - filled)}] ${percent}%`
+}
+
+export function parsePullProgress(input: string): PullProgress | undefined {
+  const line = input.trim()
+  if (!line) return
+  try {
+    const data = JSON.parse(line) as { status?: unknown; completed?: unknown; total?: unknown }
+    if (typeof data.status !== "string") return
+    const completed = typeof data.completed === "number" ? data.completed : undefined
+    const total = typeof data.total === "number" ? data.total : undefined
+    return {
+      status: data.status,
+      completed,
+      total,
+      percent:
+        completed !== undefined && total
+          ? Math.min(100, Math.max(0, Math.round((completed / total) * 100)))
+          : undefined,
+    }
+  } catch {
+    const percentMatch = /(\d{1,3})\s*%/.exec(line)
+    const percent = percentMatch ? Math.min(100, Math.max(0, Number(percentMatch[1]))) : undefined
+    return {
+      status: line,
+      percent,
+    }
+  }
+}
+
+export async function ensure(modelID?: string, options?: { onServerStart?: () => void }) {
+  if (!(await running())) {
+    if (!installed()) {
+      throw new Error("Ollama is not installed. Install Ollama from https://ollama.com/download to use local models.")
+    }
+
+    register()
+    options?.onServerStart?.()
+    const child = spawn("ollama", ["serve"], {
+      detached: process.platform !== "win32",
+      stdio: "ignore",
+      windowsHide: true,
+    })
+    started.add(child)
+    child.unref()
+    child.once("exit", () => started.delete(child))
+
+    const deadline = Date.now() + 15_000
+    while (Date.now() < deadline) {
+      if (await running()) break
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+  }
+
+  if (!(await running())) {
+    throw new Error("Timed out starting Ollama. Run `ollama serve` manually and try again.")
+  }
+
+  if (modelID && !(await hasModel(modelID))) {
+    throw new MissingModelError(modelID)
+  }
+}
+
+export async function pullModel(modelID: string, options?: { onProgress?: (progress: PullProgress) => void }) {
+  await ensure()
+  const response = await fetch(pullURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name: modelID, stream: true }),
+  })
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "")
+    throw new Error(`Failed to download Ollama model ${modelID}: ${detail || response.statusText}`)
+  }
+  if (!response.body) {
+    throw new Error(`Failed to download Ollama model ${modelID}: missing progress stream`)
+  }
+
+  const decoder = new TextDecoder()
+  const reader = response.body.getReader()
+  let leftover = ""
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    const text = leftover + decoder.decode(value, { stream: true })
+    const lines = text.split(/\r?\n/)
+    leftover = lines.pop() ?? ""
+    for (const line of lines) {
+      handlePullLine(modelID, line, options)
+    }
+  }
+
+  const finalLine = leftover + decoder.decode()
+  handlePullLine(modelID, finalLine, options)
+  await ensure(modelID)
+}
+
+export function shutdown() {
+  for (const child of [...started]) {
+    stop(child)
+  }
+  started.clear()
+}
+
+async function running() {
+  try {
+    const response = await fetch(tagsURL, { signal: AbortSignal.timeout(1_000) })
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+async function hasModel(modelID: string) {
+  try {
+    const response = await fetch(tagsURL, { signal: AbortSignal.timeout(2_000) })
+    if (!response.ok) return false
+    const data = (await response.json()) as { models?: Array<{ name?: string; model?: string }> }
+    return isModelListed(modelID, data)
+  } catch {
+    return false
+  }
+}
+
+function installed() {
+  const result = spawnSync("ollama", ["--version"], {
+    stdio: "ignore",
+    windowsHide: true,
+  })
+  return result.status === 0
+}
+
+function handlePullLine(modelID: string, line: string, options?: { onProgress?: (progress: PullProgress) => void }) {
+  const trimmed = line.trim()
+  if (!trimmed) return
+  try {
+    const data = JSON.parse(trimmed) as { error?: unknown }
+    if (typeof data.error === "string" && data.error) {
+      throw new Error(`Failed to download Ollama model ${modelID}: ${data.error}`)
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Failed to download Ollama model")) throw error
+  }
+  const progress = parsePullProgress(trimmed)
+  if (progress) options?.onProgress?.(progress)
+}
+
+function register() {
+  if (handlers) return
+  handlers = true
+  process.once("exit", shutdown)
+  process.once("SIGHUP", () => {
+    shutdown()
+    process.exit(0)
+  })
+  process.once("SIGINT", () => {
+    shutdown()
+    process.exit(130)
+  })
+  process.once("SIGTERM", () => {
+    shutdown()
+    process.exit(143)
+  })
+}
+
+function stop(child: ChildProcess) {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  const pid = child.pid
+  if (pid) stopPid(pid)
+}
+
+function stopPid(pid: number) {
+  try {
+    if (process.platform === "win32") {
+      spawnSync("taskkill", ["/pid", String(pid), "/f", "/t"], {
+        stdio: "ignore",
+        windowsHide: true,
+      })
+      return
+    }
+    try {
+      process.kill(-pid, "SIGTERM")
+    } catch {
+      process.kill(pid, "SIGTERM")
+    }
+  } catch (error) {
+    log.warn("failed to stop owned Ollama pid", {
+      pid,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+export * as AgencySwarmOllama from "./ollama"

--- a/packages/opencode/src/agency-swarm/ollama.ts
+++ b/packages/opencode/src/agency-swarm/ollama.ts
@@ -33,7 +33,8 @@ export function isMissingModelError(error: unknown): error is MissingModelError 
 }
 
 export function isModelListed(modelID: string, data: { models?: Array<{ name?: string; model?: string }> }) {
-  return (data.models ?? []).some((model) => model.name === modelID || model.model === modelID)
+  const names = modelID.includes(":") ? [modelID] : [modelID, `${modelID}:latest`]
+  return (data.models ?? []).some((model) => names.includes(model.name ?? "") || names.includes(model.model ?? ""))
 }
 
 export function formatMissingModelInstallHint(modelID: string) {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -55,7 +55,7 @@ import { PromptStashProvider } from "./component/prompt/stash"
 import { AgencySwarmConnectionProvider } from "@tui/context/agency-swarm-connection"
 import { DialogAlert } from "./ui/dialog-alert"
 import { DialogConfirm } from "./ui/dialog-confirm"
-import { ToastProvider, useToast } from "./ui/toast"
+import { Toast, ToastProvider, useToast } from "./ui/toast"
 import { ExitProvider, useExit } from "./context/exit"
 import { Session as SessionApi } from "@/session/session"
 import { TuiEvent } from "./event"
@@ -74,6 +74,7 @@ import { FormatError, FormatUnknownError } from "@/cli/error"
 import { CommandPaletteProvider, useCommandPalette } from "./context/command-palette"
 import { OpencodeKeymapProvider, registerOpencodeKeymap, useBindings, useOpencodeKeymap } from "./keymap"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { AgencySwarmOllama } from "@/agency-swarm/ollama"
 import { AgencyProduct } from "@/agency-swarm/product"
 import {
   describeAgencyAuthFailure,
@@ -195,6 +196,7 @@ export function tui(input: {
     }
     const onBeforeExit = async () => {
       offKeymap()
+      AgencySwarmOllama.shutdown()
       await TuiPluginRuntime.dispose()
       await Telemetry.flush({ timeoutMs: 500 })
       TuiAudio.dispose()
@@ -1161,6 +1163,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         <TuiPluginRuntime.Slot name="app" />
       </Show>
       <StartupLoading ready={ready} themed={themePaintReady} />
+      <Toast />
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -479,6 +479,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         providers: sync.data.provider,
         providerAuth: sync.data.provider_auth,
         frameworkMode: frameworkMode(),
+        currentProviderID: local.model.current()?.providerID,
         env: process.env,
       })
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -45,7 +45,7 @@ export function DialogModel(props: { providerID?: string }) {
   const enabledProviders = createMemo(() =>
     frameworkMode
       ? sync.data.provider.filter((provider) => isAgencySupportedProvider(provider.id))
-      : sync.data.provider.filter((provider) => provider.id !== AgencySwarmOllama.PROVIDER_ID),
+      : sync.data.provider,
   )
   // Treat framework mode as "not connected" when no agency-supported provider is usable,
   // so the disconnected fallback (filtered popular providers) keeps `/models` actionable

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -14,11 +14,15 @@ import { DialogVariant } from "./dialog-variant"
 import { isAgencySupportedProvider, isAgencySwarmFrameworkMode } from "../session-error"
 import * as fuzzysort from "fuzzysort"
 import { useConnected } from "./use-connected"
+import { AgencySwarmOllama } from "@/agency-swarm/ollama"
+import { useToast } from "../ui/toast"
+import { downloadOllamaModel } from "./download-ollama-model"
 
 export function DialogModel(props: { providerID?: string }) {
   const local = useLocal()
   const sync = useSync()
   const dialog = useDialog()
+  const toast = useToast()
   const [query, setQuery] = createSignal("")
 
   const rawConnected = useConnected()
@@ -41,7 +45,7 @@ export function DialogModel(props: { providerID?: string }) {
   const enabledProviders = createMemo(() =>
     frameworkMode
       ? sync.data.provider.filter((provider) => isAgencySupportedProvider(provider.id))
-      : sync.data.provider,
+      : sync.data.provider.filter((provider) => provider.id !== AgencySwarmOllama.PROVIDER_ID),
   )
   // Treat framework mode as "not connected" when no agency-supported provider is usable,
   // so the disconnected fallback (filtered popular providers) keeps `/models` actionable
@@ -73,7 +77,7 @@ export function DialogModel(props: { providerID?: string }) {
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
             footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
             onSelect: () => {
-              onSelect(provider.id, model.id)
+              void onSelect(provider.id, model.id)
             },
           },
         ]
@@ -110,7 +114,7 @@ export function DialogModel(props: { providerID?: string }) {
             disabled: provider.id === "opencode" && model.includes("-nano"),
             footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
             onSelect() {
-              onSelect(provider.id, model)
+              void onSelect(provider.id, model)
             },
           })),
           filter((x) => {
@@ -160,7 +164,50 @@ export function DialogModel(props: { providerID?: string }) {
     return value.name
   })
 
-  function onSelect(providerID: string, modelID: string) {
+  async function onSelect(providerID: string, modelID: string) {
+    if (frameworkMode && providerID === AgencySwarmOllama.PROVIDER_ID) {
+      try {
+        await AgencySwarmOllama.ensure(modelID, {
+          onServerStart() {
+            toast.show({
+              variant: "info",
+              message: "Starting Ollama server...",
+              duration: 5000,
+            })
+          },
+        })
+      } catch (error) {
+        if (AgencySwarmOllama.isMissingModelError(error)) {
+          const downloaded = await downloadOllamaModel({
+            dialog,
+            toast,
+            modelID,
+          })
+          if (!downloaded) return
+        } else {
+          toast.show({
+            variant: "warning",
+            message: error instanceof Error ? error.message : String(error),
+            duration: 8000,
+          })
+          return
+        }
+      }
+      try {
+        await AgencySwarmOllama.ensure(modelID)
+      } catch (error) {
+        toast.show({
+          variant: "warning",
+          message: AgencySwarmOllama.isMissingModelError(error)
+            ? AgencySwarmOllama.formatMissingModelInstallHint(modelID)
+            : error instanceof Error
+              ? error.message
+              : String(error),
+          duration: 8000,
+        })
+        return
+      }
+    }
     local.model.set({ providerID, modelID }, { recent: true, explicit: true })
     const list = local.model.variant.list()
     const cur = local.model.variant.selected()

--- a/packages/opencode/src/cli/cmd/tui/component/download-ollama-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/download-ollama-model.tsx
@@ -1,0 +1,103 @@
+import { TextAttributes } from "@opentui/core"
+import { createSignal, onMount } from "solid-js"
+import { AgencySwarmOllama } from "@/agency-swarm/ollama"
+import { useTheme } from "@tui/context/theme"
+import { DialogConfirm } from "../ui/dialog-confirm"
+import type { DialogContext } from "../ui/dialog"
+import type { ToastContext } from "../ui/toast"
+
+type PullProgress = AgencySwarmOllama.PullProgress
+
+export async function downloadOllamaModel(input: { dialog: DialogContext; toast: ToastContext; modelID: string }) {
+  const confirmed = await DialogConfirm.show(
+    input.dialog,
+    "Download model",
+    `${input.modelID} is not installed locally. Download it with Ollama now?`,
+    "skip",
+  )
+  if (!confirmed) return false
+
+  try {
+    await showOllamaDownloadDialog(input.dialog, input.modelID)
+    input.toast.show({
+      variant: "success",
+      message: `Downloaded ${input.modelID}`,
+      duration: 3000,
+    })
+    return true
+  } catch (error) {
+    input.dialog.clear()
+    input.toast.show({
+      variant: "error",
+      message: error instanceof Error ? error.message : String(error),
+      duration: 8000,
+    })
+    return false
+  }
+}
+
+function showOllamaDownloadDialog(dialog: DialogContext, modelID: string) {
+  return new Promise<void>((resolve, reject) => {
+    let done = false
+    dialog.replace(
+      () => (
+        <DialogOllamaModelDownload
+          modelID={modelID}
+          onDone={() => {
+            done = true
+            dialog.clear()
+            resolve()
+          }}
+          onError={(error) => {
+            done = true
+            reject(error)
+          }}
+        />
+      ),
+      () => {
+        if (!done) {
+          reject(new Error(`Download for ${modelID} was dismissed. The Ollama pull may still be running.`))
+        }
+      },
+    )
+  })
+}
+
+function DialogOllamaModelDownload(props: { modelID: string; onDone: () => void; onError: (error: unknown) => void }) {
+  const { theme } = useTheme()
+  const [progress, setProgress] = createSignal<PullProgress>({
+    status: "starting download",
+    percent: 0,
+  })
+
+  onMount(() => {
+    void AgencySwarmOllama.pullModel(props.modelID, {
+      onProgress(next) {
+        setProgress(next)
+      },
+    })
+      .then(props.onDone)
+      .catch(props.onError)
+  })
+
+  return (
+    <box paddingLeft={2} paddingRight={2} paddingBottom={1} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          Downloading {props.modelID}
+        </text>
+      </box>
+      <box paddingTop={1}>
+        <text fg={theme.text}>{AgencySwarmOllama.formatProgressBar(progress().percent)}</text>
+      </box>
+      <box>
+        <text fg={theme.textMuted} wrapMode="word" width="100%">
+          {progress().status}
+        </text>
+      </box>
+      <box paddingTop={1}>
+        <text fg={theme.textMuted}>Keep this window open until the download completes.</text>
+      </box>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/download-ollama-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/download-ollama-model.tsx
@@ -39,27 +39,32 @@ export async function downloadOllamaModel(input: { dialog: DialogContext; toast:
 function showOllamaDownloadDialog(dialog: DialogContext, modelID: string) {
   return new Promise<void>((resolve, reject) => {
     let done = false
-    dialog.replace(
-      () => (
-        <DialogOllamaModelDownload
-          modelID={modelID}
-          onDone={() => {
-            done = true
-            dialog.clear()
+    let active = true
+    let render: (() => unknown) | undefined
+    render = () => (
+      <DialogOllamaModelDownload
+        modelID={modelID}
+        onDone={() => {
+          done = true
+          if (!active || dialog.stack.at(-1)?.element !== render) {
             resolve()
-          }}
-          onError={(error) => {
-            done = true
-            reject(error)
-          }}
-        />
-      ),
-      () => {
-        if (!done) {
-          reject(new Error(`Download for ${modelID} was dismissed. The Ollama pull may still be running.`))
-        }
-      },
+            return
+          }
+          dialog.clear()
+          resolve()
+        }}
+        onError={(error) => {
+          done = true
+          reject(error)
+        }}
+      />
     )
+    dialog.replace(render, () => {
+      active = false
+      if (!done) {
+        reject(new Error(`Download for ${modelID} was dismissed. The Ollama pull may still be running.`))
+      }
+    })
   })
 }
 

--- a/packages/opencode/src/cli/cmd/tui/component/download-ollama-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/download-ollama-model.tsx
@@ -8,6 +8,8 @@ import type { ToastContext } from "../ui/toast"
 
 type PullProgress = AgencySwarmOllama.PullProgress
 
+class OllamaDownloadDismissedError extends Error {}
+
 export async function downloadOllamaModel(input: { dialog: DialogContext; toast: ToastContext; modelID: string }) {
   const confirmed = await DialogConfirm.show(
     input.dialog,
@@ -26,7 +28,9 @@ export async function downloadOllamaModel(input: { dialog: DialogContext; toast:
     })
     return true
   } catch (error) {
-    input.dialog.clear()
+    if (!(error instanceof OllamaDownloadDismissedError)) {
+      input.dialog.clear()
+    }
     input.toast.show({
       variant: "error",
       message: error instanceof Error ? error.message : String(error),
@@ -62,7 +66,11 @@ function showOllamaDownloadDialog(dialog: DialogContext, modelID: string) {
     dialog.replace(render, () => {
       active = false
       if (!done) {
-        reject(new Error(`Download for ${modelID} was dismissed. The Ollama pull may still be running.`))
+        reject(
+          new OllamaDownloadDismissedError(
+            `Download for ${modelID} was dismissed. The Ollama pull may still be running.`,
+          ),
+        )
       }
     })
   })

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1022,6 +1022,7 @@ export function Prompt(props: PromptProps) {
     set(prompt) {
       input.setText(prompt.input)
       setStore("prompt", prompt)
+      if (prompt.mode) setStore("mode", prompt.mode)
       restoreExtmarksFromParts(prompt.parts)
       input.gotoBufferEnd()
     },
@@ -1455,6 +1456,7 @@ export function Prompt(props: PromptProps) {
       return true
     }
 
+    const currentMode = store.mode
     const selectedModel = local.model.current()
     if (!selectedModel) {
       void promptModelWarning()
@@ -1479,7 +1481,7 @@ export function Prompt(props: PromptProps) {
       selectedModel.providerID === "openrouter"
         ? Object.fromEntries(openrouterEnvNames.map((name) => [name, process.env[name]]))
         : process.env
-    if (frameworkMode() && AgencySwarmOllama.isModel(selectedModel)) {
+    if (currentMode !== "shell" && frameworkMode() && AgencySwarmOllama.isModel(selectedModel)) {
       try {
         await AgencySwarmOllama.ensure(selectedModel.modelID, {
           onServerStart() {
@@ -1510,7 +1512,6 @@ export function Prompt(props: PromptProps) {
     }
     const productProviderID = frameworkMode() ? AgencySwarmAdapter.PROVIDER_ID : selectedModel.providerID
 
-    const currentMode = store.mode
     const variant = local.model.variant.current()
     const serverSlashCommand = inputText.startsWith("/")
       ? iife(() => {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -61,8 +61,10 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { createFadeIn } from "../../util/signal"
 import { DialogSkill } from "../dialog-skill"
+import { downloadOllamaModel } from "../download-ollama-model"
 import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "@tui/util/provider-origin"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { AgencySwarmOllama } from "@/agency-swarm/ollama"
 import { AgencySwarmRunSession } from "@/agency-swarm/run-session"
 import {
   describeAgencyAuthFailure,
@@ -1477,6 +1479,35 @@ export function Prompt(props: PromptProps) {
       selectedModel.providerID === "openrouter"
         ? Object.fromEntries(openrouterEnvNames.map((name) => [name, process.env[name]]))
         : process.env
+    if (frameworkMode() && AgencySwarmOllama.isModel(selectedModel)) {
+      try {
+        await AgencySwarmOllama.ensure(selectedModel.modelID, {
+          onServerStart() {
+            toast.show({
+              variant: "info",
+              message: "Starting Ollama server...",
+              duration: 5000,
+            })
+          },
+        })
+      } catch (error) {
+        if (AgencySwarmOllama.isMissingModelError(error)) {
+          const downloaded = await downloadOllamaModel({
+            dialog,
+            toast,
+            modelID: selectedModel.modelID,
+          })
+          if (!downloaded) return false
+        } else {
+          toast.show({
+            variant: "warning",
+            message: error instanceof Error ? error.message : String(error),
+            duration: 8000,
+          })
+          return false
+        }
+      }
+    }
     const productProviderID = frameworkMode() ? AgencySwarmAdapter.PROVIDER_ID : selectedModel.providerID
 
     const currentMode = store.mode

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1539,7 +1539,7 @@ export function Prompt(props: PromptProps) {
 
     if (
       shouldBlockAgencyPromptSubmit({
-        currentProviderID: productProviderID,
+        currentProviderID: selectedModel.providerID,
         configuredModel: sync.data.config.model,
         agentModel: local.agent.current()?.model,
         providers: authProviders,

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -3,7 +3,6 @@ import { createEffect, createSignal, onMount } from "solid-js"
 import { Logo } from "../component/logo"
 import { useProject } from "../context/project"
 import { useSync } from "../context/sync"
-import { Toast } from "../ui/toast"
 import { useArgs } from "../context/args"
 import { useRouteData } from "@tui/context/route"
 import { usePromptRef } from "../context/prompt"
@@ -86,7 +85,6 @@ export function Home() {
         </box>
         <TuiPluginRuntime.Slot name="home_bottom" />
         <box flexGrow={1} minHeight={0} />
-        <Toast />
       </box>
       <box width="100%" flexShrink={0}>
         <TuiPluginRuntime.Slot name="home_footer" mode="single_winner" />

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -1,5 +1,6 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { hasClientConfigCredential } from "@/agency-swarm/client-config"
+import { AgencySwarmOllama } from "@/agency-swarm/ollama"
 import { isAgencySwarmRunMode, type AgencySwarmRunModeInput } from "@/agency-swarm/run-mode"
 import { isLocalAgencyURL } from "@/session/agency-swarm-client-config"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -26,6 +27,7 @@ const log = Log.create({ service: "tui.session-error" })
  */
 export function isAgencySupportedProvider(providerID: string) {
   if (providerID === AgencySwarmAdapter.PROVIDER_ID) return true
+  if (providerID === AgencySwarmOllama.PROVIDER_ID) return true
   return (AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS as readonly string[]).includes(providerID)
 }
 
@@ -173,6 +175,7 @@ export function shouldOpenStartupAuthDialog(input: {
   providers: Provider[]
   providerAuth?: ProviderAuthMap
   frameworkMode: boolean
+  currentProviderID?: string
   /** Override for the upstream-credential forwarding path; when undefined the value is inferred from env + provider options. */
   forwardUpstreamCredentials?: boolean
   /** Process env snapshot; production callers pass `process.env`, tests pass a controlled map. */
@@ -182,6 +185,7 @@ export function shouldOpenStartupAuthDialog(input: {
 
   const env = input.env ?? {}
   const agencyProvider = input.providers.find((provider) => provider.id === AgencySwarmAdapter.PROVIDER_ID)
+  if (input.currentProviderID === AgencySwarmOllama.PROVIDER_ID) return false
   const forwardingActive = isForwardUpstreamCredentialsActive(input.providers, input.forwardUpstreamCredentials)
 
   // Explicit client_config on the agency-swarm provider carries upstream creds and satisfies either mode.
@@ -209,6 +213,7 @@ export function shouldBlockAgencyPromptSend(input: {
     providers: input.providers,
     providerAuth: input.providerAuth,
     frameworkMode: true,
+    currentProviderID: input.currentProviderID,
     env: input.env,
   })
 }

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -26,6 +26,7 @@ export function Toast() {
           alignItems="flex-start"
           top={2}
           right={2}
+          zIndex={4000}
           maxWidth={Math.min(60, dimensions().width - 6)}
           paddingLeft={2}
           paddingRight={2}

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1256,7 +1256,7 @@ function createOllamaProvider(): Info {
           family: "ollama",
           api: {
             id: modelID,
-            url: "http://127.0.0.1:11434",
+            url: "http://127.0.0.1:11434/v1",
             npm: "@ai-sdk/openai-compatible",
           },
           status: "active" as const,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -28,6 +28,7 @@ import { ModelID, ProviderID } from "./schema"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import { AgencySwarmOllama } from "@/agency-swarm/ollama"
 
 const log = Log.create({ service: "provider" })
 
@@ -1229,6 +1230,87 @@ function createAgencySwarmProvider(): Info {
   }
 }
 
+function createOllamaProvider(): Info {
+  const providerID = ProviderID.make(AgencySwarmOllama.PROVIDER_ID)
+  const names = [
+    ["gemma4:e4b", "Gemma 4 E4B"],
+    ["gemma3:4b", "Gemma 3 4B"],
+    ["gemma3:12b", "Gemma 3 12B"],
+    ["llama3.2:3b", "Llama 3.2 3B"],
+    ["llama3.1:8b", "Llama 3.1 8B"],
+    ["qwen3:4b", "Qwen 3 4B"],
+    ["qwen3:8b", "Qwen 3 8B"],
+    ["mistral:7b", "Mistral 7B"],
+    ["deepseek-r1:7b", "DeepSeek R1 7B"],
+    ["phi4-mini:3.8b", "Phi 4 Mini"],
+  ] as const
+  const models = Object.fromEntries(
+    names.map(([id, name]) => {
+      const modelID = ModelID.make(id)
+      return [
+        modelID,
+        {
+          id: modelID,
+          providerID,
+          name,
+          family: "ollama",
+          api: {
+            id: modelID,
+            url: "http://127.0.0.1:11434",
+            npm: "@ai-sdk/openai-compatible",
+          },
+          status: "active" as const,
+          headers: {},
+          options: {},
+          cost: {
+            input: 0,
+            output: 0,
+            cache: {
+              read: 0,
+              write: 0,
+            },
+          },
+          limit: {
+            context: 128_000,
+            output: 8_192,
+          },
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: true,
+            input: {
+              text: true,
+              audio: false,
+              image: false,
+              video: false,
+              pdf: false,
+            },
+            output: {
+              text: true,
+              audio: false,
+              image: false,
+              video: false,
+              pdf: false,
+            },
+            interleaved: false,
+          },
+          release_date: "",
+          variants: {},
+        },
+      ]
+    }),
+  )
+  return {
+    id: providerID,
+    name: "Ollama",
+    source: "config",
+    env: [],
+    options: {},
+    models,
+  }
+}
+
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -1249,6 +1331,7 @@ export const layer = Layer.effect(
         const catalog = mapValues(modelsDev, fromModelsDevProvider)
         const database = mapValues(catalog, toPublicInfo)
         database[AgencySwarmAdapter.PROVIDER_ID] = createAgencySwarmProvider()
+        database[AgencySwarmOllama.PROVIDER_ID] = createOllamaProvider()
 
         const providers: Record<ProviderID, Info> = {} as Record<ProviderID, Info>
         const languages = new Map<string, LanguageModelV3>()
@@ -1475,6 +1558,18 @@ export const layer = Layer.effect(
           if (provider.name) partial.name = provider.name
           if (provider.options) partial.options = provider.options
           mergeProvider(providerID, partial)
+        }
+
+        const agencySwarmProviderID = ProviderID.make(AgencySwarmAdapter.PROVIDER_ID)
+        const ollamaProviderID = ProviderID.make(AgencySwarmOllama.PROVIDER_ID)
+        const shouldLoadOllamaProvider =
+          isProviderAllowed(ollamaProviderID) &&
+          !providers[ollamaProviderID] &&
+          (providers[agencySwarmProviderID] !== undefined ||
+            cfg.model === `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`)
+
+        if (shouldLoadOllamaProvider) {
+          mergeProvider(ollamaProviderID, { source: "config" })
         }
 
         const gitlab = ProviderID.make("gitlab")

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -1,6 +1,7 @@
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { AgencySwarmHistory } from "@/agency-swarm/history"
 import { buildLitellmModelForClientConfig } from "@/agency-swarm/litellm-provider"
+import { AgencySwarmOllama } from "@/agency-swarm/ollama"
 import { Provider } from "@/provider/provider"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionID } from "@/session/schema"
@@ -422,10 +423,14 @@ export namespace SessionAgencySwarm {
         configuredRecipientSelectedAt: input.options.recipientAgentSelectedAt,
         loadSessionMessages: input.loadSessionMessages,
       })
+      const sessionModel = input.sessionModel
       const sessionLitellmModel =
         input.sessionModel &&
         buildLitellmModelForClientConfig(input.sessionModel.providerID, input.sessionModel.modelID)
       const sessionModelSettingsExtraArgs = normalizeVariantOptionsForClientConfig(input.sessionModel)
+      if (sessionModel?.providerID === AgencySwarmOllama.PROVIDER_ID) {
+        await AgencySwarmOllama.ensure(sessionModel.modelID)
+      }
       const clientConfig = await resolveClientConfig(
         input.options.baseURL,
         agency,

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -428,7 +428,7 @@ export namespace SessionAgencySwarm {
         input.sessionModel &&
         buildLitellmModelForClientConfig(input.sessionModel.providerID, input.sessionModel.modelID)
       const sessionModelSettingsExtraArgs = normalizeVariantOptionsForClientConfig(input.sessionModel)
-      if (sessionModel?.providerID === AgencySwarmOllama.PROVIDER_ID) {
+      if (sessionModel?.providerID === AgencySwarmOllama.PROVIDER_ID && isLocalAgencyURL(input.options.baseURL)) {
         await AgencySwarmOllama.ensure(sessionModel.modelID)
       }
       const clientConfig = await resolveClientConfig(

--- a/packages/opencode/test/agency-swarm/client-config.test.ts
+++ b/packages/opencode/test/agency-swarm/client-config.test.ts
@@ -123,6 +123,11 @@ describe("agency-swarm litellm model routing", () => {
     expect(buildLitellmModelForClientConfig("anthropic", "anthropic/claude-3")).toBe("litellm/anthropic/claude-3")
   })
 
+  test("buildLitellmModelForClientConfig routes Ollama selections through ollama_chat", () => {
+    expect(buildLitellmModelForClientConfig("ollama", "gemma4:e4b")).toBe("litellm/ollama_chat/gemma4:e4b")
+    expect(buildLitellmModelForClientConfig("ollama", "ollama_chat/gemma4:e4b")).toBe("litellm/ollama_chat/gemma4:e4b")
+  })
+
   test("normalizeExplicitClientConfigModel preserves non-OpenAI provider namespaces", () => {
     expect(normalizeExplicitClientConfigModel("openrouter/openai/gpt-5.2")).toBe("openrouter/openai/gpt-5.2")
     expect(normalizeExplicitClientConfigModel("litellm/openrouter/openai/gpt-5.2")).toBe(

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1879,15 +1879,21 @@ describe("agency-swarm npx onboarding", () => {
       throw new Error(`Unexpected command: ${cmd.join(" ")}`)
     })
 
+    let launchSettled = false
     const launchPromise = prepareProjectLaunch({
       directory: dir.path,
       agencyFile: path.join(dir.path, "agency.py"),
       moduleName: "agency",
+    }).finally(() => {
+      launchSettled = true
     })
 
     let launch: Awaited<ReturnType<typeof prepareProjectLaunch>>
     try {
-      await new Promise((resolve) => realSetTimeout(resolve, 20))
+      const deadline = Date.now() + 1000
+      while (timers.length === 0 && !launchSettled && Date.now() < deadline) {
+        await new Promise((resolve) => realSetTimeout(resolve, 5))
+      }
 
       expect(timers).not.toHaveLength(0)
       expect(timers[0]?.cleared).toBe(true)

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1812,6 +1812,13 @@ describe("agency-swarm npx onboarding", () => {
     const clearTimeoutSpy = spyOn(globalThis, "clearTimeout").mockImplementation(((timer: { cleared?: boolean }) => {
       timer.cleared = true
     }) as unknown as typeof clearTimeout)
+    let restored = false
+    const restoreTimers = () => {
+      if (restored) return
+      setTimeoutSpy.mockRestore()
+      clearTimeoutSpy.mockRestore()
+      restored = true
+    }
     spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
 
     const installStderr = createTextOutputStream("install finished\n")
@@ -1878,19 +1885,25 @@ describe("agency-swarm npx onboarding", () => {
       moduleName: "agency",
     })
 
-    await new Promise((resolve) => realSetTimeout(resolve, 20))
+    let launch: Awaited<ReturnType<typeof prepareProjectLaunch>>
+    try {
+      await new Promise((resolve) => realSetTimeout(resolve, 20))
 
-    expect(timers).not.toHaveLength(0)
-    expect(timers[0]?.cleared).toBe(true)
-    const installTimeout = timers[0]
-    if (typeof installTimeout?.fn !== "function") throw new Error("Expected install timeout callback")
-    await installTimeout.fn()
+      expect(timers).not.toHaveLength(0)
+      expect(timers[0]?.cleared).toBe(true)
+      const installTimeout = timers[0]
+      if (typeof installTimeout?.fn !== "function") throw new Error("Expected install timeout callback")
+      await installTimeout.fn()
+      restoreTimers()
+      installStderr.close()
 
-    setTimeoutSpy.mockRestore()
-    clearTimeoutSpy.mockRestore()
-    installStderr.close()
-    const launch = await launchPromise
-    await launch?.cleanup?.()
+      launch = await launchPromise
+    } finally {
+      restoreTimers()
+      installStderr.close()
+      launch ??= await launchPromise.catch(() => undefined)
+      await launch?.cleanup?.()
+    }
   })
 
   test("prepareProjectLaunch keeps refresh failures compact and logged", async () => {

--- a/packages/opencode/test/agency-swarm/ollama-live.e2e.test.ts
+++ b/packages/opencode/test/agency-swarm/ollama-live.e2e.test.ts
@@ -54,7 +54,7 @@ describe("agency-swarm live Ollama e2e", () => {
         parts: [
           {
             type: "text",
-            text: "Return exactly OLLAMA_E2E_OK and no other text.",
+            text: "Return exactly OK and no other text.",
             ignored: false,
           },
         ],
@@ -75,6 +75,6 @@ describe("agency-swarm live Ollama e2e", () => {
       if (event.type === "text-delta") text.push(event.text)
     }
 
-    expect(text.join("")).toContain("OLLAMA_E2E_OK")
+    expect(text.join("").trim()).toBe("OK")
   })
 })

--- a/packages/opencode/test/agency-swarm/ollama-live.e2e.test.ts
+++ b/packages/opencode/test/agency-swarm/ollama-live.e2e.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test"
+import { AgencySwarmHistory } from "../../src/agency-swarm/history"
+import { SessionAgencySwarm } from "../../src/session/agency-swarm"
+import { MessageID, SessionID } from "../../src/session/schema"
+
+const live = process.env["AGENTSWARM_LIVE_OLLAMA_E2E"] === "1" ? test : test.skip
+
+describe("agency-swarm live Ollama e2e", () => {
+  live("streams a selected Ollama model through the Agency Swarm bridge", async () => {
+    const sessionID = SessionID.descending()
+    const userID = MessageID.ascending()
+    const assistantID = MessageID.ascending()
+    AgencySwarmHistory.load = async () => ({
+      scope: "manual",
+      chat_history: [],
+      updated_at: Date.now(),
+    })
+    AgencySwarmHistory.appendMessages = async (_scope, messages) => ({
+      scope: "manual",
+      chat_history: Array.isArray(messages) ? messages : [],
+      updated_at: Date.now(),
+    })
+    AgencySwarmHistory.setLastRunID = async (_scope, runID) => ({
+      scope: "manual",
+      chat_history: [],
+      last_run_id: runID,
+      updated_at: Date.now(),
+    })
+
+    const stream = await SessionAgencySwarm.stream({
+      sessionID,
+      assistantMessage: {
+        id: assistantID,
+        parentID: userID,
+        role: "assistant",
+        mode: "Default",
+        agent: "Default",
+        path: { cwd: process.cwd(), root: process.cwd() },
+        cost: 0,
+        tokens: {
+          total: 0,
+          input: 0,
+          output: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: "qwen2.5:0.5b",
+        providerID: "ollama",
+        time: { created: Date.now() },
+        sessionID,
+      } as unknown as SessionAgencySwarm.StreamInput["assistantMessage"],
+      userMessage: {
+        info: { id: userID, role: "user" },
+        parts: [
+          {
+            type: "text",
+            text: "Return exactly OLLAMA_E2E_OK and no other text.",
+            ignored: false,
+          },
+        ],
+      } as unknown as SessionAgencySwarm.StreamInput["userMessage"],
+      options: {
+        baseURL: process.env["AGENTSWARM_LIVE_AGENCY_URL"] ?? "http://127.0.0.1:8765",
+        agency: process.env["AGENTSWARM_LIVE_AGENCY_ID"] ?? "local",
+        discoveryTimeoutMs: 5000,
+      },
+      abort: new AbortController().signal,
+      sessionModel: { providerID: "ollama", modelID: "qwen2.5:0.5b" },
+      loadSessionMessages: async () => [],
+      updateSessionMessage: async (message) => message,
+    })
+
+    const text: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "text-delta") text.push(event.text)
+    }
+
+    expect(text.join("")).toContain("OLLAMA_E2E_OK")
+  })
+})

--- a/packages/opencode/test/agency-swarm/ollama.test.ts
+++ b/packages/opencode/test/agency-swarm/ollama.test.ts
@@ -13,6 +13,17 @@ describe("AgencySwarmOllama", () => {
     expect(AgencySwarmOllama.isModelListed("qwen3:4b", tags)).toBe(false)
   })
 
+  test("isModelListed treats tagless names as latest", () => {
+    const tags = {
+      models: [{ name: "llama3.2:latest" }, { model: "qwen2.5:latest" }],
+    }
+
+    expect(AgencySwarmOllama.isModelListed("llama3.2", tags)).toBe(true)
+    expect(AgencySwarmOllama.isModelListed("qwen2.5", tags)).toBe(true)
+    expect(AgencySwarmOllama.isModelListed("llama3.2:latest", tags)).toBe(true)
+    expect(AgencySwarmOllama.isModelListed("llama3.2:3b", tags)).toBe(false)
+  })
+
   test("parsePullProgress reads Ollama JSON progress", () => {
     expect(AgencySwarmOllama.parsePullProgress('{"status":"downloading","completed":50,"total":200}')).toEqual({
       status: "downloading",

--- a/packages/opencode/test/agency-swarm/ollama.test.ts
+++ b/packages/opencode/test/agency-swarm/ollama.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { AgencySwarmOllama } from "../../src/agency-swarm/ollama"
+
+describe("AgencySwarmOllama", () => {
+  test("isModelListed matches Ollama tag names and model ids", () => {
+    const tags = {
+      models: [{ name: "gemma4:e4b", model: "gemma4:e4b" }, { name: "qwen3:8b" }, { model: "llama3.1:8b" }],
+    }
+
+    expect(AgencySwarmOllama.isModelListed("gemma4:e4b", tags)).toBe(true)
+    expect(AgencySwarmOllama.isModelListed("qwen3:8b", tags)).toBe(true)
+    expect(AgencySwarmOllama.isModelListed("llama3.1:8b", tags)).toBe(true)
+    expect(AgencySwarmOllama.isModelListed("qwen3:4b", tags)).toBe(false)
+  })
+
+  test("parsePullProgress reads Ollama JSON progress", () => {
+    expect(AgencySwarmOllama.parsePullProgress('{"status":"downloading","completed":50,"total":200}')).toEqual({
+      status: "downloading",
+      completed: 50,
+      total: 200,
+      percent: 25,
+    })
+  })
+
+  test("parsePullProgress reads CLI percent progress", () => {
+    expect(AgencySwarmOllama.parsePullProgress("pulling manifest 42%")).toEqual({
+      status: "pulling manifest 42%",
+      percent: 42,
+    })
+  })
+
+  test("formatProgressBar renders known and unknown progress", () => {
+    expect(AgencySwarmOllama.formatProgressBar(undefined)).toBe("[--------------------] --%")
+    expect(AgencySwarmOllama.formatProgressBar(25)).toBe("[#####---------------] 25%")
+  })
+})

--- a/packages/opencode/test/agency-swarm/session-runtime.test.ts
+++ b/packages/opencode/test/agency-swarm/session-runtime.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { AgencySwarmAdapter } from "../../src/agency-swarm/adapter"
 import { AgencySwarmHistory } from "../../src/agency-swarm/history"
+import { AgencySwarmOllama } from "../../src/agency-swarm/ollama"
 import { CODEX_API_BASE_URL } from "../../src/plugin/codex"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session/index"
@@ -130,6 +131,27 @@ describe("session.agency-swarm runtime history", () => {
       [{ type: "input_text", text: "queued follow up" }],
       [{ type: "output_text", text: "queued answer" }],
     ])
+  })
+
+  test("stream skips local Ollama checks for remote Agency backends", async () => {
+    const ensure = spyOn(AgencySwarmOllama, "ensure").mockRejectedValue(new Error("local Ollama should not be checked"))
+    let clientConfig: Record<string, unknown> | undefined
+
+    stubSessionMessages([userMessage("current", "remote ollama", 1)])
+    mockHistory([])
+    AgencySwarmAdapter.streamRun = async function* (args) {
+      clientConfig = args.clientConfig as Record<string, unknown>
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = makeInput("current", "remote ollama")
+    input.options.baseURL = "https://agency.example"
+    input.sessionModel = { providerID: "ollama", modelID: "llama3.2" }
+
+    await consumeStream(input)
+
+    expect(ensure).not.toHaveBeenCalled()
+    expect(clientConfig?.["model"]).toBe("litellm/ollama_chat/llama3.2")
   })
 
   test("stream rebuilds local history when stored history has only tool items", async () => {

--- a/packages/opencode/test/cli/tui/dialog-model.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-model.test.tsx
@@ -104,4 +104,100 @@ describe("DialogModel framework mode", () => {
 
     expect(selectProps?.actions?.[0]?.title).toBe("Manage provider auth")
   })
+
+  test("native mode keeps custom ollama providers visible", async () => {
+    let selectProps: DialogSelectModule.DialogSelectProps<any> | undefined
+
+    spyOn(DialogSelectModule, "DialogSelect").mockImplementation((props: any) => {
+      selectProps = props
+      return <box />
+    })
+    spyOn(DialogContext, "useDialog").mockReturnValue({
+      clear: mock(() => undefined),
+      replace: mock(() => undefined),
+      stack: [],
+      size: "medium",
+      setSize: mock(() => undefined),
+    } as any)
+    spyOn(DialogModelConnectedModule, "useConnected").mockReturnValue(() => true)
+    spyOn(SDKContext, "useSDK").mockReturnValue({ client: {} } as any)
+    spyOn(ToastContext, "useToast").mockReturnValue({
+      show: mock(() => undefined),
+      error: mock(() => undefined),
+      currentToast: null,
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {},
+    } as any)
+    spyOn(KeybindContext, "useKeybind").mockReturnValue({
+      all: {
+        model_provider_list: ["ctrl+a"],
+        model_favorite_toggle: ["ctrl+f"],
+      },
+    } as any)
+    spyOn(LocalContext, "useLocal").mockReturnValue({
+      agent: {
+        current: () => ({
+          name: "build",
+          model: {
+            providerID: "openai",
+            modelID: "gpt-4o",
+          },
+        }),
+      },
+      model: {
+        current: () => ({
+          providerID: "openai",
+          modelID: "gpt-4o",
+        }),
+        favorite: () => [],
+        recent: () => [],
+        set: mock(() => undefined),
+        toggleFavorite: mock(() => undefined),
+        variant: {
+          selected: () => undefined,
+          list: () => [],
+        },
+      },
+    } as any)
+    spyOn(SyncContext, "useSync").mockReturnValue({
+      data: {
+        config: {
+          model: "openai/gpt-4o",
+        },
+        provider_next: {
+          all: [
+            {
+              id: "ollama",
+              name: "Ollama",
+            },
+          ],
+          connected: ["ollama"],
+        },
+        console_state: {
+          consoleManagedProviders: [],
+        },
+        provider: [
+          {
+            id: "ollama",
+            name: "Ollama",
+            models: {
+              local: {
+                id: "local",
+                name: "Local",
+                providerID: "ollama",
+                status: "active",
+                cost: { input: 0 },
+              },
+            },
+          },
+        ],
+      },
+    } as any)
+
+    const { DialogModel } = await import("../../../src/cli/cmd/tui/component/dialog-model")
+    await testRender(() => <DialogModel />)
+
+    expect(selectProps?.options.some((option) => option.value.providerID === "ollama")).toBe(true)
+  })
 })

--- a/packages/opencode/test/cli/tui/download-ollama-model.test.ts
+++ b/packages/opencode/test/cli/tui/download-ollama-model.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { downloadOllamaModel } from "../../../src/cli/cmd/tui/component/download-ollama-model"
+import { DialogConfirm } from "../../../src/cli/cmd/tui/ui/dialog-confirm"
+import type { DialogContext } from "../../../src/cli/cmd/tui/ui/dialog"
+import type { ToastContext } from "../../../src/cli/cmd/tui/ui/toast"
+
+describe("downloadOllamaModel", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test("does not clear a newer dialog after the download dialog is dismissed", async () => {
+    spyOn(DialogConfirm, "show").mockResolvedValue(true)
+
+    const stack: DialogContext["stack"] = []
+    const clear = mock(() => {
+      stack.splice(0, stack.length)
+    })
+    const newer = {} as DialogContext["stack"][number]["element"]
+    const dialog = {
+      clear,
+      replace: (_element: DialogContext["stack"][number]["element"], onClose?: () => void) => {
+        stack.splice(0, stack.length, { element: newer })
+        queueMicrotask(() => onClose?.())
+      },
+      get stack() {
+        return stack
+      },
+      get size() {
+        return "medium" as const
+      },
+      setSize: () => {},
+    } satisfies DialogContext
+    const toast = {
+      show: mock(() => {}),
+      error: mock(() => {}),
+      currentToast: null,
+    } as unknown as ToastContext
+
+    const result = await downloadOllamaModel({
+      dialog,
+      toast,
+      modelID: "qwen2.5:0.5b",
+    })
+
+    expect(result).toBe(false)
+    expect(clear).not.toHaveBeenCalled()
+    expect(toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "error",
+        message: "Download for qwen2.5:0.5b was dismissed. The Ollama pull may still be running.",
+      }),
+    )
+    expect(stack).toHaveLength(1)
+  })
+})

--- a/packages/opencode/test/cli/tui/prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt.test.tsx
@@ -27,6 +27,7 @@ import * as PromptStashModule from "../../../src/cli/cmd/tui/component/prompt/st
 import * as TextareaKeybindingsModule from "@tui/component/textarea-keybindings"
 import { DialogProvider, useDialog } from "../../../src/cli/cmd/tui/ui/dialog"
 import * as ToastModule from "../../../src/cli/cmd/tui/ui/toast"
+import { AgencySwarmOllama } from "../../../src/agency-swarm/ollama"
 import { AgencySwarmRunSession } from "../../../src/agency-swarm/run-session"
 import { Telemetry } from "../../../src/telemetry/telemetry"
 import { OpencodeKeymapProvider } from "../../../src/cli/cmd/tui/keymap"
@@ -101,13 +102,15 @@ describe("prompt auth rejection handling", () => {
   async function renderTelemetryPrompt(input: {
     events: ReturnType<typeof createEventBus>
     frameworkMode?: boolean
+    openaiCredential?: boolean
     openrouterEnv?: string[]
     selectedModel?: { providerID: string; modelID: string }
     prompt: (input: { messageID: string; sessionID: string }) => Promise<unknown>
     sessionID: string
     workspaceID: string
   }) {
-    process.env.OPENAI_API_KEY = "sk-test"
+    if (input.openaiCredential === false) delete process.env.OPENAI_API_KEY
+    else process.env.OPENAI_API_KEY = "sk-test"
     const agency = input.frameworkMode ?? true
     const model = agency ? "agency-swarm/default" : "openai/gpt-4.1"
     const providerID = agency ? "agency-swarm" : "openai"
@@ -252,6 +255,18 @@ describe("prompt auth rejection handling", () => {
                 },
               ]
             : []),
+          ...(selectedModel.providerID === "ollama"
+            ? [
+                {
+                  id: "ollama",
+                  name: "Ollama",
+                  source: "config",
+                  env: [],
+                  options: {},
+                  models: {},
+                },
+              ]
+            : []),
         ],
         provider_auth: {},
         provider_next: {
@@ -349,6 +364,33 @@ describe("prompt auth rejection handling", () => {
     await flushEffects()
 
     expect(promptSession).not.toHaveBeenCalled()
+  })
+
+  test("submits selected Ollama prompts without upstream credentials", async () => {
+    const ensure = spyOn(AgencySwarmOllama, "ensure").mockResolvedValue(undefined)
+    const { promptRef, promptSession } = await renderTelemetryPrompt({
+      events: createEventBus(),
+      openaiCredential: false,
+      selectedModel: {
+        providerID: "ollama",
+        modelID: "llama3.2",
+      },
+      prompt: async () => ({ data: {} }),
+      sessionID: "session_ollama_auth_guard_allowed",
+      workspaceID: "workspace_ollama_auth_guard_allowed",
+    })
+
+    promptRef.set({
+      input: "use ollama",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef.submit()
+    await flushEffects()
+
+    expect(ensure).toHaveBeenCalledWith("llama3.2", expect.any(Object))
+    expect(promptSession).toHaveBeenCalledTimes(1)
   })
 
   test("submits selected OpenRouter prompts when custom OpenRouter env credentials exist", async () => {

--- a/packages/opencode/test/cli/tui/prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt.test.tsx
@@ -125,6 +125,12 @@ describe("prompt auth rejection handling", () => {
       },
       "prompt",
     )
+    const shellSession = spyOn(
+      {
+        shell: async () => ({}),
+      },
+      "shell",
+    )
 
     spyOn(AgencySwarmRunSession, "sync").mockResolvedValue(undefined)
     spyOn(AutocompleteModule, "Autocomplete").mockImplementation((props: any) => {
@@ -216,6 +222,7 @@ describe("prompt auth rejection handling", () => {
       client: {
         session: {
           prompt: promptSession,
+          shell: shellSession,
         },
       },
       event: input.events,
@@ -338,7 +345,7 @@ describe("prompt auth rejection handling", () => {
     ))
 
     expect(promptRef).toBeDefined()
-    return { parts, promptRef: promptRef!, promptSession }
+    return { parts, promptRef: promptRef!, promptSession, shellSession }
   }
 
   test("blocks selected OpenRouter prompts when only OpenAI env credentials exist", async () => {
@@ -391,6 +398,35 @@ describe("prompt auth rejection handling", () => {
 
     expect(ensure).toHaveBeenCalledWith("llama3.2", expect.any(Object))
     expect(promptSession).toHaveBeenCalledTimes(1)
+  })
+
+  test("submits selected Ollama shell commands without local model setup", async () => {
+    const ensure = spyOn(AgencySwarmOllama, "ensure").mockRejectedValue(new Error("missing model"))
+    const { promptRef, promptSession, shellSession } = await renderTelemetryPrompt({
+      events: createEventBus(),
+      openaiCredential: false,
+      selectedModel: {
+        providerID: "ollama",
+        modelID: "llama3.2",
+      },
+      prompt: async () => ({ data: {} }),
+      sessionID: "session_ollama_shell",
+      workspaceID: "workspace_ollama_shell",
+    })
+
+    promptRef.set({
+      input: "echo shell",
+      mode: "shell",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef.submit()
+    await flushEffects()
+
+    expect(ensure).not.toHaveBeenCalled()
+    expect(shellSession).toHaveBeenCalledTimes(1)
+    expect(promptSession).not.toHaveBeenCalled()
   })
 
   test("submits selected OpenRouter prompts when custom OpenRouter env credentials exist", async () => {

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -145,6 +145,33 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
+  test("framework mode skips provider auth when Ollama is selected", () => {
+    expect(
+      shouldOpenStartupAuthDialog({
+        frameworkMode: true,
+        currentProviderID: "ollama",
+        providers: [
+          {
+            id: "agency-swarm",
+            name: "Agency Swarm",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+          {
+            id: "ollama",
+            name: "Ollama",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
   test("framework mode skips local provider auth for remote agency-swarm backends", () => {
     expect(
       shouldOpenStartupAuthDialog({
@@ -1103,6 +1130,7 @@ describe("isAgencySupportedProvider (/models filter)", () => {
     { id: "xai", name: "xAI", source: "config", env: [], options: {}, models: {} },
     { id: "openrouter", name: "OpenRouter", source: "config", env: [], options: {}, models: {} },
     { id: "github-copilot", name: "GitHub Copilot", source: "config", env: [], options: {}, models: {} },
+    { id: "ollama", name: "Ollama", source: "config", env: [], options: {}, models: {} },
     { id: "openai", name: "OpenAI", source: "config", env: [], options: {}, models: {} },
     { id: "anthropic", name: "Anthropic", source: "config", env: [], options: {}, models: {} },
     { id: "agency-swarm", name: "Agent Swarm", source: "config", env: [], options: {}, models: {} },
@@ -1119,6 +1147,7 @@ describe("isAgencySupportedProvider (/models filter)", () => {
       "google",
       "xai",
       "openrouter",
+      "ollama",
       "openai",
       "anthropic",
       "agency-swarm",
@@ -1132,6 +1161,7 @@ describe("isAgencySupportedProvider (/models filter)", () => {
       "xai",
       "openrouter",
       "github-copilot",
+      "ollama",
       "openai",
       "anthropic",
       "agency-swarm",

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -806,6 +806,30 @@ test("provider api field sets model api.url", async () => {
   })
 })
 
+test("ollama provider uses Ollama's OpenAI-compatible v1 base URL", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          model: "agency-swarm/default",
+        }),
+      )
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const provider = providers[ProviderID.make("ollama")]
+
+      expect(provider).toBeDefined()
+      expect(provider.models["qwen3:4b"].api.url).toBe("http://127.0.0.1:11434/v1")
+    },
+  })
+})
+
 test("explicit baseURL overrides api field", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

N/A - `feat:` PR, issue check is skipped by this repo's PR workflow.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Ollama as a local model option for Agent Swarm Run mode.

The CLI can start an owned Ollama server, list local Ollama models, prompt for a missing local model download, and route selected Ollama models through the Agency Swarm LiteLLM client config without requiring cloud provider credentials.

Existing OpenAI, Anthropic, Gemini, Google, xAI, OpenRouter, shell, custom provider, and remote Agency Swarm backend flows are preserved. Local Ollama setup is only enforced for local Agency Swarm backends.

### How did you verify your code works?

- `bun test test/agency-swarm/ollama.test.ts test/agency-swarm/session-runtime.test.ts test/agency-swarm/client-config.test.ts test/cli/tui/download-ollama-model.test.ts test/cli/tui/prompt.test.tsx test/cli/tui/dialog-model.test.tsx test/provider/provider.test.ts test/cli/tui/session-error.test.ts --timeout 60000` passed with 202 tests.
- `bun typecheck` passed.
- `git diff --check` passed.
- Live Ollama bridge E2E passed after pulling `qwen2.5:0.5b`: `AGENTSWARM_LIVE_OLLAMA_E2E=1 AGENTSWARM_LIVE_AGENCY_URL=http://127.0.0.1:8765 AGENTSWARM_LIVE_AGENCY_ID=local bun test --timeout 60000 test/agency-swarm/ollama-live.e2e.test.ts`.
- Local Codex review found no actionable issues at `71471ceab193ba7a956e6f8558891fc54c64ca7c`.

### Screenshots / recordings

Not captured for this draft. The changed flow is covered by terminal TUI component tests and a live Ollama bridge E2E test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
