### PR TITLE
fix: normalize forced cumulative reasoning flush

### DIFF
--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -51,9 +51,17 @@ type PendingReasoning = {
   extra?: Record<string, unknown>
 }
 
+type PendingReasoningDeltaItem = {
+  delta: string
+  meta: AgencySwarmEventMeta
+  extra?: Record<string, unknown>
+}
+
 type PendingReasoningDelta = PendingReasoning & {
   current: string
   delta: string
+  forced?: boolean
+  tail?: PendingReasoningDeltaItem[]
 }
 
 type StreamEventsInput = {
@@ -533,7 +541,9 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
   const flushPendingText = (force: boolean) => {
     if (!force && hasOpenReasoning()) return []
     const parts: StreamPart[] = drainRetiredParts()
-    if (force) parts.push(...flushPendingReasoningDeltas())
+    if (force) {
+      for (const pending of reasoningDeltaPending.values()) pending.forced = true
+    }
     flushingText = true
     for (const [key, pending] of Array.from(textPending.entries())) {
       textPending.delete(key)
@@ -715,13 +725,36 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!pending) return []
     reasoningDeltaPending.delete(key)
     const text = cumulative ? pending.delta.slice(pending.current.length) : pending.delta
-    return text ? emitReasoningDelta(pending.itemID, pending.index, text, pending.meta, pending.extra) : []
+    const parts = text ? emitReasoningDelta(pending.itemID, pending.index, text, pending.meta, pending.extra) : []
+    for (const item of pending.tail ?? []) {
+      parts.push(...emitReasoningDelta(pending.itemID, pending.index, item.delta, item.meta, item.extra))
+    }
+    return parts
   }
 
-  const flushPendingReasoningDeltas = () => {
-    return Array.from(reasoningDeltaPending.keys()).flatMap((key) => {
-      return flushPendingReasoningDelta(key, false)
-    })
+  const flushPendingReasoningDeltaForFinal = (key: string, final: string | undefined): StreamPart[] => {
+    const pending = reasoningDeltaPending.get(key)
+    if (!pending) return []
+    if (!pending.forced || final === undefined) {
+      return flushPendingReasoningDelta(key, final !== undefined && final.startsWith(pending.delta))
+    }
+
+    reasoningDeltaPending.delete(key)
+    let current = pending.current
+    const parts: StreamPart[] = []
+    const items: PendingReasoningDeltaItem[] = [
+      { delta: pending.delta, meta: pending.meta, extra: pending.extra },
+      ...(pending.tail ?? []),
+    ]
+    for (const item of items) {
+      const incremental = final.startsWith(current + item.delta)
+      const cumulative = item.delta.startsWith(current) && final.startsWith(item.delta)
+      const text = incremental ? item.delta : cumulative ? item.delta.slice(current.length) : item.delta
+      if (!text) continue
+      parts.push(...emitReasoningDelta(pending.itemID, pending.index, text, item.meta, item.extra))
+      current += text
+    }
+    return parts
   }
 
   const reasoningDelta = (
@@ -734,6 +767,13 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     if (!delta) return []
     const key = reasoningKey(itemID, index)
     const pending = reasoningDeltaPending.get(key)
+    if (pending?.forced) {
+      reasoningDeltaPending.set(key, {
+        ...pending,
+        tail: [...(pending.tail ?? []), { delta, meta, extra }],
+      })
+      return []
+    }
     const parts = pending
       ? flushPendingReasoningDelta(key, isLikelyCumulativeReasoningDelta(pending.current, pending.delta))
       : []
@@ -807,9 +847,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
     const isOpen = reasoningOpen.has(key)
     const pending = reasoningDeltaPending.get(key)
     const raw = reasoningBuffer.get(key) || ""
-    const parts: StreamPart[] = pending
-      ? flushPendingReasoningDelta(key, text !== undefined && text.startsWith(pending.delta))
-      : []
+    const parts: StreamPart[] = pending ? flushPendingReasoningDeltaForFinal(key, text) : []
     if (!isOpen && text !== undefined && raw && !text.startsWith(raw)) {
       reasoningBuffer.delete(key)
     }

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -8128,7 +8128,7 @@ describe("session.agency-swarm", () => {
     expect(events).toEqual(["reasoning:The ", "reasoning:The answer", "reasoning-end"])
   })
 
-  test("stream preserves pending cumulative-looking reasoning before forced text and tool output", async () => {
+  test("stream normalizes pending cumulative reasoning before forced text and tool output", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {
       yield {
@@ -8211,7 +8211,7 @@ describe("session.agency-swarm", () => {
       if (event.type === "tool-input-start") events.push(`tool:${event.toolName}`)
     }
 
-    expect(events).toEqual(["reasoning:A", "reasoning:AB", "text:I will check.", "tool:lookup"])
+    expect(events).toEqual(["reasoning:A", "text:I will check.", "tool:lookup", "reasoning:B"])
   })
 
   test("stream normalizes mixed cumulative and incremental reasoning deltas", async () => {
@@ -9514,6 +9514,323 @@ describe("session.agency-swarm", () => {
     }
 
     expect(events).toEqual(["reasoning:Need answer.", "reasoning-end", "text:OK"])
+  })
+
+  test("stream force-flushes cumulative reasoning as an incremental delta", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      for (const delta of ["The user", "The user has"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_1",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "I can help.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "2",
+            item: {
+              type: "function_call",
+              id: "fc_1",
+              call_id: "call_1",
+              name: "lookup",
+              arguments: '{"query":"status"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "The user has",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "reasoning-end") events.push("reasoning-end")
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+      if (event.type === "tool-input-start") events.push(`tool:${event.toolName}`)
+    }
+
+    expect(events).toEqual(["reasoning:The user", "text:I can help.", "tool:lookup", "reasoning: has", "reasoning-end"])
+  })
+
+  test("stream preserves prefix-sharing incremental reasoning across forced text and tool output", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      for (const delta of ["Check cache", "Check cache again"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_1",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "I can help.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "2",
+            item: {
+              type: "function_call",
+              id: "fc_1",
+              call_id: "call_1",
+              name: "lookup",
+              arguments: '{"query":"status"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Check cacheCheck cache again",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "reasoning-end") events.push("reasoning-end")
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+      if (event.type === "tool-input-start") events.push(`tool:${event.toolName}`)
+    }
+
+    expect(events).toEqual([
+      "reasoning:Check cache",
+      "text:I can help.",
+      "tool:lookup",
+      "reasoning:Check cache again",
+      "reasoning-end",
+    ])
+  })
+
+  test("stream preserves forced prefix-sharing incremental reasoning when another reasoning delta follows", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "0",
+            item: { type: "reasoning", id: "rs_1" },
+          },
+        },
+      }
+      for (const delta of ["Check cache", "Check cache again"]) {
+        yield {
+          type: "data",
+          payload: {
+            type: "raw_response_event",
+            data: {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_1",
+              summary_index: "0",
+              output_index: "0",
+              delta,
+            },
+          },
+        }
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: "1",
+            delta: "I can help.",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.output_item.added",
+            output_index: "2",
+            item: {
+              type: "function_call",
+              id: "fc_1",
+              call_id: "call_1",
+              name: "lookup",
+              arguments: '{"query":"status"}',
+            },
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.delta",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            delta: "Then inspect",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.reasoning_summary_text.done",
+            item_id: "rs_1",
+            summary_index: "0",
+            output_index: "0",
+            text: "Check cacheCheck cache againThen inspect",
+          },
+        },
+      }
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "response.completed",
+            response: {},
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: string[] = []
+    for await (const event of stream.fullStream) {
+      if (event.type === "reasoning-delta") events.push(`reasoning:${event.text}`)
+      if (event.type === "reasoning-end") events.push("reasoning-end")
+      if (event.type === "text-delta") events.push(`text:${event.text}`)
+      if (event.type === "tool-input-start") events.push(`tool:${event.toolName}`)
+    }
+
+    expect(events).toEqual([
+      "reasoning:Check cache",
+      "text:I can help.",
+      "tool:lookup",
+      "reasoning:Check cache again",
+      "reasoning:Then inspect",
+      "reasoning-end",
+    ])
   })
 
   test("stream keeps same-text assistant message from final messages payload when item is distinct", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #263

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes forced OpenRouter reasoning flush edge cases in Agent Swarm streams.

When text or tool output arrives before final reasoning text, the stream now keeps ambiguous reasoning pending until final text proves whether it is cumulative or incremental. This prevents duplicated cumulative reasoning and prevents valid prefix-sharing incremental reasoning from being dropped.

### How did you verify your code works?

- `bun test test/session/agency-swarm.test.ts -t "stream preserves forced prefix-sharing incremental reasoning when another reasoning delta follows"`
- `bun test test/session/agency-swarm.test.ts -t "stream force-flushes cumulative reasoning as an incremental delta"`
- `bun test test/session/agency-swarm.test.ts -t "stream preserves prefix-sharing incremental reasoning across forced text and tool output"`
- `bun test test/session/agency-swarm.test.ts`
- `bun typecheck`
- local Codex review against `vrsen/dev`: no findings
- pre-push `bun turbo typecheck`: passed

### Screenshots / recordings

Not applicable. This is stream conversion logic covered by focused tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
