### PR TITLE
fix(openswarm): refresh stale Agency Swarm venvs

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -136,16 +136,51 @@ interface ServerStderrCollector {
   stop(): void
 }
 
-const VENV_CANARY_SCRIPT = ["import agency_swarm", "from agency_swarm.integrations.fastapi import run_fastapi"].join(
-  "\n",
-)
+const MIN_AGENCY_SWARM_VERSION = "1.10.1"
+function buildVenvCanaryScript(minimumAgencySwarmVersion?: string) {
+  const imports = ["import agency_swarm", "from agency_swarm.integrations.fastapi import run_fastapi"]
+  if (!minimumAgencySwarmVersion) return imports.join("\n")
+
+  return [
+    "from importlib.metadata import version",
+    "import re",
+    ...imports,
+    "def pep440_floor(value):",
+    "    public = value.split('+', 1)[0]",
+    "    epoch = 0",
+    "    if '!' in public:",
+    "        raw_epoch, public = public.split('!', 1)",
+    "        epoch = int(raw_epoch) if raw_epoch.isdigit() else 0",
+    "    match = re.match(r'^(\\d+(?:\\.\\d+)*)(.*)$', public)",
+    "    if not match:",
+    "        return (-1, (0, 0, 0), True)",
+    "    release = tuple(int(part) for part in match.group(1).split('.'))",
+    "    while len(release) > 1 and release[-1] == 0:",
+    "        release = release[:-1]",
+    "    suffix = match.group(2).lower().lstrip('.-_')",
+    "    prerelease = suffix.startswith(('a', 'b', 'c', 'rc', 'alpha', 'beta', 'pre', 'preview', 'dev'))",
+    "    return (epoch, release, prerelease)",
+    "def meets_floor(value, floor):",
+    "    current = pep440_floor(value)",
+    "    minimum = pep440_floor(floor)",
+    "    if current[0] != minimum[0]:",
+    "        return current[0] > minimum[0]",
+    "    width = max(len(current[1]), len(minimum[1]))",
+    "    current_release = current[1] + (0,) * (width - len(current[1]))",
+    "    minimum_release = minimum[1] + (0,) * (width - len(minimum[1]))",
+    "    if current_release != minimum_release:",
+    "        return current_release > minimum_release",
+    "    return not current[2] or minimum[2]",
+    `raise SystemExit(0 if meets_floor(version("agency-swarm"), "${minimumAgencySwarmVersion}") else 1)`,
+  ].join("\n")
+}
 const EXISTING_VENV_CANARY_TIMEOUT_MS = 60 * 1000
 const VENV_CANARY_TIMEOUT_MS = 3 * 60 * 1000
 const SERVER_START_TIMEOUT_MS = 2 * 60 * 1000
 const SERVER_STDERR_COLLECT_TIMEOUT_MS = 1000
 const REBUILD_INSTALL_TIMEOUT_MS = 10 * 60 * 1000
 const PROCESS_KILL_GRACE_MS = 5000
