### PR TITLE
fix: keep encrypted reasoning open for final metadata

### DIFF
--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -801,6 +801,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     meta: AgencySwarmEventMeta,
     extra?: Record<string, unknown>,
     close = true,
+    closeWaiting = false,
   ) => {
     const key = reasoningKey(itemID, index)
     const isOpen = reasoningOpen.has(key)
@@ -822,6 +823,12 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
       parts.push(...reasoningDelta(itemID, index, suffix, meta, extra))
     }
     if (!close) {
+      if (reasoningOpen.has(key)) {
+        reasoningDonePending.set(key, { itemID, index, meta, extra })
+      }
+      return parts
+    }
+    if (!closeWaiting && reasoningWaitForDone.has(itemID)) {
       if (reasoningOpen.has(key)) {
         reasoningDonePending.set(key, { itemID, index, meta, extra })
       }
@@ -1134,6 +1141,8 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
             summaryText(summary, summaryIndex),
             eventMeta,
             outputMeta(outputIndex, { encrypted_content: item["encrypted_content"] ?? null }),
+            true,
+            true,
           )
         })
     }

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -9031,6 +9031,62 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:Need a lookup.", "tool-start:lookup", "reasoning-end:sealed"])
   })
 
+  test("stream waits for encrypted reasoning output item done after empty run item replay", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1", encrypted_content: null },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "run_item_stream_event",
+          name: "reasoning_item_created",
+          item: {
+            raw_item: {
+              type: "reasoning",
+              id: "rs_1",
+              summary: [],
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.done",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1", encrypted_content: "sealed" },
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    let starts = 0
+    const ends: Record<string, unknown>[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-start") starts++
+      if (event.type === "reasoning-end") ends.push(event)
+    }
+
+    expect(starts).toBe(1)
+    expect(ends).toHaveLength(1)
+    expect(ends[0]?.providerMetadata).toMatchObject({ encrypted_content: "sealed" })
+  })
+
   test("stream force flushes pending text before tool input while reasoning stays open", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #262

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps encrypted reasoning items open when an empty reasoning replay arrives before the final `response.output_item.done` event. This lets the final OpenRouter `encrypted_content` metadata attach to the reasoning end event instead of being dropped after an early close.

### How did you verify your code works?

- `git diff --check`
- `bun test test/session/agency-swarm.test.ts -t "stream waits for encrypted reasoning output item done after empty run item replay"`
- `bun test test/session/agency-swarm.test.ts`
- `bun typecheck`
- Pre-push `bun turbo typecheck`

### Screenshots / recordings

Not applicable. This is a stream metadata fix covered by automated tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
