### PR TITLE
refactor(provider): align reasoning transform with upstream

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -393,7 +393,7 @@
         "@actions/github": "6.0.1",
         "@agentclientprotocol/sdk": "0.21.0",
         "@ai-sdk/alibaba": "1.0.17",
-        "@ai-sdk/amazon-bedrock": "4.0.96",
+        "@ai-sdk/amazon-bedrock": "4.0.112",
         "@ai-sdk/anthropic": "3.0.71",
         "@ai-sdk/azure": "3.0.49",
         "@ai-sdk/cerebras": "2.0.41",
@@ -5617,6 +5617,8 @@
 
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
+    "agentswarm-cli/@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@4.0.112", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.81", "@ai-sdk/openai": "3.0.67", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-PsSh7a6qW+3kQXPs1kD4wDwuZby0t1PIaB6j/1aMKmPFJ5LxcIcULLMF/bjITLt5o/8lc0t6TXIwG0zlhH7uZw=="],
+
     "agentswarm-cli/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.71", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg=="],
 
     "agentswarm-cli/@ai-sdk/openai": ["@ai-sdk/openai@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ=="],
@@ -6371,6 +6373,18 @@
 
     "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "agentswarm-cli/@ai-sdk/amazon-bedrock/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.81", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA=="],
+
+    "agentswarm-cli/@ai-sdk/amazon-bedrock/@ai-sdk/openai": ["@ai-sdk/openai@3.0.67", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oAiGC9eWG7IgtdsdS74bOCnAAHarAfTJhWN9x5INwnWPekL802AvF+0I5DvLzIF1MIRmNw4N8mPSL/GUVbX9Mw=="],
+
+    "agentswarm-cli/@ai-sdk/amazon-bedrock/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "agentswarm-cli/@ai-sdk/amazon-bedrock/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
+
+    "agentswarm-cli/@ai-sdk/amazon-bedrock/@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.14", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw=="],
+
+    "agentswarm-cli/@ai-sdk/amazon-bedrock/@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
+
     "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -6726,6 +6740,8 @@
     "@slack/web-api/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "@solidjs/start/shiki/@shikijs/engine-javascript/oniguruma-to-es": ["oniguruma-to-es@2.3.0", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^5.1.1", "regex-recursion": "^5.1.1" } }, "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g=="],
+
+    "agentswarm-cli/@ai-sdk/amazon-bedrock/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -90,7 +90,7 @@
     "@actions/github": "6.0.1",
     "@agentclientprotocol/sdk": "0.21.0",
     "@ai-sdk/alibaba": "1.0.17",
-    "@ai-sdk/amazon-bedrock": "4.0.96",
+    "@ai-sdk/amazon-bedrock": "4.0.112",
     "@ai-sdk/anthropic": "3.0.71",
     "@ai-sdk/azure": "3.0.49",
     "@ai-sdk/cerebras": "2.0.41",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -289,6 +289,9 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
 
       const awsAccessKeyId = env["AWS_ACCESS_KEY_ID"]
       const configApiKey = providerConfig?.options?.apiKey
+      const configSigV4Credentials = Boolean(
+        providerConfig?.options?.accessKeyId && providerConfig?.options?.secretAccessKey,
+      )
 
       // TODO: Using process.env directly because Env.set only updates a process.env shallow copy,
       // until the scope of the Env API is clarified (test only or runtime?)
@@ -313,6 +316,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         !awsAccessKeyId &&
         !awsBearerToken &&
         !configApiKey &&
+        !configSigV4Credentials &&
         !awsWebIdentityTokenFile &&
         !containerCreds
       )
@@ -326,7 +330,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
 
       // Only use credential chain if no bearer token exists
       // Bearer token takes precedence over credential chain (profiles, access keys, IAM roles, web identity tokens)