-const FALLBACK_AGENCY_SWARM_REQUIREMENT = "agency-swarm[fastapi,litellm]>=1.9.6"
+const FALLBACK_AGENCY_SWARM_REQUIREMENT = `agency-swarm[fastapi,litellm]>=${MIN_AGENCY_SWARM_VERSION}`
 
 export function shouldRunNpxOnboarding(input: {
   env: NodeJS.ProcessEnv
@@ -890,6 +925,7 @@ async function ensureProjectPython(
   const venvDir = path.resolve(path.join(directory, ".venv"))
   let selfHealing = false
   let corruptedVenv = false
+  const hasManifests = await hasDependencyManifest(directory)
   const hasVenvPath = await Filesystem.exists(venvDir)
   const hasVenv = await Filesystem.exists(venvPython)
   if (hasVenv) {
@@ -916,6 +952,7 @@ async function ensureProjectPython(
       try {
         canary = await venvCanaryPasses([venvPython], {
           includeStderr: true,
+          minimumAgencySwarmVersion: hasManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
           timeoutMs: EXISTING_VENV_CANARY_TIMEOUT_MS,
         })
       } catch {
@@ -954,7 +991,10 @@ async function ensureProjectPython(
         prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
         let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
         try {
-          canary = await venvCanaryPasses([venvPython], { includeStderr: true })
+          canary = await venvCanaryPasses([venvPython], {
+            includeStderr: true,
+            minimumAgencySwarmVersion: hasManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+          })
         } catch {
           canary = { healthy: false, stderr: "", timedOut: false }
         }
@@ -1048,7 +1088,11 @@ async function ensureProjectPython(
     throw new Error(formatCommandFailure(install, "Dependency install failed"))
   }
   prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
-  const canary = await venvCanaryPasses([venvPython], { cwd: directory, includeStderr: true })
+  const canary = await venvCanaryPasses([venvPython], {
+    cwd: directory,
+    includeStderr: true,
+    minimumAgencySwarmVersion: install.hadManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+  })
   if (canary.timedOut) {
     throw new Error(await formatCanaryTimeoutFailure(directory, canary.stderr))
   }
@@ -1181,20 +1225,23 @@ async function findProjectShadowingFiles(directory: string) {
   return shadowingFiles.flatMap((file) => (file ? [file] : []))
 }
 
-async function venvCanaryPasses(python: string[], options?: { cwd?: string; timeoutMs?: number }): Promise<boolean>
 async function venvCanaryPasses(
   python: string[],
-  options: { cwd?: string; includeStderr: true; timeoutMs?: number },
+  options?: { cwd?: string; minimumAgencySwarmVersion?: string; timeoutMs?: number },
+): Promise<boolean>
+async function venvCanaryPasses(
+  python: string[],
+  options: { cwd?: string; includeStderr: true; minimumAgencySwarmVersion?: string; timeoutMs?: number },
 ): Promise<VenvCanaryResult>
 async function venvCanaryPasses(
   python: string[],
-  options?: { cwd?: string; includeStderr?: boolean; timeoutMs?: number },
+  options?: { cwd?: string; includeStderr?: boolean; minimumAgencySwarmVersion?: string; timeoutMs?: number },
 ) {
   // No cwd by default: the canary must not pick up project-local modules (e.g. `fastapi.py`
   // sitting next to `agency.py`) that shadow installed packages and falsely flag a healthy
   // .venv as broken. Callers that need the server-launch cwd (post-install verification)
   // pass it explicitly.
-  const result = await runCommand([...python, "-c", VENV_CANARY_SCRIPT], {
+  const result = await runCommand([...python, "-c", buildVenvCanaryScript(options?.minimumAgencySwarmVersion)], {
     cwd: options?.cwd,
     timeoutMs: options?.timeoutMs ?? VENV_CANARY_TIMEOUT_MS,
   })
@@ -1219,7 +1266,15 @@ async function ensureLatestAgencySwarm(
 ): Promise<{ installerFailed: boolean }> {
   try {
     const result = await runCommand(
-      [localUv, "pip", "install", "--python", venvPython, "--upgrade", "agency-swarm[fastapi,litellm]"],
+      [
+        localUv,
+        "pip",
+        "install",
+        "--python",
+        venvPython,
+        "--upgrade",
+        `agency-swarm[fastapi,litellm]>=${MIN_AGENCY_SWARM_VERSION}`,
+      ],
       {
         cwd: directory,
         logFile: options?.logFile,

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -309,7 +309,7 @@ describe("agency-swarm npx onboarding", () => {
       "install",
       "--python",
       getTestVenvPython(dir.path),
-      "agency-swarm[fastapi,litellm]>=1.9.6",
+      "agency-swarm[fastapi,litellm]>=1.10.1",
     ])
   })
 
@@ -527,7 +527,7 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
-  test("prepareProjectLaunch refreshes existing requirements venv without unpinned agency-swarm upgrade", async () => {
+  test("prepareProjectLaunch refreshes older pinned requirements venv without forcing the launcher floor", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
     await Bun.write(path.join(dir.path, "requirements.txt"), "agency-swarm==1.9.6\n")
@@ -565,9 +565,10 @@ describe("agency-swarm npx onboarding", () => {
         } as never
       }
       if (isCanaryCommand(cmd)) {
+        const script = cmd.at(-1) ?? ""
         canaryRuns++
         return {
-          exited: Promise.resolve(canaryRuns === 1 ? 1 : 0),
+          exited: Promise.resolve(canaryRuns === 1 ? 1 : runVenvCanaryScript(script, "1.9.6")),
           stdout: "",
           stderr: "",
         } as never
@@ -609,12 +610,13 @@ describe("agency-swarm npx onboarding", () => {
     ])
     expect(commands.some(isPythonVenvCommand)).toBe(false)
     expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
+    expect(commands.filter(isCanaryCommand).every((cmd) => !(cmd.at(-1) ?? "").includes("meets_floor"))).toBe(true)
     expect(canaryRuns).toBe(2)
 
     await launch?.cleanup?.()
   })
 
-  test("prepareProjectLaunch refreshes existing pyproject venv without unpinned agency-swarm upgrade", async () => {
+  test("prepareProjectLaunch refreshes older pinned pyproject venv without forcing the launcher floor", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
     await Bun.write(path.join(dir.path, "pyproject.toml"), "[project]\ndependencies = ['agency-swarm==1.9.6']\n")
@@ -652,9 +654,10 @@ describe("agency-swarm npx onboarding", () => {
         } as never
       }
       if (isCanaryCommand(cmd)) {
+        const script = cmd.at(-1) ?? ""
         canaryRuns++
         return {
-          exited: Promise.resolve(canaryRuns === 1 ? 1 : 0),
+          exited: Promise.resolve(canaryRuns === 1 ? 1 : runVenvCanaryScript(script, "1.9.6")),
           stdout: "",
           stderr: "",
         } as never
@@ -687,6 +690,7 @@ describe("agency-swarm npx onboarding", () => {
     ])
     expect(commands.some(isPythonVenvCommand)).toBe(false)
     expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
+    expect(commands.filter(isCanaryCommand).every((cmd) => !(cmd.at(-1) ?? "").includes("meets_floor"))).toBe(true)
     expect(canaryRuns).toBe(2)
 
     await launch?.cleanup?.()
@@ -1306,9 +1310,10 @@ describe("agency-swarm npx onboarding", () => {
         } as never
       }
       if (isCanaryCommand(cmd)) {
+        const script = cmd.at(-1) ?? ""
         canaryRuns++
         return {
-          exited: Promise.resolve(canaryRuns === 1 ? 1 : 0),
+          exited: Promise.resolve(runVenvCanaryScript(script, canaryRuns === 1 ? "1.10.0" : "1.10.1")),
           stdout: "",
           stderr: "",
         } as never
@@ -1340,6 +1345,7 @@ describe("agency-swarm npx onboarding", () => {
     expect(commands.filter(isPythonVenvCommand)).toEqual([expectedVenvCommand(replacementPython)])
     expect(uvInstallRuns).toBe(2)
     expect(canaryRuns).toBe(2)
+    expect(commands.filter(isCanaryCommand).every((cmd) => (cmd.at(-1) ?? "").includes("meets_floor"))).toBe(true)
     await launch?.cleanup?.()
   })
 
@@ -2332,7 +2338,7 @@ describe("agency-swarm npx onboarding", () => {
     await launch?.cleanup?.()
   })
 
-  test("prepareProjectLaunch checks the FastAPI launcher symbol in the canary", async () => {
+  test("prepareProjectLaunch checks the FastAPI launcher symbol and version floor in the canary", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
     await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
@@ -2400,11 +2406,24 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     const canaryScripts = commands.filter(isCanaryCommand).map((cmd) => cmd.at(-1) ?? "")
+    const canaryScript = canaryScripts[0]
     const launcherCommand = commands.find((cmd) => cmd[1]?.endsWith("launch_agency.py"))
     expect(canaryScripts.length).toBeGreaterThan(0)
     expect(
       canaryScripts.every((script) => script.includes("from agency_swarm.integrations.fastapi import run_fastapi")),
     ).toBe(true)
+    if (!canaryScript) throw new Error("Expected canary script")
+    expect(runVenvCanaryScript(canaryScript, "1.10.1")).toBe(0)
+    expect(runVenvCanaryScript(canaryScript, "1.10.1.0")).toBe(0)
+    expect(runVenvCanaryScript(canaryScript, "1.10.1+local")).toBe(0)
+    expect(runVenvCanaryScript(canaryScript, "1.10.1.0+local")).toBe(0)
+    expect(runVenvCanaryScript(canaryScript, "1.10.1.1")).toBe(0)
+    expect(runVenvCanaryScript(canaryScript, "1.10.1.1rc1")).toBe(0)
+    expect(runVenvCanaryScript(canaryScript, "1.10.2rc1")).toBe(0)
+    expect(runVenvCanaryScript(canaryScript, "1!1.10.1")).toBe(0)
+    expect(runVenvCanaryScript(canaryScript, "1.10.0")).toBe(1)
+    expect(runVenvCanaryScript(canaryScript, "1.10.1rc1")).toBe(1)
+    expect(runVenvCanaryScript(canaryScript, "1.10.1.0rc1")).toBe(1)
     expect(launcherCommand?.at(-1)).toBe("agency")
 
     await launch?.cleanup?.()
@@ -2715,7 +2734,7 @@ describe("agency-swarm npx onboarding", () => {
         "--python",
         getTestVenvPython(dir.path),
         "--upgrade",
-        "agency-swarm[fastapi,litellm]",
+        "agency-swarm[fastapi,litellm]>=1.10.1",
       ],
     ])
     expect(commands.some(isPythonVenvCommand)).toBe(false)
@@ -4923,6 +4942,52 @@ function getTestVenvPython(directory: string) {
     process.platform === "win32" ? "Scripts" : "bin",
     process.platform === "win32" ? "python.exe" : "python",
   )
+}
+
+function findCanaryTestPython() {
+  const commands = process.platform === "win32" ? [["py", "-3"], ["python"]] : [["python3"], ["python"]]
+  return commands.find((cmd) => {
+    try {
+      return (
+        Bun.spawnSync({
+          cmd: [...cmd, "-c", "import sys"],
+          stdout: "pipe",
+          stderr: "pipe",
+        }).exitCode === 0
+      )
+    } catch {
+      return false
+    }
+  })
+}
+
+function runVenvCanaryScript(script: string, installed: string) {
+  const python = findCanaryTestPython()
+  if (!python) throw new Error("Python is required to verify the generated Agency Swarm canary script")
+  const wrapper = [
+    "import importlib.metadata",
+    "import sys",
+    "import types",
+    `installed = ${JSON.stringify(installed)}`,
+    "agency_swarm = types.ModuleType('agency_swarm')",
+    "agency_swarm.__path__ = []",
+    "integrations = types.ModuleType('agency_swarm.integrations')",
+    "integrations.__path__ = []",
+    "fastapi = types.ModuleType('agency_swarm.integrations.fastapi')",
+    "fastapi.run_fastapi = object()",
+    "agency_swarm.integrations = integrations",
+    "integrations.fastapi = fastapi",
+    "sys.modules['agency_swarm'] = agency_swarm",
+    "sys.modules['agency_swarm.integrations'] = integrations",
+    "sys.modules['agency_swarm.integrations.fastapi'] = fastapi",
+    "importlib.metadata.version = lambda name: installed",
+    script,
+  ].join("\n")
+  return Bun.spawnSync({
+    cmd: [...python, "-c", wrapper],
+    stdout: "pipe",
+    stderr: "pipe",
+  }).exitCode
 }
 
 function getTestVenvUv(directory: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #267.

Release blocker: old OpenSwarm projects with launcher-managed `.venv` can keep `agency-swarm` below the compatibility patch and fail during startup.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates the Agent Swarm launcher so launcher-managed Python environments refresh to `agency-swarm>=1.10.1` before startup.

Manifest-backed projects keep their own dependency rules and use the import-only canary, so pinned `requirements.txt` or `pyproject.toml` projects are not forced to the launcher floor.

### How did you verify your code works?

Focused launcher tests passed locally, package typecheck passed locally, and a local OpenSwarm-branded binary upgraded an old project `.venv` from `agency-swarm 1.10.0` to `1.10.1` and reached the OpenSwarm TUI.

### Screenshots / recordings

Not a visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
