### PR TITLE
fix(tui): preserve OpenRouter reasoning display

### DIFF
--- a/packages/opencode/src/cli/cmd/run/demo.ts
+++ b/packages/opencode/src/cli/cmd/run/demo.ts
@@ -705,7 +705,7 @@ function emitTask(state: State): void {
       },
       {
         kind: "reasoning",
-        text: "Thinking: tracing reducer and footer boundaries",
+        text: "tracing reducer and footer boundaries",
         phase: "progress",
         source: "reasoning",
         messageID: "sub_demo_msg_reasoning",

--- a/packages/opencode/src/cli/cmd/run/entry.body.ts
+++ b/packages/opencode/src/cli/cmd/run/entry.body.ts
@@ -66,7 +66,7 @@ function reasoningBody(raw: string): RunEntryBody {
 
   const lead = clean.match(/^\n+/)?.[0] ?? ""
   const body = lead ? clean.slice(lead.length) : clean
-  return codeBody(`${lead}Thought:\n\n${body.trimStart()}`, "markdown")
+  return codeBody(`${lead}Thought:\n\n${body}`, "markdown")
 }
 
 function systemBody(raw: string, phase: StreamCommit["phase"]): RunEntryBody {

--- a/packages/opencode/src/cli/cmd/run/entry.body.ts
+++ b/packages/opencode/src/cli/cmd/run/entry.body.ts
@@ -66,12 +66,7 @@ function reasoningBody(raw: string): RunEntryBody {
 
   const lead = clean.match(/^\n+/)?.[0] ?? ""
   const body = lead ? clean.slice(lead.length) : clean
-  const mark = "Thinking:"
-  if (body.startsWith(mark)) {
-    return codeBody(`${lead}_Thinking:_ ${body.slice(mark.length).trimStart()}`, "markdown")
-  }
-
-  return codeBody(clean, "markdown")
+  return codeBody(`${lead}Thought:\n\n${body.trimStart()}`, "markdown")
 }
 
 function systemBody(raw: string, phase: StreamCommit["phase"]): RunEntryBody {

--- a/packages/opencode/src/cli/cmd/run/scrollback.surface.ts
+++ b/packages/opencode/src/cli/cmd/run/scrollback.surface.ts
@@ -35,6 +35,7 @@ type ActiveEntry = {
 }
 
 let nextId = 0
+const REASONING_HEADER = "Thought:\n\n"
 
 function commitMarkdownBlocks(input: {
   surface: ScrollbackSurface
@@ -81,6 +82,23 @@ function staticBody(commit: StreamCommit, body: RunEntryBody, spaced: number): R
   return {
     ...body,
     content: body.content.replace(/^\n/, ""),
+  }
+}
+
+function streamingBody(commit: StreamCommit, body: ActiveBody, active: ActiveEntry | undefined): ActiveBody {
+  if (!active || !sameEntryGroup(active.commit, commit) || commit.kind !== "reasoning" || body.type !== "code") {
+    return body
+  }
+
+  const lead = body.content.match(/^\n+/)?.[0] ?? ""
+  const content = lead ? body.content.slice(lead.length) : body.content
+  if (!content.startsWith(REASONING_HEADER)) {
+    return body
+  }
+
+  return {
+    ...body,
+    content: `${lead}${content.slice(REASONING_HEADER.length)}`,
   }
 }
 
@@ -294,17 +312,24 @@ export class RunScrollbackStream {
   }
 
   private async writeStreaming(commit: StreamCommit, body: ActiveBody): Promise<void> {
-    if (!this.active || !sameEntryGroup(this.active.commit, commit) || this.active.body.type !== body.type) {
+    const continuing = !!this.active && sameEntryGroup(this.active.commit, commit) && this.active.body.type === body.type
+    if (!continuing) {
       this.markRendered(await this.finishActive(false))
       this.active = this.createEntry(commit, body)
     }
 
-    this.active.body = body
-    this.active.commit = commit
-    this.active.content += body.content
+    const active = this.active
+    if (!active) {
+      return
+    }
+
+    const next = continuing ? streamingBody(commit, body, active) : body
+    active.body = next
+    active.commit = commit
+    active.content += next.content
     await this.flushActive(false, false)
-    if (this.active.rendered) {
-      this.markRendered(this.active.commit)
+    if (active.rendered) {
+      this.markRendered(active.commit)
     }
   }
 

--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -568,6 +568,9 @@ function flushPart(data: SessionData, commits: SessionCommit[], partID: string, 
     if (kind === "reasoning" && chunk) {
       chunk = chunk.replace(/\[REDACTED\]/g, "")
       if (!chunk.trim()) {
+        if (!data.end.has(partID) && !interrupted) {
+          return
+        }
         chunk = "Thinking..."
       }
     }

--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -610,11 +610,16 @@ function drop(data: SessionData, partID: string) {
 // buffered text parts that were waiting on role confirmation. User-role
 // parts are silently dropped.
 function replay(data: SessionData, commits: SessionCommit[], messageID: string, role: MessageRole, thinking: boolean) {
-  for (const [partID, msg] of data.msg.entries()) {
-    if (msg !== messageID || data.ids.has(partID)) {
-      continue
-    }
+  const entries = Array.from(data.msg.entries()).filter(([partID, msg]) => msg === messageID && !data.ids.has(partID))
+  const ordered =
+    role === "assistant"
+      ? [
+          ...entries.filter(([partID]) => data.part.get(partID) === "reasoning"),
+          ...entries.filter(([partID]) => data.part.get(partID) !== "reasoning"),
+        ]
+      : entries
 
+  for (const [partID] of ordered) {
     if (role === "user" && !data.includeUserText) {
       data.ids.add(partID)
       drop(data, partID)

--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -431,6 +431,49 @@ function ready(data: SessionData, partID: string): boolean {
   return data.includeUserText && role === "user"
 }
 
+function hasOpenReasoning(data: SessionData, messageID: string | undefined): boolean {
+  if (!messageID) {
+    return false
+  }
+
+  for (const [partID, kind] of data.part.entries()) {
+    if (kind !== "reasoning") {
+      continue
+    }
+
+    if (data.msg.get(partID) !== messageID) {
+      continue
+    }
+
+    if (!data.end.has(partID)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function flushReadyAssistant(data: SessionData, commits: SessionCommit[], messageID: string | undefined) {
+  if (!messageID || hasOpenReasoning(data, messageID)) {
+    return
+  }
+
+  for (const [partID, msg] of data.msg.entries()) {
+    if (msg !== messageID || data.ids.has(partID) || data.part.get(partID) !== "assistant" || !ready(data, partID)) {
+      continue
+    }
+
+    flushPart(data, commits, partID)
+
+    if (!data.end.has(partID)) {
+      continue
+    }
+
+    data.ids.add(partID)
+    drop(data, partID)
+  }
+}
+
 function syncText(data: SessionData, partID: string, next: string) {
   const prev = data.text.get(partID) ?? ""
   if (!next) {
@@ -518,7 +561,7 @@ function flushPart(data: SessionData, commits: SessionCommit[], partID: string, 
       return
     }
     if (kind === "reasoning" && chunk) {
-      chunk = `Thinking: ${chunk.replace(/\[REDACTED\]/g, "")}`
+      chunk = chunk.replace(/\[REDACTED\]/g, "")
     }
     if (kind === "assistant" && chunk) {
       chunk = stripEcho(data, msg, chunk)
@@ -592,6 +635,10 @@ function replay(data: SessionData, commits: SessionCommit[], messageID: string, 
         data.ids.add(partID)
       }
       drop(data, partID)
+      continue
+    }
+
+    if (role === "assistant" && kind === "assistant" && hasOpenReasoning(data, messageID)) {
       continue
     }
 
@@ -766,7 +813,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
       return out(data, commits)
     }
 
-    if (!ready(data, partID)) {
+    if (!ready(data, partID) || (kind === "assistant" && hasOpenReasoning(data, data.msg.get(partID)))) {
       return out(data, commits)
     }
 
@@ -892,7 +939,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
       return out(data, commits)
     }
 
-    if (!ready(data, part.id)) {
+    if (!ready(data, part.id) || (kind === "assistant" && hasOpenReasoning(data, msg))) {
       return out(data, commits)
     }
 
@@ -904,6 +951,9 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
 
     data.ids.add(part.id)
     drop(data, part.id)
+    if (kind === "reasoning") {
+      flushReadyAssistant(data, commits, msg)
+    }
     return out(data, commits)
   }
 

--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -453,8 +453,13 @@ function hasOpenReasoning(data: SessionData, messageID: string | undefined): boo
   return false
 }
 
-function flushReadyAssistant(data: SessionData, commits: SessionCommit[], messageID: string | undefined) {
-  if (!messageID || hasOpenReasoning(data, messageID)) {
+function flushReadyAssistant(
+  data: SessionData,
+  commits: SessionCommit[],
+  messageID: string | undefined,
+  includeOpenReasoning = false,
+) {
+  if (!messageID || (!includeOpenReasoning && hasOpenReasoning(data, messageID))) {
     return
   }
 
@@ -834,6 +839,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
 
     if (part.type === "tool") {
       const view = syncPermission(data, part) ?? syncQuestion(data, part)
+      flushReadyAssistant(data, commits, part.messageID, true)
 
       if (part.state.status === "running") {
         if (data.ids.has(part.id)) {

--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -567,6 +567,9 @@ function flushPart(data: SessionData, commits: SessionCommit[], partID: string, 
     }
     if (kind === "reasoning" && chunk) {
       chunk = chunk.replace(/\[REDACTED\]/g, "")
+      if (!chunk.trim()) {
+        chunk = "Thinking..."
+      }
     }
     if (kind === "assistant" && chunk) {
       chunk = stripEcho(data, msg, chunk)

--- a/packages/opencode/src/cli/cmd/tui/context/sync-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync-v2.tsx
@@ -41,9 +41,18 @@ function latestText(assistant: SessionMessageAssistant | undefined) {
   return assistant?.content.findLast((item): item is SessionMessageAssistantText => item.type === "text")
 }
 
+type ReasoningTime = {
+  start?: number
+  end?: number
+}
+
+type ReasoningPart = SessionMessageAssistantReasoning & {
+  time?: ReasoningTime
+}
+
 function latestReasoning(assistant: SessionMessageAssistant | undefined, reasoningID: string) {
   return assistant?.content.findLast(
-    (item): item is SessionMessageAssistantReasoning => item.type === "reasoning" && item.id === reasoningID,
+    (item): item is ReasoningPart => item.type === "reasoning" && item.id === reasoningID,
   )
 }
 
@@ -236,11 +245,13 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
           break
         case "session.next.reasoning.started":
           update(event.properties.sessionID, (draft) => {
-            activeAssistant(draft)?.content.push({
+            const part: ReasoningPart = {
               type: "reasoning",
               id: event.properties.reasoningID,
               text: "",
-            })
+              time: { start: event.properties.timestamp },
+            }
+            activeAssistant(draft)?.content.push(part)
           })
           break
         case "session.next.reasoning.delta":
@@ -252,7 +263,10 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.reasoning.ended":
           update(event.properties.sessionID, (draft) => {
             const match = latestReasoning(activeAssistant(draft), event.properties.reasoningID)
-            if (match) match.text = event.properties.text
+            if (match) {
+              match.text = event.properties.text
+              match.time = { ...match.time, end: event.properties.timestamp }
+            }
           })
           break
         case "session.next.retried":

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -388,7 +388,7 @@ function AssistantText(props: { part: SessionMessageAssistantText; syntax: Synta
 function AssistantReasoning(props: { part: AssistantReasoningPart; subtleSyntax: SyntaxStyle }) {
   const { theme } = useTheme()
   const content = createMemo(() => props.part.text.replace("[REDACTED]", "").trim())
-  const isDone = createMemo(() => props.part.time?.end !== undefined)
+  const isDone = createMemo(() => props.part.time === undefined || props.part.time.end !== undefined)
   const duration = createMemo(() => {
     const start = props.part.time?.start
     const end = props.part.time?.end

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -32,6 +32,13 @@ import { createEffect, createMemo, createSignal, For, Match, Show, Switch } from
 
 const id = "internal:session-v2-debug"
 const route = "session.v2.messages"
+type ReasoningTime = {
+  start?: number
+  end?: number
+}
+type AssistantReasoningPart = SessionMessageAssistantReasoning & {
+  time?: ReasoningTime
+}
 
 function currentSessionID(api: TuiPluginApi) {
   const current = api.route.current
@@ -317,12 +324,7 @@ function AssistantMessage(props: {
               <AssistantText part={part as SessionMessageAssistantText} syntax={props.syntax} />
             </Match>
             <Match when={part.type === "reasoning"}>
-              <AssistantReasoning
-                part={part as SessionMessageAssistantReasoning}
-                subtleSyntax={props.subtleSyntax}
-                completedAt={() => props.message.time.completed}
-                duration={() => (duration() ? Locale.duration(duration()) : undefined)}
-              />
+              <AssistantReasoning part={part as AssistantReasoningPart} subtleSyntax={props.subtleSyntax} />
             </Match>
             <Match when={part.type === "tool"}>
               <AssistantTool part={part as SessionMessageAssistantTool} sessionID={props.sessionID} />
@@ -383,19 +385,20 @@ function AssistantText(props: { part: SessionMessageAssistantText; syntax: Synta
   )
 }
 
-function AssistantReasoning(props: {
-  part: SessionMessageAssistantReasoning
-  subtleSyntax: SyntaxStyle
-  completedAt: () => number | undefined
-  duration: () => string | undefined
-}) {
+function AssistantReasoning(props: { part: AssistantReasoningPart; subtleSyntax: SyntaxStyle }) {
   const { theme } = useTheme()
   const content = createMemo(() => props.part.text.replace("[REDACTED]", "").trim())
-  const isDone = createMemo(() => props.completedAt() !== undefined)
+  const isDone = createMemo(() => props.part.time?.end !== undefined)
+  const duration = createMemo(() => {
+    const start = props.part.time?.start
+    const end = props.part.time?.end
+    if (start === undefined || end === undefined) return
+    return Locale.duration(end - start)
+  })
   return (
     <Show when={content()}>
       <box paddingLeft={3} marginTop={1} flexDirection="column" flexShrink={0}>
-        <ReasoningHeader done={isDone()} duration={props.duration()} />
+        <ReasoningHeader done={isDone()} duration={duration()} />
         <box marginTop={1}>
           <code
             filetype="markdown"

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -395,21 +395,24 @@ function AssistantReasoning(props: { part: AssistantReasoningPart; subtleSyntax:
     if (start === undefined || end === undefined) return
     return Locale.duration(end - start)
   })
+  const visible = createMemo(() => content().length > 0 || !isDone())
   return (
-    <Show when={content()}>
+    <Show when={visible()}>
       <box paddingLeft={3} marginTop={1} flexDirection="column" flexShrink={0}>
         <ReasoningHeader done={isDone()} duration={duration()} />
-        <box marginTop={1}>
-          <code
-            filetype="markdown"
-            drawUnstyledText={false}
-            streaming={true}
-            syntaxStyle={props.subtleSyntax}
-            content={content()}
-            conceal={true}
-            fg={theme.textMuted}
-          />
-        </box>
+        <Show when={content()}>
+          <box marginTop={1}>
+            <code
+              filetype="markdown"
+              drawUnstyledText={false}
+              streaming={true}
+              syntaxStyle={props.subtleSyntax}
+              content={content()}
+              conceal={true}
+              fg={theme.textMuted}
+            />
+          </box>
+        </Show>
       </box>
     </Show>
   )

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -6,7 +6,7 @@ import { Spinner } from "@tui/component/spinner"
 import { useTheme } from "@tui/context/theme"
 import { useLocal } from "@tui/context/local"
 import { useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
-import { TextAttributes, type BoxRenderable, type SyntaxStyle } from "@opentui/core"
+import { RGBA, TextAttributes, type BoxRenderable, type SyntaxStyle } from "@opentui/core"
 import { useBindings } from "../../keymap"
 import { Locale } from "@/util/locale"
 import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
@@ -317,7 +317,12 @@ function AssistantMessage(props: {
               <AssistantText part={part as SessionMessageAssistantText} syntax={props.syntax} />
             </Match>
             <Match when={part.type === "reasoning"}>
-              <AssistantReasoning part={part as SessionMessageAssistantReasoning} subtleSyntax={props.subtleSyntax} />
+              <AssistantReasoning
+                part={part as SessionMessageAssistantReasoning}
+                subtleSyntax={props.subtleSyntax}
+                completedAt={() => props.message.time.completed}
+                duration={() => (duration() ? Locale.duration(duration()) : undefined)}
+              />
             </Match>
             <Match when={part.type === "tool"}>
               <AssistantTool part={part as SessionMessageAssistantTool} sessionID={props.sessionID} />
@@ -378,31 +383,55 @@ function AssistantText(props: { part: SessionMessageAssistantText; syntax: Synta
   )
 }
 
-function AssistantReasoning(props: { part: SessionMessageAssistantReasoning; subtleSyntax: SyntaxStyle }) {
+function AssistantReasoning(props: {
+  part: SessionMessageAssistantReasoning
+  subtleSyntax: SyntaxStyle
+  completedAt: () => number | undefined
+  duration: () => string | undefined
+}) {
   const { theme } = useTheme()
   const content = createMemo(() => props.part.text.replace("[REDACTED]", "").trim())
+  const isDone = createMemo(() => props.completedAt() !== undefined)
   return (
     <Show when={content()}>
-      <box
-        paddingLeft={2}
-        marginTop={1}
-        flexDirection="column"
-        border={["left"]}
-        customBorderChars={SplitBorder.customBorderChars}
-        borderColor={theme.backgroundElement}
-        flexShrink={0}
-      >
-        <code
-          filetype="markdown"
-          drawUnstyledText={false}
-          streaming={true}
-          syntaxStyle={props.subtleSyntax}
-          content={"_Thinking:_ " + content()}
-          conceal={true}
-          fg={theme.textMuted}
-        />
+      <box paddingLeft={3} marginTop={1} flexDirection="column" flexShrink={0}>
+        <ReasoningHeader done={isDone()} duration={props.duration()} />
+        <box marginTop={1}>
+          <code
+            filetype="markdown"
+            drawUnstyledText={false}
+            streaming={true}
+            syntaxStyle={props.subtleSyntax}
+            content={content()}
+            conceal={true}
+            fg={theme.textMuted}
+          />
+        </box>
       </box>
     </Show>
+  )
+}
+
+function ReasoningHeader(props: { done: boolean; duration?: string }) {
+  const { theme } = useTheme()
+  const fg = () => RGBA.fromValues(theme.warning.r, theme.warning.g, theme.warning.b, theme.thinkingOpacity)
+
+  return (
+    <Switch>
+      <Match when={!props.done}>
+        <box flexDirection="row">
+          <Spinner color={fg()}>Thinking</Spinner>
+        </box>
+      </Match>
+      <Match when={true}>
+        <text fg={fg()} wrapMode="none">
+          <span>Thought</span>
+          <Show when={props.duration}>
+            <span>: {props.duration}</span>
+          </Show>
+        </text>
+      </Match>
+    </Switch>
   )
 }
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1526,21 +1526,24 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
     const end = props.part.time.end
     return end === undefined ? undefined : Locale.duration(Math.max(0, end - props.part.time.start))
   })
+  const visible = createMemo(() => ctx.showThinking() && (content().length > 0 || !isDone()))
   return (
-    <Show when={content() && ctx.showThinking()}>
+    <Show when={visible()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexDirection="column" flexShrink={0}>
         <ReasoningHeader done={isDone()} duration={duration()} />
-        <box marginTop={1}>
-          <code
-            filetype="markdown"
-            drawUnstyledText={false}
-            streaming={true}
-            syntaxStyle={subtleSyntax()}
-            content={content()}
-            conceal={ctx.conceal()}
-            fg={theme.textMuted}
-          />
-        </box>
+        <Show when={content()}>
+          <box marginTop={1}>
+            <code
+              filetype="markdown"
+              drawUnstyledText={false}
+              streaming={true}
+              syntaxStyle={subtleSyntax()}
+              content={content()}
+              conceal={ctx.conceal()}
+              fg={theme.textMuted}
+            />
+          </box>
+        </Show>
       </box>
     </Show>
   )

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1521,28 +1521,51 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
     // OpenRouter sends encrypted reasoning data that appears as [REDACTED]
     return props.part.text.replace("[REDACTED]", "").trim()
   })
+  const isDone = createMemo(() => props.part.time.end !== undefined)
+  const duration = createMemo(() => {
+    const end = props.part.time.end
+    return end === undefined ? undefined : Locale.duration(Math.max(0, end - props.part.time.start))
+  })
   return (
     <Show when={content() && ctx.showThinking()}>
-      <box
-        id={"text-" + props.part.id}
-        paddingLeft={2}
-        marginTop={1}
-        flexDirection="column"
-        border={["left"]}
-        customBorderChars={SplitBorder.customBorderChars}
-        borderColor={theme.backgroundElement}
-      >
-        <code
-          filetype="markdown"
-          drawUnstyledText={false}
-          streaming={true}
-          syntaxStyle={subtleSyntax()}
-          content={"_Thinking:_ " + content()}
-          conceal={ctx.conceal()}
-          fg={theme.textMuted}
-        />
+      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexDirection="column" flexShrink={0}>
+        <ReasoningHeader done={isDone()} duration={duration()} />
+        <box marginTop={1}>
+          <code
+            filetype="markdown"
+            drawUnstyledText={false}
+            streaming={true}
+            syntaxStyle={subtleSyntax()}
+            content={content()}
+            conceal={ctx.conceal()}
+            fg={theme.textMuted}
+          />
+        </box>
       </box>
     </Show>
+  )
+}
+
+function ReasoningHeader(props: { done: boolean; duration?: string }) {
+  const { theme } = useTheme()
+  const fg = () => RGBA.fromValues(theme.warning.r, theme.warning.g, theme.warning.b, theme.thinkingOpacity)
+
+  return (
+    <Switch>
+      <Match when={!props.done}>
+        <box flexDirection="row">
+          <Spinner color={fg()}>Thinking</Spinner>
+        </box>
+      </Match>
+      <Match when={true}>
+        <text fg={fg()} wrapMode="none">
+          <span>Thought</span>
+          <Show when={props.duration}>
+            <span>: {props.duration}</span>
+          </Show>
+        </text>
+      </Match>
+    </Switch>
   )
 }
 

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -15,6 +15,7 @@ import {
 import { truncateLargeText } from "./agency-swarm-history-transport"
 
 const MAX_UI_TOOL_OUTPUT_CHARS = 60_000
+const MIN_REASONING_OVERLAP_CHARS = 8
 
 type StreamPart = Record<string, unknown>
 
@@ -37,6 +38,21 @@ type Tool = {
   done: boolean
 }
 
+type PendingText = {
+  itemID: string
+  index: number
+  done: boolean
+  meta: AgencySwarmEventMeta
+  extra?: Record<string, unknown>
+}
+
+type PendingReasoning = {
+  itemID: string
+  index: number
+  meta: AgencySwarmEventMeta
+  extra?: Record<string, unknown>
+}
+
 type StreamEventsInput = {
   assistantMessage: MessageV2.Assistant
   isCancelled: () => boolean
@@ -54,17 +70,24 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const textBuffer = new Map<string, string>()
   const textOpen = new Set<string>()
   const textIndex = new Map<string, number>()
+  const textPending = new Map<string, PendingText>()
 
   const reasoningBuffer = new Map<string, string>()
   const reasoningOpen = new Set<string>()
   const reasoningByItem = new Map<string, Set<string>>()
+  const reasoningDonePending = new Map<string, PendingReasoning>()
   const responseTextReplay = new Map<string, Set<string>>()
   const responseReasoningReplay = new Map<string, Set<string>>()
+  const pendingTextReplay = new Set<string>()
+  const pendingTextFlushed = new Set<string>()
+  const closedReasoningTextReplay = new Set<string>()
 
   let usage: Usage | undefined
   let lastTextItemID: string | undefined
   let lastReasoningItemID: string | undefined
   let hadDanglingTool = false
+  let sawReasoning = false
+  let flushingText = false
   const agentUpdatedHandoffAgents = new Set<string>()
 
   const mergeMeta = (meta: AgencySwarmEventMeta, extra?: Record<string, unknown>) => {
@@ -79,6 +102,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return `${itemID}:${value}`
   }
 
+  const hasOpenReasoning = () => reasoningOpen.size > 0
+  const shouldHoldText = () => !flushingText && (hasOpenReasoning() || sawReasoning)
+
   /** Skip only when the incoming event is a replay of the same `(itemID, index)` that is already closed. Body-only matches would drop legit later messages with a short repeat body like "Done" or "OK". */
   const shouldSkipDuplicateAssistantText = (itemID: string, index: number, text: string) => {
     const key = textKey(itemID, index)
@@ -86,9 +112,33 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return current === text && !textOpen.has(key)
   }
 
+  function deferText(
+    itemID: string,
+    index: number,
+    done: boolean,
+    meta: AgencySwarmEventMeta,
+    extra?: Record<string, unknown>,
+  ) {
+    const key = textKey(itemID, index)
+    const prev = textPending.get(key)
+    textPending.set(key, {
+      itemID,
+      index,
+      done: done || prev?.done === true,
+      meta,
+      extra,
+    })
+    return []
+  }
+
   const replayTextKey = (text: string) => {
     const normalized = text.trim()
     return normalized ? normalized : undefined
+  }
+
+  const replayPartKey = (itemID: string, _index: number, text: string) => {
+    const key = replayTextKey(text)
+    return key ? `${itemID}:${key}` : undefined
   }
 
   const providerResponseID = (item: Record<string, unknown> | undefined) => {
@@ -121,6 +171,57 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return !!responseID && !!key && store.get(responseID)?.has(key) === true
   }
 
+  const rememberPendingTextReplay = (itemID: string, index: number, text: string) => {
+    const key = replayPartKey(itemID, index, text)
+    if (key) pendingTextReplay.add(key)
+  }
+
+  const hasPendingTextReplay = (itemID: string, index: number, text: string) => {
+    const key = replayPartKey(itemID, index, text)
+    return !!key && pendingTextReplay.has(key)
+  }
+
+  const rememberClosedReasoningTextReplay = (itemID: string, index: number, text: string) => {
+    const key = replayPartKey(itemID, index, text)
+    if (key) closedReasoningTextReplay.add(key)
+  }
+
+  const hasClosedReasoningTextReplay = (itemID: string, index: number, text: string) => {
+    const key = replayPartKey(itemID, index, text)
+    return !!key && closedReasoningTextReplay.has(key)
+  }
+
+  const hasPendingTextBuffer = (text: string) => {
+    const key = replayTextKey(text)
+    if (!key) return false
+    return Array.from(textPending.values()).some((pending) => {
+      return replayTextKey(textBuffer.get(textKey(pending.itemID, pending.index)) || "") === key
+    })
+  }
+
+  const markPendingTextDone = (
+    itemID: string,
+    index: number,
+    text: string,
+    meta: AgencySwarmEventMeta,
+    extra?: Record<string, unknown>,
+  ) => {
+    const key = replayTextKey(text)
+    if (!key) return false
+    for (const [pendingKey, pending] of textPending.entries()) {
+      if (pending.itemID !== itemID) continue
+      if (replayTextKey(textBuffer.get(textKey(pending.itemID, pending.index)) || "") !== key) continue
+      textPending.set(pendingKey, {
+        ...pending,
+        done: true,
+        meta,
+        extra: pending.extra ?? extra,
+      })
+      return true
+    }
+    return false
+  }
+
   const agentUpdatedHandoffMetadata = (agent: string | undefined) => {
     const handoffAgent = agent ?? input.assistantMessage.agent
     return handoffAgent && agentUpdatedHandoffAgents.has(handoffAgent)
@@ -133,6 +234,19 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   }
 
   const reasoningKey = (itemID: string, index: number) => `${itemID}:${index}`
+
+  const reasoningSuffix = (current: string, delta: string) => {
+    if (!current) return delta
+    if (delta.startsWith(current)) {
+      if (delta.length === current.length && current.length < MIN_REASONING_OVERLAP_CHARS) return delta
+      return delta.slice(current.length)
+    }
+    const limit = Math.min(current.length, delta.length)
+    for (let size = limit; size >= MIN_REASONING_OVERLAP_CHARS; size--) {
+      if (current.endsWith(delta.slice(0, size))) return delta.slice(size)
+    }
+    return delta
+  }
 
   const setUsage = (value: Record<string, unknown> | undefined) => {
     if (!value) return
@@ -287,6 +401,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const ensureText = (itemID: string, index: number, meta: AgencySwarmEventMeta, extra?: Record<string, unknown>) => {
     const parts: StreamPart[] = []
     const key = textKey(itemID, index)
+    if (shouldHoldText() && !textOpen.has(key)) {
+      return deferText(itemID, index, false, meta, extra)
+    }
     const activeItemID = lastTextItemID
     const activeIndex = activeItemID ? (textIndex.get(activeItemID) ?? 0) : undefined
     const activeKey = activeItemID !== undefined ? textKey(activeItemID, activeIndex) : undefined
@@ -316,6 +433,47 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return parts
   }
 
+  const emitText = (pending: PendingText) => {
+    const key = textKey(pending.itemID, pending.index)
+    const text = textBuffer.get(key) || ""
+    if (text && sawReasoning && hasClosedReasoningTextReplay(pending.itemID, pending.index, text)) {
+      textBuffer.delete(key)
+      return []
+    }
+    const parts = ensureText(pending.itemID, pending.index, pending.meta, pending.extra)
+    pendingTextFlushed.add(key)
+    if (text) {
+      parts.push({
+        type: "text-delta",
+        text,
+        providerMetadata: mergeMeta(pending.meta, {
+          item_id: pending.itemID,
+          content_index: pending.index,
+          ...(pending.extra ?? {}),
+        }),
+      })
+    }
+    if (pending.done) {
+      if (text) rememberPendingTextReplay(pending.itemID, pending.index, text)
+      if (text && sawReasoning) rememberClosedReasoningTextReplay(pending.itemID, pending.index, text)
+      parts.push(...closeText(key, pending.meta, pending.extra))
+    }
+    return parts
+  }
+
+  const flushPendingText = (force: boolean) => {
+    if (hasOpenReasoning()) return []
+    if (sawReasoning && !force) return []
+    const parts: StreamPart[] = []
+    flushingText = true
+    for (const [key, pending] of Array.from(textPending.entries())) {
+      textPending.delete(key)
+      parts.push(...emitText(pending))
+    }
+    flushingText = false
+    return parts
+  }
+
   const textDelta = (
     itemID: string,
     index: number,
@@ -327,6 +485,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     const key = textKey(itemID, index)
     const existing = textBuffer.get(key) || ""
     textBuffer.set(key, existing + delta)
+    if (shouldHoldText() && !textOpen.has(key)) {
+      return deferText(itemID, index, false, meta, extra)
+    }
     return [
       {
         type: "text-delta",
@@ -349,15 +510,43 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   ) => {
     const key = textKey(itemID, index)
     const isOpen = textOpen.has(key)
+    if (!isOpen && final !== undefined && hasPendingTextReplay(itemID, index, final)) {
+      return []
+    }
+    if (!isOpen && final !== undefined && sawReasoning && hasClosedReasoningTextReplay(itemID, index, final)) {
+      return []
+    }
+    if (
+      !isOpen &&
+      final !== undefined &&
+      !textPending.has(key) &&
+      markPendingTextDone(itemID, index, final, meta, extra)
+    ) {
+      return []
+    }
     const raw = textBuffer.get(key) || ""
     if (!isOpen && final !== undefined && raw && !final.startsWith(raw)) {
       textBuffer.delete(key)
     }
     const current = textBuffer.get(key) || ""
+    if (!isOpen && final !== undefined && final === current && textPending.has(key)) {
+      return deferText(itemID, index, true, meta, extra)
+    }
     if (!isOpen && (final === undefined || final === current)) {
       return []
     }
+    if (shouldHoldText() && !isOpen) {
+      if (final) {
+        const suffix = final.startsWith(current) ? final.slice(current.length) : current ? "" : final
+        if (suffix) {
+          textBuffer.set(key, current + suffix)
+        }
+      }
+      return deferText(itemID, index, final !== undefined, meta, extra)
+    }
     if (final !== undefined && final === current) {
+      if (pendingTextFlushed.has(key) || sawReasoning) rememberPendingTextReplay(itemID, index, final)
+      if (sawReasoning) rememberClosedReasoningTextReplay(itemID, index, final)
       return closeText(key, meta, extra)
     }
     const parts = isOpen ? [] : ensureText(itemID, index, meta, extra)
@@ -368,6 +557,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!suffix && final !== undefined && current && !final.startsWith(current) && !textOpen.has(key)) {
       return []
     }
+    if (final !== undefined && (pendingTextFlushed.has(key) || sawReasoning))
+      rememberPendingTextReplay(itemID, index, final)
+    if (final !== undefined && sawReasoning) rememberClosedReasoningTextReplay(itemID, index, final)
     parts.push(...closeText(key, meta, extra))
     return parts
   }
@@ -378,6 +570,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     meta: AgencySwarmEventMeta,
     extra?: Record<string, unknown>,
   ) => {
+    sawReasoning = true
     const key = reasoningKey(itemID, index)
     if (reasoningOpen.has(key)) {
       lastReasoningItemID = itemID
@@ -414,12 +607,14 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!delta) return []
     const key = reasoningKey(itemID, index)
     const existing = reasoningBuffer.get(key) || ""
-    reasoningBuffer.set(key, existing + delta)
+    const suffix = reasoningSuffix(existing, delta)
+    if (!suffix) return []
+    reasoningBuffer.set(key, existing + suffix)
     return [
       {
         type: "reasoning-delta",
         id: key,
-        text: delta,
+        text: suffix,
         providerMetadata: mergeMeta(meta, {
           item_id: itemID,
           summary_index: index,
@@ -429,12 +624,49 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     ]
   }
 
+  const closeReasoning = (
+    itemID: string,
+    index: number,
+    meta: AgencySwarmEventMeta,
+    extra?: Record<string, unknown>,
+  ) => {
+    const key = reasoningKey(itemID, index)
+    if (!reasoningOpen.has(key)) return []
+    reasoningOpen.delete(key)
+    reasoningDonePending.delete(key)
+    const set = reasoningByItem.get(itemID)
+    if (set) {
+      set.delete(key)
+      if (set.size === 0) {
+        reasoningByItem.delete(itemID)
+      }
+    }
+    return [
+      {
+        type: "reasoning-end",
+        id: key,
+        providerMetadata: mergeMeta(meta, {
+          item_id: itemID,
+          summary_index: index,
+          ...(extra ?? {}),
+        }),
+      },
+    ]
+  }
+
+  const flushDoneReasoning = () => {
+    return Array.from(reasoningDonePending.values()).flatMap((pending) => {
+      return closeReasoning(pending.itemID, pending.index, pending.meta, pending.extra)
+    })
+  }
+
   const finishReasoning = (
     itemID: string,
     index: number,
     text: string | undefined,
     meta: AgencySwarmEventMeta,
     extra?: Record<string, unknown>,
+    close = true,
   ) => {
     const key = reasoningKey(itemID, index)
     const isOpen = reasoningOpen.has(key)
@@ -446,29 +678,21 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!isOpen && (text === undefined || text === current)) {
       return []
     }
-    const parts = isOpen ? [] : ensureReasoning(itemID, index, meta, extra)
+    const parts: StreamPart[] = isOpen ? [] : ensureReasoning(itemID, index, meta, extra)
     const suffix = text ? (text.startsWith(current) ? text.slice(current.length) : current ? "" : text) : ""
     if (suffix) {
       parts.push(...reasoningDelta(itemID, index, suffix, meta, extra))
     }
-    if (reasoningOpen.has(key)) {
-      reasoningOpen.delete(key)
-      const set = reasoningByItem.get(itemID)
-      if (set) {
-        set.delete(key)
-        if (set.size === 0) {
-          reasoningByItem.delete(itemID)
-        }
+    if (!close) {
+      if (reasoningOpen.has(key)) {
+        reasoningDonePending.set(key, { itemID, index, meta, extra })
       }
-      parts.push({
-        type: "reasoning-end",
-        id: key,
-        providerMetadata: mergeMeta(meta, {
-          item_id: itemID,
-          summary_index: index,
-          ...(extra ?? {}),
-        }),
-      })
+      return parts
+    }
+    const closed = closeReasoning(itemID, index, meta, extra)
+    if (closed.length > 0) {
+      parts.push(...closed)
+      parts.push(...flushPendingText(false))
     }
     return parts
   }
@@ -480,7 +704,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     meta: AgencySwarmEventMeta,
     extra?: Record<string, unknown>,
   ) => {
-    const parts: StreamPart[] = []
+    const parts: StreamPart[] = flushDoneReasoning()
     const tool = ensureTool(callID, toolName)
     if (!tool.started) {
       tool.started = true
@@ -852,6 +1076,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       if (hasResponseReplay(responseTextReplay, rawItem, text)) {
         return []
       }
+      if (hasPendingTextReplay(itemID, 0, text) || hasPendingTextBuffer(text)) {
+        return []
+      }
       const index = 0
       if (shouldSkipDuplicateAssistantText(itemID, index, text)) {
         return []
@@ -898,7 +1125,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       responseType === "response.incomplete"
     ) {
       setUsage(asRecord(asRecord(nested["response"])?.["usage"]))
-      return { parts: [] }
+      return { parts: responseType === "response.completed" ? flushPendingText(true) : [] }
     }
 
     if (responseType === "response.output_item.added" && item) {
@@ -997,7 +1224,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const part = asRecord(nested["part"])
       const text = asRawString(nested["text"])
       const final = text ?? asRawString(part?.["text"])
-      return { parts: finishReasoning(itemID, summaryIndex, final, eventMeta, outputMeta(outputIndex)) }
+      return { parts: finishReasoning(itemID, summaryIndex, final, eventMeta, outputMeta(outputIndex), false) }
     }
 
     if (
@@ -1122,6 +1349,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const text = extractMessageText(message)
       if (!text) continue
       if (hasResponseReplay(responseTextReplay, message, text)) continue
+      if (hasPendingTextReplay(itemID, 0, text) || hasPendingTextBuffer(text)) continue
       if (shouldSkipDuplicateAssistantText(itemID, 0, text)) continue
       parts.push(
         ...finishText(itemID, 0, text, messageMeta, {
@@ -1139,19 +1367,31 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     for (const key of Array.from(textBuffer.keys())) {
       if (!textOpen.has(key)) textBuffer.delete(key)
     }
+    reasoningDonePending.clear()
+    pendingTextReplay.clear()
+    pendingTextFlushed.clear()
+    closedReasoningTextReplay.clear()
   }
 
   const flushOpen = () => {
     const parts: StreamPart[] = []
 
+    for (const key of Array.from(reasoningOpen.values())) {
+      const pending = reasoningDonePending.get(key)
+      if (pending) {
+        parts.push(...closeReasoning(pending.itemID, pending.index, pending.meta, pending.extra))
+        continue
+      }
+      reasoningOpen.delete(key)
+      reasoningDonePending.delete(key)
+      parts.push({ type: "reasoning-end", id: key, providerMetadata: {} })
+    }
+
+    parts.push(...flushPendingText(true))
+
     for (const key of Array.from(textOpen.values())) {
       textOpen.delete(key)
       parts.push({ type: "text-end", providerMetadata: {} })
-    }
-
-    for (const key of Array.from(reasoningOpen.values())) {
-      reasoningOpen.delete(key)
-      parts.push({ type: "reasoning-end", id: key, providerMetadata: {} })
     }
 
     for (const tool of Array.from(tools.values())) {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -81,6 +81,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const pendingTextReplay = new Set<string>()
   const pendingTextFlushed = new Set<string>()
   const closedReasoningTextReplay = new Set<string>()
+  const completedResponseTextReplay = new Set<string>()
 
   let usage: Usage | undefined
   let lastTextItemID: string | undefined
@@ -191,12 +192,16 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return !!key && closedReasoningTextReplay.has(key)
   }
 
-  const hasPendingTextBuffer = (text: string) => {
+  const rememberCompletedResponseTextReplay = () => {
+    for (const text of textBuffer.values()) {
+      const key = replayTextKey(text)
+      if (key) completedResponseTextReplay.add(key)
+    }
+  }
+
+  const hasCompletedResponseTextReplay = (text: string) => {
     const key = replayTextKey(text)
-    if (!key) return false
-    return Array.from(textPending.values()).some((pending) => {
-      return replayTextKey(textBuffer.get(textKey(pending.itemID, pending.index)) || "") === key
-    })
+    return !!key && completedResponseTextReplay.has(key)
   }
 
   const markPendingTextDone = (
@@ -1076,7 +1081,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       if (hasResponseReplay(responseTextReplay, rawItem, text)) {
         return []
       }
-      if (hasPendingTextReplay(itemID, 0, text) || hasPendingTextBuffer(text)) {
+      if (hasPendingTextReplay(itemID, 0, text)) {
         return []
       }
       const index = 0
@@ -1125,7 +1130,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       responseType === "response.incomplete"
     ) {
       setUsage(asRecord(asRecord(nested["response"])?.["usage"]))
-      return { parts: responseType === "response.completed" ? flushPendingText(true) : [] }
+      if (responseType !== "response.completed") return { parts: [] }
+      rememberCompletedResponseTextReplay()
+      return { parts: flushPendingText(true) }
     }
 
     if (responseType === "response.output_item.added" && item) {
@@ -1349,7 +1356,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const text = extractMessageText(message)
       if (!text) continue
       if (hasResponseReplay(responseTextReplay, message, text)) continue
-      if (hasPendingTextReplay(itemID, 0, text) || hasPendingTextBuffer(text)) continue
+      if (hasPendingTextReplay(itemID, 0, text) || hasCompletedResponseTextReplay(text)) continue
       if (shouldSkipDuplicateAssistantText(itemID, 0, text)) continue
       parts.push(
         ...finishText(itemID, 0, text, messageMeta, {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -74,6 +74,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const textOpen = new Set<string>()
   const textIndex = new Map<string, number>()
   const textPending = new Map<string, PendingText>()
+  const textExplicit = new Set<string>()
 
   const reasoningBuffer = new Map<string, string>()
   const reasoningOpen = new Set<string>()
@@ -88,6 +89,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const closedReasoningTextReplay = new Set<string>()
   const completedResponseTextReplay = new Set<string>()
   const doneItemTextReplay = new Set<string>()
+  const doneItemShiftedTextReplay = new Set<string>()
   const retiredParts: StreamPart[] = []
 
   let usage: Usage | undefined
@@ -236,14 +238,26 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     )
   }
 
-  const rememberDoneItemTextReplay = (itemID: string, text: string) => {
+  const rememberDoneItemTextReplay = (itemID: string, index: number, text: string) => {
+    const part = replayPartKey(itemID, index, text)
+    if (part) doneItemTextReplay.add(part)
     const key = replayItemKey(itemID, text)
-    if (key) doneItemTextReplay.add(key)
+    if (key) doneItemShiftedTextReplay.add(key)
   }
 
-  const hasDoneItemTextReplay = (itemID: string, text: string) => {
-    const key = replayItemKey(itemID, text)
+  const hasDoneItemTextReplay = (itemID: string, index: number, text: string) => {
+    const key = replayPartKey(itemID, index, text)
     return !!key && doneItemTextReplay.has(key)
+  }
+
+  const isShiftedDoneItemTextReplay = (itemID: string, index: number, text: string) => {
+    const key = replayItemKey(itemID, text)
+    return (
+      !!key &&
+      doneItemShiftedTextReplay.has(key) &&
+      !hasDoneItemTextReplay(itemID, index, text) &&
+      !textExplicit.has(textKey(itemID, index))
+    )
   }
 
   const markPendingTextDone = (
@@ -520,7 +534,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   ) => {
     if (!delta) return []
     const key = textKey(itemID, index)
-    if (!textOpen.has(key) && hasDoneItemTextReplay(itemID, delta)) return []
+    if (!textOpen.has(key) && isShiftedDoneItemTextReplay(itemID, index, delta)) return []
     const existing = textBuffer.get(key) || ""
     textBuffer.set(key, existing + delta)
     if (shouldHoldText() && !textOpen.has(key)) {
@@ -548,7 +562,11 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   ) => {
     const key = textKey(itemID, index)
     const isOpen = textOpen.has(key)
-    if (!isOpen && final !== undefined && hasDoneItemTextReplay(itemID, final)) {
+    if (
+      !isOpen &&
+      final !== undefined &&
+      (hasDoneItemTextReplay(itemID, index, final) || isShiftedDoneItemTextReplay(itemID, index, final))
+    ) {
       return []
     }
     if (!isOpen && final !== undefined && hasAnyPendingTextReplay(itemID, final)) {
@@ -959,6 +977,11 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const textItemID = (event: Record<string, unknown>) => asString(event["item_id"]) || lastTextItemID
   const reasoningItemID = (event: Record<string, unknown>) => asString(event["item_id"]) || lastReasoningItemID
 
+  const summaryText = (summary: unknown[], index: number) => {
+    const record = asRecord(summary[index])
+    return asRawString(record?.["text"])
+  }
+
   const handleOutputItemAdded = (
     item: Record<string, unknown>,
     outputIndex: number | undefined,
@@ -1040,7 +1063,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const parts = finishText(itemID, index, text, eventMeta, outputMeta(outputIndex))
       if (text && textBuffer.get(textKey(itemID, index)) === text) {
         rememberResponseReplay(responseTextReplay, item, text)
-        rememberDoneItemTextReplay(itemID, text)
+        rememberDoneItemTextReplay(itemID, index, text)
       }
       return parts
     }
@@ -1057,10 +1080,11 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
         .filter((value) => reasoningOpen.has(value))
         .flatMap((key) => {
           const index = Number(key.split(":")[1] || "0")
+          const summaryIndex = Number.isFinite(index) ? index : 0
           return finishReasoning(
             itemID,
-            Number.isFinite(index) ? index : 0,
-            undefined,
+            summaryIndex,
+            summaryText(summary, summaryIndex),
             eventMeta,
             outputMeta(outputIndex, { encrypted_content: item["encrypted_content"] ?? null }),
           )
@@ -1222,6 +1246,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const partType = asString(part?.["type"]) || ""
       if (partType !== "output_text" && partType !== "refusal") return { parts: [] }
       const contentIndex = asNumber(nested["content_index"]) ?? 0
+      textExplicit.add(textKey(itemID, contentIndex))
       return {
         parts: ensureText(
           itemID,
@@ -1429,7 +1454,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const text = extractMessageText(message)
       if (!text) continue
       if (hasResponseReplay(responseTextReplay, message, text)) continue
-      if (hasDoneItemTextReplay(itemID, text)) continue
+      if (hasDoneItemTextReplay(itemID, 0, text)) continue
       if (hasAnyPendingTextReplay(itemID, text) || hasAnyCompletedResponseTextReplay(itemID, text)) continue
       if (shouldSkipDuplicateAssistantText(itemID, 0, text)) continue
       parts.push(
@@ -1457,6 +1482,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     closedReasoningTextReplay.clear()
     completedResponseTextReplay.clear()
     doneItemTextReplay.clear()
+    doneItemShiftedTextReplay.clear()
   }
 
   const flushOpen = () => {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -720,9 +720,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
 
   const flushPendingReasoningDeltas = () => {
     return Array.from(reasoningDeltaPending.keys()).flatMap((key) => {
-      const pending = reasoningDeltaPending.get(key)
-      const current = reasoningBuffer.get(key) || ""
-      return flushPendingReasoningDelta(key, !!pending && isLikelyCumulativeReasoningDelta(current, pending.delta))
+      return flushPendingReasoningDelta(key, false)
     })
   }
 
@@ -755,9 +753,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   ) => {
     const key = reasoningKey(itemID, index)
     if (!reasoningOpen.has(key)) return []
-    const pending = reasoningDeltaPending.get(key)
-    const current = reasoningBuffer.get(key) || ""
-    const parts = flushPendingReasoningDelta(key, !!pending && isLikelyCumulativeReasoningDelta(current, pending.delta))
+    const parts = flushPendingReasoningDelta(key, false)
     reasoningOpen.delete(key)
     reasoningDonePending.delete(key)
     const set = reasoningByItem.get(itemID)
@@ -811,10 +807,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     const pending = reasoningDeltaPending.get(key)
     const raw = reasoningBuffer.get(key) || ""
     const parts: StreamPart[] = pending
-      ? flushPendingReasoningDelta(
-          key,
-          text !== undefined ? text.startsWith(pending.delta) : isLikelyCumulativeReasoningDelta(raw, pending.delta),
-        )
+      ? flushPendingReasoningDelta(key, text !== undefined && text.startsWith(pending.delta))
       : []
     if (!isOpen && text !== undefined && raw && !text.startsWith(raw)) {
       reasoningBuffer.delete(key)

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -81,6 +81,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const pendingTextFlushed = new Set<string>()
   const closedReasoningTextReplay = new Set<string>()
   const completedResponseTextReplay = new Set<string>()
+  const doneItemTextReplay = new Set<string>()
 
   let usage: Usage | undefined
   let lastTextItemID: string | undefined
@@ -136,7 +137,12 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return normalized ? normalized : undefined
   }
 
-  const replayPartKey = (itemID: string, _index: number, text: string) => {
+  const replayPartKey = (itemID: string, index: number, text: string) => {
+    const key = replayTextKey(text)
+    return key ? `${itemID}:${index}:${key}` : undefined
+  }
+
+  const replayItemKey = (itemID: string, text: string) => {
     const key = replayTextKey(text)
     return key ? `${itemID}:${key}` : undefined
   }
@@ -181,6 +187,14 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return !!key && pendingTextReplay.has(key)
   }
 
+  const hasAnyPendingTextReplay = (itemID: string, text: string) => {
+    const key = replayTextKey(text)
+    return (
+      !!key &&
+      Array.from(pendingTextReplay).some((value) => value.startsWith(`${itemID}:`) && value.endsWith(`:${key}`))
+    )
+  }
+
   const rememberClosedReasoningTextReplay = (itemID: string, index: number, text: string) => {
     const key = replayPartKey(itemID, index, text)
     if (key) closedReasoningTextReplay.add(key)
@@ -196,14 +210,31 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const separator = part.lastIndexOf(":")
       if (separator < 0) continue
       const itemID = part.slice(0, separator)
-      const key = replayPartKey(itemID, 0, text)
+      const index = Number(part.slice(separator + 1))
+      if (!Number.isFinite(index)) continue
+      const key = replayPartKey(itemID, index, text)
       if (key) completedResponseTextReplay.add(key)
     }
   }
 
-  const hasCompletedResponseTextReplay = (itemID: string, index: number, text: string) => {
-    const key = replayPartKey(itemID, index, text)
-    return !!key && completedResponseTextReplay.has(key)
+  const hasAnyCompletedResponseTextReplay = (itemID: string, text: string) => {
+    const key = replayTextKey(text)
+    return (
+      !!key &&
+      Array.from(completedResponseTextReplay).some(
+        (value) => value.startsWith(`${itemID}:`) && value.endsWith(`:${key}`),
+      )
+    )
+  }
+
+  const rememberDoneItemTextReplay = (itemID: string, text: string) => {
+    const key = replayItemKey(itemID, text)
+    if (key) doneItemTextReplay.add(key)
+  }
+
+  const hasDoneItemTextReplay = (itemID: string, text: string) => {
+    const key = replayItemKey(itemID, text)
+    return !!key && doneItemTextReplay.has(key)
   }
 
   const markPendingTextDone = (
@@ -217,6 +248,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!key) return false
     for (const [pendingKey, pending] of textPending.entries()) {
       if (pending.itemID !== itemID) continue
+      if (pending.index !== index && pending.done) continue
       if (replayTextKey(textBuffer.get(textKey(pending.itemID, pending.index)) || "") !== key) continue
       textPending.set(pendingKey, {
         ...pending,
@@ -456,9 +488,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
           ...(pending.extra ?? {}),
         }),
       })
+      rememberPendingTextReplay(pending.itemID, pending.index, text)
     }
     if (pending.done) {
-      if (text) rememberPendingTextReplay(pending.itemID, pending.index, text)
       if (text && sawReasoning) rememberClosedReasoningTextReplay(pending.itemID, pending.index, text)
       parts.push(...closeText(key, pending.meta, pending.extra))
     }
@@ -486,6 +518,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   ) => {
     if (!delta) return []
     const key = textKey(itemID, index)
+    if (!textOpen.has(key) && hasDoneItemTextReplay(itemID, delta)) return []
     const existing = textBuffer.get(key) || ""
     textBuffer.set(key, existing + delta)
     if (shouldHoldText() && !textOpen.has(key)) {
@@ -513,6 +546,12 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   ) => {
     const key = textKey(itemID, index)
     const isOpen = textOpen.has(key)
+    if (!isOpen && final !== undefined && hasDoneItemTextReplay(itemID, final)) {
+      return []
+    }
+    if (!isOpen && final !== undefined && hasAnyPendingTextReplay(itemID, final)) {
+      return []
+    }
     if (!isOpen && final !== undefined && hasPendingTextReplay(itemID, index, final)) {
       return []
     }
@@ -971,6 +1010,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const parts = finishText(itemID, index, text, eventMeta, outputMeta(outputIndex))
       if (text && textBuffer.get(textKey(itemID, index)) === text) {
         rememberResponseReplay(responseTextReplay, item, text)
+        rememberDoneItemTextReplay(itemID, text)
       }
       return parts
     }
@@ -1083,7 +1123,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       if (hasResponseReplay(responseTextReplay, rawItem, text)) {
         return []
       }
-      if (hasPendingTextReplay(itemID, 0, text)) {
+      if (hasAnyPendingTextReplay(itemID, text) || hasAnyCompletedResponseTextReplay(itemID, text)) {
         return []
       }
       const index = 0
@@ -1358,7 +1398,8 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const text = extractMessageText(message)
       if (!text) continue
       if (hasResponseReplay(responseTextReplay, message, text)) continue
-      if (hasPendingTextReplay(itemID, 0, text) || hasCompletedResponseTextReplay(itemID, 0, text)) continue
+      if (hasDoneItemTextReplay(itemID, text)) continue
+      if (hasAnyPendingTextReplay(itemID, text) || hasAnyCompletedResponseTextReplay(itemID, text)) continue
       if (shouldSkipDuplicateAssistantText(itemID, 0, text)) continue
       parts.push(
         ...finishText(itemID, 0, text, messageMeta, {
@@ -1382,6 +1423,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     pendingTextFlushed.clear()
     closedReasoningTextReplay.clear()
     completedResponseTextReplay.clear()
+    doneItemTextReplay.clear()
   }
 
   const flushOpen = () => {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -75,6 +75,8 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const textIndex = new Map<string, number>()
   const textPending = new Map<string, PendingText>()
   const textExplicit = new Set<string>()
+  const textDeclared = new Set<string>()
+  const textDeltaSeen = new Set<string>()
 
   const reasoningBuffer = new Map<string, string>()
   const reasoningOpen = new Set<string>()
@@ -90,6 +92,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const completedResponseTextReplay = new Set<string>()
   const doneItemTextReplay = new Set<string>()
   const doneItemShiftedTextReplay = new Set<string>()
+  const doneItemDeltaTextReplay = new Set<string>()
   const retiredParts: StreamPart[] = []
 
   let usage: Usage | undefined
@@ -243,6 +246,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (part) doneItemTextReplay.add(part)
     const key = replayItemKey(itemID, text)
     if (key) doneItemShiftedTextReplay.add(key)
+    if (key && textDeltaSeen.has(textKey(itemID, index))) doneItemDeltaTextReplay.add(key)
   }
 
   const hasDoneItemTextReplay = (itemID: string, index: number, text: string) => {
@@ -250,14 +254,17 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return !!key && doneItemTextReplay.has(key)
   }
 
-  const isShiftedDoneItemTextReplay = (itemID: string, index: number, text: string) => {
+  const hasShiftedDoneItemTextReplay = (itemID: string, index: number, text: string) => {
     const key = replayItemKey(itemID, text)
-    return (
-      !!key &&
-      doneItemShiftedTextReplay.has(key) &&
-      !hasDoneItemTextReplay(itemID, index, text) &&
-      !textExplicit.has(textKey(itemID, index))
-    )
+    return !!key && doneItemShiftedTextReplay.has(key) && !hasDoneItemTextReplay(itemID, index, text)
+  }
+
+  const isShiftedDoneItemTextReplay = (itemID: string, index: number, text: string) =>
+    hasShiftedDoneItemTextReplay(itemID, index, text) && !textExplicit.has(textKey(itemID, index))
+
+  const hasDeltaBackedDoneItemTextReplay = (itemID: string, text: string) => {
+    const key = replayItemKey(itemID, text)
+    return !!key && doneItemDeltaTextReplay.has(key)
   }
 
   const markPendingTextDone = (
@@ -488,6 +495,15 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const emitText = (pending: PendingText) => {
     const key = textKey(pending.itemID, pending.index)
     const text = textBuffer.get(key) || ""
+    if (
+      text &&
+      !pending.done &&
+      hasShiftedDoneItemTextReplay(pending.itemID, pending.index, text) &&
+      !textDeclared.has(key)
+    ) {
+      textBuffer.delete(key)
+      return []
+    }
     if (text && sawReasoning && hasClosedReasoningTextReplay(pending.itemID, pending.index, text)) {
       textBuffer.delete(key)
       return []
@@ -537,6 +553,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!textOpen.has(key) && isShiftedDoneItemTextReplay(itemID, index, delta)) return []
     const existing = textBuffer.get(key) || ""
     textBuffer.set(key, existing + delta)
+    textDeltaSeen.add(key)
     if (shouldHoldText() && !textOpen.has(key)) {
       return deferText(itemID, index, false, meta, extra)
     }
@@ -1248,7 +1265,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const partType = asString(part?.["type"]) || ""
       if (partType !== "output_text" && partType !== "refusal") return { parts: [] }
       const contentIndex = asNumber(nested["content_index"]) ?? 0
-      textExplicit.add(textKey(itemID, contentIndex))
+      const key = textKey(itemID, contentIndex)
+      textExplicit.add(key)
+      textDeclared.add(key)
       return {
         parts: ensureText(
           itemID,
@@ -1264,7 +1283,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       if (delta === undefined) return { parts: [] }
       const itemID = textItemID(nested)
       if (!itemID) return { parts: [] }
-      const contentIndex = asNumber(nested["content_index"]) ?? textIndex.get(itemID) ?? 0
+      const explicitIndex = asNumber(nested["content_index"])
+      const contentIndex = explicitIndex ?? textIndex.get(itemID) ?? 0
+      if (explicitIndex !== undefined) textExplicit.add(textKey(itemID, contentIndex))
       const textMeta = outputMeta(outputIndex, { content_index: contentIndex })
       return {
         parts: [
@@ -1277,13 +1298,21 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (responseType === "response.output_text.done" || responseType === "response.content_part.done") {
       const itemID = textItemID(nested)
       if (!itemID) return { parts: [] }
-      const contentIndex = asNumber(nested["content_index"]) ?? textIndex.get(itemID) ?? 0
+      const explicitIndex = asNumber(nested["content_index"])
+      const contentIndex = explicitIndex ?? textIndex.get(itemID) ?? 0
+      const key = textKey(itemID, contentIndex)
       const part = asRecord(nested["part"])
       const final =
         asRawString(nested["text"]) ??
         asRawString(part?.["text"]) ??
         asRawString(part?.["refusal"]) ??
         asRawString(nested["delta"])
+      if (
+        explicitIndex !== undefined &&
+        (textBuffer.has(key) || (final !== undefined && !hasDeltaBackedDoneItemTextReplay(itemID, final)))
+      ) {
+        textExplicit.add(key)
+      }
       return {
         parts: finishText(
           itemID,

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -407,6 +407,8 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     const parts: StreamPart[] = []
     const key = textKey(itemID, index)
     if (shouldHoldText() && !textOpen.has(key)) {
+      lastTextItemID = itemID
+      textIndex.set(itemID, index)
       return deferText(itemID, index, false, meta, extra)
     }
     const activeItemID = lastTextItemID
@@ -467,7 +469,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   }
 
   const flushPendingText = (force: boolean) => {
-    if (hasOpenReasoning()) return []
+    if (!force && hasOpenReasoning()) return []
     const parts: StreamPart[] = []
     flushingText = true
     for (const [key, pending] of Array.from(textPending.entries())) {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -15,6 +15,7 @@ import {
 import { truncateLargeText } from "./agency-swarm-history-transport"
 
 const MAX_UI_TOOL_OUTPUT_CHARS = 60_000
+const MIN_CUMULATIVE_REASONING_PREFIX_CHARS = 8
 type StreamPart = Record<string, unknown>
 
 type Usage = {
@@ -276,7 +277,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
 
   const reasoningSuffix = (current: string, delta: string) => {
     if (!current) return delta
-    if (delta.startsWith(current)) {
+    if (current.length >= MIN_CUMULATIVE_REASONING_PREFIX_CHARS && delta.startsWith(current)) {
       return delta.slice(current.length)
     }
     return delta
@@ -697,9 +698,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     ]
   }
 
-  const flushDoneReasoning = () => {
+  const flushDoneReasoning = (force = false) => {
     return Array.from(reasoningDonePending.values()).flatMap((pending) => {
-      if (reasoningWaitForDone.has(pending.itemID)) return []
+      if (!force && reasoningWaitForDone.has(pending.itemID)) return []
       return closeReasoning(pending.itemID, pending.index, pending.meta, pending.extra)
     })
   }
@@ -1174,7 +1175,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       setUsage(asRecord(asRecord(nested["response"])?.["usage"]))
       if (responseType !== "response.completed") return { parts: [] }
       rememberCompletedResponseTextReplay()
-      return { parts: flushPendingText(true) }
+      return { parts: [...flushDoneReasoning(true), ...flushPendingText(true)] }
     }
 
     if (responseType === "response.output_item.added" && item) {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -718,7 +718,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   ) => {
     const key = reasoningKey(itemID, index)
     if (!reasoningOpen.has(key)) return []
-    const parts = flushPendingReasoningDelta(key, false)
+    const pending = reasoningDeltaPending.get(key)
+    const current = reasoningBuffer.get(key) || ""
+    const parts = flushPendingReasoningDelta(key, !!pending && pending.delta.startsWith(current))
     reasoningOpen.delete(key)
     reasoningDonePending.delete(key)
     const set = reasoningByItem.get(itemID)
@@ -759,10 +761,13 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     const key = reasoningKey(itemID, index)
     const isOpen = reasoningOpen.has(key)
     const pending = reasoningDeltaPending.get(key)
-    const parts: StreamPart[] = pending
-      ? flushPendingReasoningDelta(key, text !== undefined && text.startsWith(pending.delta))
-      : []
     const raw = reasoningBuffer.get(key) || ""
+    const parts: StreamPart[] = pending
+      ? flushPendingReasoningDelta(
+          key,
+          text !== undefined ? text.startsWith(pending.delta) : pending.delta.startsWith(raw),
+        )
+      : []
     if (!isOpen && text !== undefined && raw && !text.startsWith(raw)) {
       reasoningBuffer.delete(key)
     }

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -1515,6 +1515,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     completedResponseTextReplay.clear()
     doneItemTextReplay.clear()
     doneItemShiftedTextReplay.clear()
+    doneItemDeltaTextReplay.clear()
   }
 
   const flushOpen = () => {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -569,9 +569,6 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     ) {
       return []
     }
-    if (!isOpen && final !== undefined && hasAnyPendingTextReplay(itemID, final)) {
-      return []
-    }
     if (!isOpen && final !== undefined && hasPendingTextReplay(itemID, index, final)) {
       return []
     }
@@ -1499,9 +1496,10 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
         parts.push(...closeReasoning(pending.itemID, pending.index, pending.meta, pending.extra))
         continue
       }
-      reasoningOpen.delete(key)
-      reasoningDonePending.delete(key)
-      parts.push({ type: "reasoning-end", id: key, providerMetadata: {} })
+      const separator = key.lastIndexOf(":")
+      const itemID = separator < 0 ? key : key.slice(0, separator)
+      const index = separator < 0 ? 0 : Number(key.slice(separator + 1))
+      parts.push(...closeReasoning(itemID, Number.isFinite(index) ? index : 0, {}, {}))
     }
 
     parts.push(...flushPendingText(true))

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -76,6 +76,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const reasoningOpen = new Set<string>()
   const reasoningByItem = new Map<string, Set<string>>()
   const reasoningDonePending = new Map<string, PendingReasoning>()
+  const reasoningWaitForDone = new Set<string>()
   const responseTextReplay = new Map<string, Set<string>>()
   const responseReasoningReplay = new Map<string, Set<string>>()
   const pendingTextReplay = new Set<string>()
@@ -193,14 +194,17 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   }
 
   const rememberCompletedResponseTextReplay = () => {
-    for (const text of textBuffer.values()) {
-      const key = replayTextKey(text)
+    for (const [part, text] of textBuffer.entries()) {
+      const separator = part.lastIndexOf(":")
+      if (separator < 0) continue
+      const itemID = part.slice(0, separator)
+      const key = replayPartKey(itemID, 0, text)
       if (key) completedResponseTextReplay.add(key)
     }
   }
 
-  const hasCompletedResponseTextReplay = (text: string) => {
-    const key = replayTextKey(text)
+  const hasCompletedResponseTextReplay = (itemID: string, index: number, text: string) => {
+    const key = replayPartKey(itemID, index, text)
     return !!key && completedResponseTextReplay.has(key)
   }
 
@@ -647,6 +651,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
         reasoningByItem.delete(itemID)
       }
     }
+    reasoningWaitForDone.delete(itemID)
     return [
       {
         type: "reasoning-end",
@@ -662,6 +667,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
 
   const flushDoneReasoning = () => {
     return Array.from(reasoningDonePending.values()).flatMap((pending) => {
+      if (reasoningWaitForDone.has(pending.itemID)) return []
       return closeReasoning(pending.itemID, pending.index, pending.meta, pending.extra)
     })
   }
@@ -910,6 +916,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
 
     if (itemType === "reasoning") {
       if (!itemID) return []
+      if (Object.hasOwn(item, "encrypted_content")) reasoningWaitForDone.add(itemID)
       return ensureReasoning(
         itemID,
         0,
@@ -1358,7 +1365,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       const text = extractMessageText(message)
       if (!text) continue
       if (hasResponseReplay(responseTextReplay, message, text)) continue
-      if (hasPendingTextReplay(itemID, 0, text) || hasCompletedResponseTextReplay(text)) continue
+      if (hasPendingTextReplay(itemID, 0, text) || hasCompletedResponseTextReplay(itemID, 0, text)) continue
       if (shouldSkipDuplicateAssistantText(itemID, 0, text)) continue
       parts.push(
         ...finishText(itemID, 0, text, messageMeta, {
@@ -1377,6 +1384,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       if (!textOpen.has(key)) textBuffer.delete(key)
     }
     reasoningDonePending.clear()
+    reasoningWaitForDone.clear()
     pendingTextReplay.clear()
     pendingTextFlushed.clear()
     closedReasoningTextReplay.clear()

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -88,6 +88,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const closedReasoningTextReplay = new Set<string>()
   const completedResponseTextReplay = new Set<string>()
   const doneItemTextReplay = new Set<string>()
+  const retiredParts: StreamPart[] = []
 
   let usage: Usage | undefined
   let lastTextItemID: string | undefined
@@ -96,6 +97,8 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   let sawReasoning = false
   let flushingText = false
   const agentUpdatedHandoffAgents = new Set<string>()
+
+  const drainRetiredParts = () => retiredParts.splice(0)
 
   const mergeMeta = (meta: AgencySwarmEventMeta, extra?: Record<string, unknown>) => {
     return {
@@ -431,12 +434,13 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   }
 
   const ensureText = (itemID: string, index: number, meta: AgencySwarmEventMeta, extra?: Record<string, unknown>) => {
-    const parts: StreamPart[] = []
+    const parts: StreamPart[] = drainRetiredParts()
     const key = textKey(itemID, index)
     if (shouldHoldText() && !textOpen.has(key)) {
       lastTextItemID = itemID
       textIndex.set(itemID, index)
-      return deferText(itemID, index, false, meta, extra)
+      deferText(itemID, index, false, meta, extra)
+      return parts
     }
     const activeItemID = lastTextItemID
     const activeIndex = activeItemID ? (textIndex.get(activeItemID) ?? 0) : undefined
@@ -497,7 +501,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
 
   const flushPendingText = (force: boolean) => {
     if (!force && hasOpenReasoning()) return []
-    const parts: StreamPart[] = []
+    const parts: StreamPart[] = drainRetiredParts()
     flushingText = true
     for (const [key, pending] of Array.from(textPending.entries())) {
       textPending.delete(key)
@@ -707,17 +711,15 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       }
     }
     reasoningWaitForDone.delete(itemID)
-    parts.push(
-      {
-        type: "reasoning-end",
-        id: key,
-        providerMetadata: mergeMeta(meta, {
-          item_id: itemID,
-          summary_index: index,
-          ...(extra ?? {}),
-        }),
-      },
-    )
+    parts.push({
+      type: "reasoning-end",
+      id: key,
+      providerMetadata: mergeMeta(meta, {
+        item_id: itemID,
+        summary_index: index,
+        ...(extra ?? {}),
+      }),
+    })
     return parts
   }
 
@@ -776,7 +778,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     meta: AgencySwarmEventMeta,
     extra?: Record<string, unknown>,
   ) => {
-    const parts: StreamPart[] = flushDoneReasoning()
+    const parts: StreamPart[] = [...drainRetiredParts(), ...flushDoneReasoning()]
     parts.push(...flushPendingText(true))
     const tool = ensureTool(callID, toolName)
     if (!tool.started) {
@@ -1399,7 +1401,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   }
 
   const handleMessagesPayload = async (payload: Record<string, unknown>) => {
-    const parts: StreamPart[] = []
+    const parts: StreamPart[] = drainRetiredParts()
     const newMessages = Array.isArray(payload["new_messages"]) ? payload["new_messages"] : []
     await input.persistMessages(newMessages)
     setUsage(asRecord(payload["usage"]))
@@ -1407,6 +1409,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     const runFromMessages = asString(payload["run_id"])
     if (runFromMessages) {
       await input.handleRunID(runFromMessages)
+      parts.push(...drainRetiredParts())
     }
 
     for (const output of extractFunctionCallOutputs(newMessages)) {
@@ -1445,8 +1448,10 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     for (const key of Array.from(textBuffer.keys())) {
       if (!textOpen.has(key)) textBuffer.delete(key)
     }
-    reasoningDonePending.clear()
-    reasoningWaitForDone.clear()
+    for (const pending of Array.from(reasoningDonePending.values())) {
+      retiredParts.push(...closeReasoning(pending.itemID, pending.index, pending.meta, pending.extra))
+    }
+    retiredParts.push(...flushPendingText(false))
     pendingTextReplay.clear()
     pendingTextFlushed.clear()
     closedReasoningTextReplay.clear()
@@ -1455,7 +1460,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   }
 
   const flushOpen = () => {
-    const parts: StreamPart[] = []
+    const parts: StreamPart[] = drainRetiredParts()
 
     for (const key of Array.from(reasoningOpen.values())) {
       const pending = reasoningDonePending.get(key)

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -15,8 +15,6 @@ import {
 import { truncateLargeText } from "./agency-swarm-history-transport"
 
 const MAX_UI_TOOL_OUTPUT_CHARS = 60_000
-const MIN_REASONING_OVERLAP_CHARS = 8
-
 type StreamPart = Record<string, unknown>
 
 type Usage = {
@@ -247,12 +245,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const reasoningSuffix = (current: string, delta: string) => {
     if (!current) return delta
     if (delta.startsWith(current)) {
-      if (delta.length === current.length && current.length < MIN_REASONING_OVERLAP_CHARS) return delta
       return delta.slice(current.length)
-    }
-    const limit = Math.min(current.length, delta.length)
-    for (let size = limit; size >= MIN_REASONING_OVERLAP_CHARS; size--) {
-      if (current.endsWith(delta.slice(0, size))) return delta.slice(size)
     }
     return delta
   }

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -1378,6 +1378,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     pendingTextReplay.clear()
     pendingTextFlushed.clear()
     closedReasoningTextReplay.clear()
+    completedResponseTextReplay.clear()
   }
 
   const flushOpen = () => {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -15,7 +15,6 @@ import {
 import { truncateLargeText } from "./agency-swarm-history-transport"
 
 const MAX_UI_TOOL_OUTPUT_CHARS = 60_000
-const MIN_CUMULATIVE_REASONING_PREFIX_CHARS = 8
 type StreamPart = Record<string, unknown>
 
 type Usage = {
@@ -52,6 +51,11 @@ type PendingReasoning = {
   extra?: Record<string, unknown>
 }
 
+type PendingReasoningDelta = PendingReasoning & {
+  current: string
+  delta: string
+}
+
 type StreamEventsInput = {
   assistantMessage: MessageV2.Assistant
   isCancelled: () => boolean
@@ -75,6 +79,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const reasoningOpen = new Set<string>()
   const reasoningByItem = new Map<string, Set<string>>()
   const reasoningDonePending = new Map<string, PendingReasoning>()
+  const reasoningDeltaPending = new Map<string, PendingReasoningDelta>()
   const reasoningWaitForDone = new Set<string>()
   const responseTextReplay = new Map<string, Set<string>>()
   const responseReasoningReplay = new Map<string, Set<string>>()
@@ -274,14 +279,6 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   }
 
   const reasoningKey = (itemID: string, index: number) => `${itemID}:${index}`
-
-  const reasoningSuffix = (current: string, delta: string) => {
-    if (!current) return delta
-    if (current.length >= MIN_CUMULATIVE_REASONING_PREFIX_CHARS && delta.startsWith(current)) {
-      return delta.slice(current.length)
-    }
-    return delta
-  }
 
   const setUsage = (value: Record<string, unknown> | undefined) => {
     if (!value) return
@@ -640,6 +637,38 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     ]
   }
 
+  const emitReasoningDelta = (
+    itemID: string,
+    index: number,
+    text: string,
+    meta: AgencySwarmEventMeta,
+    extra?: Record<string, unknown>,
+  ) => {
+    const key = reasoningKey(itemID, index)
+    const existing = reasoningBuffer.get(key) || ""
+    reasoningBuffer.set(key, existing + text)
+    return [
+      {
+        type: "reasoning-delta",
+        id: key,
+        text,
+        providerMetadata: mergeMeta(meta, {
+          item_id: itemID,
+          summary_index: index,
+          ...(extra ?? {}),
+        }),
+      },
+    ]
+  }
+
+  const flushPendingReasoningDelta = (key: string, cumulative: boolean): StreamPart[] => {
+    const pending = reasoningDeltaPending.get(key)
+    if (!pending) return []
+    reasoningDeltaPending.delete(key)
+    const text = cumulative ? pending.delta.slice(pending.current.length) : pending.delta
+    return text ? emitReasoningDelta(pending.itemID, pending.index, text, pending.meta, pending.extra) : []
+  }
+
   const reasoningDelta = (
     itemID: string,
     index: number,
@@ -649,22 +678,14 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   ) => {
     if (!delta) return []
     const key = reasoningKey(itemID, index)
-    const existing = reasoningBuffer.get(key) || ""
-    const suffix = reasoningSuffix(existing, delta)
-    if (!suffix) return []
-    reasoningBuffer.set(key, existing + suffix)
-    return [
-      {
-        type: "reasoning-delta",
-        id: key,
-        text: suffix,
-        providerMetadata: mergeMeta(meta, {
-          item_id: itemID,
-          summary_index: index,
-          ...(extra ?? {}),
-        }),
-      },
-    ]
+    const pending = reasoningDeltaPending.get(key)
+    const parts = pending ? flushPendingReasoningDelta(key, delta.startsWith(pending.delta)) : []
+    const current = reasoningBuffer.get(key) || ""
+    if (current && delta.startsWith(current)) {
+      reasoningDeltaPending.set(key, { itemID, index, current, delta, meta, extra })
+      return parts
+    }
+    return [...parts, ...emitReasoningDelta(itemID, index, delta, meta, extra)]
   }
 
   const closeReasoning = (
@@ -675,6 +696,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   ) => {
     const key = reasoningKey(itemID, index)
     if (!reasoningOpen.has(key)) return []
+    const parts = flushPendingReasoningDelta(key, false)
     reasoningOpen.delete(key)
     reasoningDonePending.delete(key)
     const set = reasoningByItem.get(itemID)
@@ -685,7 +707,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       }
     }
     reasoningWaitForDone.delete(itemID)
-    return [
+    parts.push(
       {
         type: "reasoning-end",
         id: key,
@@ -695,7 +717,8 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
           ...(extra ?? {}),
         }),
       },
-    ]
+    )
+    return parts
   }
 
   const flushDoneReasoning = (force = false) => {
@@ -715,15 +738,19 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   ) => {
     const key = reasoningKey(itemID, index)
     const isOpen = reasoningOpen.has(key)
+    const pending = reasoningDeltaPending.get(key)
+    const parts: StreamPart[] = pending
+      ? flushPendingReasoningDelta(key, text !== undefined && text.startsWith(pending.delta))
+      : []
     const raw = reasoningBuffer.get(key) || ""
     if (!isOpen && text !== undefined && raw && !text.startsWith(raw)) {
       reasoningBuffer.delete(key)
     }
     const current = reasoningBuffer.get(key) || ""
     if (!isOpen && (text === undefined || text === current)) {
-      return []
+      return parts
     }
-    const parts: StreamPart[] = isOpen ? [] : ensureReasoning(itemID, index, meta, extra)
+    if (!isOpen) parts.push(...ensureReasoning(itemID, index, meta, extra))
     const suffix = text ? (text.startsWith(current) ? text.slice(current.length) : current ? "" : text) : ""
     if (suffix) {
       parts.push(...reasoningDelta(itemID, index, suffix, meta, extra))

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -698,7 +698,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!delta) return []
     const key = reasoningKey(itemID, index)
     const pending = reasoningDeltaPending.get(key)
-    const parts = pending ? flushPendingReasoningDelta(key, delta.startsWith(pending.delta)) : []
+    const parts = pending ? flushPendingReasoningDelta(key, pending.delta.startsWith(pending.current)) : []
     const current = reasoningBuffer.get(key) || ""
     if (current && delta.startsWith(current)) {
       reasoningDeltaPending.set(key, { itemID, index, current, delta, meta, extra })

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -787,6 +787,17 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     })
   }
 
+  const closeOpenReasoning = () => {
+    return Array.from(reasoningOpen.values()).flatMap((key) => {
+      const pending = reasoningDonePending.get(key)
+      if (pending) return closeReasoning(pending.itemID, pending.index, pending.meta, pending.extra)
+      const separator = key.lastIndexOf(":")
+      const itemID = separator < 0 ? key : key.slice(0, separator)
+      const index = separator < 0 ? 0 : Number(key.slice(separator + 1))
+      return closeReasoning(itemID, Number.isFinite(index) ? index : 0, {}, {})
+    })
+  }
+
   const finishReasoning = (
     itemID: string,
     index: number,
@@ -1271,7 +1282,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       setUsage(asRecord(asRecord(nested["response"])?.["usage"]))
       if (responseType !== "response.completed") return { parts: [] }
       rememberCompletedResponseTextReplay()
-      return { parts: [...flushDoneReasoning(true), ...flushPendingText(true)] }
+      return { parts: [...flushDoneReasoning(true), ...closeOpenReasoning(), ...flushPendingText(true)] }
     }
 
     if (responseType === "response.output_item.added" && item) {
@@ -1543,19 +1554,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
 
   const flushOpen = () => {
     const parts: StreamPart[] = drainRetiredParts()
-
-    for (const key of Array.from(reasoningOpen.values())) {
-      const pending = reasoningDonePending.get(key)
-      if (pending) {
-        parts.push(...closeReasoning(pending.itemID, pending.index, pending.meta, pending.extra))
-        continue
-      }
-      const separator = key.lastIndexOf(":")
-      const itemID = separator < 0 ? key : key.slice(0, separator)
-      const index = separator < 0 ? 0 : Number(key.slice(separator + 1))
-      parts.push(...closeReasoning(itemID, Number.isFinite(index) ? index : 0, {}, {}))
-    }
-
+    parts.push(...closeOpenReasoning())
     parts.push(...flushPendingText(true))
 
     for (const key of Array.from(textOpen.values())) {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -705,6 +705,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     extra?: Record<string, unknown>,
   ) => {
     const parts: StreamPart[] = flushDoneReasoning()
+    parts.push(...flushPendingText(true))
     const tool = ensureTool(callID, toolName)
     if (!tool.started) {
       tool.started = true

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -241,12 +241,12 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     )
   }
 
-  const rememberDoneItemTextReplay = (itemID: string, index: number, text: string) => {
+  const rememberDoneItemTextReplay = (itemID: string, index: number, text: string, deltaBacked: boolean) => {
     const part = replayPartKey(itemID, index, text)
     if (part) doneItemTextReplay.add(part)
     const key = replayItemKey(itemID, text)
     if (key) doneItemShiftedTextReplay.add(key)
-    if (key && textDeltaSeen.has(textKey(itemID, index))) doneItemDeltaTextReplay.add(key)
+    if (key && deltaBacked) doneItemDeltaTextReplay.add(key)
   }
 
   const hasDoneItemTextReplay = (itemID: string, index: number, text: string) => {
@@ -1079,10 +1079,11 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       if (!itemID) return []
       const text = extractMessageText(item)
       const index = textIndex.get(itemID) ?? 0
+      const deltaBacked = textDeltaSeen.has(textKey(itemID, index))
       const parts = finishText(itemID, index, text, eventMeta, outputMeta(outputIndex))
       if (text && textBuffer.get(textKey(itemID, index)) === text) {
         rememberResponseReplay(responseTextReplay, item, text)
-        rememberDoneItemTextReplay(itemID, index, text)
+        rememberDoneItemTextReplay(itemID, index, text, deltaBacked)
       }
       return parts
     }

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -103,7 +103,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   }
 
   const hasOpenReasoning = () => reasoningOpen.size > 0
-  const shouldHoldText = () => !flushingText && (hasOpenReasoning() || sawReasoning)
+  const shouldHoldText = () => !flushingText && hasOpenReasoning()
 
   /** Skip only when the incoming event is a replay of the same `(itemID, index)` that is already closed. Body-only matches would drop legit later messages with a short repeat body like "Done" or "OK". */
   const shouldSkipDuplicateAssistantText = (itemID: string, index: number, text: string) => {
@@ -463,7 +463,6 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
 
   const flushPendingText = (force: boolean) => {
     if (hasOpenReasoning()) return []
-    if (sawReasoning && !force) return []
     const parts: StreamPart[] = []
     flushingText = true
     for (const [key, pending] of Array.from(textPending.entries())) {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -699,6 +699,17 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     ]
   }
 
+  const isPrefixReasoningDelta = (current: string, delta: string) => {
+    if (!current || !delta.startsWith(current)) return false
+    return true
+  }
+
+  const isLikelyCumulativeReasoningDelta = (current: string, delta: string) => {
+    if (!isPrefixReasoningDelta(current, delta)) return false
+    if (delta.length === current.length) return true
+    return !/\s$/.test(current)
+  }
+
   const flushPendingReasoningDelta = (key: string, cumulative: boolean): StreamPart[] => {
     const pending = reasoningDeltaPending.get(key)
     if (!pending) return []
@@ -711,7 +722,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     return Array.from(reasoningDeltaPending.keys()).flatMap((key) => {
       const pending = reasoningDeltaPending.get(key)
       const current = reasoningBuffer.get(key) || ""
-      return flushPendingReasoningDelta(key, !!pending && pending.delta.startsWith(current))
+      return flushPendingReasoningDelta(key, !!pending && isLikelyCumulativeReasoningDelta(current, pending.delta))
     })
   }
 
@@ -725,9 +736,11 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!delta) return []
     const key = reasoningKey(itemID, index)
     const pending = reasoningDeltaPending.get(key)
-    const parts = pending ? flushPendingReasoningDelta(key, pending.delta.startsWith(pending.current)) : []
+    const parts = pending
+      ? flushPendingReasoningDelta(key, isLikelyCumulativeReasoningDelta(pending.current, pending.delta))
+      : []
     const current = reasoningBuffer.get(key) || ""
-    if (current && delta.startsWith(current)) {
+    if (isPrefixReasoningDelta(current, delta)) {
       reasoningDeltaPending.set(key, { itemID, index, current, delta, meta, extra })
       return parts
     }
@@ -744,7 +757,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!reasoningOpen.has(key)) return []
     const pending = reasoningDeltaPending.get(key)
     const current = reasoningBuffer.get(key) || ""
-    const parts = flushPendingReasoningDelta(key, !!pending && pending.delta.startsWith(current))
+    const parts = flushPendingReasoningDelta(key, !!pending && isLikelyCumulativeReasoningDelta(current, pending.delta))
     reasoningOpen.delete(key)
     reasoningDonePending.delete(key)
     const set = reasoningByItem.get(itemID)
@@ -789,7 +802,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     const parts: StreamPart[] = pending
       ? flushPendingReasoningDelta(
           key,
-          text !== undefined ? text.startsWith(pending.delta) : pending.delta.startsWith(raw),
+          text !== undefined ? text.startsWith(pending.delta) : isLikelyCumulativeReasoningDelta(raw, pending.delta),
         )
       : []
     if (!isOpen && text !== undefined && raw && !text.startsWith(raw)) {

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -278,7 +278,8 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!key) return false
     for (const [pendingKey, pending] of textPending.entries()) {
       if (pending.itemID !== itemID) continue
-      if (pending.index !== index && pending.done) continue
+      if (pending.index !== index && (pending.done || textExplicit.has(textKey(pending.itemID, pending.index))))
+        continue
       if (replayTextKey(textBuffer.get(textKey(pending.itemID, pending.index)) || "") !== key) continue
       textPending.set(pendingKey, {
         ...pending,
@@ -532,6 +533,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const flushPendingText = (force: boolean) => {
     if (!force && hasOpenReasoning()) return []
     const parts: StreamPart[] = drainRetiredParts()
+    if (force) parts.push(...flushPendingReasoningDeltas())
     flushingText = true
     for (const [key, pending] of Array.from(textPending.entries())) {
       textPending.delete(key)
@@ -703,6 +705,14 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     reasoningDeltaPending.delete(key)
     const text = cumulative ? pending.delta.slice(pending.current.length) : pending.delta
     return text ? emitReasoningDelta(pending.itemID, pending.index, text, pending.meta, pending.extra) : []
+  }
+
+  const flushPendingReasoningDeltas = () => {
+    return Array.from(reasoningDeltaPending.keys()).flatMap((key) => {
+      const pending = reasoningDeltaPending.get(key)
+      const current = reasoningBuffer.get(key) || ""
+      return flushPendingReasoningDelta(key, !!pending && pending.delta.startsWith(current))
+    })
   }
 
   const reasoningDelta = (

--- a/packages/opencode/test/cli/run/entry.body.test.ts
+++ b/packages/opencode/test/cli/run/entry.body.test.ts
@@ -69,7 +69,7 @@ describe("run entry body", () => {
     const reasoning = entryBody(
       commit({
         kind: "reasoning",
-        text: "Thinking: plan next steps",
+        text: "plan next steps",
         phase: "progress",
         source: "reasoning",
         partID: "reason-1",
@@ -78,13 +78,13 @@ describe("run entry body", () => {
     expect(reasoning).toEqual({
       type: "code",
       filetype: "markdown",
-      content: "_Thinking:_ plan next steps",
+      content: "Thought:\n\nplan next steps",
     })
     expect(
       entryCanStream(
         commit({
           kind: "reasoning",
-          text: "Thinking: plan next steps",
+          text: "plan next steps",
           phase: "progress",
           source: "reasoning",
         }),

--- a/packages/opencode/test/cli/run/scrollback.surface.test.ts
+++ b/packages/opencode/test/cli/run/scrollback.surface.test.ts
@@ -233,11 +233,13 @@ test("adds the reasoning header once for streamed reasoning chunks", async () =>
   try {
     await out.scrollback.append(reasoning("first "))
     await out.scrollback.append(reasoning("second"))
+    await out.scrollback.append(reasoning(" chunk"))
 
     const activeEntry = Reflect.get(out.scrollback, "active") as { content?: string } | undefined
     expect(activeEntry?.content?.match(/Thought/g) ?? []).toHaveLength(1)
     expect(activeEntry?.content).toContain("first")
     expect(activeEntry?.content).toContain("second")
+    expect(activeEntry?.content).toContain("second chunk")
 
     await out.scrollback.complete()
 
@@ -246,6 +248,7 @@ test("adds the reasoning header once for streamed reasoning chunks", async () =>
       const output = render(commits)
       expect(output).toContain("first")
       expect(output).toContain("second")
+      expect(output).toContain("second chunk")
     } finally {
       destroy(commits)
     }

--- a/packages/opencode/test/cli/run/scrollback.surface.test.ts
+++ b/packages/opencode/test/cli/run/scrollback.surface.test.ts
@@ -96,6 +96,17 @@ function assistant(text: string, phase: StreamCommit["phase"] = "progress"): Str
   }
 }
 
+function reasoning(text: string, phase: StreamCommit["phase"] = "progress"): StreamCommit {
+  return {
+    kind: "reasoning",
+    text,
+    phase,
+    source: "reasoning",
+    messageID: "msg-1",
+    partID: "reason-1",
+  }
+}
+
 function user(text: string): StreamCommit {
   return {
     kind: "user",
@@ -210,6 +221,33 @@ test("holds markdown code blocks until final commit and keeps newline ownership"
       expect(render(final)).toContain("console.log(message)")
     } finally {
       destroy(final)
+    }
+  } finally {
+    out.scrollback.destroy()
+  }
+})
+
+test("adds the reasoning header once for streamed reasoning chunks", async () => {
+  const out = await setup()
+
+  try {
+    await out.scrollback.append(reasoning("first "))
+    await out.scrollback.append(reasoning("second"))
+
+    const activeEntry = Reflect.get(out.scrollback, "active") as { content?: string } | undefined
+    expect(activeEntry?.content?.match(/Thought/g) ?? []).toHaveLength(1)
+    expect(activeEntry?.content).toContain("first")
+    expect(activeEntry?.content).toContain("second")
+
+    await out.scrollback.complete()
+
+    const commits = claim(out.renderer)
+    try {
+      const output = render(commits)
+      expect(output).toContain("first")
+      expect(output).toContain("second")
+    } finally {
+      destroy(commits)
     }
   } finally {
     out.scrollback.destroy()

--- a/packages/opencode/test/cli/run/session-data.test.ts
+++ b/packages/opencode/test/cli/run/session-data.test.ts
@@ -257,6 +257,35 @@ describe("run session data", () => {
     ])
   })
 
+  test("keeps delayed role replayed assistant text behind completed reasoning", () => {
+    let data = createSessionData()
+    data = reduce(data, text({ id: "txt-1", messageID: "msg-1", text: "Answer later.", time: { start: 2, end: 3 } })).data
+    data = reduce(
+      data,
+      reasoning({
+        id: "reason-1",
+        messageID: "msg-1",
+        text: "Thinking first.",
+        time: { start: 1, end: 2 },
+      }),
+    ).data
+
+    const out = reduce(data, assistant("msg-1"))
+
+    expect(out.commits).toEqual([
+      expect.objectContaining({
+        kind: "reasoning",
+        text: "Thinking first.",
+        partID: "reason-1",
+      }),
+      expect.objectContaining({
+        kind: "assistant",
+        text: "Answer later.",
+        partID: "txt-1",
+      }),
+    ])
+  })
+
   test("keeps permission precedence over queued questions", () => {
     let data = createSessionData()
     data = reduce(data, {

--- a/packages/opencode/test/cli/run/session-data.test.ts
+++ b/packages/opencode/test/cli/run/session-data.test.ts
@@ -178,6 +178,85 @@ describe("run session data", () => {
     expect(out.data.ids.has("reason-1")).toBe(true)
   })
 
+  test("keeps streamed reasoning ahead of assistant text for the same message", () => {
+    let data = createSessionData()
+    data = reduce(data, assistant("msg-1")).data
+    data = reduce(data, reasoning({ id: "reason-1", messageID: "msg-1", text: "", time: { start: 1 } })).data
+
+    let out = reduce(data, delta("msg-1", "reason-1", 'The user just said "hey". I shoul'))
+    expect(out.commits).toEqual([
+      expect.objectContaining({
+        kind: "reasoning",
+        text: 'The user just said "hey". I shoul',
+        partID: "reason-1",
+      }),
+    ])
+
+    data = reduce(out.data, text({ id: "txt-1", messageID: "msg-1", text: "", time: { start: 2 } })).data
+    out = reduce(data, delta("msg-1", "txt-1", "Hey there!"))
+    expect(out.commits).toEqual([])
+
+    out = reduce(out.data, delta("msg-1", "reason-1", "d respond politely."))
+    expect(out.commits).toEqual([
+      expect.objectContaining({
+        kind: "reasoning",
+        text: "d respond politely.",
+        partID: "reason-1",
+      }),
+    ])
+
+    out = reduce(
+      out.data,
+      reasoning({
+        id: "reason-1",
+        messageID: "msg-1",
+        text: 'The user just said "hey". I should respond politely.',
+        time: { start: 1, end: 3 },
+      }),
+    )
+    expect(out.commits).toEqual([
+      expect.objectContaining({
+        kind: "assistant",
+        text: "Hey there!",
+        partID: "txt-1",
+      }),
+    ])
+  })
+
+  test("keeps delayed role replayed assistant text behind open reasoning", () => {
+    let data = createSessionData()
+    data = reduce(data, reasoning({ id: "reason-1", messageID: "msg-1", text: "", time: { start: 1 } })).data
+    data = reduce(data, delta("msg-1", "reason-1", "Thinking first.")).data
+    data = reduce(data, text({ id: "txt-1", messageID: "msg-1", text: "", time: { start: 2 } })).data
+    data = reduce(data, delta("msg-1", "txt-1", "Answer later.")).data
+
+    let out = reduce(data, assistant("msg-1"))
+    expect(out.commits).toEqual([
+      expect.objectContaining({
+        kind: "reasoning",
+        text: "Thinking first.",
+        partID: "reason-1",
+      }),
+    ])
+
+    out = reduce(
+      out.data,
+      reasoning({
+        id: "reason-1",
+        messageID: "msg-1",
+        text: "Thinking first.",
+        time: { start: 1, end: 3 },
+      }),
+    )
+    expect(out.commits).toEqual([
+      expect.objectContaining({
+        kind: "assistant",
+        text: "Answer later.",
+        partID: "txt-1",
+      }),
+    ])
+  })
+
   test("keeps permission precedence over queued questions", () => {
     let data = createSessionData()
     data = reduce(data, {

--- a/packages/opencode/test/cli/run/session-data.test.ts
+++ b/packages/opencode/test/cli/run/session-data.test.ts
@@ -178,6 +178,22 @@ describe("run session data", () => {
     expect(out.data.ids.has("reason-1")).toBe(true)
   })
 
+  test("shows progress for redacted-only reasoning when thinking is enabled", () => {
+    let data = createSessionData()
+    data = reduce(data, assistant("msg-1")).data
+    data = reduce(data, reasoning({ id: "reason-1", messageID: "msg-1", text: "", time: { start: 1 } })).data
+
+    const out = reduce(data, delta("msg-1", "reason-1", "[REDACTED]"))
+
+    expect(out.commits).toEqual([
+      expect.objectContaining({
+        kind: "reasoning",
+        text: "Thinking...",
+        partID: "reason-1",
+      }),
+    ])
+  })
+
   test("keeps streamed reasoning ahead of assistant text for the same message", () => {
     let data = createSessionData()
     data = reduce(data, assistant("msg-1")).data
@@ -259,7 +275,10 @@ describe("run session data", () => {
 
   test("keeps delayed role replayed assistant text behind completed reasoning", () => {
     let data = createSessionData()
-    data = reduce(data, text({ id: "txt-1", messageID: "msg-1", text: "Answer later.", time: { start: 2, end: 3 } })).data
+    data = reduce(
+      data,
+      text({ id: "txt-1", messageID: "msg-1", text: "Answer later.", time: { start: 2, end: 3 } }),
+    ).data
     data = reduce(
       data,
       reasoning({

--- a/packages/opencode/test/cli/run/session-data.test.ts
+++ b/packages/opencode/test/cli/run/session-data.test.ts
@@ -178,17 +178,41 @@ describe("run session data", () => {
     expect(out.data.ids.has("reason-1")).toBe(true)
   })
 
-  test("shows progress for redacted-only reasoning when thinking is enabled", () => {
+  test("shows placeholder for redacted-only reasoning when thinking is enabled", () => {
     let data = createSessionData()
     data = reduce(data, assistant("msg-1")).data
     data = reduce(data, reasoning({ id: "reason-1", messageID: "msg-1", text: "", time: { start: 1 } })).data
 
-    const out = reduce(data, delta("msg-1", "reason-1", "[REDACTED]"))
+    let out = reduce(data, delta("msg-1", "reason-1", "[REDACTED]"))
+    expect(out.commits).toEqual([])
+
+    out = reduce(
+      out.data,
+      reasoning({ id: "reason-1", messageID: "msg-1", text: "[REDACTED]", time: { start: 1, end: 2 } }),
+    )
 
     expect(out.commits).toEqual([
       expect.objectContaining({
         kind: "reasoning",
         text: "Thinking...",
+        partID: "reason-1",
+      }),
+    ])
+  })
+
+  test("does not prepend placeholder when redacted reasoning later reveals text", () => {
+    let data = createSessionData()
+    data = reduce(data, assistant("msg-1")).data
+    data = reduce(data, reasoning({ id: "reason-1", messageID: "msg-1", text: "", time: { start: 1 } })).data
+
+    let out = reduce(data, delta("msg-1", "reason-1", "[REDACTED]"))
+    expect(out.commits).toEqual([])
+
+    out = reduce(out.data, delta("msg-1", "reason-1", "Visible reasoning."))
+    expect(out.commits).toEqual([
+      expect.objectContaining({
+        kind: "reasoning",
+        text: "Visible reasoning.",
         partID: "reason-1",
       }),
     ])

--- a/packages/opencode/test/cli/run/session-data.test.ts
+++ b/packages/opencode/test/cli/run/session-data.test.ts
@@ -286,6 +286,41 @@ describe("run session data", () => {
     ])
   })
 
+  test("flushes held assistant text before a later tool update", () => {
+    let data = createSessionData()
+    data = reduce(data, assistant("msg-1")).data
+    data = reduce(data, reasoning({ id: "reason-1", messageID: "msg-1", text: "", time: { start: 1 } })).data
+    data = reduce(data, delta("msg-1", "reason-1", "Need a tool.")).data
+    data = reduce(data, text({ id: "txt-1", messageID: "msg-1", text: "", time: { start: 2 } })).data
+    data = reduce(data, delta("msg-1", "txt-1", "I will check.")).data
+
+    const out = reduce(
+      data,
+      tool({
+        id: "tool-1",
+        messageID: "msg-1",
+        tool: "bash",
+        state: {
+          status: "running",
+          input: { command: "date" },
+        },
+      }),
+    )
+
+    expect(out.commits).toEqual([
+      expect.objectContaining({
+        kind: "assistant",
+        text: "I will check.",
+        partID: "txt-1",
+      }),
+      expect.objectContaining({
+        kind: "tool",
+        phase: "start",
+        partID: "tool-1",
+      }),
+    ])
+  })
+
   test("keeps permission precedence over queued questions", () => {
     let data = createSessionData()
     data = reduce(data, {

--- a/packages/opencode/test/cli/run/subagent-data.test.ts
+++ b/packages/opencode/test/cli/run/subagent-data.test.ts
@@ -286,7 +286,7 @@ describe("run subagent data", () => {
           sessionID: "child-1",
           type: "reasoning",
           text: "planning next steps",
-          time: { start: 1 },
+          time: { start: 1, end: 2 },
         },
       },
     })
@@ -353,7 +353,7 @@ describe("run subagent data", () => {
     expect(snapshot.tabs).toEqual([expect.objectContaining({ sessionID: "child-1", status: "running" })])
     expect(visible(snapshot.details["child-1"]?.commits ?? [])).toEqual([
       "› Inspect footer tabs",
-      "_Thinking:_ planning next steps",
+      "Thought:\n\nplanning next steps",
       "# Shell\n$ git status --short",
       "hello world",
     ])
@@ -432,7 +432,7 @@ describe("run subagent data", () => {
 
     expect(visible(snapshotSubagentData(data).details["child-1"]?.commits ?? [])).toEqual([
       "› Inspect footer tabs",
-      "_Thinking:_ planning next steps",
+      "Thought:\n\nplanning next steps",
       "hello world",
     ])
   })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7935,7 +7935,7 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["A", "B"])
   })
 
-  test("stream normalizes cumulative reasoning when output item done has no summary", async () => {
+  test("stream preserves pending cumulative-looking reasoning when output item done has no summary", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
       yield {
@@ -7985,10 +7985,10 @@ describe("session.agency-swarm", () => {
       if (event.type === "reasoning-delta") deltas.push(event.text)
     }
 
-    expect(deltas).toEqual(["A", "B"])
+    expect(deltas).toEqual(["A", "AB"])
   })
 
-  test("stream flushes cumulative reasoning delta before stream-end close", async () => {
+  test("stream preserves pending cumulative-looking reasoning before stream-end close", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
       yield {
@@ -8028,7 +8028,7 @@ describe("session.agency-swarm", () => {
       if (event.type === "reasoning-end") events.push("reasoning-end")
     }
 
-    expect(events).toEqual(["reasoning:A", "reasoning:B", "reasoning-end"])
+    expect(events).toEqual(["reasoning:A", "reasoning:AB", "reasoning-end"])
   })
 
   test("stream preserves prefix-matching incremental reasoning when item done has no summary", async () => {
@@ -8128,7 +8128,7 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:The ", "reasoning:The answer", "reasoning-end"])
   })
 
-  test("stream flushes pending cumulative reasoning before forced text and tool output", async () => {
+  test("stream preserves pending cumulative-looking reasoning before forced text and tool output", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
       yield {
@@ -8211,7 +8211,7 @@ describe("session.agency-swarm", () => {
       if (event.type === "tool-input-start") events.push(`tool:${event.toolName}`)
     }
 
-    expect(events).toEqual(["reasoning:A", "reasoning:B", "text:I will check.", "tool:lookup"])
+    expect(events).toEqual(["reasoning:A", "reasoning:AB", "text:I will check.", "tool:lookup"])
   })
 
   test("stream normalizes mixed cumulative and incremental reasoning deltas", async () => {
@@ -8431,6 +8431,100 @@ describe("session.agency-swarm", () => {
             text: "Check cacheCheck cache again",
           },
         },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["Check cache", "Check cache again"])
+  })
+
+  test("stream preserves prefix-sharing incremental reasoning when response.completed closes it", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      for (const delta of ["Check cache", "Check cache again"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_1",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["Check cache", "Check cache again"])
+  })
+
+  test("stream preserves prefix-sharing incremental reasoning when stream end closes it", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      for (const delta of ["Check cache", "Check cache again"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_1",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
       }
       yield { type: "end" }
     } as typeof AgencySwarmAdapter.streamRun

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7998,6 +7998,61 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["The ", "The answer"])
   })
 
+  test("stream keeps longer incremental reasoning delta that starts with the prior delta", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      for (const delta of ["Check cache", "Check cache again"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_1",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Check cacheCheck cache again",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["Check cache", "Check cache again"])
+  })
+
   test("stream keeps text behind open reasoning for TUI ordering", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -9291,6 +9291,81 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:Need answer.", "reasoning-end", "text:OK"])
   })
 
+  test("stream closes open reasoning before response completed flushes held text", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Need answer.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "reasoning-end") events.push("reasoning-end")
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need answer.", "reasoning-end", "text:OK"])
+  })
+
   test("stream keeps same-text assistant message from final messages payload when item is distinct", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7430,6 +7430,95 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["OK", "OK"])
   })
 
+  test("stream keeps repeated pending assistant text from a different item", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Think.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "message_output_created",
+          item: {
+            raw_item: {
+              type: "message",
+              id: "msg_2",
+              content: [{ type: "output_text", text: "OK" }],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Think.", "text:OK", "text:OK"])
+  })
+
   test("stream keeps both distinct short assistant messages in the same run (no body-only dedupe)", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7988,6 +7988,49 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["A", "B"])
   })
 
+  test("stream flushes cumulative reasoning delta before stream-end close", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_stream_end" },
+          },
+        },
+      }
+      for (const delta of ["A", "AB"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_stream_end",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "reasoning-end") events.push("reasoning-end")
+    }
+
+    expect(events).toEqual(["reasoning:A", "reasoning:B", "reasoning-end"])
+  })
+
   test("stream preserves valid overlapping incremental reasoning deltas", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
@@ -9278,6 +9321,73 @@ describe("session.agency-swarm", () => {
             text: "Need answer.",
           },
         },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need answer.", "text:OK", "text:OK"])
+  })
+
+  test("stream keeps repeated content-index done text after reasoning closes", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Need answer.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      for (const contentIndex of ["0", "1"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.output_text.done",
+              item_id: "msg_multi",
+              output_index: "1",
+              content_index: contentIndex,
+              text: "OK",
+            },
+          },
+        }
       }
       yield { type: "end" }
     } as typeof AgencySwarmAdapter.streamRun

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -8905,6 +8905,86 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:Need answer.", "text:OK", "text:OK"])
   })
 
+  test("stream keeps repeated content-index text while reasoning is held", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Need answer.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_multi" },
+          },
+        },
+      }
+      for (const contentIndex of ["0", "1"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.output_text.done",
+              item_id: "msg_multi",
+              output_index: "1",
+              content_index: contentIndex,
+              text: "OK",
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Need answer.",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need answer.", "text:OK", "text:OK"])
+  })
+
   test("stream does not duplicate response-scoped reasoning replay when LiteLLM changes item id", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -8031,6 +8031,92 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:A", "reasoning:B", "reasoning-end"])
   })
 
+  test("stream flushes pending cumulative reasoning before forced text and tool output", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_forced_order" },
+          },
+        },
+      }
+      for (const delta of ["A", "AB"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_forced_order",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_forced_order",
+            output_index: "1",
+            delta: "I will check.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "2",
+            item: {
+              type: "function_call",
+              id: "fc_forced_order",
+              call_id: "call_forced_order",
+              name: "lookup",
+              arguments: '{"query":"status"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_forced_order",
+            summary_index: "0",
+            output_index: "0",
+            text: "AB",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+      if (event.type === "tool-input-start") events.push(`tool:${event.toolName}`)
+    }
+
+    expect(events).toEqual(["reasoning:A", "reasoning:B", "text:I will check.", "tool:lookup"])
+  })
+
   test("stream normalizes mixed cumulative and incremental reasoning deltas", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
@@ -9363,6 +9449,86 @@ describe("session.agency-swarm", () => {
             },
           },
         }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Need answer.",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need answer.", "text:OK", "text:OK"])
+  })
+
+  test("stream matches held text completion by content index", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Need answer.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_multi",
+            output_index: "1",
+            content_index: "0",
+            delta: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_multi",
+            output_index: "1",
+            content_index: "1",
+            text: "OK",
+          },
+        },
       }
       yield {
         type: "data",

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7935,6 +7935,59 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["A", "B"])
   })
 
+  test("stream normalizes cumulative reasoning when output item done has no summary", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_summary_missing" },
+          },
+        },
+      }
+      for (const delta of ["A", "AB"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_summary_missing",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_summary_missing" },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["A", "B"])
+  })
+
   test("stream preserves valid overlapping incremental reasoning deltas", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -9553,6 +9553,183 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:Need answer.", "text:OK", "text:OK"])
   })
 
+  test("stream keeps repeated explicit content-index text without content_part added after message item done", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Need answer.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "1",
+            item: {
+              type: "message",
+              id: "msg_multi",
+              content: [{ type: "output_text", text: "OK" }],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_multi",
+            output_index: "1",
+            content_index: "1",
+            delta: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_multi",
+            output_index: "1",
+            content_index: "1",
+            text: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Need answer.",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need answer.", "text:OK", "text:OK"])
+  })
+
+  test("stream keeps repeated explicit content-index done text without content_part added after message item done", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Need answer.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "1",
+            item: {
+              type: "message",
+              id: "msg_multi",
+              content: [{ type: "output_text", text: "OK" }],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_multi",
+            output_index: "1",
+            content_index: "1",
+            text: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Need answer.",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need answer.", "text:OK", "text:OK"])
+  })
+
   test("stream does not duplicate response-scoped reasoning replay when LiteLLM changes item id", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7563,7 +7563,7 @@ describe("session.agency-swarm", () => {
             {
               type: "message",
               role: "assistant",
-              id: "msg_1_final",
+              id: "msg_1",
               content: [{ type: "output_text", text: "OK" }],
             },
           ],
@@ -7983,7 +7983,7 @@ describe("session.agency-swarm", () => {
             {
               type: "message",
               role: "assistant",
-              id: "msg_final",
+              id: "msg_1",
               content: [{ type: "output_text", text: "Hey there!" }],
             },
           ],
@@ -8299,6 +8299,76 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:Need a lookup.", "text:I will check.", "tool-start:lookup", "tool-call:lookup"])
   })
 
+  test("stream preserves encrypted reasoning metadata when tool starts before reasoning item done", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1", encrypted_content: null },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Need a lookup.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: {
+              type: "function_call",
+              id: "fc_1",
+              call_id: "call_1",
+              name: "lookup",
+              arguments: '{"query":"status"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1", encrypted_content: "sealed" },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "tool-input-start") events.push(`tool-start:${event.toolName}`)
+      if (event.type === "reasoning-end") events.push(`reasoning-end:${event.providerMetadata?.encrypted_content}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need a lookup.", "tool-start:lookup", "reasoning-end:sealed"])
+  })
+
   test("stream force flushes pending text before tool input while reasoning stays open", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
@@ -8546,7 +8616,7 @@ describe("session.agency-swarm", () => {
             {
               type: "message",
               role: "assistant",
-              id: "msg_final",
+              id: "msg_1",
               content: [{ type: "output_text", text: "Hey there!" }],
             },
           ],
@@ -8564,6 +8634,60 @@ describe("session.agency-swarm", () => {
     }
 
     expect(events).toEqual(["reasoning:Simple greeting.", "text:Hey there!"])
+  })
+
+  test("stream keeps same-text assistant message from final messages payload when item is distinct", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: {
+              type: "message",
+              id: "msg_1",
+              content: [{ type: "output_text", text: "OK" }],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield {
+        type: "messages",
+        payload: {
+          new_messages: [
+            {
+              type: "message",
+              role: "assistant",
+              id: "msg_2",
+              content: [{ type: "output_text", text: "OK" }],
+            },
+          ],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "text-delta") events.push(event.text)
+    }
+
+    expect(events).toEqual(["OK", "OK"])
   })
 
   test("stream does not flush shifted pending text after response message final", async () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -8031,6 +8031,61 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:A", "reasoning:B", "reasoning-end"])
   })
 
+  test("stream normalizes mixed cumulative and incremental reasoning deltas", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_mixed" },
+          },
+        },
+      }
+      for (const delta of ["A", "AB", "C"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_mixed",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_mixed",
+            summary_index: "0",
+            output_index: "0",
+            text: "ABC",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["A", "B", "C"])
+  })
+
   test("stream preserves valid overlapping incremental reasoning deltas", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -9730,6 +9730,50 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:Need answer.", "text:OK", "text:OK"])
   })
 
+  test("stream keeps repeated explicit content-index done text after message item done without reasoning", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: {
+              type: "message",
+              id: "msg_multi",
+              content: [{ type: "output_text", text: "OK" }],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_multi",
+            output_index: "0",
+            content_index: "1",
+            text: "OK",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "text-delta") events.push(event.text)
+    }
+
+    expect(events).toEqual(["OK", "OK"])
+  })
+
   test("stream does not duplicate response-scoped reasoning replay when LiteLLM changes item id", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7877,6 +7877,72 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["The user has", " just greeted", "The user has"])
   })
 
+  test("stream preserves valid overlapping incremental reasoning deltas", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Look at the file ",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "the file path next.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Look at the file the file path next.",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["Look at the file ", "the file path next."])
+  })
+
   test("stream keeps text behind open reasoning for TUI ordering", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -8048,6 +8048,81 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:Need a lookup.", "text:I will check.", "tool-start:lookup", "tool-call:lookup"])
   })
 
+  test("stream keeps post-reasoning assistant text streaming after reasoning closes", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Think.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "Answer",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Think.", "text:Answer"])
+  })
+
   test("stream does not replay pending text when response completes before text done", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7950,6 +7950,104 @@ describe("session.agency-swarm", () => {
     ])
   })
 
+  test("stream flushes completed reasoning and pending text before tool input", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Need a lookup.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "1",
+            item: {
+              type: "message",
+              id: "msg_1",
+              content: [{ type: "output_text", text: "I will check." }],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "2",
+            item: {
+              type: "function_call",
+              id: "fc_1",
+              call_id: "call_1",
+              name: "lookup",
+              arguments: '{"query":"status"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "2",
+            item: {
+              type: "function_call",
+              id: "fc_1",
+              call_id: "call_1",
+              name: "lookup",
+              arguments: '{"query":"status"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "messages",
+        payload: {
+          new_messages: [{ type: "function_call_output", call_id: "call_1", output: "ok" }],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+      if (event.type === "tool-input-start") events.push(`tool-start:${event.toolName}`)
+      if (event.type === "tool-call") events.push(`tool-call:${event.toolName}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need a lookup.", "text:I will check.", "tool-start:lookup", "tool-call:lookup"])
+  })
+
   test("stream does not replay pending text when response completes before text done", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7519,6 +7519,83 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:Think.", "text:OK", "text:OK"])
   })
 
+  test("stream clears completed response replay text when a new run starts", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield { type: "meta", runID: "run_1" }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "message", id: "msg_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "0",
+            delta: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield {
+        type: "messages",
+        payload: {
+          new_messages: [
+            {
+              type: "message",
+              role: "assistant",
+              id: "msg_1_final",
+              content: [{ type: "output_text", text: "OK" }],
+            },
+          ],
+        },
+      }
+      yield { type: "meta", runID: "run_2" }
+      yield {
+        type: "messages",
+        payload: {
+          new_messages: [
+            {
+              type: "message",
+              role: "assistant",
+              id: "msg_2",
+              content: [{ type: "output_text", text: "OK" }],
+            },
+          ],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "text-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["OK", "OK"])
+  })
+
   test("stream keeps both distinct short assistant messages in the same run (no body-only dedupe)", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7943,6 +7943,61 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["Look at the file ", "the file path next."])
   })
 
+  test("stream keeps incremental reasoning delta that starts with the prior prefix", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      for (const delta of ["The ", "The answer"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_1",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "The The answer",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["The ", "The answer"])
+  })
+
   test("stream keeps text behind open reasoning for TUI ordering", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
@@ -8700,6 +8755,93 @@ describe("session.agency-swarm", () => {
     }
 
     expect(events).toEqual(["reasoning:Simple greeting.", "text:Hey there!"])
+  })
+
+  test("stream closes completed reasoning before response completed flushes held text", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Need answer.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_1",
+            output_index: "1",
+            text: "OK",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "reasoning-end") events.push("reasoning-end")
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need answer.", "reasoning-end", "text:OK"])
   })
 
   test("stream keeps same-text assistant message from final messages payload when item is distinct", async () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -8031,6 +8031,103 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:A", "reasoning:B", "reasoning-end"])
   })
 
+  test("stream preserves prefix-matching incremental reasoning when item done has no summary", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_prefix_done" },
+          },
+        },
+      }
+      for (const delta of ["The ", "The answer"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_prefix_done",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_prefix_done" },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "reasoning-end") events.push("reasoning-end")
+    }
+
+    expect(events).toEqual(["reasoning:The ", "reasoning:The answer", "reasoning-end"])
+  })
+
+  test("stream preserves prefix-matching incremental reasoning before stream-end close", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_prefix_stream_end" },
+          },
+        },
+      }
+      for (const delta of ["The ", "The answer"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_prefix_stream_end",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "reasoning-end") events.push("reasoning-end")
+    }
+
+    expect(events).toEqual(["reasoning:The ", "reasoning:The answer", "reasoning-end"])
+  })
+
   test("stream flushes pending cumulative reasoning before forced text and tool output", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7878,6 +7878,63 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["The user has", " just greeted", "The user has"])
   })
 
+  test("stream normalizes cumulative reasoning when output item done carries final summary", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_summary_done" },
+          },
+        },
+      }
+      for (const delta of ["A", "AB"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_summary_done",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: {
+              type: "reasoning",
+              id: "rs_summary_done",
+              summary: [{ text: "AB" }],
+            },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["A", "B"])
+  })
+
   test("stream preserves valid overlapping incremental reasoning deltas", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
@@ -9155,6 +9212,101 @@ describe("session.agency-swarm", () => {
             },
           },
         }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Need answer.",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need answer.", "text:OK", "text:OK"])
+  })
+
+  test("stream keeps repeated explicit content-index deltas after message item done", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Need answer.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "1",
+            item: {
+              type: "message",
+              id: "msg_multi",
+              content: [{ type: "output_text", text: "OK" }],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.content_part.added",
+            item_id: "msg_multi",
+            output_index: "1",
+            content_index: "1",
+            part: { type: "output_text" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_multi",
+            output_index: "1",
+            content_index: "1",
+            delta: "OK",
+          },
+        },
       }
       yield {
         type: "data",

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -13,6 +13,7 @@ import { Provider } from "../../src/provider/provider"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session/index"
 import { SessionAgencySwarm } from "../../src/session/agency-swarm"
+import { createAgencySwarmStreamEvents } from "../../src/session/agency-swarm-stream-events"
 import { MessageID, PartID } from "../../src/session/schema"
 import { tmpdir } from "../fixture/fixture"
 
@@ -10014,5 +10015,52 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["Think", "ing"])
     expect(ends).toHaveLength(1)
     expect(ends[0]?.providerMetadata).toMatchObject({ encrypted_content: "sealed" })
+  })
+
+  test("stream closes pending reasoning when replay candidates retire on a new run", () => {
+    const events = createAgencySwarmStreamEvents({
+      assistantMessage: {} as never,
+      isCancelled: () => false,
+      isAborted: () => false,
+      handleRunID: async () => {},
+      persistMessages: async () => {},
+      applyAssistantLabel: async () => {},
+    })
+
+    events.handleRawResponseEvent(
+      {
+        type: "response.output_item.added",
+        output_index: "0",
+        item: { type: "reasoning", id: "rs_pending", encrypted_content: null },
+      },
+      {},
+    )
+
+    const done = events.handleRawResponseEvent(
+      {
+        type: "response.reasoning_summary_text.done",
+        item_id: "rs_pending",
+        summary_index: "0",
+        output_index: "0",
+        text: "Need answer.",
+      },
+      {},
+    )
+    expect(done.parts.map((part) => part.type)).toEqual(["reasoning-delta"])
+
+    events.retireClosedReplayCandidates()
+
+    const text = events.handleRawResponseEvent(
+      {
+        type: "response.output_text.delta",
+        item_id: "msg_next",
+        output_index: "1",
+        delta: "OK",
+      },
+      {},
+    )
+
+    expect(text.parts.map((part) => part.type)).toEqual(["reasoning-end", "text-start", "text-delta"])
+    expect(text.parts.find((part) => part.type === "text-delta")?.text).toBe("OK")
   })
 })

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -8007,6 +8007,91 @@ describe("session.agency-swarm", () => {
     ])
   })
 
+  test("stream preserves pending text fallback id while reasoning is open", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Think.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            output_index: "1",
+            delta: "Answer",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            output_index: "1",
+            text: "Answer",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Think.", "text:Answer"])
+  })
+
   test("stream keeps text behind late reasoning for TUI ordering", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
@@ -8212,6 +8297,99 @@ describe("session.agency-swarm", () => {
     }
 
     expect(events).toEqual(["reasoning:Need a lookup.", "text:I will check.", "tool-start:lookup", "tool-call:lookup"])
+  })
+
+  test("stream force flushes pending text before tool input while reasoning stays open", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Need a lookup.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "I will check.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "2",
+            item: {
+              type: "function_call",
+              id: "fc_1",
+              call_id: "call_1",
+              name: "lookup",
+              arguments: '{"query":"status"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+      if (event.type === "tool-input-start") events.push(`tool-start:${event.toolName}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need a lookup.", "text:I will check.", "tool-start:lookup"])
   })
 
   test("stream keeps post-reasoning assistant text streaming after reasoning closes", async () => {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -7586,6 +7586,618 @@ describe("session.agency-swarm", () => {
     expect(deltas).toEqual(["Find the right file first."])
   })
 
+  test("stream normalizes cumulative reasoning deltas without dropping later reasoning items", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "The user has",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "The user has just greeted",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "The user has just greeted",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "reasoning", id: "rs_2" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_2",
+            summary_index: "0",
+            output_index: "1",
+            delta: "The user has",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_2",
+            summary_index: "0",
+            output_index: "1",
+            text: "The user has",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "1",
+            item: { type: "reasoning", id: "rs_2" },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const deltas: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") deltas.push(event.text)
+    }
+
+    expect(deltas).toEqual(["The user has", " just greeted", "The user has"])
+  })
+
+  test("stream keeps text behind open reasoning for TUI ordering", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: 'The user just said "hey". I shoul',
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "Hey there!",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "d respond warmly.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: 'The user just said "hey". I should respond warmly.',
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_1",
+            output_index: "1",
+            content_index: "1",
+            text: "Hey there!",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield {
+        type: "messages",
+        payload: {
+          new_messages: [
+            {
+              type: "message",
+              role: "assistant",
+              id: "msg_final",
+              content: [{ type: "output_text", text: "Hey there!" }],
+            },
+          ],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual([
+      'reasoning:The user just said "hey". I shoul',
+      "reasoning:d respond warmly.",
+      "text:Hey there!",
+    ])
+  })
+
+  test("stream keeps text behind late reasoning for TUI ordering", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: 'The user just said "hey". I shoul',
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "Hey there!",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "1",
+            output_index: "0",
+            delta: "d respond warmly.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "1",
+            item: {
+              type: "message",
+              id: "msg_1",
+              content: [{ type: "output_text", text: "Hey there!" }],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_1",
+            output_index: "1",
+            text: "Hey there!",
+            content_index: "1",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual([
+      'reasoning:The user just said "hey". I shoul',
+      "reasoning:d respond warmly.",
+      "text:Hey there!",
+    ])
+  })
+
+  test("stream does not replay pending text when response completes before text done", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Simple greeting.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "1",
+            item: { type: "message", id: "msg_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "Hey there!",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.done",
+            item_id: "msg_1",
+            output_index: "1",
+            text: "Hey there!",
+          },
+        },
+      }
+      yield {
+        type: "messages",
+        payload: {
+          new_messages: [
+            {
+              type: "message",
+              role: "assistant",
+              id: "msg_final",
+              content: [{ type: "output_text", text: "Hey there!" }],
+            },
+          ],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Simple greeting.", "text:Hey there!"])
+  })
+
+  test("stream does not flush shifted pending text after response message final", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Simple greeting.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "1",
+            item: {
+              type: "message",
+              id: "msg_1",
+              content: [{ type: "output_text", text: "Hey there!" }],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            content_index: "1",
+            delta: "Hey there!",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Simple greeting.", "text:Hey there!"])
+  })
+
+  test("stream keeps repeated assistant text outputs after reasoning", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Need answer.",
+          },
+        },
+      }
+      for (const id of ["msg_1", "msg_2"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.output_item.done",
+              output_index: id === "msg_1" ? "1" : "2",
+              item: {
+                type: "message",
+                id,
+                content: [{ type: "output_text", text: "OK" }],
+              },
+            },
+          },
+        }
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.output_text.done",
+              item_id: id,
+              output_index: id === "msg_1" ? "1" : "2",
+              text: "OK",
+            },
+          },
+        }
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+    }
+
+    expect(events).toEqual(["reasoning:Need answer.", "text:OK", "text:OK"])
+  })
+
   test("stream does not duplicate response-scoped reasoning replay when LiteLLM changes item id", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
@@ -8366,7 +8978,7 @@ describe("session.agency-swarm", () => {
             item_id: "rs_dup",
             summary_index: "0",
             output_index: "1",
-            delta: "Thinking",
+            delta: "Think",
           },
         },
       }
@@ -8390,7 +9002,7 @@ describe("session.agency-swarm", () => {
           data: {
             type: "response.output_item.done",
             output_index: "1",
-            item: { type: "reasoning", id: "rs_dup" },
+            item: { type: "reasoning", id: "rs_dup", encrypted_content: "sealed" },
           },
         },
       }
@@ -8400,10 +9012,14 @@ describe("session.agency-swarm", () => {
     const { input } = helper()
     const stream = await SessionAgencySwarm.stream(input)
     const starts: any[] = []
+    const deltas: string[] = []
     const ends: any[] = []
     for await (const event of stream.fullStream) {
       if (event.type === "reasoning-start") {
         starts.push(event)
+      }
+      if (event.type === "reasoning-delta") {
+        deltas.push(event.text)
       }
       if (event.type === "reasoning-end") {
         ends.push(event)
@@ -8411,6 +9027,8 @@ describe("session.agency-swarm", () => {
     }
 
     expect(starts).toHaveLength(1)
+    expect(deltas).toEqual(["Think", "ing"])
     expect(ends).toHaveLength(1)
+    expect(ends[0]?.providerMetadata).toMatchObject({ encrypted_content: "sealed" })
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #259

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes Agent Swarm CLI reasoning display for OpenRouter models.

The stream adapter now handles cumulative or replayed OpenRouter reasoning chunks without duplicating text. It also keeps assistant text behind active reasoning so the TUI can show one reasoning block before the answer.

The TUI reasoning display now keeps the upstream behavior: `Thinking` while reasoning is still streaming, then `Thought: <elapsed>` once reasoning is done.

### How did you verify your code works?

Local checks passed:

- `bun test test/cli/run`
- `bun test test/session/agency-swarm.test.ts`
- `bun run typecheck`
- `bun run test:agentswarm:e2e` (`28 pass`, `1 skip`)
- `OPENCODE_VERSION=1.4.38-dev GH_REPO=VRSEN/agentswarm-cli bun run --cwd packages/opencode build --single --skip-install`

Manual QA passed from `/Users/nick/Desktop/agentswarm-test/my-agency` with the rebuilt binary:

- selected `Claude Haiku 4.5 (latest)` through OpenRouter using `/models`
- sent `hey`
- saw live `Thinking`, then `Thought: 1.2s`, then one assistant answer
- checked the local session DB: one reasoning part with start/end timing and encrypted metadata, then one assistant text part

User manual QA also confirmed the fix worked before this PR was opened.

### Screenshots / recordings

Manual terminal QA confirmed the changed UI state: `Thinking` while streaming and `Thought: 1.2s` after reasoning completed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