-      if (!awsBearerToken && !configApiKey) {
+      if (!awsBearerToken && !configApiKey && !configSigV4Credentials) {
         // Build credential provider options (only pass profile if specified)
         const credentialProviderOptions = profile ? { profile } : {}
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -88,10 +88,13 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
 
 type BundledSDK = {
   languageModel(modelId: string): LanguageModelV3
+  chat?: (modelId: string) => LanguageModelV3
+  responses?: (modelId: string) => LanguageModelV3
 }
 
 const BUNDLED_PROVIDERS: Record<string, () => Promise<(opts: any) => BundledSDK>> = {
   "@ai-sdk/amazon-bedrock": () => import("@ai-sdk/amazon-bedrock").then((m) => m.createAmazonBedrock),
+  "@ai-sdk/amazon-bedrock/mantle": () => import("@ai-sdk/amazon-bedrock/mantle").then((m) => m.createBedrockMantle),
   "@ai-sdk/anthropic": () => import("@ai-sdk/anthropic").then((m) => m.createAnthropic),
   "@ai-sdk/azure": () => import("@ai-sdk/azure").then((m) => m.createAzure),
   "@ai-sdk/google": () => import("@ai-sdk/google").then((m) => m.createGoogleGenerativeAI),
@@ -118,7 +121,7 @@ const BUNDLED_PROVIDERS: Record<string, () => Promise<(opts: any) => BundledSDK>
   "venice-ai-sdk-provider": () => import("venice-ai-sdk-provider").then((m) => m.createVenice),
 }
 
-type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
+type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>, model?: Model) => Promise<any>
 type CustomVarsLoader = (options: Record<string, any>) => Record<string, string>
 type CustomDiscoverModels = () => Promise<Record<string, Model>>
 type CustomLoader = (provider: Info) => Effect.Effect<{
@@ -146,6 +149,12 @@ function selectAzureLanguageModel(sdk: any, modelID: string, useChat: boolean) {
   if (sdk.messages) return sdk.messages(modelID)
   if (sdk.chat) return sdk.chat(modelID)
   return sdk.languageModel(modelID)
+}
+
+function selectBedrockMantleLanguageModel(sdk: BundledSDK, modelID: string) {
+  if (modelID === "openai.gpt-oss-safeguard-20b" || modelID === "openai.gpt-oss-safeguard-120b")
+    return sdk.chat?.(modelID) ?? sdk.languageModel(modelID)
+  return sdk.responses?.(modelID) ?? sdk.languageModel(modelID)
 }
 
 function custom(dep: CustomDep): Record<string, CustomLoader> {
@@ -321,7 +330,9 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       return {
         autoload: true,
         options: providerOptions,
-        async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+        async getModel(sdk: any, modelID: string, options?: Record<string, any>, model?: Model) {
+          if (model?.api.npm === "@ai-sdk/amazon-bedrock/mantle") return selectBedrockMantleLanguageModel(sdk, modelID)
+
           // Skip region prefixing if model already has a cross-region inference profile prefix
           // Models from models.dev may already include prefixes like us., eu., global., etc.
           const crossRegionPrefixes = ["global.", "us.", "eu.", "jp.", "apac.", "au."]
@@ -1861,10 +1872,15 @@ export const layer = Layer.effect(
         async () => {
           const sdk = await resolveSDK(model, s, envs)
           const language = s.modelLoaders[model.providerID]
-            ? await s.modelLoaders[model.providerID](sdk, model.api.id, {
-                ...provider.options,
-                ...model.options,
-              })
+            ? await s.modelLoaders[model.providerID](
+                sdk,
+                model.api.id,
+                {
+                  ...provider.options,
+                  ...model.options,
+                },
+                model,
+              )
             : sdk.languageModel(model.api.id)
           s.models.set(key, language)
           return language

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -288,6 +288,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       const profile = configProfile ?? envProfile
 
       const awsAccessKeyId = env["AWS_ACCESS_KEY_ID"]
+      const configApiKey = providerConfig?.options?.apiKey
 
       // TODO: Using process.env directly because Env.set only updates a process.env shallow copy,
       // until the scope of the Env API is clarified (test only or runtime?)
@@ -307,7 +308,14 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
       )
 
-      if (!profile && !awsAccessKeyId && !awsBearerToken && !awsWebIdentityTokenFile && !containerCreds)
+      if (
+        !profile &&
+        !awsAccessKeyId &&
+        !awsBearerToken &&
+        !configApiKey &&
+        !awsWebIdentityTokenFile &&
+        !containerCreds
+      )
         return { autoload: false }
 
       const { fromNodeProviderChain } = yield* Effect.promise(() => import("@aws-sdk/credential-providers"))
@@ -318,7 +326,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
 
       // Only use credential chain if no bearer token exists
       // Bearer token takes precedence over credential chain (profiles, access keys, IAM roles, web identity tokens)
-      if (!awsBearerToken) {
+      if (!awsBearerToken && !configApiKey) {
         // Build credential provider options (only pass profile if specified)
         const credentialProviderOptions = profile ? { profile } : {}
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1871,17 +1871,21 @@ export const layer = Layer.effect(
       return yield* EffectPromise.refineRejection(
         async () => {
           const sdk = await resolveSDK(model, s, envs)
-          const language = s.modelLoaders[model.providerID]
-            ? await s.modelLoaders[model.providerID](
-                sdk,
-                model.api.id,
-                {
-                  ...provider.options,
-                  ...model.options,
-                },
-                model,
-              )
-            : sdk.languageModel(model.api.id)
+          const loader = s.modelLoaders[model.providerID]
+          const language =
+            model.api.npm === "@ai-sdk/amazon-bedrock/mantle"
+              ? selectBedrockMantleLanguageModel(sdk as BundledSDK, model.api.id)
+              : loader
+                ? await loader(
+                    sdk,
+                    model.api.id,
+                    {
+                      ...provider.options,
+                      ...model.options,
+                    },
+                    model,
+                  )
+                : sdk.languageModel(model.api.id)
           s.models.set(key, language)
           return language
         },

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -157,6 +157,10 @@ function selectBedrockMantleLanguageModel(sdk: BundledSDK, modelID: string) {
   return sdk.responses?.(modelID) ?? sdk.languageModel(modelID)
 }
 
+function normalizeBedrockMantleBaseURL(url: string) {
+  return url.replace(/\/openai\/v1\/?$/i, "/v1")
+}
+
 function custom(dep: CustomDep): Record<string, CustomLoader> {
   return {
     anthropic: () =>
@@ -1727,7 +1731,10 @@ export const layer = Layer.effect(
           return url
         })
 
-        if (baseURL !== undefined) options["baseURL"] = baseURL
+        if (baseURL !== undefined) {
+          options["baseURL"] =
+            model.api.npm === "@ai-sdk/amazon-bedrock/mantle" ? normalizeBedrockMantleBaseURL(baseURL) : baseURL
+        }
         if (options["apiKey"] === undefined && provider.key) options["apiKey"] = provider.key
         if (model.headers)
           options["headers"] = {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -334,6 +334,11 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       return {
         autoload: true,
         options: providerOptions,
+        vars(options): Record<string, string> {
+          return {
+            AWS_REGION: String(options.region ?? defaultRegion),
+          }
+        },
         async getModel(sdk: any, modelID: string, options?: Record<string, any>, model?: Model) {
           if (model?.api.npm === "@ai-sdk/amazon-bedrock/mantle") return selectBedrockMantleLanguageModel(sdk, modelID)
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1193,12 +1193,13 @@ export function options(input: {
       ) {
         result["reasoningSummary"] = "auto"
       }
-      if (input.model.api.npm === "@ai-sdk/openai" || input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle") {
+      if (input.model.api.npm === "@ai-sdk/openai") {
         result["include"] = INCLUDE_ENCRYPTED_REASONING
       }
-      if (input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle") {
-        result["forceReasoning"] = true
-      }
+    }
+    if (input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle") {
+      result["include"] = INCLUDE_ENCRYPTED_REASONING
+      result["forceReasoning"] = true
     }
 
     // Only set textVerbosity for non-chat gpt-5.x models

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -18,10 +18,11 @@ function mimeToModality(mime: string): Modality | undefined {
 
 export const OUTPUT_TOKEN_MAX = Flag.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
 
-// OpenAI Responses `include` value that returns the encrypted reasoning state
-// needed for stateless multi-turn reasoning (store: false). Hoisted so every
-// branch that requests it stays in lockstep.
-const INCLUDE_ENCRYPTED_REASONING = ["reasoning.encrypted_content"] as const
+const ENCRYPTED_REASONING_INCLUDE = "reasoning.encrypted_content"
+
+function encryptedReasoningInclude() {
+  return [ENCRYPTED_REASONING_INCLUDE]
+}
 
 export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
@@ -845,7 +846,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           {
             reasoningEffort: effort,
             reasoningSummary: "auto",
-            include: INCLUDE_ENCRYPTED_REASONING,
+            include: encryptedReasoningInclude(),
           },
         ]),
       )
@@ -879,7 +880,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           {
             reasoningEffort: effort,
             reasoningSummary: "auto",
-            include: INCLUDE_ENCRYPTED_REASONING,
+            include: encryptedReasoningInclude(),
           },
         ]),
       )
@@ -895,7 +896,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
             reasoningEffort: effort,
             reasoningSummary: "auto",
             ...(model.api.npm === "@ai-sdk/amazon-bedrock/mantle" ? { forceReasoning: true } : {}),
-            include: INCLUDE_ENCRYPTED_REASONING,
+            include: encryptedReasoningInclude(),
           },
         ]),
       )
@@ -1194,11 +1195,11 @@ export function options(input: {
         result["reasoningSummary"] = "auto"
       }
       if (input.model.api.npm === "@ai-sdk/openai") {
-        result["include"] = INCLUDE_ENCRYPTED_REASONING
+        result["include"] = encryptedReasoningInclude()
       }
     }
     if (input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle") {
-      result["include"] = INCLUDE_ENCRYPTED_REASONING
+      result["include"] = encryptedReasoningInclude()
       result["forceReasoning"] = true
     }
 
@@ -1215,7 +1216,7 @@ export function options(input: {
 
     if (input.model.providerID.startsWith("opencode")) {
       result["promptCacheKey"] = input.sessionID
-      result["include"] = INCLUDE_ENCRYPTED_REASONING
+      result["include"] = encryptedReasoningInclude()
       result["reasoningSummary"] = "auto"
     }
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -4,7 +4,6 @@ import type { JSONSchema7 } from "@ai-sdk/provider"
 import type * as Provider from "./provider"
 import type * as ModelsDev from "@opencode-ai/core/models"
 import { iife } from "@/util/iife"
-import { Flag } from "@opencode-ai/core/flag/flag"
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
 
@@ -16,7 +15,12 @@ function mimeToModality(mime: string): Modality | undefined {
   return undefined
 }
 
-export const OUTPUT_TOKEN_MAX = Flag.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
+export const OUTPUT_TOKEN_MAX = 32_000
+
+// OpenAI Responses `include` value that returns the encrypted reasoning state
+// needed for stateless multi-turn reasoning (store: false). Hoisted so every
+// branch that requests it stays in lockstep.
+const INCLUDE_ENCRYPTED_REASONING = ["reasoning.encrypted_content"] as const
 
 export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
@@ -30,6 +34,8 @@ function sdkKey(npm: string): string | undefined {
     case "@ai-sdk/azure":
       return "azure"
     case "@ai-sdk/openai":
+      return "openai"
+    case "@ai-sdk/amazon-bedrock/mantle":
       return "openai"
     case "@ai-sdk/amazon-bedrock":
       return "bedrock"
@@ -208,31 +214,7 @@ function normalizeMessages(
       return msg
     })
   }
-  if (["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
-    // Anthropic rejects assistant turns where tool_use blocks are followed by non-tool
-    // content, e.g. [tool_use, tool_use, text], with:
-    // `tool_use` ids were found without `tool_result` blocks immediately after...
-    //
-    // Reorder that invalid shape into [text] + [tool_use, tool_use]. Consecutive
-    // assistant messages are later merged by the provider/SDK, so preserving the
-    // original [tool_use...] then [text] order still produces the invalid payload.
-    //
-    // The root cause appears to be somewhere upstream where the stream is originally
-    // processed. We were unable to locate an exact narrower reproduction elsewhere,
-    // so we keep this transform in place for the time being.
-    msgs = msgs.flatMap((msg) => {
-      if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [msg]
 
-      const parts = msg.content
-      const first = parts.findIndex((part) => part.type === "tool-call")
-      if (first === -1) return [msg]
-      if (!parts.slice(first).some((part) => part.type !== "tool-call")) return [msg]
-      return [
-        { ...msg, content: parts.filter((part) => part.type !== "tool-call") },
-        { ...msg, content: parts.filter((part) => part.type === "tool-call") },
-      ]
-    })
-  }
   if (
     model.providerID === "mistral" ||
     model.api.id.toLowerCase().includes("mistral") ||
@@ -427,6 +409,24 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
   })
 }
 
+function mapProviderOptions(
+  msgs: ModelMessage[],
+  transform: (options: Record<string, any> | undefined) => Record<string, any> | undefined,
+) {
+  return msgs.map((msg) => {
+    if (!Array.isArray(msg.content)) return { ...msg, providerOptions: transform(msg.providerOptions) }
+    return {
+      ...msg,
+      providerOptions: transform(msg.providerOptions),
+      content: msg.content.map((part) =>
+        part.type === "tool-approval-request" || part.type === "tool-approval-response"
+          ? part
+          : { ...part, providerOptions: transform(part.providerOptions) },
+      ),
+    } as typeof msg
+  })
+}
+
 export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
   msgs = unsupportedParts(msgs, model)
   msgs = normalizeMessages(msgs, model, options)
@@ -456,18 +456,20 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
       return result
     }
 
-    msgs = msgs.map((msg) => {
-      if (!Array.isArray(msg.content)) return { ...msg, providerOptions: remap(msg.providerOptions) }
-      return {
-        ...msg,
-        providerOptions: remap(msg.providerOptions),
-        content: msg.content.map((part) => {
-          if (part.type === "tool-approval-request" || part.type === "tool-approval-response") {
-            return { ...part }
-          }
-          return { ...part, providerOptions: remap(part.providerOptions) }
-        }),
-      } as typeof msg
+    msgs = mapProviderOptions(msgs, remap)
+  }
+
+  // Strip Responses item IDs before serialization, following Codex and keeping signed request bodies immutable.
+  if (
+    options.store !== true &&
+    key &&
+    ["@ai-sdk/openai", "@ai-sdk/azure", "@ai-sdk/amazon-bedrock/mantle"].includes(model.api.npm)
+  ) {
+    msgs = mapProviderOptions(msgs, (options) => {
+      if (!options?.[key] || !("itemId" in options[key])) return options
+      const metadata = { ...options[key] }
+      delete metadata.itemId
+      return { ...options, [key]: metadata }
     })
   }
 
@@ -476,6 +478,7 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
 
 export function temperature(model: Provider.Model) {
   const id = model.id.toLowerCase()
+  if (id.includes("north-mini-code")) return 1.0
   if (id.includes("qwen")) return 0.55
   if (id.includes("claude")) return undefined
   if (id.includes("gemini")) return 1.0
@@ -520,14 +523,6 @@ const OPENAI_GPT5_PRO_2_PLUS_EFFORTS = ["medium", "high", "xhigh"]
 const OPENAI_GPT5_CHAT_EFFORTS = ["medium"]
 const OPENAI_GPT5_CODEX_XHIGH_EFFORTS = [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 const OPENAI_GPT5_CODEX_3_PLUS_EFFORTS = ["none", ...OPENAI_GPT5_CODEX_XHIGH_EFFORTS]
-const OPENROUTER_GEMINI_REASONING_BUDGETS = {
-  none: { reasoning: { enabled: false } },
-  minimal: { reasoning: { max_tokens: 64 } },
-  low: { reasoning: { max_tokens: 256 } },
-  medium: { reasoning: { max_tokens: 512 } },
-  high: { reasoning: { max_tokens: 768 } },
-  xhigh: { reasoning: { max_tokens: 900 } },
-}
 
 // OpenAI rolled out the `none` reasoning_effort tier on this date (Responses API).
 // Models released before it 400 on `reasoning_effort: "none"`, so we only expose
@@ -600,14 +595,32 @@ function openaiCompatibleReasoningEfforts(id: string) {
   return gpt5CodexReasoningEfforts(apiId) ?? versionedGpt5ReasoningEfforts(apiId) ?? OPENAI_EFFORTS
 }
 
+function anthropicOpus47OrLater(apiId: string) {
+  // Matches "opus-4.7" (Anthropic/Bedrock/Vertex) and "claude-4.7-opus" (SAP AI Core inverted).
+  // Greedy \d+ correctly extends to multi-digit majors (e.g. "claude-10.0-opus") for forward compatibility.
+  const version = /opus-(\d+)[.-](\d+)(?:[.@-]|$)|claude-(\d+)[.-](\d+)-opus(?:[.@-]|$)/i.exec(apiId)
+  if (!version) return false
+  const major = Number(version[1] ?? version[3])
+  const minor = Number(version[2] ?? version[4])
+  return major > 4 || (major === 4 && minor >= 7)
+}
+
 function anthropicAdaptiveEfforts(apiId: string): string[] | null {
-  if (["opus-4-7", "opus-4.7"].some((v) => apiId.includes(v))) {
+  if (anthropicOpus47OrLater(apiId) || apiId.includes("fable-5")) {
     return ["low", "medium", "high", "xhigh", "max"]
   }
-  if (["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"].some((v) => apiId.includes(v))) {
+  if (
+    ["opus-4-6", "opus-4.6", "4-6-opus", "4.6-opus", "sonnet-4-6", "sonnet-4.6", "4-6-sonnet", "4.6-sonnet"].some((v) =>
+      apiId.includes(v),
+    )
+  ) {
     return ["low", "medium", "high", "max"]
   }
   return null
+}
+
+function anthropicOmitsThinking(apiId: string) {
+  return anthropicOpus47OrLater(apiId) || apiId.includes("fable-5")
 }
 
 function googleThinkingLevelEfforts(apiId: string) {
@@ -625,22 +638,45 @@ function googleThinkingBudgetMax(apiId: string) {
   return 24_576
 }
 
-function isGemini25(id: string) {
-  return id.toLowerCase().includes("gemini-2.5")
+// SAP's Zod schema drops unknown top-level keys; reasoning controls survive
+// only via `modelParams` (catchall), forwarded verbatim by the SAP SDKs.
+function wrapInSapModelParams(variants: Record<string, Record<string, any>>): Record<string, Record<string, any>> {
+  return Object.fromEntries(Object.entries(variants).map(([k, v]) => [k, { modelParams: v }]))
 }
 
-function isGemini3(id: string) {
-  return id.toLowerCase().includes("gemini-3")
+function googleThinkingVariants(model: Provider.Model): Record<string, Record<string, any>> {
+  const id = model.api.id.toLowerCase()
+  if (id.includes("2.5")) {
+    return {
+      high: { thinkingConfig: { includeThoughts: true, thinkingBudget: 16000 } },
+      max: {
+        thinkingConfig: { includeThoughts: true, thinkingBudget: googleThinkingBudgetMax(id) },
+      },
+    }
+  }
+  return Object.fromEntries(
+    googleThinkingLevelEfforts(id).map((effort) => [
+      effort,
+      { thinkingConfig: { includeThoughts: true, thinkingLevel: effort } },
+    ]),
+  )
 }
 
 export function variants(model: Provider.Model): Record<string, Record<string, any>> {
   if (!model.capabilities.reasoning) return {}
 
   const id = model.id.toLowerCase()
-  const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
-  function isGrok43(id: string): boolean {
-    return id.includes("grok-4.3") || id.includes("grok-4-3")
+  if (
+    model.api.id.toLowerCase().includes("minimax-m3") &&
+    ["@ai-sdk/anthropic", "@ai-sdk/openai-compatible"].includes(model.api.npm)
+  ) {
+    return {
+      none: { thinking: { type: "disabled" } },
+      thinking: { thinking: { type: "adaptive" } },
+    }
   }
+  const adaptiveThinkingOmitted = anthropicOmitsThinking(model.api.id)
+  const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
   if (
     id.includes("deepseek-chat") ||
     id.includes("deepseek-reasoner") ||
@@ -668,24 +704,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       high: { reasoningEffort: "high" },
     }
   }
-  if (id.includes("grok") && isGrok43(id)) {
-    const efforts = ["none", ...WIDELY_SUPPORTED_EFFORTS]
-    if (model.api.npm === "@openrouter/ai-sdk-provider") {
-      return Object.fromEntries(efforts.map((effort) => [effort, { reasoning: { effort } }]))
-    }
-    return Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }]))
-  }
   if (id.includes("grok")) return {}
 
   switch (model.api.npm) {
     case "@openrouter/ai-sdk-provider":
-      if (!id.includes("gpt") && !id.includes("claude") && !isGemini25(id) && !isGemini3(id)) return {}
-      if (isGemini25(id)) return OPENROUTER_GEMINI_REASONING_BUDGETS
       return Object.fromEntries(
-        (id.includes("gpt") ? openaiCompatibleReasoningEfforts(id) : OPENAI_EFFORTS).map((effort) => [
-          effort,
-          { reasoning: { effort } },
-        ]),
+        (model.api.id.startsWith("openai/") || id.includes("gpt")
+          ? openaiCompatibleReasoningEfforts(model.api.id)
+          : WIDELY_SUPPORTED_EFFORTS
+        ).map((effort) => [effort, { reasoning: { effort } }]),
       )
 
     case "ai-gateway-provider": {
@@ -711,6 +738,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
               {
                 thinking: {
                   type: "adaptive",
+                  // Newer adaptive-only models default `display` to "omitted", which
+                  // returns empty thinking blocks. Force "summarized" so summaries
+                  // survive (4.6/Sonnet 4.6 already default to "summarized").
+                  ...(adaptiveThinkingOmitted ? { display: "summarized" } : {}),
                 },
                 effort,
               },
@@ -744,7 +775,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
             max: {
               thinkingConfig: {
                 includeThoughts: true,
-                thinkingBudget: 24576,
+                thinkingBudget: googleThinkingBudgetMax(id),
               },
             },
           }
@@ -784,7 +815,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           {
             reasoningEffort: effort,
             reasoningSummary: "auto",
-            include: ["reasoning.encrypted_content"],
+            include: INCLUDE_ENCRYPTED_REASONING,
           },
         ]),
       )
@@ -800,6 +831,9 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "venice-ai-sdk-provider":
     // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
     case "@ai-sdk/openai-compatible":
+      if (model.api.id.toLowerCase().includes("north-mini-code")) {
+        return Object.fromEntries(["none", "high"].map((effort) => [effort, { reasoningEffort: effort }]))
+      }
       const efforts = [...WIDELY_SUPPORTED_EFFORTS]
       if (model.api.id.toLowerCase().includes("deepseek-v4")) {
         efforts.push("max")
@@ -810,18 +844,16 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
       return Object.fromEntries(
-        (GPT5_FAMILY_RE.test(id) && gpt5Version(id) === undefined
-          ? ["minimal", ...WIDELY_SUPPORTED_EFFORTS]
-          : WIDELY_SUPPORTED_EFFORTS
-        ).map((effort) => [
+        openaiReasoningEfforts(id, model.release_date).map((effort) => [
           effort,
           {
             reasoningEffort: effort,
             reasoningSummary: "auto",
-            include: ["reasoning.encrypted_content"],
+            include: INCLUDE_ENCRYPTED_REASONING,
           },
         ]),
       )
+    case "@ai-sdk/amazon-bedrock/mantle":
     case "@ai-sdk/openai": {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
       const efforts = openaiReasoningEfforts(model.api.id, model.release_date)
@@ -831,7 +863,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           {
             reasoningEffort: effort,
             reasoningSummary: "auto",
-            include: ["reasoning.encrypted_content"],
+            include: INCLUDE_ENCRYPTED_REASONING,
           },
         ]),
       )
@@ -856,9 +888,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
             {
               thinking: {
                 type: "adaptive",
-                ...(model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")
-                  ? { display: "summarized" }
-                  : {}),
+                ...(adaptiveThinkingOmitted ? { display: "summarized" } : {}),
               },
               effort,
             },
@@ -895,9 +925,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
               reasoningConfig: {
                 type: "adaptive",
                 maxReasoningEffort: effort,
-                ...(model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")
-                  ? { display: "summarized" }
-                  : {}),
+                ...(adaptiveThinkingOmitted ? { display: "summarized" } : {}),
               },
             },
           ]),
@@ -938,34 +966,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex
     case "@ai-sdk/google":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai
-      if (id.includes("2.5")) {
-        return {
-          high: {
-            thinkingConfig: {
-              includeThoughts: true,
-              thinkingBudget: 16000,
-            },
-          },
-          max: {
-            thinkingConfig: {
-              includeThoughts: true,
-              thinkingBudget: googleThinkingBudgetMax(id),
-            },
-          },
-        }
-      }
-
-      return Object.fromEntries(
-        googleThinkingLevelEfforts(id).map((effort) => [
-          effort,
-          {
-            thinkingConfig: {
-              includeThoughts: true,
-              thinkingLevel: effort,
-            },
-          },
-        ]),
-      )
+      return googleThinkingVariants(model)
 
     case "@ai-sdk/mistral":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/mistral
@@ -1004,56 +1005,39 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/perplexity
       return {}
 
-    case "@jerome-benoit/sap-ai-provider-v2":
-      if (model.api.id.includes("anthropic")) {
+    case "@jerome-benoit/sap-ai-provider-v2": {
+      if (id.includes("anthropic")) {
         if (adaptiveEfforts) {
-          return Object.fromEntries(
-            adaptiveEfforts.map((effort) => [
-              effort,
-              {
-                thinking: {
-                  type: "adaptive",
-                },
+          // Bedrock adaptive splits `effort` out into `output_config` (vs Anthropic
+          // native which inlines it). Opus 4.7+ flipped `display` default to "omitted".
+          return wrapInSapModelParams(
+            Object.fromEntries(
+              adaptiveEfforts.map((effort) => [
                 effort,
-              },
-            ]),
+                {
+                  thinking: { type: "adaptive", ...(adaptiveThinkingOmitted ? { display: "summarized" } : {}) },
+                  output_config: { effort },
+                },
+              ]),
+            ),
           )
         }
-        return {
-          high: {
-            thinking: {
-              type: "enabled",
-              budgetTokens: 16000,
-            },
-          },
-          max: {
-            thinking: {
-              type: "enabled",
-              budgetTokens: 31999,
-            },
-          },
-        }
+        return wrapInSapModelParams({
+          high: { thinking: { type: "enabled", budget_tokens: 16000 } },
+          max: { thinking: { type: "enabled", budget_tokens: 31999 } },
+        })
       }
-      if (model.api.id.includes("gemini") && id.includes("2.5")) {
-        return {
-          high: {
-            thinkingConfig: {
-              includeThoughts: true,
-              thinkingBudget: 16000,
-            },
-          },
-          max: {
-            thinkingConfig: {
-              includeThoughts: true,
-              thinkingBudget: 24576,
-            },
-          },
-        }
+      if (id.includes("gemini") && id.includes("2.5")) {
+        return wrapInSapModelParams(googleThinkingVariants(model))
       }
-      if (model.api.id.includes("gpt") || /\bo[1-9]/.test(model.api.id)) {
-        return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+      if (id.includes("gpt") || /\bo[1-9]/.test(id)) {
+        const efforts = openaiReasoningEfforts(id, model.release_date)
+        return wrapInSapModelParams(Object.fromEntries(efforts.map((effort) => [effort, { reasoning_effort: effort }])))
       }
-      return {}
+      return wrapInSapModelParams(
+        Object.fromEntries(["low", "medium", "high"].map((effort) => [effort, { reasoning_effort: effort }])),
+      )
+    }
   }
   return {}
 }
@@ -1076,7 +1060,8 @@ export function options(input: {
   if (
     input.model.providerID === "openai" ||
     input.model.api.npm === "@ai-sdk/openai" ||
-    input.model.api.npm === "@ai-sdk/github-copilot"
+    input.model.api.npm === "@ai-sdk/github-copilot" ||
+    input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle"
   ) {
     result["store"] = false
   }
@@ -1090,12 +1075,8 @@ export function options(input: {
     result["usage"] = {
       include: true,
     }
-    if (input.model.capabilities.reasoning) {
-      if (input.model.api.npm === "@openrouter/ai-sdk-provider" && isGemini25(input.model.api.id)) {
-        result["reasoning"] = OPENROUTER_GEMINI_REASONING_BUDGETS.high.reasoning
-      } else if (isGemini3(input.model.api.id)) {
-        result["reasoning"] = { effort: "high" }
-      }
+    if (input.model.api.id.includes("gemini-3")) {
+      result["reasoning"] = { effort: "high" }
     }
   }
 
@@ -1131,8 +1112,14 @@ export function options(input: {
     }
   }
 
-  // Enable thinking by default for kimi models using anthropic SDK
   const modelId = input.model.api.id.toLowerCase()
+
+  // MiniMax's Anthropic interface defaults thinking off, unlike Chat Completions.
+  if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
+    result["thinking"] = { type: "adaptive" }
+  }
+
+  // Enable thinking by default for kimi models using anthropic SDK
   if (
     (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
     (modelId.includes("k2p") || modelId.includes("kimi-k2.") || modelId.includes("kimi-k2p"))
@@ -1168,9 +1155,13 @@ export function options(input: {
       if (
         input.model.api.npm === "@ai-sdk/openai" ||
         input.model.api.npm === "@ai-sdk/azure" ||
-        input.model.api.npm === "@ai-sdk/github-copilot"
+        input.model.api.npm === "@ai-sdk/github-copilot" ||
+        input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle"
       ) {
         result["reasoningSummary"] = "auto"
+      }
+      if (input.model.api.npm === "@ai-sdk/openai" || input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle") {
+        result["include"] = INCLUDE_ENCRYPTED_REASONING
       }
     }
 
@@ -1187,7 +1178,7 @@ export function options(input: {
 
     if (input.model.providerID.startsWith("opencode")) {
       result["promptCacheKey"] = input.sessionID
-      result["include"] = ["reasoning.encrypted_content"]
+      result["include"] = INCLUDE_ENCRYPTED_REASONING
       result["reasoningSummary"] = "auto"
     }
   }
@@ -1219,6 +1210,9 @@ export function smallOptions(model: Provider.Model) {
     return mergeDeep(base, small)
   }
   if (model.providerID === "openrouter" || model.providerID === "llmgateway") {
+    if (model.providerID === "openrouter" && small.reasoning?.effort === "low") {
+      return { reasoning: { effort: "none" } }
+    }
     if (Object.keys(small).length === 0 && model.api.id.includes("google")) {
       return { reasoning: { enabled: false } }
     }
@@ -1288,8 +1282,8 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
   return { [key]: options }
 }
 
-export function maxOutputTokens(model: Provider.Model): number {
-  return Math.min(model.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
+export function maxOutputTokens(model: Provider.Model, outputTokenMax = OUTPUT_TOKEN_MAX): number {
+  return Math.min(model.limit.output, outputTokenMax) || outputTokenMax
 }
 
 export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 {
@@ -1378,6 +1372,24 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
           result[key] = sanitizeGemini(value)
         } else {
           result[key] = value
+        }
+      }
+
+      // Gemini requires a single `type`, not a JSON Schema type array such as
+      // `["number","string"]` (emitted by some MCP servers). Plain `@ai-sdk/google`
+      // rewrites these into an `anyOf` of single-type schemas, but OpenAI-compatible
+      // transports (e.g. GitHub Copilot proxying to Gemini) forward them verbatim
+      // and the backend rejects the array form. Mirror the SDK: split non-null
+      // types into `anyOf`, and lift `null` into `nullable`.
+      if (Array.isArray(result.type)) {
+        const hasNull = result.type.includes("null")
+        const nonNull = result.type.filter((entry: unknown) => entry !== "null")
+        if (nonNull.length === 0) {
+          result.type = "null"
+        } else {
+          delete result.type
+          result.anyOf = nonNull.map((entry: unknown) => ({ type: entry }))
+          if (hasNull) result.nullable = true
         }
       }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -681,6 +681,10 @@ function googleThinkingVariants(model: Provider.Model): Record<string, Record<st
   )
 }
 
+function isGrok43(id: string) {
+  return id.includes("grok-4.3") || id.includes("grok-4-3")
+}
+
 export function variants(model: Provider.Model): Record<string, Record<string, any>> {
   if (!model.capabilities.reasoning) return {}
 
@@ -722,6 +726,13 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       low: { reasoningEffort: "low" },
       high: { reasoningEffort: "high" },
     }
+  }
+  if (id.includes("grok") && isGrok43(id)) {
+    const efforts = ["none", ...WIDELY_SUPPORTED_EFFORTS]
+    if (model.api.npm === "@openrouter/ai-sdk-provider") {
+      return Object.fromEntries(efforts.map((effort) => [effort, { reasoning: { effort } }]))
+    }
+    return Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }]))
   }
   if (id.includes("grok")) return {}
 
@@ -1235,9 +1246,6 @@ export function smallOptions(model: Provider.Model) {
     return mergeDeep(base, small)
   }
   if (model.providerID === "openrouter" || model.providerID === "llmgateway") {
-    if (model.providerID === "openrouter" && small.reasoning?.effort === "low") {
-      return { reasoning: { effort: "none" } }
-    }
     if (Object.keys(small).length === 0 && model.api.id.includes("google")) {
       return { reasoning: { enabled: false } }
     }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -214,6 +214,20 @@ function normalizeMessages(
       return msg
     })
   }
+  if (["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
+    msgs = msgs.flatMap((msg) => {
+      if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [msg]
+
+      const parts = msg.content
+      const first = parts.findIndex((part) => part.type === "tool-call")
+      if (first === -1) return [msg]
+      if (!parts.slice(first).some((part) => part.type !== "tool-call")) return [msg]
+      return [
+        { ...msg, content: parts.filter((part) => part.type !== "tool-call") },
+        { ...msg, content: parts.filter((part) => part.type === "tool-call") },
+      ]
+    })
+  }
 
   if (
     model.providerID === "mistral" ||

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -555,6 +555,7 @@ const GPT5_FAMILY_RE = /(?:^|\/)gpt-5(?:[.-]|$)/
 const GPT5_VERSION_RE = /(?:^|\/)gpt-5[.-](\d+)(?:[.-]|$)/
 const GPT5_PRO_RE = /(?:^|\/)gpt-5[.-]?pro(?:[.-]|$)/
 const GPT5_VERSIONED_PRO_RE = /(?:^|\/)gpt-5[.-]\d+[.-]pro(?:[.-]|$)/
+const OPENAI_O_SERIES_RE = /(?:^|\/)o[1-9](?:[.-]|$)/
 
 function gpt5Version(apiId: string) {
   return Number(GPT5_VERSION_RE.exec(apiId)?.[1]) || undefined
@@ -581,12 +582,19 @@ function gpt5ChatReasoningEfforts(apiId: string) {
   return gpt5Version(apiId) === undefined ? [] : OPENAI_GPT5_CHAT_EFFORTS
 }
 
+function openaiOSeriesReasoningEfforts(apiId: string) {
+  if (!OPENAI_O_SERIES_RE.test(apiId)) return undefined
+  if (apiId.includes("deep-research")) return ["medium"]
+  return WIDELY_SUPPORTED_EFFORTS
+}
+
 // Computes the reasoning_effort tiers an OpenAI (or OpenAI-compatible upstream
 // routed through it, e.g. cf-ai-gateway) model exposes. Effort order: weakest
 // to strongest.
 function openaiReasoningEfforts(apiId: string, releaseDate: string) {
   const id = apiId.toLowerCase()
-  if (id.includes("deep-research")) return ["medium"]
+  const oSeriesEfforts = openaiOSeriesReasoningEfforts(id)
+  if (oSeriesEfforts) return oSeriesEfforts
   const chatEfforts = gpt5ChatReasoningEfforts(id)
   if (chatEfforts) return chatEfforts
   if (GPT5_PRO_RE.test(id)) return OPENAI_GPT5_PRO_EFFORTS
@@ -605,6 +613,8 @@ function openaiReasoningEfforts(apiId: string, releaseDate: string) {
 
 function openaiCompatibleReasoningEfforts(id: string) {
   const apiId = id.toLowerCase()
+  const oSeriesEfforts = openaiOSeriesReasoningEfforts(apiId)
+  if (oSeriesEfforts) return oSeriesEfforts
   const chatEfforts = gpt5ChatReasoningEfforts(apiId)
   if (chatEfforts) return chatEfforts
   if (GPT5_PRO_RE.test(apiId)) return OPENAI_GPT5_PRO_EFFORTS

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1313,6 +1313,27 @@ function isPlainObject(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
+function scalarTypes(values: unknown[]): string[] {
+  const result: string[] = []
+  for (const value of values) {
+    const type =
+      typeof value === "number"
+        ? Number.isInteger(value)
+          ? "integer"
+          : "number"
+        : value === null
+          ? "null"
+          : typeof value === "string" || typeof value === "boolean"
+            ? typeof value
+            : undefined
+    if (type && !result.includes(type)) result.push(type)
+  }
+  if (result.includes("number") && result.includes("integer")) {
+    return result.filter((type) => type !== "integer")
+  }
+  return result
+}
+
 // Mirrors Codex's Rust JSON schema compatibility lowering for OpenAI tool schemas.
 function sanitizeOpenAISchema(value: unknown): unknown {
   const types = ["string", "number", "boolean", "integer", "object", "array", "null"]
@@ -1376,6 +1397,7 @@ function sanitizeOpenAISchema(value: unknown): unknown {
 
   // MCP schemas may omit `type` while still using keywords that imply one.
   // Keep the schema usable after unsupported keywords are dropped.
+  const enumTypes = Array.isArray(result.enum) ? scalarTypes(result.enum) : []
   const inferredTypes =
     schemaTypes.length > 0
       ? schemaTypes
@@ -1383,11 +1405,13 @@ function sanitizeOpenAISchema(value: unknown): unknown {
         ? ["object"]
         : ["items", "prefixItems"].some((key) => key in value)
           ? ["array"]
-          : "enum" in result || "format" in value
-            ? ["string"]
-            : ["minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"].some((key) => key in value)
-              ? ["number"]
-              : []
+          : enumTypes.length > 0
+            ? enumTypes
+            : "enum" in result || "format" in value
+              ? ["string"]
+              : ["minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"].some((key) => key in value)
+                ? ["number"]
+                : []
 
   if (inferredTypes.length === 0) return {}
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1301,6 +1301,96 @@ export function maxOutputTokens(model: Provider.Model, outputTokenMax = OUTPUT_T
   return Math.min(model.limit.output, outputTokenMax) || outputTokenMax
 }
 
+type JsonRecord = Record<string, unknown>
+
+function isPlainObject(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+// Mirrors Codex's Rust JSON schema compatibility lowering for OpenAI tool schemas.
+function sanitizeOpenAISchema(value: unknown): unknown {
+  const types = ["string", "number", "boolean", "integer", "object", "array", "null"]
+  const compositionKeys = ["anyOf", "oneOf", "allOf"]
+
+  // JSON Schema's boolean form (`true`/`false`) is unsupported by OpenAI tool schemas.
+  if (typeof value === "boolean") return { type: "string" }
+  if (Array.isArray(value)) return value.map(sanitizeOpenAISchema)
+  if (!isPlainObject(value)) return value
+
+  const result: JsonRecord = {}
+
+  if (typeof value.$ref === "string") result.$ref = value.$ref
+  if (typeof value.description === "string") result.description = value.description
+  if ("const" in value) result.enum = [value.const]
+  else if (Array.isArray(value.enum)) result.enum = value.enum
+
+  if (isPlainObject(value.properties)) {
+    result.properties = Object.fromEntries(
+      Object.entries(value.properties).map(([key, item]) => [key, sanitizeOpenAISchema(item)]),
+    )
+  }
+
+  if (Array.isArray(value.required)) {
+    result.required = value.required.filter((item) => typeof item === "string")
+  }
+
+  if ("items" in value) result.items = sanitizeOpenAISchema(value.items)
+
+  if ("additionalProperties" in value) {
+    result.additionalProperties =
+      typeof value.additionalProperties === "boolean"
+        ? value.additionalProperties
+        : sanitizeOpenAISchema(value.additionalProperties)
+  }
+
+  for (const key of compositionKeys) {
+    if (Array.isArray(value[key])) result[key] = value[key].map(sanitizeOpenAISchema)
+  }
+
+  for (const key of ["$defs", "definitions"]) {
+    if (isPlainObject(value[key])) {
+      result[key] = Object.fromEntries(
+        Object.entries(value[key]).map(([name, item]) => [name, sanitizeOpenAISchema(item)]),
+      )
+    }
+  }
+
+  const schemaTypes =
+    typeof value.type === "string"
+      ? types.includes(value.type)
+        ? [value.type]
+        : []
+      : Array.isArray(value.type)
+        ? value.type.filter((item) => typeof item === "string" && types.includes(item))
+        : []
+
+  if (schemaTypes.length === 0 && (typeof result.$ref === "string" || compositionKeys.some((key) => key in result))) {
+    return result
+  }
+
+  // MCP schemas may omit `type` while still using keywords that imply one.
+  // Keep the schema usable after unsupported keywords are dropped.
+  const inferredTypes =
+    schemaTypes.length > 0
+      ? schemaTypes
+      : ["properties", "required", "additionalProperties"].some((key) => key in value)
+        ? ["object"]
+        : ["items", "prefixItems"].some((key) => key in value)
+          ? ["array"]
+          : "enum" in result || "format" in value
+            ? ["string"]
+            : ["minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"].some((key) => key in value)
+              ? ["number"]
+              : []
+
+  if (inferredTypes.length === 0) return {}
+
+  result.type = inferredTypes.length === 1 ? inferredTypes[0] : inferredTypes
+  if (inferredTypes.includes("object") && !("properties" in result)) result.properties = {}
+  if (inferredTypes.includes("array") && !("items" in result)) result.items = { type: "string" }
+  return result
+}
+
 export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 {
   /*
   if (["openai", "azure"].includes(providerID)) {
@@ -1319,6 +1409,11 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
     }
   }
   */
+
+  if (model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/azure") {
+    schema = sanitizeOpenAISchema(schema) as JSONSchema7
+    // Codex also applies lossy compaction above 4 KB; defer that until OpenCode needs the same schema budget.
+  }
 
   if (model.providerID === "moonshotai" || model.api.id.toLowerCase().includes("kimi")) {
     const sanitizeMoonshot = (obj: unknown): unknown => {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -4,6 +4,7 @@ import type { JSONSchema7 } from "@ai-sdk/provider"
 import type * as Provider from "./provider"
 import type * as ModelsDev from "@opencode-ai/core/models"
 import { iife } from "@/util/iife"
+import { Flag } from "@opencode-ai/core/flag/flag"
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
 
@@ -15,7 +16,7 @@ function mimeToModality(mime: string): Modality | undefined {
   return undefined
 }
 
-export const OUTPUT_TOKEN_MAX = 32_000
+export const OUTPUT_TOKEN_MAX = Flag.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
 
 // OpenAI Responses `include` value that returns the encrypted reasoning state
 // needed for stateless multi-turn reasoning (store: false). Hoisted so every

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -610,6 +610,10 @@ function openaiCompatibleReasoningEfforts(id: string) {
   return gpt5CodexReasoningEfforts(apiId) ?? versionedGpt5ReasoningEfforts(apiId) ?? OPENAI_EFFORTS
 }
 
+function mantleOpenAIModelID(id: string) {
+  return id.replace(/^openai\.(?=gpt-)/i, "")
+}
+
 function anthropicOpus47OrLater(apiId: string) {
   // Matches "opus-4.7" (Anthropic/Bedrock/Vertex) and "claude-4.7-opus" (SAP AI Core inverted).
   // Greedy \d+ correctly extends to multi-digit majors (e.g. "claude-10.0-opus") for forward compatibility.
@@ -871,7 +875,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "@ai-sdk/amazon-bedrock/mantle":
     case "@ai-sdk/openai": {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
-      const efforts = openaiReasoningEfforts(model.api.id, model.release_date)
+      const apiID = model.api.npm === "@ai-sdk/amazon-bedrock/mantle" ? mantleOpenAIModelID(model.api.id) : model.api.id
+      const efforts = openaiReasoningEfforts(apiID, model.release_date)
       return Object.fromEntries(
         efforts.map((effort) => [
           effort,
@@ -1219,7 +1224,8 @@ export function smallOptions(model: Provider.Model) {
   if (
     model.providerID === "openai" ||
     model.api.npm === "@ai-sdk/openai" ||
-    model.api.npm === "@ai-sdk/github-copilot"
+    model.api.npm === "@ai-sdk/github-copilot" ||
+    model.api.npm === "@ai-sdk/amazon-bedrock/mantle"
   ) {
     const base = { store: false }
     return mergeDeep(base, small)
@@ -1410,7 +1416,11 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
   }
   */
 
-  if (model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/azure") {
+  if (
+    model.api.npm === "@ai-sdk/openai" ||
+    model.api.npm === "@ai-sdk/azure" ||
+    model.api.npm === "@ai-sdk/amazon-bedrock/mantle"
+  ) {
     schema = sanitizeOpenAISchema(schema) as JSONSchema7
     // Codex also applies lossy compaction above 4 KB; defer that until OpenCode needs the same schema budget.
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1038,7 +1038,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       return {}
 
     case "@jerome-benoit/sap-ai-provider-v2": {
-      if (id.includes("anthropic")) {
+      const apiID = model.api.id.toLowerCase()
+      if (apiID.includes("anthropic")) {
         if (adaptiveEfforts) {
           // Bedrock adaptive splits `effort` out into `output_config` (vs Anthropic
           // native which inlines it). Opus 4.7+ flipped `display` default to "omitted".
@@ -1059,11 +1060,11 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           max: { thinking: { type: "enabled", budget_tokens: 31999 } },
         })
       }
-      if (id.includes("gemini") && id.includes("2.5")) {
+      if (apiID.includes("gemini") && apiID.includes("2.5")) {
         return wrapInSapModelParams(googleThinkingVariants(model))
       }
-      if (id.includes("gpt") || /\bo[1-9]/.test(id)) {
-        const efforts = openaiReasoningEfforts(id, model.release_date)
+      if (apiID.includes("gpt") || /\bo[1-9]/.test(apiID)) {
+        const efforts = openaiReasoningEfforts(apiID, model.release_date)
         return wrapInSapModelParams(Object.fromEntries(efforts.map((effort) => [effort, { reasoning_effort: effort }])))
       }
       return wrapInSapModelParams(
@@ -1107,7 +1108,7 @@ export function options(input: {
     result["usage"] = {
       include: true,
     }
-    if (input.model.api.id.includes("gemini-3")) {
+    if (input.model.capabilities.reasoning && input.model.api.id.includes("gemini-3")) {
       result["reasoning"] = { effort: "high" }
     }
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -883,6 +883,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           {
             reasoningEffort: effort,
             reasoningSummary: "auto",
+            ...(model.api.npm === "@ai-sdk/amazon-bedrock/mantle" ? { forceReasoning: true } : {}),
             include: INCLUDE_ENCRYPTED_REASONING,
           },
         ]),
@@ -1182,6 +1183,9 @@ export function options(input: {
       }
       if (input.model.api.npm === "@ai-sdk/openai" || input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle") {
         result["include"] = INCLUDE_ENCRYPTED_REASONING
+      }
+      if (input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle") {
+        result["forceReasoning"] = true
       }
     }
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -29,28 +29,8 @@ export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
 type Result = Awaited<ReturnType<typeof streamText>>
 
 // Avoid re-instantiating remeda's deep merge types in this hot LLM path; the runtime behavior is still mergeDeep.
-const mergeOptions = (target: Record<string, any>, source: Record<string, any> | undefined): Record<string, any> => {
-  let sourceOptions = source ?? {}
-  if (isReasoningDisabled(target.reasoning) && source?.reasoning !== undefined) {
-    sourceOptions = { ...source }
-    delete sourceOptions.reasoning
-  }
-  const result = mergeDeep(target, sourceOptions) as Record<string, any>
-  const reasoning = source?.reasoning
-  if (isReasoningDisabled(reasoning)) {
-    result.reasoning = reasoning
-  }
-  return result
-}
-
-function isReasoningDisabled(value: unknown) {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "enabled" in value &&
-    (value as Record<string, unknown>).enabled === false
-  )
-}
+const mergeOptions = (target: Record<string, any>, source: Record<string, any> | undefined): Record<string, any> =>
+  mergeDeep(target, source ?? {}) as Record<string, any>
 
 export type StreamInput = {
   user: MessageV2.User

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -55,6 +55,8 @@ function removeReasoningControls(options: Record<string, unknown>) {
   delete options.reasoningSummary
   delete options.reasoning_summary
   delete options.forceReasoning
+  delete options.effort
+  delete options.reasoningConfig
   delete options.thinking
   delete options.thinkingConfig
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -399,7 +399,7 @@ const live: Layer.Layer<
               async transformParams(args) {
                 if (args.type === "stream") {
                   // @ts-expect-error
-                  args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, options)
+                  args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, params.options)
                 }
                 return args.params
               },

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -29,8 +29,13 @@ export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
 type Result = Awaited<ReturnType<typeof streamText>>
 
 // Avoid re-instantiating remeda's deep merge types in this hot LLM path; the runtime behavior is still mergeDeep.
-const mergeOptions = (target: Record<string, any>, source: Record<string, any> | undefined): Record<string, any> =>
-  mergeDeep(target, source ?? {}) as Record<string, any>
+const mergeOptions = (target: Record<string, any>, source: Record<string, any> | undefined): Record<string, any> => {
+  const result = mergeDeep(target, source ?? {}) as Record<string, any>
+  if (source?.reasoning && typeof source.reasoning === "object" && !Array.isArray(source.reasoning)) {
+    result.reasoning = source.reasoning
+  }
+  return result
+}
 
 export type StreamInput = {
   user: MessageV2.User

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -36,19 +36,39 @@ const mergeOptions = (target: Record<string, any>, source: Record<string, any> |
   const result = mergeDeep(target, source ?? {}) as Record<string, any>
   if (disabled) {
     result.reasoning = { enabled: false }
-    delete result.reasoningEffort
-    delete result.reasoning_effort
-    delete result.reasoningSummary
-    delete result.reasoning_summary
-    delete result.forceReasoning
-    const include = result.include
-    if (Array.isArray(include)) {
-      const next = include.filter((item) => item !== ENCRYPTED_REASONING_INCLUDE)
-      if (next.length === 0) delete result.include
-      else result.include = next
+    removeReasoningControls(result)
+    const params = result.modelParams
+    if (params && typeof params === "object" && !Array.isArray(params)) {
+      delete params.reasoning
+      removeReasoningControls(params)
+      if (Object.keys(params).length === 0) delete result.modelParams
     }
   }
   return result
+}
+
+function removeReasoningControls(options: Record<string, unknown>) {
+  delete options.reasoningEffort
+  delete options.reasoning_effort
+  delete options.reasoningSummary
+  delete options.reasoning_summary
+  delete options.forceReasoning
+  delete options.thinking
+  delete options.thinkingConfig
+
+  const output = options.output_config
+  if (output && typeof output === "object" && !Array.isArray(output)) {
+    const config = output as Record<string, unknown>
+    delete config.effort
+    if (Object.keys(config).length === 0) delete options.output_config
+  }
+
+  const include = options.include
+  if (Array.isArray(include)) {
+    const next = include.filter((item) => item !== ENCRYPTED_REASONING_INCLUDE)
+    if (next.length === 0) delete options.include
+    else options.include = next
+  }
 }
 
 function isReasoningDisabled(value: unknown) {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -39,9 +39,11 @@ const mergeOptions = (target: Record<string, any>, source: Record<string, any> |
     removeReasoningControls(result)
     const params = result.modelParams
     if (params && typeof params === "object" && !Array.isArray(params)) {
-      delete params.reasoning
-      removeReasoningControls(params)
-      if (Object.keys(params).length === 0) delete result.modelParams
+      const next = { ...params }
+      result.modelParams = next
+      delete next.reasoning
+      removeReasoningControls(next)
+      if (Object.keys(next).length === 0) delete result.modelParams
     }
   }
   return result
@@ -58,9 +60,10 @@ function removeReasoningControls(options: Record<string, unknown>) {
 
   const output = options.output_config
   if (output && typeof output === "object" && !Array.isArray(output)) {
-    const config = output as Record<string, unknown>
+    const config = { ...(output as Record<string, unknown>) }
     delete config.effort
     if (Object.keys(config).length === 0) delete options.output_config
+    else options.output_config = config
   }
 
   const include = options.include

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -28,18 +28,36 @@ const log = Log.create({ service: "llm" })
 export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
 type Result = Awaited<ReturnType<typeof streamText>>
 
+const ENCRYPTED_REASONING_INCLUDE = "reasoning.encrypted_content"
+
 // Avoid re-instantiating remeda's deep merge types in this hot LLM path; the runtime behavior is still mergeDeep.
 const mergeOptions = (target: Record<string, any>, source: Record<string, any> | undefined): Record<string, any> => {
+  const disabled = isReasoningDisabled(target.reasoning) || isReasoningDisabled(source?.reasoning)
   const result = mergeDeep(target, source ?? {}) as Record<string, any>
-  if (
-    source?.reasoning &&
-    typeof source.reasoning === "object" &&
-    !Array.isArray(source.reasoning) &&
-    source.reasoning["enabled"] === false
-  ) {
-    result.reasoning = source.reasoning
+  if (disabled) {
+    result.reasoning = { enabled: false }
+    delete result.reasoningEffort
+    delete result.reasoning_effort
+    delete result.reasoningSummary
+    delete result.reasoning_summary
+    delete result.forceReasoning
+    const include = result.include
+    if (Array.isArray(include)) {
+      const next = include.filter((item) => item !== ENCRYPTED_REASONING_INCLUDE)
+      if (next.length === 0) delete result.include
+      else result.include = next
+    }
   }
   return result
+}
+
+function isReasoningDisabled(value: unknown) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "enabled" in value &&
+    (value as Record<string, unknown>).enabled === false
+  )
 }
 
 export type StreamInput = {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -31,7 +31,12 @@ type Result = Awaited<ReturnType<typeof streamText>>
 // Avoid re-instantiating remeda's deep merge types in this hot LLM path; the runtime behavior is still mergeDeep.
 const mergeOptions = (target: Record<string, any>, source: Record<string, any> | undefined): Record<string, any> => {
   const result = mergeDeep(target, source ?? {}) as Record<string, any>
-  if (source?.reasoning && typeof source.reasoning === "object" && !Array.isArray(source.reasoning)) {
+  if (
+    source?.reasoning &&
+    typeof source.reasoning === "object" &&
+    !Array.isArray(source.reasoning) &&
+    source.reasoning["enabled"] === false
+  ) {
     result.reasoning = source.reasoning
   }
   return result

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -101,6 +101,46 @@ test("Bedrock Mantle: uses chat for safeguard models and responses otherwise", a
   })
 })
 
+test("Bedrock Mantle: custom provider IDs use responses for GPT-5 models", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "custom-mantle": {
+              name: "Custom Mantle",
+              npm: "@ai-sdk/amazon-bedrock/mantle",
+              api: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+              options: {
+                region: "us-east-2",
+                apiKey: "test-key",
+              },
+              models: {
+                "openai.gpt-5.5": {
+                  name: "GPT 5.5",
+                  reasoning: true,
+                  release_date: "2026-04-23",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = await getModel(ProviderID.make("custom-mantle"), ModelID.make("openai.gpt-5.5"))
+      const language = await getLanguage(model)
+      expect((language as { provider: string }).provider).toBe("bedrock-mantle.responses")
+    },
+  })
+})
+
 test("Bedrock Mantle: prefixed GPT-5 responses send reasoning controls", async () => {
   let captured: { url: string; body: Record<string, unknown> } | undefined
   const handle = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]): Promise<Response> => {

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe } from "bun:test"
 import path from "path"
 import { unlink } from "fs/promises"
 
-import { ProviderID } from "../../src/provider/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { WithInstance } from "../../src/project/with-instance"
@@ -25,6 +25,74 @@ async function list() {
     }),
   )
 }
+
+async function getModel(providerID: ProviderID, modelID: ModelID) {
+  return AppRuntime.runPromise(
+    Effect.gen(function* () {
+      const provider = yield* Provider.Service
+      return yield* provider.getModel(providerID, modelID)
+    }),
+  )
+}
+
+async function getLanguage(model: Provider.Model) {
+  return AppRuntime.runPromise(
+    Effect.gen(function* () {
+      const provider = yield* Provider.Service
+      return yield* provider.getLanguage(model)
+    }),
+  )
+}
+
+test("Bedrock Mantle: uses chat for safeguard models and responses otherwise", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "amazon-bedrock": {
+              options: {
+                region: "us-east-1",
+              },
+              models: {
+                "openai.gpt-oss-20b": {
+                  name: "GPT OSS 20B",
+                  reasoning: true,
+                  provider: { npm: "@ai-sdk/amazon-bedrock/mantle" },
+                },
+                "openai.gpt-oss-safeguard-20b": {
+                  name: "GPT OSS Safeguard 20B",
+                  reasoning: true,
+                  provider: { npm: "@ai-sdk/amazon-bedrock/mantle" },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      set("AWS_REGION", "us-east-1")
+      set("AWS_PROFILE", "")
+      set("AWS_ACCESS_KEY_ID", "test-key-id")
+      set("AWS_SECRET_ACCESS_KEY", "test-secret")
+
+      const responses = await getLanguage(await getModel(ProviderID.amazonBedrock, ModelID.make("openai.gpt-oss-20b")))
+      const chat = await getLanguage(
+        await getModel(ProviderID.amazonBedrock, ModelID.make("openai.gpt-oss-safeguard-20b")),
+      )
+
+      expect((responses as { provider: string }).provider).toBe("bedrock-mantle.responses")
+      expect((chat as { provider: string }).provider).toBe("bedrock-mantle.chat")
+    },
+  })
+})
 
 test("Bedrock: config region takes precedence over AWS_REGION env var", async () => {
   await using tmp = await tmpdir({

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -23,6 +23,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 const env = makeRuntime(Env.Service, Env.defaultLayer)
 const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
+const remove = (k: string) => env.runSync((svc) => svc.remove(k))
 
 async function list() {
   return AppRuntime.runPromise(
@@ -181,6 +182,93 @@ test("Bedrock Mantle: custom provider IDs use responses for GPT-5 models", async
 
       expect(captured?.url).toBe("https://bedrock-mantle.us-east-2.api.aws/v1/responses")
       expect(captured?.body.model).toBe("openai.gpt-5.5")
+    },
+  })
+})
+
+test("Bedrock Mantle: resolves AWS_REGION placeholder from configured region", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "amazon-bedrock": {
+              options: {
+                region: "us-west-2",
+              },
+              models: {
+                "openai.gpt-5.5": {
+                  name: "GPT 5.5",
+                  reasoning: true,
+                  release_date: "2026-04-23",
+                  provider: {
+                    api: "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+                    npm: "@ai-sdk/amazon-bedrock/mantle",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      remove("AWS_REGION")
+      const token = process.env.AWS_BEARER_TOKEN_BEDROCK
+      process.env.AWS_BEARER_TOKEN_BEDROCK = "test-bearer-token"
+
+      try {
+        const model = await getModel(ProviderID.amazonBedrock, ModelID.make("openai.gpt-5.5"))
+        let captured: { url: string; body: Record<string, unknown> } | undefined
+        const handle = async (
+          input: Parameters<typeof fetch>[0],
+          init?: Parameters<typeof fetch>[1],
+        ): Promise<Response> => {
+          const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+          const text = typeof init?.body === "string" ? init.body : ""
+          const body = text ? JSON.parse(text) : {}
+          captured = { url, body: isRecord(body) ? body : {} }
+
+          return new Response(
+            JSON.stringify({
+              id: "resp_test",
+              created_at: 0,
+              model: "openai.gpt-5.5",
+              output: [
+                {
+                  type: "message",
+                  id: "msg_test",
+                  role: "assistant",
+                  content: [{ type: "output_text", text: "ok", annotations: [] }],
+                },
+              ],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          )
+        }
+        const fetch: typeof globalThis.fetch = Object.assign(handle, {
+          preconnect: globalThis.fetch.preconnect.bind(globalThis.fetch),
+        })
+        const providers = await list()
+        providers[ProviderID.amazonBedrock].options.fetch = fetch
+
+        await generateText({
+          model: await getLanguage(model),
+          prompt: "hi",
+        })
+
+        expect(captured?.url).toBe("https://bedrock-mantle.us-west-2.api.aws/v1/responses")
+      } finally {
+        if (token === undefined) delete process.env.AWS_BEARER_TOKEN_BEDROCK
+        else process.env.AWS_BEARER_TOKEN_BEDROCK = token
+      }
     },
   })
 })

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -375,6 +375,110 @@ test("Bedrock Mantle: resolves AWS_REGION placeholder with config apiKey auth", 
   })
 })
 
+test("Bedrock Mantle: resolves AWS_REGION placeholder with config static SigV4 auth", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "amazon-bedrock": {
+              options: {
+                accessKeyId: "test-key-id",
+                secretAccessKey: "test-secret",
+                region: "us-west-2",
+              },
+              models: {
+                "openai.gpt-5.5": {
+                  name: "GPT 5.5",
+                  reasoning: true,
+                  release_date: "2026-04-23",
+                  provider: {
+                    api: "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+                    npm: "@ai-sdk/amazon-bedrock/mantle",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      remove("AWS_REGION")
+      remove("AWS_PROFILE")
+      remove("AWS_ACCESS_KEY_ID")
+      remove("AWS_WEB_IDENTITY_TOKEN_FILE")
+      remove("AWS_BEARER_TOKEN_BEDROCK")
+      const saved = {
+        bearer: process.env.AWS_BEARER_TOKEN_BEDROCK,
+        relative: process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
+        full: process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+      }
+      delete process.env.AWS_BEARER_TOKEN_BEDROCK
+      delete process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+      delete process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI
+
+      try {
+        const model = await getModel(ProviderID.amazonBedrock, ModelID.make("openai.gpt-5.5"))
+        let captured: { url: string; body: Record<string, unknown> } | undefined
+        const handle = async (
+          input: Parameters<typeof fetch>[0],
+          init?: Parameters<typeof fetch>[1],
+        ): Promise<Response> => {
+          const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+          const text = typeof init?.body === "string" ? init.body : ""
+          const body = text ? JSON.parse(text) : {}
+          captured = { url, body: isRecord(body) ? body : {} }
+
+          return new Response(
+            JSON.stringify({
+              id: "resp_test",
+              created_at: 0,
+              model: "openai.gpt-5.5",
+              output: [
+                {
+                  type: "message",
+                  id: "msg_test",
+                  role: "assistant",
+                  content: [{ type: "output_text", text: "ok", annotations: [] }],
+                },
+              ],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          )
+        }
+        const fetch: typeof globalThis.fetch = Object.assign(handle, {
+          preconnect: globalThis.fetch.preconnect.bind(globalThis.fetch),
+        })
+        const providers = await list()
+        expect(providers[ProviderID.amazonBedrock].options.credentialProvider).toBeUndefined()
+        providers[ProviderID.amazonBedrock].options.fetch = fetch
+
+        await generateText({
+          model: await getLanguage(model),
+          prompt: "hi",
+        })
+
+        expect(captured?.url).toBe("https://bedrock-mantle.us-west-2.api.aws/v1/responses")
+      } finally {
+        if (saved.bearer === undefined) delete process.env.AWS_BEARER_TOKEN_BEDROCK
+        else process.env.AWS_BEARER_TOKEN_BEDROCK = saved.bearer
+        if (saved.relative === undefined) delete process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+        else process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = saved.relative
+        if (saved.full === undefined) delete process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI
+        else process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI = saved.full
+      }
+    },
+  })
+})
+
 test("Bedrock Mantle: prefixed GPT-5 responses send reasoning controls", async () => {
   let captured: { url: string; body: Record<string, unknown> } | undefined
   const handle = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]): Promise<Response> => {

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -135,8 +135,52 @@ test("Bedrock Mantle: custom provider IDs use responses for GPT-5 models", async
     directory: tmp.path,
     fn: async () => {
       const model = await getModel(ProviderID.make("custom-mantle"), ModelID.make("openai.gpt-5.5"))
+      let captured: { url: string; body: Record<string, unknown> } | undefined
+      const handle = async (
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ): Promise<Response> => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+        const text = typeof init?.body === "string" ? init.body : ""
+        const body = text ? JSON.parse(text) : {}
+        captured = { url, body: isRecord(body) ? body : {} }
+
+        return new Response(
+          JSON.stringify({
+            id: "resp_test",
+            created_at: 0,
+            model: "openai.gpt-5.5",
+            output: [
+              {
+                type: "message",
+                id: "msg_test",
+                role: "assistant",
+                content: [{ type: "output_text", text: "ok", annotations: [] }],
+              },
+            ],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )
+      }
+      const fetch: typeof globalThis.fetch = Object.assign(handle, {
+        preconnect: globalThis.fetch.preconnect.bind(globalThis.fetch),
+      })
+      const providers = await list()
+      providers[ProviderID.make("custom-mantle")].options.fetch = fetch
       const language = await getLanguage(model)
       expect((language as { provider: string }).provider).toBe("bedrock-mantle.responses")
+
+      const variants = ProviderTransform.variants(model)
+      const options = ProviderTransform.providerOptions(model, variants.medium)
+      await generateText({
+        model: language,
+        prompt: "hi",
+        providerOptions: options,
+      })
+
+      expect(captured?.url).toBe("https://bedrock-mantle.us-east-2.api.aws/v1/responses")
+      expect(captured?.body.model).toBe("openai.gpt-5.5")
     },
   })
 })

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -273,6 +273,108 @@ test("Bedrock Mantle: resolves AWS_REGION placeholder from configured region", a
   })
 })
 
+test("Bedrock Mantle: resolves AWS_REGION placeholder with config apiKey auth", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "amazon-bedrock": {
+              options: {
+                apiKey: "test-bearer-token",
+                region: "us-west-2",
+              },
+              models: {
+                "openai.gpt-5.5": {
+                  name: "GPT 5.5",
+                  reasoning: true,
+                  release_date: "2026-04-23",
+                  provider: {
+                    api: "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+                    npm: "@ai-sdk/amazon-bedrock/mantle",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      remove("AWS_REGION")
+      remove("AWS_PROFILE")
+      remove("AWS_ACCESS_KEY_ID")
+      remove("AWS_WEB_IDENTITY_TOKEN_FILE")
+      remove("AWS_BEARER_TOKEN_BEDROCK")
+      const saved = {
+        bearer: process.env.AWS_BEARER_TOKEN_BEDROCK,
+        relative: process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
+        full: process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+      }
+      delete process.env.AWS_BEARER_TOKEN_BEDROCK
+      delete process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+      delete process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI
+
+      try {
+        const model = await getModel(ProviderID.amazonBedrock, ModelID.make("openai.gpt-5.5"))
+        let captured: { url: string; body: Record<string, unknown> } | undefined
+        const handle = async (
+          input: Parameters<typeof fetch>[0],
+          init?: Parameters<typeof fetch>[1],
+        ): Promise<Response> => {
+          const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+          const text = typeof init?.body === "string" ? init.body : ""
+          const body = text ? JSON.parse(text) : {}
+          captured = { url, body: isRecord(body) ? body : {} }
+
+          return new Response(
+            JSON.stringify({
+              id: "resp_test",
+              created_at: 0,
+              model: "openai.gpt-5.5",
+              output: [
+                {
+                  type: "message",
+                  id: "msg_test",
+                  role: "assistant",
+                  content: [{ type: "output_text", text: "ok", annotations: [] }],
+                },
+              ],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          )
+        }
+        const fetch: typeof globalThis.fetch = Object.assign(handle, {
+          preconnect: globalThis.fetch.preconnect.bind(globalThis.fetch),
+        })
+        const providers = await list()
+        providers[ProviderID.amazonBedrock].options.fetch = fetch
+
+        await generateText({
+          model: await getLanguage(model),
+          prompt: "hi",
+        })
+
+        expect(captured?.url).toBe("https://bedrock-mantle.us-west-2.api.aws/v1/responses")
+      } finally {
+        if (saved.bearer === undefined) delete process.env.AWS_BEARER_TOKEN_BEDROCK
+        else process.env.AWS_BEARER_TOKEN_BEDROCK = saved.bearer
+        if (saved.relative === undefined) delete process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+        else process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = saved.relative
+        if (saved.full === undefined) delete process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI
+        else process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI = saved.full
+      }
+    },
+  })
+})
+
 test("Bedrock Mantle: prefixed GPT-5 responses send reasoning controls", async () => {
   let captured: { url: string; body: Record<string, unknown> } | undefined
   const handle = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]): Promise<Response> => {

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -1,3 +1,5 @@
+import { createBedrockMantle } from "@ai-sdk/amazon-bedrock/mantle"
+import { generateText } from "ai"
 import { test, expect, describe } from "bun:test"
 import path from "path"
 import { unlink } from "fs/promises"
@@ -7,12 +9,17 @@ import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { WithInstance } from "../../src/project/with-instance"
 import { Provider } from "@/provider/provider"
+import { ProviderTransform } from "@/provider/transform"
 import { Env } from "../../src/env"
 import { Global } from "@opencode-ai/core/global"
 import { Filesystem } from "@/util/filesystem"
 import { Effect } from "effect"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { makeRuntime } from "../../src/effect/run-service"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
 
 const env = makeRuntime(Env.Service, Env.defaultLayer)
 const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
@@ -92,6 +99,85 @@ test("Bedrock Mantle: uses chat for safeguard models and responses otherwise", a
       expect((chat as { provider: string }).provider).toBe("bedrock-mantle.chat")
     },
   })
+})
+
+test("Bedrock Mantle: prefixed GPT-5 responses send reasoning controls", async () => {
+  let captured: { url: string; body: Record<string, unknown> } | undefined
+  const handle = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    const text = typeof init?.body === "string" ? init.body : ""
+    const body = text ? JSON.parse(text) : {}
+    captured = { url, body: isRecord(body) ? body : {} }
+
+    return new Response(
+      JSON.stringify({
+        id: "resp_test",
+        created_at: 0,
+        model: "openai.gpt-5.5",
+        output: [
+          {
+            type: "message",
+            id: "msg_test",
+            role: "assistant",
+            content: [{ type: "output_text", text: "ok", annotations: [] }],
+          },
+        ],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    )
+  }
+
+  const model: Provider.Model = {
+    id: ModelID.make("openai.gpt-5.5"),
+    providerID: ProviderID.amazonBedrock,
+    api: {
+      id: "openai.gpt-5.5",
+      url: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+      npm: "@ai-sdk/amazon-bedrock/mantle",
+    },
+    name: "GPT 5.5",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.03, output: 0.06, cache: { read: 0.001, write: 0.002 } },
+    limit: { context: 128_000, output: 4_096 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-04-23",
+  }
+
+  const variants = ProviderTransform.variants(model)
+  const options = ProviderTransform.providerOptions(model, variants.medium)
+  const fetch: typeof globalThis.fetch = Object.assign(handle, {
+    preconnect: globalThis.fetch.preconnect.bind(globalThis.fetch),
+  })
+  const mantle = createBedrockMantle({ region: "us-east-2", apiKey: "test-key", fetch })
+
+  await generateText({
+    model: mantle.responses("openai.gpt-5.5"),
+    prompt: "hi",
+    providerOptions: options,
+  })
+
+  expect(options).toEqual({
+    openai: {
+      reasoningEffort: "medium",
+      reasoningSummary: "auto",
+      forceReasoning: true,
+      include: ["reasoning.encrypted_content"],
+    },
+  })
+  expect(captured?.url).toBe("https://bedrock-mantle.us-east-2.api.aws/v1/responses")
+  expect(captured?.body.model).toBe("openai.gpt-5.5")
+  expect(captured?.body.reasoning).toEqual({ effort: "medium", summary: "auto" })
 })
 
 test("Bedrock: config region takes precedence over AWS_REGION env var", async () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -376,6 +376,17 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.include).toEqual(["reasoning.encrypted_content"])
   })
 
+  test("gpt-5 options return fresh encrypted reasoning include arrays", () => {
+    const model = createGpt5Model("gpt-5.2")
+    const first = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    const include = first.include as string[]
+    include.push("leaked")
+
+    const second = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(second.include).toEqual(["reasoning.encrypted_content"])
+    expect(second.include).not.toBe(first.include)
+  })
+
   test("Bedrock Mantle gpt-5.5 uses OpenAI Responses defaults", () => {
     const model = {
       ...createGpt5Model("openai.gpt-5.5"),

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3072,6 +3072,24 @@ describe("ProviderTransform.variants", () => {
       expect(result).toEqual({})
     })
 
+    test("grok-4.3 keeps OpenRouter reasoning controls", () => {
+      for (const id of ["grok-4.3", "grok-4-3"]) {
+        const model = createMockModel({
+          id: `openrouter/${id}`,
+          providerID: "openrouter",
+          api: {
+            id,
+            url: "https://openrouter.ai",
+            npm: "@openrouter/ai-sdk-provider",
+          },
+        })
+        const result = ProviderTransform.variants(model)
+        expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
+        expect(result.none).toEqual({ reasoning: { effort: "none" } })
+        expect(result.high).toEqual({ reasoning: { effort: "high" } })
+      }
+    })
+
     test("grok-3-mini returns low and high with reasoning", () => {
       const model = createMockModel({
         id: "openrouter/grok-3-mini",
@@ -3476,6 +3494,24 @@ describe("ProviderTransform.variants", () => {
       })
       const result = ProviderTransform.variants(model)
       expect(result).toEqual({})
+    })
+
+    test("grok-4.3 keeps xAI reasoning controls", () => {
+      for (const id of ["grok-4.3", "grok-4-3"]) {
+        const model = createMockModel({
+          id: `xai/${id}`,
+          providerID: "xai",
+          api: {
+            id,
+            url: "https://api.x.ai/v1",
+            npm: "@ai-sdk/xai",
+          },
+        })
+        const result = ProviderTransform.variants(model)
+        expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
+        expect(result.none).toEqual({ reasoningEffort: "none" })
+        expect(result.high).toEqual({ reasoningEffort: "high" })
+      }
     })
 
     test("grok-3-mini returns low and high with reasoningEffort", () => {
@@ -4411,7 +4447,7 @@ test("ProviderTransform.smallOptions keeps store=false for Bedrock Mantle", () =
   })
 })
 
-test("ProviderTransform.smallOptions disables OpenRouter reasoning when the weakest effort is low", () => {
+test("ProviderTransform.smallOptions uses OpenRouter low effort when it is the weakest supported option", () => {
   expect(
     ProviderTransform.smallOptions({
       providerID: "openrouter",
@@ -4425,7 +4461,7 @@ test("ProviderTransform.smallOptions disables OpenRouter reasoning when the weak
         high: { reasoning: { effort: "high" } },
       },
     } as any),
-  ).toEqual({ reasoning: { effort: "none" } })
+  ).toEqual({ reasoning: { effort: "low" } })
 })
 
 describe("ProviderTransform.smallOptions - google thinking controls", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1311,6 +1311,7 @@ describe("ProviderTransform.schema - openai supported schema subset", () => {
     ["opencode", "@ai-sdk/openai"],
     ["custom-openai-compatible", "@ai-sdk/openai"],
     ["azure", "@ai-sdk/azure"],
+    ["amazon-bedrock", "@ai-sdk/amazon-bedrock/mantle"],
   ])("sanitizes %s models using %s", (providerID, npm) => {
     expect(
       ProviderTransform.schema(
@@ -3727,6 +3728,41 @@ describe("ProviderTransform.variants", () => {
         include: ["reasoning.encrypted_content"],
       })
     })
+
+    test("dotted gpt-5 returns base OpenAI reasoning variants", () => {
+      const model = createMockModel({
+        id: "openai.gpt-5",
+        providerID: "amazon-bedrock",
+        api: {
+          id: "openai.gpt-5",
+          url: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+          npm: "@ai-sdk/amazon-bedrock/mantle",
+        },
+        release_date: "2025-08-07",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
+      expect(result.minimal).toEqual({
+        reasoningEffort: "minimal",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      })
+    })
+
+    test("dotted gpt-5-pro returns only high effort", () => {
+      const model = createMockModel({
+        id: "openai.gpt-5-pro",
+        providerID: "amazon-bedrock",
+        api: {
+          id: "openai.gpt-5-pro",
+          url: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+          npm: "@ai-sdk/amazon-bedrock/mantle",
+        },
+        release_date: "2025-08-07",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["high"])
+    })
   })
 
   describe("@ai-sdk/anthropic", () => {
@@ -4289,6 +4325,48 @@ describe("ProviderTransform.smallOptions - gpt-5 chat/search", () => {
       expect(ProviderTransform.smallOptions(createModel(testCase.id))).toEqual(testCase.options)
     })
   }
+})
+
+test("ProviderTransform.smallOptions keeps store=false for Bedrock Mantle", () => {
+  const model: Provider.Model = {
+    id: ModelID.make("openai.gpt-5"),
+    providerID: ProviderID.amazonBedrock,
+    api: {
+      id: "openai.gpt-5",
+      url: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+      npm: "@ai-sdk/amazon-bedrock/mantle",
+    },
+    name: "GPT 5",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.03, output: 0.06, cache: { read: 0.001, write: 0.002 } },
+    limit: { context: 128_000, output: 4_096 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2025-08-07",
+    variants: {
+      minimal: {
+        reasoningEffort: "minimal",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      },
+    },
+  }
+
+  expect(ProviderTransform.smallOptions(model)).toEqual({
+    store: false,
+    reasoningEffort: "minimal",
+    reasoningSummary: "auto",
+    include: ["reasoning.encrypted_content"],
+  })
 })
 
 test("ProviderTransform.smallOptions disables OpenRouter reasoning when the weakest effort is low", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
+import type { JSONSchema7 } from "@ai-sdk/provider"
 import path from "node:path"
+import type { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 
@@ -1123,6 +1125,220 @@ describe("ProviderTransform.schema - gemini non-object properties removal", () =
     const result = ProviderTransform.schema(openaiModel, schema) as any
 
     expect(result.properties.data.properties).toBeDefined()
+  })
+})
+
+describe("ProviderTransform.schema - openai supported schema subset", () => {
+  const openaiModel = {
+    providerID: "openai",
+    api: {
+      id: "gpt-4.1",
+      npm: "@ai-sdk/openai",
+    },
+  } as Provider.Model
+
+  test("removes unsupported JSON Schema keywords recursively", () => {
+    const result = ProviderTransform.schema(openaiModel, {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      title: "Search",
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search query",
+          format: "uri",
+          pattern: "^https://",
+          minLength: 1,
+          maxLength: 100,
+          default: "https://example.com",
+        },
+        count: {
+          type: "integer",
+          minimum: 1,
+          maximum: 10,
+          multipleOf: 1,
+        },
+        createdAt: {
+          format: "date-time",
+        },
+        mode: {
+          const: "fast",
+        },
+        tags: {
+          type: "array",
+          minItems: 1,
+          maxItems: 3,
+          uniqueItems: true,
+        },
+        tuple: {
+          type: "array",
+          items: [
+            { type: "number", minimum: 0 },
+            { type: "string", pattern: "^ok$" },
+          ],
+        },
+        metadata: {
+          type: "object",
+          patternProperties: {
+            "^x-": { type: "string" },
+          },
+          additionalProperties: {
+            type: "string",
+            pattern: "^safe$",
+          },
+        },
+      },
+      patternProperties: {
+        "^extra": { type: "string" },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    } as JSONSchema7)
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search query",
+        },
+        count: {
+          type: "integer",
+        },
+        createdAt: {
+          type: "string",
+        },
+        mode: {
+          enum: ["fast"],
+          type: "string",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+        },
+        tuple: {
+          type: "array",
+          items: [{ type: "number" }, { type: "string" }],
+        },
+        metadata: {
+          type: "object",
+          properties: {},
+          additionalProperties: {
+            type: "string",
+          },
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    })
+  })
+
+  test("keeps local references and sanitizes definitions", () => {
+    const result = ProviderTransform.schema(openaiModel, {
+      type: "object",
+      properties: {
+        value: {
+          $ref: "#/$defs/Value",
+          description: "Referenced value",
+          examples: ["ignored"],
+        },
+      },
+      $defs: {
+        Value: {
+          type: "string",
+          pattern: "^value$",
+          description: "Definition description",
+        },
+        Unused: {
+          type: "number",
+          minimum: 0,
+        },
+      },
+    } as JSONSchema7)
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        value: {
+          $ref: "#/$defs/Value",
+          description: "Referenced value",
+        },
+      },
+      $defs: {
+        Value: {
+          type: "string",
+          description: "Definition description",
+        },
+        Unused: {
+          type: "number",
+        },
+      },
+    })
+  })
+
+  test("does not sanitize non-openai providers", () => {
+    const result = ProviderTransform.schema(
+      {
+        providerID: "anthropic",
+        api: {
+          id: "claude-sonnet-4",
+          npm: "@ai-sdk/anthropic",
+        },
+      } as Provider.Model,
+      {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            pattern: "^https://",
+          },
+        },
+      } as JSONSchema7,
+    )
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          pattern: "^https://",
+        },
+      },
+    })
+  })
+
+  test.each([
+    ["opencode", "@ai-sdk/openai"],
+    ["custom-openai-compatible", "@ai-sdk/openai"],
+    ["azure", "@ai-sdk/azure"],
+  ])("sanitizes %s models using %s", (providerID, npm) => {
+    expect(
+      ProviderTransform.schema(
+        {
+          providerID,
+          api: {
+            id: "custom-model",
+            npm,
+          },
+        } as Provider.Model,
+        {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              pattern: "^https://",
+            },
+          },
+        } as JSONSchema7,
+      ),
+    ).toEqual({
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+        },
+      },
+    })
   })
 })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1233,6 +1233,43 @@ describe("ProviderTransform.schema - openai supported schema subset", () => {
     })
   })
 
+  test("infers omitted enum and const types from scalar values", () => {
+    const result = ProviderTransform.schema(openaiModel, {
+      type: "object",
+      properties: {
+        count: {
+          const: 1,
+        },
+        ratio: {
+          enum: [0.5, 1.25],
+        },
+        active: {
+          enum: [true, false],
+        },
+        mixed: {
+          enum: ["one", 1, null],
+        },
+      },
+    } as JSONSchema7) as { properties: Record<string, unknown> }
+
+    expect(result.properties.count).toEqual({
+      enum: [1],
+      type: "integer",
+    })
+    expect(result.properties.ratio).toEqual({
+      enum: [0.5, 1.25],
+      type: "number",
+    })
+    expect(result.properties.active).toEqual({
+      enum: [true, false],
+      type: "boolean",
+    })
+    expect(result.properties.mixed).toEqual({
+      enum: ["one", 1, null],
+      type: ["string", "integer", "null"],
+    })
+  })
+
   test("keeps local references and sanitizes definitions", () => {
     const result = ProviderTransform.schema(openaiModel, {
       type: "object",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1,6 +1,36 @@
 import { describe, expect, test } from "bun:test"
+import path from "node:path"
 import { ProviderTransform } from "@/provider/transform"
 import { ModelID, ProviderID } from "../../src/provider/schema"
+
+describe("ProviderTransform.OUTPUT_TOKEN_MAX", () => {
+  test("honors OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX at startup", async () => {
+    const child = Bun.spawn({
+      cmd: [
+        process.execPath,
+        "--conditions=browser",
+        "-e",
+        `import { ProviderTransform } from "./src/provider/transform.ts"; process.stdout.write(String(ProviderTransform.OUTPUT_TOKEN_MAX))`,
+      ],
+      cwd: path.resolve(import.meta.dir, "../.."),
+      env: {
+        ...process.env,
+        OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX: "12345",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ])
+
+    expect(code).toBe(0)
+    expect(stderr).toBe("")
+    expect(stdout).toBe("12345")
+  })
+})
 
 describe("ProviderTransform.options - setCacheKey", () => {
   const sessionID = "test-session-123"

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -354,6 +354,7 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.store).toBe(false)
     expect(result.reasoningEffort).toBe("medium")
     expect(result.reasoningSummary).toBe("auto")
+    expect(result.forceReasoning).toBe(true)
     expect(result.include).toEqual(["reasoning.encrypted_content"])
     expect(result.textVerbosity).toBe("low")
   })
@@ -673,8 +674,8 @@ describe("ProviderTransform.providerOptions", () => {
       },
     })
 
-    expect(ProviderTransform.providerOptions(model, { reasoningEffort: "medium" })).toEqual({
-      openai: { reasoningEffort: "medium" },
+    expect(ProviderTransform.providerOptions(model, { reasoningEffort: "medium", forceReasoning: true })).toEqual({
+      openai: { reasoningEffort: "medium", forceReasoning: true },
     })
   })
 
@@ -3762,6 +3763,7 @@ describe("ProviderTransform.variants", () => {
       expect(result.medium).toEqual({
         reasoningEffort: "medium",
         reasoningSummary: "auto",
+        forceReasoning: true,
         include: ["reasoning.encrypted_content"],
       })
     })
@@ -3782,6 +3784,7 @@ describe("ProviderTransform.variants", () => {
       expect(result.minimal).toEqual({
         reasoningEffort: "minimal",
         reasoningSummary: "auto",
+        forceReasoning: true,
         include: ["reasoning.encrypted_content"],
       })
     })
@@ -4393,6 +4396,7 @@ test("ProviderTransform.smallOptions keeps store=false for Bedrock Mantle", () =
       minimal: {
         reasoningEffort: "minimal",
         reasoningSummary: "auto",
+        forceReasoning: true,
         include: ["reasoning.encrypted_content"],
       },
     },
@@ -4402,6 +4406,7 @@ test("ProviderTransform.smallOptions keeps store=false for Bedrock Mantle", () =
     store: false,
     reasoningEffort: "minimal",
     reasoningSummary: "auto",
+    forceReasoning: true,
     include: ["reasoning.encrypted_content"],
   })
 })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -237,6 +237,43 @@ describe("ProviderTransform.options - minimax m3 thinking", () => {
   })
 })
 
+describe("ProviderTransform.options - OpenRouter and LLMGateway Gemini 3 defaults", () => {
+  const createModel = (npm: "@openrouter/ai-sdk-provider" | "@llmgateway/ai-sdk-provider", reasoning: boolean) =>
+    ({
+      id: "openrouter/google/gemini-3-pro",
+      providerID: npm === "@openrouter/ai-sdk-provider" ? "openrouter" : "llmgateway",
+      api: {
+        id: "google/gemini-3-pro",
+        url: "https://gateway.example.test",
+        npm,
+      },
+      capabilities: {
+        reasoning,
+      },
+    }) as Provider.Model
+
+  for (const npm of ["@openrouter/ai-sdk-provider", "@llmgateway/ai-sdk-provider"] as const) {
+    test(`${npm} does not default Gemini 3 reasoning when unsupported`, () => {
+      const result = ProviderTransform.options({
+        model: createModel(npm, false),
+        sessionID: "test-session-123",
+      })
+
+      expect(result.usage).toEqual({ include: true })
+      expect(result.reasoning).toBeUndefined()
+    })
+
+    test(`${npm} defaults Gemini 3 reasoning when supported`, () => {
+      const result = ProviderTransform.options({
+        model: createModel(npm, true),
+        sessionID: "test-session-123",
+      })
+
+      expect(result.reasoning).toEqual({ effort: "high" })
+    })
+  }
+})
+
 describe("ProviderTransform.options - google thinkingConfig gating", () => {
   const sessionID = "test-session-123"
 
@@ -4188,9 +4225,9 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@jerome-benoit/sap-ai-provider-v2", () => {
-    const sapModel = (apiId: string, releaseDate = "2024-01-01") =>
+    const sapModel = (apiId: string, releaseDate = "2024-01-01", id = `sap-ai-core/${apiId}`) =>
       createMockModel({
-        id: `sap-ai-core/${apiId}`,
+        id,
         providerID: "sap-ai-core",
         api: {
           id: apiId,
@@ -4199,6 +4236,24 @@ describe("ProviderTransform.variants", () => {
         },
         release_date: releaseDate,
       })
+
+    test("classifies aliased SAP models by API id", () => {
+      const anthropic = ProviderTransform.variants(sapModel("anthropic--claude-sonnet-4", "2024-01-01", "claude"))
+      expect(Object.keys(anthropic)).toEqual(["high", "max"])
+      expect(anthropic.high).toEqual({
+        modelParams: { thinking: { type: "enabled", budget_tokens: 16000 } },
+      })
+
+      const gemini = ProviderTransform.variants(sapModel("gemini-2.5-pro", "2024-01-01", "gemini"))
+      expect(Object.keys(gemini)).toEqual(["high", "max"])
+      expect(gemini.max).toEqual({
+        modelParams: { thinkingConfig: { includeThoughts: true, thinkingBudget: 32768 } },
+      })
+
+      const gpt = ProviderTransform.variants(sapModel("gpt-5", "2025-08-07", "gpt"))
+      expect(Object.keys(gpt)).toEqual(["minimal", "low", "medium", "high"])
+      expect(gpt.minimal).toEqual({ modelParams: { reasoning_effort: "minimal" } })
+    })
 
     for (const testCase of [
       {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -172,6 +172,39 @@ describe("ProviderTransform.options - zai/zhipuai thinking", () => {
   }
 })
 
+describe("ProviderTransform.options - minimax m3 thinking", () => {
+  const createModel = (npm: string) =>
+    ({
+      id: "minimax/minimax-m3",
+      providerID: "minimax",
+      api: {
+        id: "minimax-m3",
+        url: "https://api.minimax.com",
+        npm,
+      },
+      capabilities: { reasoning: true },
+      limit: { output: 64_000 },
+    }) as any
+
+  test("explicitly enables adaptive thinking with the anthropic SDK", () => {
+    expect(
+      ProviderTransform.options({
+        model: createModel("@ai-sdk/anthropic"),
+        sessionID: "test-session-123",
+      }).thinking,
+    ).toEqual({ type: "adaptive" })
+  })
+
+  test("uses the native default with the openai-compatible SDK", () => {
+    expect(
+      ProviderTransform.options({
+        model: createModel("@ai-sdk/openai-compatible"),
+        sessionID: "test-session-123",
+      }).thinking,
+    ).toBeUndefined()
+  })
+})
+
 describe("ProviderTransform.options - google thinkingConfig gating", () => {
   const sessionID = "test-session-123"
 
@@ -238,105 +271,6 @@ describe("ProviderTransform.options - google thinkingConfig gating", () => {
   })
 })
 
-describe("ProviderTransform.options - OpenRouter Gemini reasoning", () => {
-  const sessionID = "ses_test"
-  const createOpenRouterModel = (apiId: string) =>
-    ({
-      id: `openrouter/${apiId}`,
-      providerID: "openrouter",
-      api: {
-        id: apiId,
-        url: "https://openrouter.ai",
-        npm: "@openrouter/ai-sdk-provider",
-      },
-      name: apiId,
-      capabilities: {
-        temperature: true,
-        reasoning: true,
-        attachment: true,
-        toolcall: true,
-        input: { text: true, audio: false, image: true, video: false, pdf: false },
-        output: { text: true, audio: false, image: false, video: false, pdf: false },
-        interleaved: false,
-      },
-      cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
-      limit: { context: 128000, output: 8192 },
-      status: "active",
-      options: {},
-      headers: {},
-    }) as any
-
-  test("enables OpenRouter Gemini reasoning by default", () => {
-    const model = createOpenRouterModel("google/gemini-2.5-flash")
-
-    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
-      usage: { include: true },
-      prompt_cache_key: sessionID,
-      reasoning: { max_tokens: 768 },
-    })
-  })
-
-  test("keeps OpenRouter Gemini 3 reasoning effort by default", () => {
-    const model = createOpenRouterModel("google/gemini-3-pro-preview")
-
-    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
-      usage: { include: true },
-      prompt_cache_key: sessionID,
-      reasoning: { effort: "high" },
-    })
-  })
-
-  test("does not enable default reasoning for non-Gemini OpenRouter models", () => {
-    const model = createOpenRouterModel("anthropic/claude-haiku-4.5")
-
-    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
-      usage: { include: true },
-      prompt_cache_key: sessionID,
-    })
-  })
-
-  test("does not enable default reasoning for OpenRouter Gemini models without reasoning", () => {
-    const model = createOpenRouterModel("google/gemini-2.5-flash-nothinking")
-    model.capabilities.reasoning = false
-
-    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
-      usage: { include: true },
-      prompt_cache_key: sessionID,
-    })
-  })
-
-  test("keeps llmgateway Gemini defaults unchanged", () => {
-    const model = createOpenRouterModel("google/gemini-2.5-flash")
-    model.id = "llmgateway/google/gemini-2.5-flash"
-    model.providerID = "llmgateway"
-    model.api = {
-      id: "google/gemini-2.5-flash",
-      url: "https://llmgateway.ai",
-      npm: "@llmgateway/ai-sdk-provider",
-    }
-
-    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
-      usage: { include: true },
-    })
-  })
-
-  test("keeps llmgateway Gemini 3 reasoning effort by default", () => {
-    const model = createOpenRouterModel("google/gemini-3-pro-preview")
-    model.id = "llmgateway/google/gemini-3-pro-preview"
-    model.providerID = "llmgateway"
-    model.api = {
-      id: "google/gemini-3-pro-preview",
-      url: "https://llmgateway.ai",
-      npm: "@llmgateway/ai-sdk-provider",
-    }
-
-    expect(ProviderTransform.options({ model, sessionID, providerOptions: {} })).toEqual({
-      usage: { include: true },
-      reasoning: { effort: "high" },
-    })
-  })
-})
-
 describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
   const sessionID = "test-session-123"
 
@@ -370,6 +304,43 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     const model = createGpt5Model("gpt-5.2")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
     expect(result.textVerbosity).toBe("low")
+    expect(result.include).toEqual(["reasoning.encrypted_content"])
+  })
+
+  test("Bedrock Mantle gpt-5.5 uses OpenAI Responses defaults", () => {
+    const model = {
+      ...createGpt5Model("openai.gpt-5.5"),
+      id: "amazon-bedrock/openai.gpt-5.5",
+      providerID: "amazon-bedrock",
+      api: {
+        id: "openai.gpt-5.5",
+        url: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+        npm: "@ai-sdk/amazon-bedrock/mantle",
+      },
+    }
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.store).toBe(false)
+    expect(result.reasoningEffort).toBe("medium")
+    expect(result.reasoningSummary).toBe("auto")
+    expect(result.include).toEqual(["reasoning.encrypted_content"])
+    expect(result.textVerbosity).toBe("low")
+  })
+
+  test("openai-compatible gpt-5 models omit Responses-only reasoningSummary", () => {
+    const model = {
+      ...createGpt5Model("gpt-5.4"),
+      id: "cortecs/gpt-5.4",
+      providerID: "cortecs",
+      api: {
+        id: "gpt-5.4",
+        url: "https://api.cortecs.ai/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    }
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.reasoningEffort).toBe("medium")
+    expect(result.reasoningSummary).toBeUndefined()
+    expect(result.include).toBeUndefined()
   })
 
   test("gpt-5.1 should have textVerbosity set to low", () => {
@@ -465,26 +436,6 @@ describe("ProviderTransform.options - gpt-5 reasoningEffort", () => {
     })
 
     expect(result.reasoningEffort).toBeUndefined()
-  })
-
-  test("openai-compatible gpt-5 should not set reasoningSummary", () => {
-    const model = createModel("gpt-5.2")
-    model.id = "litellm/gpt-5.2"
-    model.providerID = "litellm"
-    model.api = {
-      id: "gpt-5.2",
-      url: "https://litellm.example/v1",
-      npm: "@ai-sdk/openai-compatible",
-    }
-
-    const result = ProviderTransform.options({
-      model,
-      sessionID,
-      providerOptions: {},
-    })
-
-    expect(result.reasoningEffort).toBe("medium")
-    expect(result.reasoningSummary).toBeUndefined()
   })
 
   test("gpt-5.5 should NOT set reasoningEffort", () => {
@@ -680,6 +631,21 @@ describe("ProviderTransform.providerOptions", () => {
     })
   })
 
+  test("maps Bedrock Mantle provider options to OpenAI namespace", () => {
+    const model = createModel({
+      providerID: "amazon-bedrock",
+      api: {
+        id: "openai.gpt-5.5",
+        url: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+        npm: "@ai-sdk/amazon-bedrock/mantle",
+      },
+    })
+
+    expect(ProviderTransform.providerOptions(model, { reasoningEffort: "medium" })).toEqual({
+      openai: { reasoningEffort: "medium" },
+    })
+  })
+
   test("uses groq slug for groq models", () => {
     const model = createModel({
       providerID: "vercel",
@@ -830,6 +796,93 @@ describe("ProviderTransform.schema - gemini nested array items", () => {
     const result = ProviderTransform.schema(geminiModel, schema) as any
 
     expect(result.properties.spreadsheetData.properties.rows.items.items.type).toBe("string")
+  })
+})
+
+describe("ProviderTransform.schema - gemini type arrays", () => {
+  // Mirrors @ai-sdk/google's convertJSONSchemaToOpenAPISchema: JSON Schema type
+  // arrays (e.g. `["number","string"]`, common in MCP tool schemas) become an
+  // `anyOf` of single-type schemas, with `null` lifted into `nullable`. Plain
+  // @ai-sdk/google rewrites these, but OpenAI-compatible transports such as
+  // GitHub Copilot (proxying to Gemini) forward them verbatim and the backend
+  // rejects the array form.
+  const geminiModel = {
+    providerID: "google",
+    api: {
+      id: "gemini-3-pro",
+    },
+  } as any
+
+  test("splits a multi-type array into anyOf and drops the type array", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        status: { type: ["number", "string"], description: "status filter" },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+
+    expect(result.properties.status.type).toBeUndefined()
+    expect(result.properties.status.anyOf).toEqual([{ type: "number" }, { type: "string" }])
+    expect(result.properties.status.nullable).toBeUndefined()
+    // Sibling keywords stay alongside the generated anyOf.
+    expect(result.properties.status.description).toBe("status filter")
+  })
+
+  test("lifts null into nullable for a nullable type array", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        maybe: { type: ["string", "null"], description: "nullable string" },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+
+    expect(result.properties.maybe.type).toBeUndefined()
+    expect(result.properties.maybe.anyOf).toEqual([{ type: "string" }])
+    expect(result.properties.maybe.nullable).toBe(true)
+  })
+
+  test("collapses an all-null type array to type null", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        nothing: { type: ["null"] },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+
+    expect(result.properties.nothing.type).toBe("null")
+    expect(result.properties.nothing.anyOf).toBeUndefined()
+  })
+
+  test("rewrites type arrays for gemini served through github-copilot", () => {
+    const copilotGeminiModel = {
+      providerID: "github-copilot",
+      api: {
+        id: "gemini-3.5-flash",
+        npm: "@ai-sdk/github-copilot",
+      },
+    } as any
+
+    const schema = {
+      type: "object",
+      properties: {
+        hook_id: { type: "number", description: "ID of the webhook" },
+        status: { type: ["number", "string"], description: "Filter by response status code" },
+      },
+      required: ["hook_id"],
+      additionalProperties: false,
+    } as any
+
+    const result = ProviderTransform.schema(copilotGeminiModel, schema) as any
+
+    expect(result.properties.status.anyOf).toEqual([{ type: "number" }, { type: "string" }])
+    expect(result.properties.status.type).toBeUndefined()
+    expect(result.properties.hook_id.type).toBe("number")
   })
 })
 
@@ -1732,50 +1785,6 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     expect(result[1].content).toHaveLength(1)
   })
 
-  test("splits anthropic assistant messages when text trails tool calls", () => {
-    const msgs = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "Check my home directory for PDFs" }],
-      },
-      {
-        role: "assistant",
-        content: [
-          { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
-          { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
-          { type: "text", text: "I checked your home directory and looked for PDF files." },
-        ],
-      },
-      {
-        role: "tool",
-        content: [
-          { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
-          {
-            type: "tool-result",
-            toolCallId: "toolu_2",
-            toolName: "glob",
-            output: { type: "text", value: "No files found" },
-          },
-        ],
-      },
-    ] as any[]
-
-    const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
-
-    expect(result).toHaveLength(4)
-    expect(result[1]).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "I checked your home directory and looked for PDF files." }],
-    })
-    expect(result[2]).toMatchObject({
-      role: "assistant",
-      content: [
-        { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
-        { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
-      ],
-    })
-  })
-
   test("leaves valid anthropic assistant tool ordering unchanged", () => {
     const msgs = [
       {
@@ -1796,44 +1805,6 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
       { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
     ])
-  })
-
-  test("splits vertex anthropic assistant messages when text trails tool calls", () => {
-    const model = {
-      ...anthropicModel,
-      providerID: "google-vertex-anthropic",
-      api: {
-        id: "claude-sonnet-4@20250514",
-        url: "https://us-central1-aiplatform.googleapis.com",
-        npm: "@ai-sdk/google-vertex/anthropic",
-      },
-    }
-
-    const msgs = [
-      {
-        role: "assistant",
-        content: [
-          { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
-          { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
-          { type: "text", text: "I checked your home directory and looked for PDF files." },
-        ],
-      },
-    ] as any[]
-
-    const result = ProviderTransform.message(msgs, model, {}) as any[]
-
-    expect(result).toHaveLength(2)
-    expect(result[0]).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "I checked your home directory and looked for PDF files." }],
-    })
-    expect(result[1]).toMatchObject({
-      role: "assistant",
-      content: [
-        { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
-        { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
-      ],
-    })
   })
 })
 
@@ -1863,7 +1834,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
     headers: {},
   } as any
 
-  test("preserves itemId and reasoningEncryptedContent when store=false", () => {
+  test("strips OpenAI itemId and preserves reasoningEncryptedContent when store=false", () => {
     const msgs = [
       {
         role: "assistant",
@@ -1894,11 +1865,12 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
     const result = ProviderTransform.message(msgs, openaiModel, { store: false }) as any[]
 
     expect(result).toHaveLength(1)
-    expect(result[0].content[0].providerOptions?.openai?.itemId).toBe("rs_123")
-    expect(result[0].content[1].providerOptions?.openai?.itemId).toBe("msg_456")
+    expect(result[0].content[0].providerOptions?.openai?.itemId).toBeUndefined()
+    expect(result[0].content[0].providerOptions?.openai?.reasoningEncryptedContent).toBe("encrypted")
+    expect(result[0].content[1].providerOptions?.openai?.itemId).toBeUndefined()
   })
 
-  test("preserves itemId and reasoningEncryptedContent when store=false even when not openai", () => {
+  test("uses the SDK package namespace rather than provider ID", () => {
     const zenModel = {
       ...openaiModel,
       providerID: "zen",
@@ -1933,11 +1905,12 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
     const result = ProviderTransform.message(msgs, zenModel, { store: false }) as any[]
 
     expect(result).toHaveLength(1)
-    expect(result[0].content[0].providerOptions?.openai?.itemId).toBe("rs_123")
-    expect(result[0].content[1].providerOptions?.openai?.itemId).toBe("msg_456")
+    expect(result[0].content[0].providerOptions?.openai?.itemId).toBeUndefined()
+    expect(result[0].content[0].providerOptions?.openai?.reasoningEncryptedContent).toBe("encrypted")
+    expect(result[0].content[1].providerOptions?.openai?.itemId).toBeUndefined()
   })
 
-  test("preserves other openai options including itemId", () => {
+  test("preserves other OpenAI options", () => {
     const msgs = [
       {
         role: "assistant",
@@ -1958,8 +1931,75 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
 
     const result = ProviderTransform.message(msgs, openaiModel, { store: false }) as any[]
 
-    expect(result[0].content[0].providerOptions?.openai?.itemId).toBe("msg_123")
+    expect(result[0].content[0].providerOptions?.openai?.itemId).toBeUndefined()
     expect(result[0].content[0].providerOptions?.openai?.otherOption).toBe("value")
+  })
+
+  test("strips Azure itemId from the Azure namespace", () => {
+    const azureModel = {
+      ...openaiModel,
+      providerID: "azure",
+      api: {
+        id: "gpt-5",
+        url: "https://example.openai.azure.com",
+        npm: "@ai-sdk/azure",
+      },
+    }
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Hello",
+            providerOptions: {
+              azure: { itemId: "msg_123", otherOption: "value" },
+              openai: { itemId: "msg_openai" },
+            },
+          },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, azureModel, { store: false }) as any[]
+
+    expect(result[0].content[0].providerOptions?.azure?.itemId).toBeUndefined()
+    expect(result[0].content[0].providerOptions?.azure?.otherOption).toBe("value")
+    expect(result[0].content[0].providerOptions?.openai?.itemId).toBe("msg_openai")
+  })
+
+  test("strips Bedrock Mantle itemId from the OpenAI namespace", () => {
+    const mantleModel = {
+      ...openaiModel,
+      providerID: "amazon-bedrock",
+      api: {
+        id: "openai.gpt-5.5",
+        url: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+        npm: "@ai-sdk/amazon-bedrock/mantle",
+      },
+    }
+    const msgs = [
+      {
+        role: "assistant",
+        providerOptions: { openai: { itemId: "msg_root", otherOption: "root-value" } },
+        content: [
+          {
+            type: "reasoning",
+            text: "thinking...",
+            providerOptions: {
+              openai: { itemId: "rs_123", reasoningEncryptedContent: "encrypted" },
+            },
+          },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, mantleModel, { store: false }) as any[]
+
+    expect(result[0].providerOptions?.openai?.itemId).toBeUndefined()
+    expect(result[0].providerOptions?.openai?.otherOption).toBe("root-value")
+    expect(result[0].content[0].providerOptions?.openai?.itemId).toBeUndefined()
+    expect(result[0].content[0].providerOptions?.openai?.reasoningEncryptedContent).toBe("encrypted")
   })
 
   test("preserves metadata for openai package when store is true", () => {
@@ -2472,6 +2512,12 @@ describe("ProviderTransform.message - cache control on gateway", () => {
   })
 })
 
+describe("ProviderTransform.temperature - Cohere North", () => {
+  test("defaults north-mini-code models to 1.0", () => {
+    expect(ProviderTransform.temperature({ id: "cohere/North-Mini-Code-1-0-latest" } as any)).toBe(1.0)
+  })
+})
+
 describe("ProviderTransform.variants", () => {
   const createMockModel = (overrides: Partial<any> = {}): any => ({
     id: "test/test-model",
@@ -2541,6 +2587,39 @@ describe("ProviderTransform.variants", () => {
     })
     const result = ProviderTransform.variants(model)
     expect(result).toEqual({})
+  })
+
+  test("minimax m3 using anthropic returns thinking toggles", () => {
+    const model = createMockModel({
+      id: "minimax/minimax-m3",
+      providerID: "minimax",
+      api: {
+        id: "MiniMax-M3",
+        url: "https://api.minimax.com/anthropic/v1",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({
+      none: { thinking: { type: "disabled" } },
+      thinking: { thinking: { type: "adaptive" } },
+    })
+  })
+
+  test("minimax m3 using openai-compatible returns thinking toggles", () => {
+    const model = createMockModel({
+      id: "minimax/minimax-m3",
+      providerID: "minimax",
+      api: {
+        id: "minimax-m3",
+        url: "https://api.minimax.com/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({
+      none: { thinking: { type: "disabled" } },
+      thinking: { thinking: { type: "adaptive" } },
+    })
   })
 
   test("glm returns empty object", () => {
@@ -2622,7 +2701,7 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@openrouter/ai-sdk-provider", () => {
-    test("returns empty object for non-qualifying models", () => {
+    test("returns widely supported efforts for other reasoning models", () => {
       const model = createMockModel({
         id: "openrouter/test-model",
         providerID: "openrouter",
@@ -2633,7 +2712,8 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
-      expect(result).toEqual({})
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+      expect(result.medium).toEqual({ reasoning: { effort: "medium" } })
     })
 
     test("gpt models return OPENAI_EFFORTS with reasoning", () => {
@@ -2653,6 +2733,7 @@ describe("ProviderTransform.variants", () => {
     })
 
     for (const testCase of [
+      { id: "openai/o3-mini", efforts: ["none", "minimal", "low", "medium", "high", "xhigh"] },
       { id: "openai/gpt-5.4", efforts: ["none", "low", "medium", "high", "xhigh"] },
       { id: "openai/gpt-5-pro", efforts: ["high"] },
       { id: "openai/gpt-5.5-pro", efforts: ["medium", "high", "xhigh"] },
@@ -2678,7 +2759,7 @@ describe("ProviderTransform.variants", () => {
       })
     }
 
-    test("gemini-3 returns OPENAI_EFFORTS with reasoning", () => {
+    test("gemini-3 returns widely supported efforts with reasoning", () => {
       const model = createMockModel({
         id: "openrouter/gemini-3-5-pro",
         providerID: "openrouter",
@@ -2689,90 +2770,7 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
-    })
-
-    test("gemini-2.5 returns fixed OpenRouter reasoning budgets", () => {
-      const model = createMockModel({
-        id: "openrouter/google/gemini-2.5-flash",
-        providerID: "openrouter",
-        api: {
-          id: "google/gemini-2.5-flash",
-          url: "https://openrouter.ai",
-          npm: "@openrouter/ai-sdk-provider",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
-      expect(result.high).toEqual({ reasoning: { max_tokens: 768 } })
-    })
-
-    test("does not expose reasoning variants for unsupported OpenRouter Gemini models", () => {
-      const model = createMockModel({
-        id: "openrouter/google/gemini-2.0-flash",
-        providerID: "openrouter",
-        api: {
-          id: "google/gemini-2.0-flash",
-          url: "https://openrouter.ai",
-          npm: "@openrouter/ai-sdk-provider",
-        },
-      })
-
-      expect(ProviderTransform.variants(model)).toEqual({})
-    })
-
-    test.each([
-      "openrouter/google/gemini-2.5-flash",
-      "openrouter/google/gemini-3-5-pro",
-      "openrouter/anthropic/claude-haiku-4.5",
-      "openrouter/x-ai/grok-4.3",
-    ])(
-      "does not cap output tokens for OpenRouter reasoning model %s",
-      (id) => {
-        const model = createMockModel({
-          id,
-          providerID: "openrouter",
-          api: {
-            id: id.replace("openrouter/", ""),
-            url: "https://openrouter.ai",
-            npm: "@openrouter/ai-sdk-provider",
-          },
-          limit: { output: 64_000 },
-        })
-
-        expect(ProviderTransform.maxOutputTokens(model)).toBe(32_000)
-      },
-    )
-
-    test("does not cap OpenRouter GPT output tokens", () => {
-      const model = createMockModel({
-        id: "openrouter/openai/gpt-5.4-mini",
-        providerID: "openrouter",
-        api: {
-          id: "openai/gpt-5.4-mini",
-          url: "https://openrouter.ai",
-          npm: "@openrouter/ai-sdk-provider",
-        },
-        limit: { output: 64_000 },
-      })
-
-      expect(ProviderTransform.maxOutputTokens(model)).toBe(32_000)
-    })
-
-    test("does not cap non-reasoning OpenRouter Grok output tokens", () => {
-      const model = createMockModel({
-        id: "openrouter/x-ai/grok-4",
-        providerID: "openrouter",
-        api: {
-          id: "x-ai/grok-4",
-          url: "https://openrouter.ai",
-          npm: "@openrouter/ai-sdk-provider",
-        },
-        capabilities: { reasoning: false },
-        limit: { output: 64_000 },
-      })
-
-      expect(ProviderTransform.maxOutputTokens(model)).toBe(32_000)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
     })
 
     test("grok-4 returns empty object", () => {
@@ -2803,37 +2801,6 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["low", "high"])
       expect(result.low).toEqual({ reasoning: { effort: "low" } })
       expect(result.high).toEqual({ reasoning: { effort: "high" } })
-    })
-
-    test("grok-4.3 returns reasoning effort variants", () => {
-      const model = createMockModel({
-        id: "openrouter/grok-4.3",
-        providerID: "openrouter",
-        api: {
-          id: "grok-4.3",
-          url: "https://openrouter.ai",
-          npm: "@openrouter/ai-sdk-provider",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
-      expect(result.none).toEqual({ reasoning: { effort: "none" } })
-      expect(result.high).toEqual({ reasoning: { effort: "high" } })
-    })
-
-    test("grok-4-3 returns reasoning effort variants", () => {
-      const model = createMockModel({
-        id: "openrouter/grok-4-3-20260430",
-        providerID: "openrouter",
-        api: {
-          id: "grok-4-3-20260430",
-          url: "https://openrouter.ai",
-          npm: "@openrouter/ai-sdk-provider",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
-      expect(result.medium).toEqual({ reasoning: { effort: "medium" } })
     })
   })
 
@@ -2913,12 +2880,14 @@ describe("ProviderTransform.variants", () => {
       expect(result.xhigh).toEqual({
         thinking: {
           type: "adaptive",
+          display: "summarized",
         },
         effort: "xhigh",
       })
       expect(result.max).toEqual({
         thinking: {
           type: "adaptive",
+          display: "summarized",
         },
         effort: "max",
       })
@@ -2936,6 +2905,47 @@ describe("ProviderTransform.variants", () => {
       })
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+    })
+
+    test("anthropic opus 4.8 forces display summarized for adaptive reasoning", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-opus-4-8",
+        providerID: "gateway",
+        api: {
+          id: "anthropic/claude-opus-4-8",
+          url: "https://gateway.ai",
+          npm: "@ai-sdk/gateway",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
+        },
+        effort: "high",
+      })
+    })
+
+    test("anthropic opus 4.6 omits display so it keeps the summarized default", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-opus-4-6",
+        providerID: "gateway",
+        api: {
+          id: "anthropic/claude-opus-4-6",
+          url: "https://gateway.ai",
+          npm: "@ai-sdk/gateway",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "high",
+      })
     })
 
     test("anthropic models return anthropic thinking options", () => {
@@ -3198,37 +3208,6 @@ describe("ProviderTransform.variants", () => {
       expect(result.low).toEqual({ reasoningEffort: "low" })
       expect(result.high).toEqual({ reasoningEffort: "high" })
     })
-
-    test("grok-4.3 returns reasoningEffort variants", () => {
-      const model = createMockModel({
-        id: "xai/grok-4.3",
-        providerID: "xai",
-        api: {
-          id: "grok-4.3",
-          url: "https://api.x.ai",
-          npm: "@ai-sdk/xai",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
-      expect(result.none).toEqual({ reasoningEffort: "none" })
-      expect(result.high).toEqual({ reasoningEffort: "high" })
-    })
-
-    test("grok-4-3 returns reasoningEffort variants", () => {
-      const model = createMockModel({
-        id: "xai/grok-4-3-20260430",
-        providerID: "xai",
-        api: {
-          id: "grok-4-3-20260430",
-          url: "https://api.x.ai",
-          npm: "@ai-sdk/xai",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
-      expect(result.medium).toEqual({ reasoningEffort: "medium" })
-    })
   })
 
   describe("@ai-sdk/deepinfra", () => {
@@ -3264,6 +3243,23 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["low", "medium", "high"])
       expect(result.low).toEqual({ reasoningEffort: "low" })
       expect(result.high).toEqual({ reasoningEffort: "high" })
+    })
+
+    test("north-mini-code-1-0 returns only none and high", () => {
+      const model = createMockModel({
+        id: "cohere/north-mini-code-1-0",
+        providerID: "cohere",
+        api: {
+          id: "North-Mini-Code-1-0-latest",
+          url: "https://api.cohere.com/compatibility/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result).toEqual({
+        none: { reasoningEffort: "none" },
+        high: { reasoningEffort: "high" },
+      })
     })
   })
 
@@ -3315,20 +3311,25 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
     })
 
-    for (const id of ["gpt-5-4", "gpt-5-5"]) {
-      test(`${id} does not add minimal effort`, () => {
+    for (const testCase of [
+      { id: "gpt-5-1", efforts: ["none", "low", "medium", "high"] },
+      { id: "gpt-5-4", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "gpt-5.4", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "gpt-5-5", efforts: ["none", "low", "medium", "high", "xhigh"] },
+    ]) {
+      test(`${testCase.id} returns supported Azure reasoning efforts`, () => {
         const result = ProviderTransform.variants(
           createMockModel({
-            id,
+            id: testCase.id,
             providerID: "azure",
             api: {
-              id,
+              id: testCase.id,
               url: "https://azure.com",
               npm: "@ai-sdk/azure",
             },
           }),
         )
-        expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+        expect(Object.keys(result)).toEqual(testCase.efforts)
       })
     }
   })
@@ -3460,6 +3461,28 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
+  describe("@ai-sdk/amazon-bedrock/mantle", () => {
+    test("gpt-5.5 returns OpenAI-style reasoning variants", () => {
+      const model = createMockModel({
+        id: "openai.gpt-5.5",
+        providerID: "amazon-bedrock",
+        api: {
+          id: "openai.gpt-5.5",
+          url: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+          npm: "@ai-sdk/amazon-bedrock/mantle",
+        },
+        release_date: "2026-04-23",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
+      expect(result.medium).toEqual({
+        reasoningEffort: "medium",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      })
+    })
+  })
+
   describe("@ai-sdk/anthropic", () => {
     for (const testCase of [
       {
@@ -3483,6 +3506,18 @@ describe("ProviderTransform.variants", () => {
       {
         name: "opus 4.7",
         apiIds: ["claude-opus-4-7", "claude-opus-4.7"],
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        expectedHigh: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
+      },
+      {
+        name: "opus 4.8",
+        apiIds: ["claude-opus-4-8", "claude-opus-4.8"],
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        expectedHigh: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
+      },
+      {
+        name: "fable 5",
+        apiIds: ["claude-fable-5"],
         efforts: ["low", "medium", "high", "xhigh", "max"],
         expectedHigh: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
       },
@@ -3555,6 +3590,30 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
+  describe("@ai-sdk/google-vertex/anthropic", () => {
+    test("opus 4.8 uses adaptive reasoning for Vertex model IDs", () => {
+      const result = ProviderTransform.variants(
+        createMockModel({
+          id: "google-vertex-anthropic/claude-opus-4-8@default",
+          providerID: "google-vertex-anthropic",
+          api: {
+            id: "claude-opus-4-8@default",
+            url: "https://us-central1-aiplatform.googleapis.com",
+            npm: "@ai-sdk/google-vertex/anthropic",
+          },
+        }),
+      )
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
+        },
+        effort: "high",
+      })
+    })
+  })
+
   describe("@ai-sdk/amazon-bedrock", () => {
     test("anthropic sonnet 4.6 returns adaptive reasoning options", () => {
       const model = createMockModel({
@@ -3599,6 +3658,28 @@ describe("ProviderTransform.variants", () => {
         reasoningConfig: {
           type: "adaptive",
           maxReasoningEffort: "max",
+          display: "summarized",
+        },
+      })
+    })
+
+    test("anthropic opus 4.8 returns adaptive reasoning options with xhigh", () => {
+      const result = ProviderTransform.variants(
+        createMockModel({
+          id: "bedrock/anthropic-claude-opus-4.8",
+          providerID: "bedrock",
+          api: {
+            id: "anthropic.claude-opus-4.8",
+            url: "https://bedrock.amazonaws.com",
+            npm: "@ai-sdk/amazon-bedrock",
+          },
+        }),
+      )
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        reasoningConfig: {
+          type: "adaptive",
+          maxReasoningEffort: "high",
           display: "summarized",
         },
       })
@@ -3749,143 +3830,119 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@jerome-benoit/sap-ai-provider-v2", () => {
-    test("anthropic models return thinking variants", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/anthropic--claude-sonnet-4",
+    const sapModel = (apiId: string, releaseDate = "2024-01-01") =>
+      createMockModel({
+        id: `sap-ai-core/${apiId}`,
         providerID: "sap-ai-core",
         api: {
-          id: "anthropic--claude-sonnet-4",
+          id: apiId,
           url: "https://api.ai.sap",
           npm: "@jerome-benoit/sap-ai-provider-v2",
         },
+        release_date: releaseDate,
       })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["high", "max"])
-      expect(result.high).toEqual({
-        thinking: {
-          type: "enabled",
-          budgetTokens: 16000,
-        },
-      })
-      expect(result.max).toEqual({
-        thinking: {
-          type: "enabled",
-          budgetTokens: 31999,
-        },
-      })
-    })
 
-    test("anthropic 4.6 models return adaptive thinking variants", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/anthropic--claude-sonnet-4-6",
-        providerID: "sap-ai-core",
-        api: {
-          id: "anthropic--claude-sonnet-4-6",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
-      expect(result.low).toEqual({
-        thinking: {
-          type: "adaptive",
-        },
-        effort: "low",
-      })
-      expect(result.max).toEqual({
-        thinking: {
-          type: "adaptive",
-        },
-        effort: "max",
-      })
-    })
+    for (const testCase of [
+      {
+        name: "sonnet 4.6",
+        apiIds: ["anthropic--claude-sonnet-4-6"],
+        efforts: ["low", "medium", "high", "max"],
+        thinking: { type: "adaptive" },
+      },
+      {
+        name: "opus 4.6",
+        apiIds: ["anthropic--claude-4.6-opus", "anthropic--claude-4-6-opus"],
+        efforts: ["low", "medium", "high", "max"],
+        thinking: { type: "adaptive" },
+      },
+      {
+        name: "opus 4.7",
+        apiIds: ["anthropic--claude-4.7-opus", "anthropic--claude-4-7-opus"],
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        thinking: { type: "adaptive", display: "summarized" },
+      },
+      {
+        name: "opus 4.8",
+        apiIds: ["anthropic--claude-4.8-opus", "anthropic--claude-4-8-opus"],
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        thinking: { type: "adaptive", display: "summarized" },
+      },
+    ]) {
+      for (const apiId of testCase.apiIds) {
+        test(`${testCase.name} ${apiId} returns adaptive thinking variants under modelParams`, () => {
+          const result = ProviderTransform.variants(sapModel(apiId))
+          expect(Object.keys(result)).toEqual(testCase.efforts)
+          for (const effort of testCase.efforts) {
+            expect(result[effort]).toEqual({
+              modelParams: {
+                thinking: testCase.thinking,
+                output_config: { effort },
+              },
+            })
+          }
+        })
+      }
+    }
 
-    test("gemini 2.5 models return thinkingConfig variants", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/gcp--gemini-2.5-pro",
-        providerID: "sap-ai-core",
-        api: {
-          id: "gcp--gemini-2.5-pro",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
+    for (const apiId of ["anthropic--claude-sonnet-4", "anthropic--claude-4.5-opus"]) {
+      test(`${apiId} returns budget_tokens variants under modelParams`, () => {
+        const result = ProviderTransform.variants(sapModel(apiId))
+        expect(Object.keys(result)).toEqual(["high", "max"])
+        expect(result.high).toEqual({
+          modelParams: { thinking: { type: "enabled", budget_tokens: 16000 } },
+        })
+        expect(result.max).toEqual({
+          modelParams: { thinking: { type: "enabled", budget_tokens: 31999 } },
+        })
       })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["high", "max"])
-      expect(result.high).toEqual({
-        thinkingConfig: {
-          includeThoughts: true,
-          thinkingBudget: 16000,
-        },
-      })
-      expect(result.max).toEqual({
-        thinkingConfig: {
-          includeThoughts: true,
-          thinkingBudget: 24576,
-        },
-      })
-    })
+    }
 
-    test("gpt models return reasoningEffort variants", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/azure-openai--gpt-4o",
-        providerID: "sap-ai-core",
-        api: {
-          id: "azure-openai--gpt-4o",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
+    for (const testCase of [
+      { apiId: "gemini-2.5-pro", maxBudget: 32768 },
+      { apiId: "gemini-2.5-flash", maxBudget: 24576 },
+    ]) {
+      test(`${testCase.apiId} returns thinkingConfig variants under modelParams`, () => {
+        const result = ProviderTransform.variants(sapModel(testCase.apiId))
+        expect(Object.keys(result)).toEqual(["high", "max"])
+        expect(result.high).toEqual({
+          modelParams: { thinkingConfig: { includeThoughts: true, thinkingBudget: 16000 } },
+        })
+        expect(result.max).toEqual({
+          modelParams: { thinkingConfig: { includeThoughts: true, thinkingBudget: testCase.maxBudget } },
+        })
       })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
-      expect(result.low).toEqual({ reasoningEffort: "low" })
-      expect(result.high).toEqual({ reasoningEffort: "high" })
-    })
+    }
 
-    test("o-series models return reasoningEffort variants", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/azure-openai--o3-mini",
-        providerID: "sap-ai-core",
-        api: {
-          id: "azure-openai--o3-mini",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
+    for (const testCase of [
+      { apiId: "gpt-5", releaseDate: "2025-08-07", efforts: ["minimal", "low", "medium", "high"] },
+      { apiId: "gpt-5-mini", releaseDate: "2025-08-07", efforts: ["minimal", "low", "medium", "high"] },
+      { apiId: "gpt-5-nano", releaseDate: "2025-08-07", efforts: ["minimal", "low", "medium", "high"] },
+      { apiId: "gpt-5.4", releaseDate: "2026-01-15", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { apiId: "azure-openai--o3-mini", releaseDate: "2024-01-01", efforts: ["low", "medium", "high"] },
+    ]) {
+      test(`${testCase.apiId} returns reasoning_effort variants under modelParams`, () => {
+        const result = ProviderTransform.variants(sapModel(testCase.apiId, testCase.releaseDate))
+        expect(Object.keys(result)).toEqual(testCase.efforts)
+        for (const effort of testCase.efforts) {
+          expect(result[effort]).toEqual({ modelParams: { reasoning_effort: effort } })
+        }
       })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
-      expect(result.low).toEqual({ reasoningEffort: "low" })
-      expect(result.high).toEqual({ reasoningEffort: "high" })
-    })
+    }
 
-    test("sonar models return empty object", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/perplexity--sonar-pro",
-        providerID: "sap-ai-core",
-        api: {
-          id: "perplexity--sonar-pro",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
+    for (const apiId of [
+      "gemini-3.1-flash-lite",
+      "cohere--command-a-reasoning",
+      "sonar-deep-research",
+      "aws--llama-opus-4.7-fake",
+    ]) {
+      test(`${apiId} falls through to harmonized reasoning_effort fallback`, () => {
+        const result = ProviderTransform.variants(sapModel(apiId))
+        expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+        for (const effort of ["low", "medium", "high"]) {
+          expect(result[effort]).toEqual({ modelParams: { reasoning_effort: effort } })
+        }
       })
-      const result = ProviderTransform.variants(model)
-      expect(result).toEqual({})
-    })
-
-    test("mistral models return empty object", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/mistral--mistral-large",
-        providerID: "sap-ai-core",
-        api: {
-          id: "mistral--mistral-large",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(result).toEqual({})
-    })
+    }
   })
 
   describe("ai-gateway-provider (cloudflare-ai-gateway)", () => {
@@ -3986,6 +4043,23 @@ describe("ProviderTransform.smallOptions - gpt-5 chat/search", () => {
       expect(ProviderTransform.smallOptions(createModel(testCase.id))).toEqual(testCase.options)
     })
   }
+})
+
+test("ProviderTransform.smallOptions disables OpenRouter reasoning when the weakest effort is low", () => {
+  expect(
+    ProviderTransform.smallOptions({
+      providerID: "openrouter",
+      api: {
+        id: "anthropic/claude-sonnet-4.6",
+        npm: "@openrouter/ai-sdk-provider",
+      },
+      variants: {
+        low: { reasoning: { effort: "low" } },
+        medium: { reasoning: { effort: "medium" } },
+        high: { reasoning: { effort: "high" } },
+      },
+    } as any),
+  ).toEqual({ reasoning: { effort: "none" } })
 })
 
 describe("ProviderTransform.smallOptions - google thinking controls", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3084,7 +3084,7 @@ describe("ProviderTransform.variants", () => {
     })
 
     for (const testCase of [
-      { id: "openai/o3-mini", efforts: ["none", "minimal", "low", "medium", "high", "xhigh"] },
+      { id: "openai/o3-mini", efforts: ["low", "medium", "high"] },
       { id: "openai/gpt-5.4", efforts: ["none", "low", "medium", "high", "xhigh"] },
       { id: "openai/gpt-5-pro", efforts: ["high"] },
       { id: "openai/gpt-5.5-pro", efforts: ["medium", "high", "xhigh"] },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -396,6 +396,24 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.textVerbosity).toBe("low")
   })
 
+  test("Bedrock Mantle gpt-5-pro keeps stateless reasoning defaults", () => {
+    const model = {
+      ...createGpt5Model("openai.gpt-5-pro"),
+      id: "amazon-bedrock/openai.gpt-5-pro",
+      providerID: "amazon-bedrock",
+      api: {
+        id: "openai.gpt-5-pro",
+        url: "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+        npm: "@ai-sdk/amazon-bedrock/mantle",
+      },
+    }
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.store).toBe(false)
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.forceReasoning).toBe(true)
+    expect(result.include).toEqual(["reasoning.encrypted_content"])
+  })
+
   test("openai-compatible gpt-5 models omit Responses-only reasoningSummary", () => {
     const model = {
       ...createGpt5Model("gpt-5.4"),

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -319,7 +319,7 @@ function createEventResponse(chunks: unknown[], includeDone = false) {
 }
 
 describe("session.llm.stream", () => {
-  test("OpenRouter Gemini 2.5 none variant replaces the default reasoning budget", async () => {
+  test("OpenRouter Gemini 2.5 none variant does not send a stale default reasoning budget", async () => {
     const server = state.server
     if (!server) {
       throw new Error("Server not initialized")
@@ -390,89 +390,7 @@ describe("session.llm.stream", () => {
         })
 
         const capture = await request
-        expect(capture.body.reasoning).toEqual({ enabled: false })
-      },
-    })
-  })
-
-  test("OpenRouter Gemini 2.5 disabled model reasoning overrides later variant budgets", async () => {
-    const server = state.server
-    if (!server) {
-      throw new Error("Server not initialized")
-    }
-
-    const providerID = "openrouter"
-    const modelID = "google/gemini-2.5-flash"
-    const fixture = await loadFixture(providerID, modelID)
-    const model = fixture.model
-
-    const request = waitRequest(
-      "/chat/completions",
-      new Response(createChatStream("Hello"), {
-        status: 200,
-        headers: { "Content-Type": "text/event-stream" },
-      }),
-    )
-
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(
-          path.join(dir, "opencode.json"),
-          JSON.stringify({
-            $schema: "https://opencode.ai/config.json",
-            enabled_providers: [providerID],
-            provider: {
-              [providerID]: {
-                options: {
-                  apiKey: "test-key",
-                  baseURL: `${server.url.origin}/v1`,
-                },
-              },
-            },
-          }),
-        )
-      },
-    })
-
-    await WithInstance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
-        const sessionID = SessionID.make("session-test-openrouter-gemini-disabled")
-        const agent = {
-          name: "test",
-          mode: "primary",
-          options: {},
-          permission: [{ permission: "*", pattern: "*", action: "allow" }],
-        } satisfies Agent.Info
-
-        const user = {
-          id: MessageID.make("msg_user-openrouter-gemini-disabled"),
-          sessionID,
-          role: "user",
-          time: { created: Date.now() },
-          agent: agent.name,
-          model: { providerID: ProviderID.make(providerID), modelID: resolved.id, variant: "high" },
-        } satisfies MessageV2.User
-
-        await drain({
-          user,
-          sessionID,
-          model: {
-            ...resolved,
-            options: {
-              ...resolved.options,
-              reasoning: { enabled: false },
-            },
-          },
-          agent,
-          system: ["You are a helpful assistant."],
-          messages: [{ role: "user", content: "Hello" }],
-          tools: {},
-        })
-
-        const capture = await request
-        expect(capture.body.reasoning).toEqual({ enabled: false })
+        expect(capture.body.reasoning).toBeUndefined()
       },
     })
   })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -705,6 +705,18 @@ describe("session.llm.stream", () => {
           options: {},
           permission: [{ permission: "*", pattern: "*", action: "allow" }],
         } satisfies Agent.Info
+        const variant = {
+          modelParams: {
+            reasoning: { effort: "high" },
+            reasoning_effort: "high",
+            thinking: { type: "enabled", budget_tokens: 16000 },
+            thinkingConfig: { includeThoughts: true, thinkingBudget: 16000 },
+            include: ["reasoning.encrypted_content", "message.output_text.logprobs"],
+            output_config: { effort: "high", format: "text" },
+            retained: "value",
+          },
+        }
+        const original = structuredClone(variant)
         const current: Provider.Model = {
           ...resolved,
           options: {
@@ -713,17 +725,7 @@ describe("session.llm.stream", () => {
           },
           variants: {
             ...resolved.variants,
-            high: {
-              modelParams: {
-                reasoning: { effort: "high" },
-                reasoning_effort: "high",
-                thinking: { type: "enabled", budget_tokens: 16000 },
-                thinkingConfig: { includeThoughts: true, thinkingBudget: 16000 },
-                include: ["reasoning.encrypted_content", "message.output_text.logprobs"],
-                output_config: { effort: "high", format: "text" },
-                retained: "value",
-              },
-            },
+            high: variant,
           },
         }
 
@@ -759,6 +761,7 @@ describe("session.llm.stream", () => {
           output_config: { format: "text" },
           retained: "value",
         })
+        expect(variant).toEqual(original)
         expect(capture.body.reasoning).toEqual({ enabled: false })
       },
     })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -478,6 +478,89 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("partial reasoning options merge across model and agent layers", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "openrouter"
+    const modelID = "google/gemini-2.5-flash"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-openrouter-partial-reasoning")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: { reasoning: { effort: "high" } },
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const current: Provider.Model = {
+          ...resolved,
+          options: {
+            ...resolved.options,
+            reasoning: { exclude: true },
+          },
+        }
+
+        const user = {
+          id: MessageID.make("msg_user-openrouter-partial-reasoning"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: current.id },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: current,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = await request
+        expect(capture.body.reasoning).toEqual({ exclude: true, effort: "high" })
+      },
+    })
+  })
+
   test("sends temperature, tokens, and reasoning options for openai-compatible models", async () => {
     const server = state.server
     if (!server) {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -76,6 +76,43 @@ async function drainStoreTrue(input: LLM.StreamInput) {
   )
 }
 
+async function drainCaptureParams(input: LLM.StreamInput, capture: { options?: Record<string, unknown> }) {
+  const capturePlugin = Layer.succeed(
+    Plugin.Service,
+    Plugin.Service.of({
+      trigger: (_name, _input, output) =>
+        Effect.sync(() => {
+          if (_name === "chat.params") {
+            const params = output as { options?: Record<string, unknown> }
+            capture.options = params.options
+          }
+          return output
+        }),
+      list: () => Effect.succeed([]),
+      init: () => Effect.void,
+    }),
+  )
+  const providerLayer = Provider.layer.pipe(
+    Layer.provide(AppFileSystem.defaultLayer),
+    Layer.provide(Env.defaultLayer),
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(Auth.defaultLayer),
+    Layer.provide(capturePlugin),
+    Layer.provide(ModelsDev.defaultLayer),
+    Layer.provide(RuntimeFlags.defaultLayer),
+  )
+  const layer = LLM.layer.pipe(
+    Layer.provide(Auth.defaultLayer),
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(providerLayer),
+    Layer.provide(capturePlugin),
+    Layer.provide(RuntimeFlags.defaultLayer),
+  )
+  return Effect.runPromise(
+    attach(LLM.Service.use((svc) => svc.stream(input).pipe(Stream.runDrain))).pipe(Effect.provide(layer)),
+  )
+}
+
 describe("session.llm.hasToolCalls", () => {
   test("returns false for empty messages array", () => {
     expect(LLM.hasToolCalls([])).toBe(false)
@@ -614,6 +651,115 @@ describe("session.llm.stream", () => {
         expect(capture.body.reasoningSummary).toBeUndefined()
         expect(capture.body.reasoning_summary).toBeUndefined()
         expect(capture.body.include).toBeUndefined()
+      },
+    })
+  })
+
+  test("disabled reasoning removes nested modelParams reasoning controls", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "openrouter"
+    const modelID = "google/gemini-2.5-flash"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-openrouter-disabled-modelparams-reasoning")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const current: Provider.Model = {
+          ...resolved,
+          options: {
+            ...resolved.options,
+            reasoning: { enabled: false },
+          },
+          variants: {
+            ...resolved.variants,
+            high: {
+              modelParams: {
+                reasoning: { effort: "high" },
+                reasoning_effort: "high",
+                thinking: { type: "enabled", budget_tokens: 16000 },
+                thinkingConfig: { includeThoughts: true, thinkingBudget: 16000 },
+                include: ["reasoning.encrypted_content", "message.output_text.logprobs"],
+                output_config: { effort: "high", format: "text" },
+                retained: "value",
+              },
+            },
+          },
+        }
+
+        const user = {
+          id: MessageID.make("msg_user-openrouter-disabled-modelparams-reasoning"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: current.id, variant: "high" },
+        } satisfies MessageV2.User
+
+        const captured: { options?: Record<string, unknown> } = {}
+        await drainCaptureParams(
+          {
+            user,
+            sessionID,
+            model: current,
+            agent,
+            system: ["You are a helpful assistant."],
+            messages: [{ role: "user", content: "Hello" }],
+            tools: {},
+          },
+          captured,
+        )
+
+        const capture = await request
+        const options = captured.options
+        expect(options?.reasoning).toEqual({ enabled: false })
+        const params = options?.modelParams as Record<string, unknown> | undefined
+        expect(params).toEqual({
+          include: ["message.output_text.logprobs"],
+          output_config: { format: "text" },
+          retained: "value",
+        })
+        expect(capture.body.reasoning).toEqual({ enabled: false })
       },
     })
   })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -521,6 +521,103 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("disabled reasoning overrides later selected variant reasoning options", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "openrouter"
+    const modelID = "google/gemini-2.5-flash"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-openrouter-disabled-variant-reasoning")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const current: Provider.Model = {
+          ...resolved,
+          options: {
+            ...resolved.options,
+            reasoning: { enabled: false },
+          },
+          variants: {
+            ...resolved.variants,
+            high: {
+              reasoning: { effort: "high", summary: "auto" },
+              reasoningEffort: "high",
+              reasoningSummary: "auto",
+              include: ["reasoning.encrypted_content"],
+            },
+          },
+        }
+
+        const user = {
+          id: MessageID.make("msg_user-openrouter-disabled-variant-reasoning"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: current.id, variant: "high" },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: current,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = await request
+        expect(capture.body.reasoning).toEqual({ enabled: false })
+        expect(capture.body.reasoningEffort).toBeUndefined()
+        expect(capture.body.reasoning_effort).toBeUndefined()
+        expect(capture.body.reasoningSummary).toBeUndefined()
+        expect(capture.body.reasoning_summary).toBeUndefined()
+        expect(capture.body.include).toBeUndefined()
+      },
+    })
+  })
+
   test("partial reasoning options merge across model and agent layers", async () => {
     const server = state.server
     if (!server) {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -620,6 +620,8 @@ describe("session.llm.stream", () => {
               reasoning: { effort: "high", summary: "auto" },
               reasoningEffort: "high",
               reasoningSummary: "auto",
+              effort: "high",
+              reasoningConfig: { type: "enabled", maxReasoningEffort: "high" },
               include: ["reasoning.encrypted_content"],
             },
           },
@@ -634,17 +636,23 @@ describe("session.llm.stream", () => {
           model: { providerID: ProviderID.make(providerID), modelID: current.id, variant: "high" },
         } satisfies MessageV2.User
 
-        await drain({
-          user,
-          sessionID,
-          model: current,
-          agent,
-          system: ["You are a helpful assistant."],
-          messages: [{ role: "user", content: "Hello" }],
-          tools: {},
-        })
+        const captured: { options?: Record<string, unknown> } = {}
+        await drainCaptureParams(
+          {
+            user,
+            sessionID,
+            model: current,
+            agent,
+            system: ["You are a helpful assistant."],
+            messages: [{ role: "user", content: "Hello" }],
+            tools: {},
+          },
+          captured,
+        )
 
         const capture = await request
+        expect(captured.options?.effort).toBeUndefined()
+        expect(captured.options?.reasoningConfig).toBeUndefined()
         expect(capture.body.reasoning).toEqual({ enabled: false })
         expect(capture.body.reasoningEffort).toBeUndefined()
         expect(capture.body.reasoning_effort).toBeUndefined()
@@ -709,6 +717,8 @@ describe("session.llm.stream", () => {
           modelParams: {
             reasoning: { effort: "high" },
             reasoning_effort: "high",
+            effort: "high",
+            reasoningConfig: { type: "enabled", maxReasoningEffort: "high" },
             thinking: { type: "enabled", budget_tokens: 16000 },
             thinkingConfig: { includeThoughts: true, thinkingBudget: 16000 },
             include: ["reasoning.encrypted_content", "message.output_text.logprobs"],

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1,15 +1,21 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
 import path from "path"
 import { tool, type ModelMessage } from "ai"
-import { Cause, Effect, Exit, Stream } from "effect"
+import { Cause, Effect, Exit, Layer, Stream } from "effect"
 import z from "zod"
-import { makeRuntime } from "../../src/effect/run-service"
+import { attach, makeRuntime } from "../../src/effect/run-service"
 import { LLM } from "../../src/session/llm"
 import { Instance } from "../../src/project/instance"
 import { WithInstance } from "../../src/project/with-instance"
 import { Provider } from "@/provider/provider"
+import { Auth } from "@/auth"
+import { Config } from "@/config/config"
+import { Plugin } from "@/plugin"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Env } from "@/env"
 import { ProviderTransform } from "@/provider/transform"
 import { ModelsDev } from "@opencode-ai/core/models"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import { Filesystem } from "@/util/filesystem"
 import { tmpdir } from "../fixture/fixture"
@@ -28,9 +34,46 @@ async function getModel(providerID: ProviderID, modelID: ModelID) {
 }
 
 const llm = makeRuntime(LLM.Service, LLM.defaultLayer)
+const storeTruePlugin = Layer.succeed(
+  Plugin.Service,
+  Plugin.Service.of({
+    trigger: (_name, _input, output) =>
+      Effect.sync(() => {
+        if (_name === "chat.params") {
+          const params = output as { options?: Record<string, unknown> }
+          params.options = { ...(params.options ?? {}), store: true }
+        }
+        return output
+      }),
+    list: () => Effect.succeed([]),
+    init: () => Effect.void,
+  }),
+)
+const providerStoreTrueLayer = Provider.layer.pipe(
+  Layer.provide(AppFileSystem.defaultLayer),
+  Layer.provide(Env.defaultLayer),
+  Layer.provide(Config.defaultLayer),
+  Layer.provide(Auth.defaultLayer),
+  Layer.provide(storeTruePlugin),
+  Layer.provide(ModelsDev.defaultLayer),
+  Layer.provide(RuntimeFlags.defaultLayer),
+)
+const llmStoreTrueLayer = LLM.layer.pipe(
+  Layer.provide(Auth.defaultLayer),
+  Layer.provide(Config.defaultLayer),
+  Layer.provide(providerStoreTrueLayer),
+  Layer.provide(storeTruePlugin),
+  Layer.provide(RuntimeFlags.defaultLayer),
+)
 
 async function drain(input: LLM.StreamInput) {
   return llm.runPromise((svc) => svc.stream(input).pipe(Stream.runDrain))
+}
+
+async function drainStoreTrue(input: LLM.StreamInput) {
+  return Effect.runPromise(
+    attach(LLM.Service.use((svc) => svc.stream(input).pipe(Stream.runDrain))).pipe(Effect.provide(llmStoreTrueLayer)),
+  )
 }
 
 describe("session.llm.hasToolCalls", () => {
@@ -1038,6 +1081,139 @@ describe("session.llm.stream", () => {
 
         const maxTokens = body.max_output_tokens as number | undefined
         expect(maxTokens).toBe(undefined) // match codex cli behavior
+      },
+    })
+  })
+
+  test("preserves Responses item IDs when a plugin enables store", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const source = await loadFixture("openai", "gpt-5.2")
+    const model = source.model
+    const chunks = [
+      {
+        type: "response.created",
+        response: {
+          id: "resp-store-true",
+          created_at: Math.floor(Date.now() / 1000),
+          model: model.id,
+          service_tier: null,
+        },
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "item-store-true",
+        delta: "Hello",
+        logprobs: null,
+      },
+      {
+        type: "response.completed",
+        response: {
+          incomplete_details: null,
+          usage: {
+            input_tokens: 1,
+            input_tokens_details: null,
+            output_tokens: 1,
+            output_tokens_details: null,
+          },
+          service_tier: null,
+        },
+      },
+    ]
+    const request = waitRequest("/responses", createEventResponse(chunks, true))
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["openai"],
+            provider: {
+              openai: {
+                name: "OpenAI",
+                env: ["OPENAI_API_KEY"],
+                npm: "@ai-sdk/openai",
+                api: "https://api.openai.com/v1",
+                models: {
+                  [model.id]: configModel(model),
+                },
+                options: {
+                  apiKey: "test-openai-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.openai, ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-store-true-item-ids")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("msg_user-store-true-item-ids"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make("openai"), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        await drainStoreTrue({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "reasoning",
+                  text: "thinking",
+                  providerOptions: {
+                    openai: {
+                      itemId: "rs_keep",
+                      reasoningEncryptedContent: "encrypted",
+                    },
+                  },
+                },
+                {
+                  type: "text",
+                  text: "Earlier answer",
+                  providerOptions: {
+                    openai: {
+                      itemId: "msg_keep",
+                    },
+                  },
+                },
+              ],
+            },
+            { role: "user", content: "Continue" },
+          ] as ModelMessage[],
+          tools: {},
+        })
+
+        const capture = await request
+        const raw = JSON.stringify(capture.body)
+        expect(capture.body.store).toBe(true)
+        expect(raw).toContain("rs_keep")
+        expect(raw).toContain("msg_keep")
       },
     })
   })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -395,6 +395,89 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("disabled reasoning replaces stale model reasoning options", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "openrouter"
+    const modelID = "google/gemini-2.5-flash"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-openrouter-disabled-reasoning")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: { reasoning: { enabled: false } },
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const current: Provider.Model = {
+          ...resolved,
+          options: {
+            ...resolved.options,
+            reasoning: { effort: "high" },
+          },
+        }
+
+        const user = {
+          id: MessageID.make("msg_user-openrouter-disabled-reasoning"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: current.id },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: current,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = await request
+        expect(capture.body.reasoning).toEqual({ enabled: false })
+      },
+    })
+  })
+
   test("sends temperature, tokens, and reasoning options for openai-compatible models", async () => {
     const server = state.server
     if (!server) {


### PR DESCRIPTION
### Issue for this PR

Not required for refactor PRs.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Aligns provider reasoning transforms with current upstream OpenCode behavior while keeping the fork's Agent Swarm LLM guard covered. This removes fork-only reasoning merge drift, preserves disabled-reasoning handling, and backports upstream OpenCode's OpenAI/Azure MCP tool-schema sanitization.

The latest update also keeps disabled reasoning complete across provider-specific controls, including top-level `effort`, Bedrock-style `reasoningConfig`, nested `modelParams`, and encrypted reasoning includes.

### How did you verify your code works?

Focused provider/session coverage exercises the changed reasoning transforms, schema sanitization, Bedrock Mantle options, and disabled-reasoning cleanup. Type checking and hosted PR checks are green on the latest head.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
