### PR TITLE
feat(opencode): restore build and plan modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ Policy summaries live in AGENTS.md files. Do not check in duplicate copies of gl
 - Drive any smoke automation yourself when it should finish in under 3 minutes.
 - When relevant full testing should finish in under 5 minutes, run it yourself before handoff.
 - When relevant full testing is likely to take more than 5 minutes, give the user a ready-to-run script and exact manual QA steps instead of calling the work done.
+- For integration-heavy Agent Swarm, OpenCode TUI, or CLI behavior, prefer the smallest meaningful integration or end-to-end tests that drive real user flows and prove boundaries. Unit tests are fine for isolated pure or local logic, but mocked unit tests are not enough proof for integration behavior.
 - Test every user-facing function touched by the change, and every nearby function that the change could affect.
 - If a check needs secrets, live services, global installs, or long human QA, say that clearly and give the safest exact command or script for the user to run.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,6 @@ Policy summaries live in AGENTS.md files. Do not check in duplicate copies of gl
 - Drive any smoke automation yourself when it should finish in under 3 minutes.
 - When relevant full testing should finish in under 5 minutes, run it yourself before handoff.
 - When relevant full testing is likely to take more than 5 minutes, give the user a ready-to-run script and exact manual QA steps instead of calling the work done.
-- For integration-heavy Agent Swarm, OpenCode TUI, or CLI behavior, prefer the smallest meaningful integration or end-to-end tests that drive real user flows and prove boundaries. Unit tests are fine for isolated pure or local logic, but mocked unit tests are not enough proof for integration behavior.
 - Test every user-facing function touched by the change, and every nearby function that the change could affect.
 - If a check needs secrets, live services, global installs, or long human QA, say that clearly and give the safest exact command or script for the user to run.
 

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -13,7 +13,7 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
 - `/auth` is the credentials flow, not a product mode switch.
 - `/models` chooses the LLM config passed to Agency Swarm, not a product mode switch.
 - Upstream OpenCode provider/model state may still exist internally for auth and LLM choice, but it must not pull the user out of Run mode by accident.
-- `/modes` is the product mode switch. It exposes Build, Plan, and Run without adding `/build` or `/plan` commands.
+- `/modes` is the product mode switch. It exposes Plan, Build, and Run without adding `/build` or `/plan` commands.
 - Build and Plan rely on native OpenCode behavior plus fork-specific Agent Swarm instructions. Run is the Agency Swarm server-backed mode.
 - Bug-like changes are not product features. Compare them against upstream, find the root cause, reduce divergence, and avoid fork-only workarounds.
 - Install, launcher, and package behavior count as user experience and belong in this file when they are intentional fork behavior.
@@ -31,8 +31,8 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 - Connection, auth, mode, and provider dialogs: `packages/opencode/src/cli/cmd/tui/app.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx`, `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`, `packages/opencode/src/cli/cmd/tui/session-error.ts`.
 - Run-mode routing, add-ons, models, and attachments: `packages/opencode/src/agency-swarm/adapter.ts`, `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx`, `packages/opencode/src/cli/cmd/tui/context/local.tsx`, `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`.
 - Run-mode local models: `packages/opencode/src/agency-swarm/ollama.ts`, `packages/opencode/src/agency-swarm/litellm-provider.ts`, `packages/opencode/src/agency-swarm/client-config.ts`, `packages/opencode/src/provider/provider.ts`, `packages/opencode/src/cli/cmd/tui/component/download-ollama-model.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx`, `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`, `packages/opencode/src/cli/cmd/tui/session-error.ts`.
-- Builder and Plan preservation: `packages/opencode/src/session/agent-builder.ts`, `packages/opencode/src/session/agent-planner.ts`, `packages/opencode/src/session/prompt/agent-builder.txt`, `packages/opencode/src/session/prompt/agent-planner.txt`.
-- History, handoff, compaction, and message metadata: `packages/opencode/src/session/agency-swarm-utils.ts`, `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/session/message-v2.ts`, `packages/opencode/src/session/compaction.ts`, `packages/opencode/src/agency-swarm/history.ts`.
+- Build and Plan instruction preservation: `packages/opencode/src/session/agent-builder.ts`, `packages/opencode/src/session/agent-planner.ts`, `packages/opencode/src/session/prompt/agent-builder.txt`, `packages/opencode/src/session/prompt/agent-planner.txt`.
+- History, handoff, compaction, and message metadata: `packages/opencode/src/session/agency-swarm-utils.ts`, `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/session/message-v2.ts`, `packages/opencode/src/session/compaction.ts`, `packages/opencode/src/session/prompt.ts`, `packages/opencode/src/agency-swarm/history.ts`.
 - Sharing, PR reopen, and backend management: `packages/opencode/src/share/share-next.ts`, `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`, `packages/opencode/src/cli/cmd/pr.ts`, `packages/opencode/src/cli/cmd/agency.ts`, `README.md`.
 - Telemetry: `packages/opencode/src/telemetry/telemetry.ts`, docs-click telemetry hooks, integration request hooks, telemetry tests, README telemetry copy, and event-list docs.
 - Branding, config, upgrade, and visual surfaces: `packages/opencode/src/agency-swarm/product.ts`, `packages/opencode/src/cli/logo.ts`, `packages/opencode/src/cli/ui.ts`, `packages/opencode/src/cli/network.ts`, `packages/opencode/src/server/mdns.ts`, `packages/opencode/src/cli/cmd/uninstall.ts`, `packages/opencode/src/cli/cmd/tui/component/logo.tsx`, `packages/opencode/src/cli/cmd/tui/context/theme.tsx`, `packages/opencode/src/config/paths.ts`, `packages/opencode/src/config/config.ts`, `packages/opencode/src/cli/cmd/tui/config/tui.ts`, `packages/opencode/src/installation/index.ts`, `packages/opencode/src/cli/cmd/upgrade.ts`.
@@ -217,23 +217,30 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Implementation: `AgencyCommand` in `packages/opencode/src/cli/cmd/agency.ts`.
   - Added by: `14abd070`
 
-- **Agent Builder instructions are retuned for Agency Swarm repos**
-  - Intent: keep Builder behavior aligned with the fork when those flows are used again.
-  - Behavior: the Builder prompt uses fork-specific Agency Swarm instructions rather than upstream OpenCode defaults.
+- **Build instructions are retuned for Agency Swarm repos**
+  - Intent: keep Build behavior aligned with the fork while preserving native OpenCode Build behavior.
+  - Behavior: the Build prompt keeps the native OpenCode system prompt and adds fork-specific Agency Swarm instructions, including reuse and repair of an existing `.venv` or `venv` for testing.
   - Implementation: `agentBuilderInstructions` in `packages/opencode/src/session/agent-builder.ts` with `packages/opencode/src/session/prompt/agent-builder.txt`.
   - Added by: `d93fd0f4`
 
 - **Plan instructions are retuned for Agency Swarm handoffs**
-  - Intent: keep Plan behavior aligned with the fork when those flows are used again.
-  - Behavior: the Plan prompt writes Agency Swarm handoff plans instead of upstream OpenCode plans.
+  - Intent: keep Plan behavior aligned with the fork while preserving native OpenCode Plan behavior.
+  - Behavior: the Plan prompt keeps the native OpenCode system prompt and adds fork-specific Agency Swarm handoff instructions.
   - Implementation: `agentPlannerInstructions` in `packages/opencode/src/session/agent-planner.ts` with `packages/opencode/src/session/prompt/agent-planner.txt`.
   - Added by: `7643fcde`
 
-- **`/modes` exposes Build, Plan, and Run**
+- **`/modes` exposes Plan, Build, and Run**
   - Intent: let users move between native Build, native Plan, and server-backed Run inside one project without adding parallel Build or Plan behavior.
-  - Behavior: `/modes` switches product mode. Build selects the native `build` agent, Plan selects the native `plan` agent, and Run keeps prompts server-backed through Agency Swarm. `/build` and `/plan` are not slash commands.
-  - Behavior: leaving Run stops prompt routing through the Agency Swarm backend; returning to Run reconnects to or keeps using the configured Agency Swarm server.
-  - Implementation: product mode state in `packages/opencode/src/cli/cmd/tui/context/local.tsx`, `DialogMode` in `packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx`, and framework-mode gates in `packages/opencode/src/cli/cmd/tui/session-error.ts`.
+  - Behavior: `/modes` switches product mode and lists choices in work order: Plan, Build, Run. Build selects the native `build` agent, Plan selects the native `plan` agent, and Run keeps prompts server-backed through Agency Swarm. `/build` and `/plan` are not slash commands.
+  - Behavior: leaving Run stops prompt routing through the Agency Swarm backend but preserves the saved Run target for the session; returning to Run reconnects to or keeps using the configured Agency Swarm server.
+  - Behavior: Build and Plan prompts, commands, shell turns, and compaction turns persist native routing metadata so reopened sessions do not silently fall back to Run.
+  - Behavior: compaction created in Build or Plan keeps native routing metadata so `/compact`, auto-compaction, and direct continuation do not switch the session back to server-backed Run.
+  - Behavior: Plan mode submits through the native `plan` agent while Plan is selected; choosing another local agent moves the turn back to native Build behavior instead of silently submitting to a different agent than the UI shows.
+  - Behavior: when Plan finishes and the user approves the native handoff question, the TUI switches to Build using the upstream Plan approval path.
+  - Behavior: the Plan approval question owns keyboard input while visible, so base session shortcuts do not fire during the question.
+  - Behavior: mixed-mode histories keep completed turn labels tied to the mode that handled each turn, including older Run turns without stored mode metadata.
+  - Behavior: message actions use the selected turn's stored or legacy-inferred Run/native routing metadata, so mode switching does not hide or expose Revert for the wrong turn.
+  - Implementation: product mode state in `packages/opencode/src/cli/cmd/tui/context/local.tsx`, `DialogMode` in `packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx`, framework-mode gates in `packages/opencode/src/cli/cmd/tui/session-error.ts`, native routing metadata in `packages/opencode/src/session/prompt.ts` and `packages/opencode/src/session/compaction.ts`, selected-turn message actions in `packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx`, and upstream-aligned question keymap isolation in `packages/opencode/src/cli/cmd/tui/keymap.tsx` and `packages/opencode/src/cli/cmd/tui/routes/session/question.tsx`.
   - Added by: `d6b9ed38`
 
 - **Tab switches native agents outside Run and swarm agents in Run**
@@ -250,7 +257,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 
 - **Configured `agency-swarm/default` beats stale stored model state in Run mode**
   - Intent: stop stale remembered provider/model state from pulling a Run mode session out of Agent Swarm behavior by accident.
-  - Behavior: `agency-swarm/default` stays active in Run mode until the user explicitly chooses another LLM model.
+  - Behavior: `agency-swarm/default` stays active in Run mode until the user explicitly chooses another LLM model, and explicit `agency-swarm/...` launch arguments infer Run mode before provider metadata is loaded.
   - Implementation: model selection logic in `packages/opencode/src/cli/cmd/tui/context/local.tsx`.
   - Added by: `PR #51`
 

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -234,6 +234,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Behavior: `/modes` switches product mode and lists choices in work order: Plan, Build, Run. Build selects the native `build` agent, Plan selects the native `plan` agent, and Run keeps prompts server-backed through Agency Swarm. `/build` and `/plan` are not slash commands.
   - Behavior: leaving Run stops prompt routing through the Agency Swarm backend but preserves the saved Run target for the session; returning to Run reconnects to or keeps using the configured Agency Swarm server.
   - Behavior: Build and Plan prompts, commands, shell turns, and compaction turns persist native routing metadata so reopened sessions do not silently fall back to Run.
+  - Behavior: reopened Plan sessions keep Plan selected in `/agents` instead of using a stale Build default.
   - Behavior: compaction created in Build or Plan keeps native routing metadata so `/compact`, auto-compaction, and direct continuation do not switch the session back to server-backed Run.
   - Behavior: Plan mode submits through the native `plan` agent while Plan is selected; choosing another local agent moves the turn back to native Build behavior instead of silently submitting to a different agent than the UI shows.
   - Behavior: when Plan finishes and the user approves the native handoff question, the TUI switches to Build using the upstream Plan approval path.

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -13,7 +13,8 @@ When a change is suspicious, unproven, not clearly fork-specific, or not clearly
 - `/auth` is the credentials flow, not a product mode switch.
 - `/models` chooses the LLM config passed to Agency Swarm, not a product mode switch.
 - Upstream OpenCode provider/model state may still exist internally for auth and LLM choice, but it must not pull the user out of Run mode by accident.
-- Agent Builder and Plan still exist conceptually, but they are currently hidden or disabled in Run mode and continue to rely on the native OpenCode backbone plus fork-specific instructions.
+- `/modes` is the product mode switch. It exposes Build, Plan, and Run without adding `/build` or `/plan` commands.
+- Build and Plan rely on native OpenCode behavior plus fork-specific Agent Swarm instructions. Run is the Agency Swarm server-backed mode.
 - Bug-like changes are not product features. Compare them against upstream, find the root cause, reduce divergence, and avoid fork-only workarounds.
 - Install, launcher, and package behavior count as user experience and belong in this file when they are intentional fork behavior.
 - `USER_FLOWS.md` is the single source of truth for full QA before every release; implementation-level file paths and symbols stay in this changelog.
@@ -27,7 +28,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 - Downstream product profile: `packages/opencode/src/agency-swarm/product.ts`, `packages/opencode/src/agency-swarm/npx.ts`, `packages/opencode/src/cli/cmd/tui/util/env-file.ts`, `packages/opencode/src/agency-swarm/server-launcher.ts`, `packages/opencode/src/installation/distribution.ts`, `packages/opencode/script/build.ts`.
 - Local project setup, starter creation, and onboarding auto-launch: `packages/opencode/src/agency-swarm/npx.ts`, `packages/opencode/src/cli/cmd/tui/thread.ts`, `packages/opencode/src/cli/cmd/tui/app.tsx`, `packages/opencode/src/cli/cmd/tui/routes/home.tsx`.
 - Agency session resume and bridge recovery: `packages/opencode/src/agency-swarm/run-session.ts`, `packages/opencode/src/agency-swarm/npx.ts`, `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/cli/cmd/tui/session-error.ts`, `packages/opencode/src/cli/cmd/tui/context/agency-swarm-connection.tsx`.
-- Connection, auth, and provider dialogs: `packages/opencode/src/cli/cmd/tui/app.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx`, `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`, `packages/opencode/src/cli/cmd/tui/session-error.ts`.
+- Connection, auth, mode, and provider dialogs: `packages/opencode/src/cli/cmd/tui/app.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx`, `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`, `packages/opencode/src/cli/cmd/tui/session-error.ts`.
 - Run-mode routing, add-ons, models, and attachments: `packages/opencode/src/agency-swarm/adapter.ts`, `packages/opencode/src/session/agency-swarm.ts`, `packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx`, `packages/opencode/src/cli/cmd/tui/context/local.tsx`, `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`.
 - Run-mode local models: `packages/opencode/src/agency-swarm/ollama.ts`, `packages/opencode/src/agency-swarm/litellm-provider.ts`, `packages/opencode/src/agency-swarm/client-config.ts`, `packages/opencode/src/provider/provider.ts`, `packages/opencode/src/cli/cmd/tui/component/download-ollama-model.tsx`, `packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx`, `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`, `packages/opencode/src/cli/cmd/tui/session-error.ts`.
 - Builder and Plan preservation: `packages/opencode/src/session/agent-builder.ts`, `packages/opencode/src/session/agent-planner.ts`, `packages/opencode/src/session/prompt/agent-builder.txt`, `packages/opencode/src/session/prompt/agent-planner.txt`.
@@ -212,7 +213,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 
 - **Agency backend management commands are debugging and development tools**
   - Intent: keep backend lifecycle commands available for debugging and development without treating them as the main end-user path.
-  - Behavior: the fork exposes backend install and maintenance commands, but they are debugging and development tools rather than core product surface.
+  - Behavior: the fork exposes backend install and maintenance commands, but they are debugging and development tools rather than core product surface. `agentswarm agency agent new` remains hidden from help instead of being expanded as an Agent Builder path.
   - Implementation: `AgencyCommand` in `packages/opencode/src/cli/cmd/agency.ts`.
   - Added by: `14abd070`
 
@@ -228,15 +229,16 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Implementation: `agentPlannerInstructions` in `packages/opencode/src/session/agent-planner.ts` with `packages/opencode/src/session/prompt/agent-planner.txt`.
   - Added by: `7643fcde`
 
-- **Builder and Plan switching are hidden in Run mode**
-  - Intent: keep Run mode focused on connected Agency Swarm execution while Builder and Plan stay conceptually preserved but currently hidden.
-  - Behavior: in Run mode, the picker becomes a run-target picker instead of a Builder or Plan mode switcher.
-  - Implementation: `frameworkMode` and `cycleAgencyRunTarget` in `packages/opencode/src/cli/cmd/tui/app.tsx` plus `DialogAgent` in `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`.
+- **`/modes` exposes Build, Plan, and Run**
+  - Intent: let users move between native Build, native Plan, and server-backed Run inside one project without adding parallel Build or Plan behavior.
+  - Behavior: `/modes` switches product mode. Build selects the native `build` agent, Plan selects the native `plan` agent, and Run keeps prompts server-backed through Agency Swarm. `/build` and `/plan` are not slash commands.
+  - Behavior: leaving Run stops prompt routing through the Agency Swarm backend; returning to Run reconnects to or keeps using the configured Agency Swarm server.
+  - Implementation: product mode state in `packages/opencode/src/cli/cmd/tui/context/local.tsx`, `DialogMode` in `packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx`, and framework-mode gates in `packages/opencode/src/cli/cmd/tui/session-error.ts`.
   - Added by: `d6b9ed38`
 
-- **Tab switches agents in Run mode**
-  - Intent: speed up agent switching during run sessions.
-  - Behavior: pressing Tab in Run mode cycles through available agents.
+- **Tab switches native agents outside Run and swarm agents in Run**
+  - Intent: preserve upstream native agent cycling while keeping fast target switching during run sessions.
+  - Behavior: pressing Tab in Run mode cycles through available Agency Swarm targets. In Build and Plan, Tab keeps the native OpenCode local-agent cycle behavior.
   - Implementation: `cycleAgencyRunTarget` in `packages/opencode/src/cli/cmd/tui/app.tsx` and `cycleAgencyTargetSelection` in `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`.
   - Added by: `d6b9ed38`
 
@@ -258,8 +260,8 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Implementation: Agent Swarm metadata parsing in `packages/opencode/src/agency-swarm/adapter.ts`, label resolution in `packages/opencode/src/cli/cmd/tui/util/model-label.ts`, and TUI/transcript display call sites.
 
 - **Run mode hides native OpenCode menus and limits model selection**
-  - Intent: keep Run mode on the connected Agency Swarm surface while preserving native OpenCode menus for Builder and Plan when those modes are available again.
-  - Behavior: Run mode hides native `/editor`, `/variants`, `/init`, and `/review`; model-selection and provider-auth surfaces remain as support flows for LLM choice and credentials, and are limited to intended Agent Swarm / Agency Swarm providers.
+  - Intent: keep Run mode on the connected Agency Swarm surface while preserving native OpenCode menus for Build and Plan.
+  - Behavior: Run mode hides native `/editor`, `/variants`, `/init`, and `/review`; those commands return in Build and Plan. Model-selection and provider-auth surfaces remain as Run support flows for LLM choice and credentials, and are limited to intended Agent Swarm / Agency Swarm providers.
   - Implementation: framework-mode command gating in `packages/opencode/src/cli/cmd/tui/app.tsx`, `packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx`, `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`, and `packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx`.
   - Added by: `PR #81`
 
@@ -338,8 +340,8 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 
 - **README mode overview explains Builder, Plan, and Run**
   - Intent: document the fork's mode model clearly at the top level.
-  - Behavior: the README explains Agent Builder, Plan, and Run, with Run as the connected Agency Swarm path and Builder or Plan preserved conceptually even if hidden in current Run mode.
-  - Implementation: the `### Agents` section in `README.md`.
+  - Behavior: the README explains `/modes`, Build, Plan, and Run, with Run as the connected Agency Swarm path and Build or Plan as native OpenCode modes under the Agent Swarm umbrella.
+  - Implementation: the `Main TUI Flows` section in `README.md`.
   - Added by: `1df2f455`
 
 - **Canonical flow map and QA source of truth**

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -213,7 +213,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 
 - **Agency backend management commands are debugging and development tools**
   - Intent: keep backend lifecycle commands available for debugging and development without treating them as the main end-user path.
-  - Behavior: the fork exposes backend install and maintenance commands, but they are debugging and development tools rather than core product surface. `agentswarm agency agent new` remains hidden from help instead of being expanded as an Agent Builder path.
+  - Behavior: the fork exposes backend install and maintenance commands, but they are debugging and development tools rather than core product surface.
   - Implementation: `AgencyCommand` in `packages/opencode/src/cli/cmd/agency.ts`.
   - Added by: `14abd070`
 
@@ -338,7 +338,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 
 ## Web/App Surface
 
-- **README mode overview explains Builder, Plan, and Run**
+- **README mode overview explains Build, Plan, and Run**
   - Intent: document the fork's mode model clearly at the top level.
   - Behavior: the README explains `/modes`, Build, Plan, and Run, with Run as the connected Agency Swarm path and Build or Plan as native OpenCode modes under the Agent Swarm umbrella.
   - Implementation: the `Main TUI Flows` section in `README.md`.

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -237,7 +237,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Behavior: reopened Plan sessions keep Plan selected in `/agents` instead of using a stale Build default.
   - Behavior: compaction created in Build or Plan keeps native routing metadata so `/compact`, auto-compaction, and direct continuation do not switch the session back to server-backed Run.
   - Behavior: Plan mode submits through the native `plan` agent while Plan is selected; choosing another local agent moves the turn back to native Build behavior instead of silently submitting to a different agent than the UI shows.
-  - Behavior: when Plan finishes and the user approves the native handoff question, the TUI switches to Build using the upstream Plan approval path.
+  - Behavior: when Plan finishes and the user approves the native handoff question, the TUI switches to Build using the upstream OpenCode Plan approval path.
   - Behavior: the Plan approval question owns keyboard input while visible, so base session shortcuts do not fire during the question.
   - Behavior: mixed-mode histories keep completed turn labels tied to the mode that handled each turn, including older Run turns without stored mode metadata.
   - Behavior: message actions use the selected turn's stored or legacy-inferred Run/native routing metadata, so mode switching does not hide or expose Revert for the wrong turn.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Agent Swarm CLI is a terminal app for running and testing Agency Swarm projects.
 It is built on the OpenCode codebase, with Agent Swarm-specific packaging, branding, auth, and TUI flows.
 
-The main user path is **Run mode**: start the TUI from an Agency Swarm project, authenticate a model provider, connect to the local Agency Swarm server, and send prompts to your agency.
+The main user path is **Run mode**: start the TUI from an Agency Swarm project, authenticate a model provider, connect to the local Agency Swarm server, and send prompts to your swarm.
 
 ## Install
 
@@ -36,12 +36,14 @@ On startup, the CLI can detect the project, prepare the project Python environme
 
 ## Main TUI Flows
 
+- `/modes` switches between Build, Plan, and Run.
+- Build is Agent Builder: native OpenCode build behavior with Agent Swarm guidance.
+- Plan is native OpenCode Plan mode for preparing work before Build.
+- Run connects to or starts an Agency Swarm FastAPI server and sends prompts to the active swarm.
 - `/auth` manages OpenAI and Anthropic credentials used by Agency Swarm runs.
 - `/connect` chooses a local or external Agency Swarm server.
-- `/agents` switches the active swarm or agent from live Agency Swarm metadata.
+- `/agents` switches native agents in Build and Plan. In Run, it switches the active swarm or agent from live Agency Swarm metadata.
 - `/models` is limited in Run mode to providers that the Agency Swarm path supports.
-
-Agent Builder and Plan are preserved from the OpenCode backbone, but they are currently hidden from the normal Run mode surface.
 
 ## Sharing
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ On startup, the CLI can detect the project, prepare the project Python environme
 ## Main TUI Flows
 
 - `/modes` switches between Build, Plan, and Run.
-- Build is Agent Builder: native OpenCode build behavior with Agent Swarm guidance.
+- Build uses native OpenCode build behavior with Agent Swarm guidance.
 - Plan is native OpenCode Plan mode for preparing work before Build.
 - Run connects to or starts an Agency Swarm FastAPI server and sends prompts to the active swarm.
 - `/auth` manages OpenAI and Anthropic credentials used by Agency Swarm runs.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ On startup, the CLI can detect the project, prepare the project Python environme
 
 ## Main TUI Flows
 
-- `/modes` switches between Build, Plan, and Run.
+- `/modes` switches between Plan, Build, and Run.
 - Build uses native OpenCode build behavior with Agent Swarm guidance.
 - Plan is native OpenCode Plan mode for preparing work before Build.
 - Run connects to or starts an Agency Swarm FastAPI server and sends prompts to the active swarm.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -12,7 +12,7 @@ Keep implementation-level file paths and symbol details in `FORK_CHANGELOG.md`; 
 - Launcher and install behavior for `npx @vrsen/agentswarm`, installed `agentswarm`, the direct fork binary, and `agentswarm pr`.
 - Downstream package builds that reuse this TUI foundation through generic product profile inputs.
 - Local Agency Swarm project detection, starter creation, Python environment repair, uv setup, bridge startup, resume recovery, and external Agency server connection.
-- TUI Run mode routing, `/auth`, `/connect`, run-target selection, attachments, history, handoffs, dead-server recovery, and hidden upstream-native commands.
+- TUI `/modes`, native Build and Plan exposure, Run mode routing, `/auth`, `/connect`, run-target selection, attachments, history, handoffs, dead-server recovery, and hidden upstream-native commands in Run.
 - Fork branding, tips, theme, config precedence, upgrade channel limits, share carry-forward, and developer/debug `agentswarm agency` commands.
 - Trust-safe telemetry metrics, event-list docs, derived dashboard metrics, opt-out behavior, and privacy proof for fork-owned Agent Swarm flows.
 - Out of scope: Python-side `agency.tui()` invocation before control reaches this repo.
@@ -183,6 +183,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** In-flight Agency runs cancel through the bridge.
 - **Happy-path proof:** Codex OAuth is stripped from non-OpenAI LiteLLM agency runs.
 - **Happy-path proof:** Run mode hides Builder, Plan, `/editor`, `/variants`, `/init`, `/review`, and other disabled upstream-native surfaces.
+- **Happy-path proof:** `/modes` remains available in Run so the user can switch to Build or Plan without leaving the project.
 - **Happy-path proof:** `/models` and `/auth` are limited to Agency-supported providers.
 - **Happy-path proof:** Upstream provider/model state used for auth or LLM choice does not pull the user out of Run mode by accident.
 - **Happy-path proof:** `agency-swarm/default` stays active over stale stored model state until the user explicitly chooses another model.
@@ -195,13 +196,20 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Failure scenarios to test:** Non-OpenAI LiteLLM agency runs do not receive Codex OAuth credentials while OpenAI-based LiteLLM runs still keep them.
 - **Failure scenarios to test:** Missing or unreachable Ollama fails visibly without switching out of Run mode.
 
-#### Builder and Plan instruction preservation
+#### `/modes`, Build, and Plan
 
-- **Trigger:** Builder or Plan flows are exercised outside Run-mode hiding.
-- **Happy-path proof:** Builder still uses fork-specific Agency Swarm repo instructions.
-- **Happy-path proof:** Plan still writes Agency Swarm handoff plans instead of upstream OpenCode defaults.
-- **Failure scenarios to test:** Run mode keeps Builder and Plan switching hidden.
-- **Failure scenarios to test:** Any re-enabled Builder or Plan path keeps the fork-specific prompt instructions.
+- **Trigger:** The user runs `/modes` and chooses Build, Plan, or Run.
+- **Happy-path proof:** `/modes` is the product mode switch; `/build` and `/plan` slash commands do not exist.
+- **Happy-path proof:** Build uses native OpenCode build behavior with fork-specific Agent Swarm repo instructions and works without an Agency Swarm server.
+- **Happy-path proof:** Plan uses native OpenCode Plan mode with fork-specific Agent Swarm handoff instructions and works without an Agency Swarm server.
+- **Happy-path proof:** Build and Plan prompts use native local agent state, not the Agency Swarm backend target state.
+- **Happy-path proof:** Native OpenCode commands hidden in Run return in Build and Plan.
+- **Happy-path proof:** `/agents` uses the native OpenCode agent picker in Build and Plan.
+- **Happy-path proof:** Tab cycles native local agents in Build and Plan.
+- **Happy-path proof:** Switching from Run to Build or Plan stops treating prompts as server-backed Run prompts.
+- **Happy-path proof:** Switching back to Run in the same project reconnects to or keeps using the Agency Swarm server and returns `/agents` to the swarm/agent picker.
+- **Failure scenarios to test:** Server failure in Run still lets the user switch to Build or Plan in the same project, make a plan or build a fix, then return to Run.
+- **Failure scenarios to test:** Run mode stays server-backed even when visible provider/model state is native.
 
 #### Attachments, history, and handoff
 
@@ -243,9 +251,8 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** `connect` stores normalized backend config and optional bearer token.
 - **Happy-path proof:** `agencies` discovers available agencies.
 - **Happy-path proof:** `use` pins a default agency id.
-- **Happy-path proof:** `agent` provides Agent Builder scaffold helpers.
+- **Happy-path proof:** `agent` scaffold helpers are not promoted in CLI help.
 - **Failure scenarios to test:** URL normalization and discovery failures surface in the CLI command.
-- **Failure scenarios to test:** `agentswarm agency agent new` fails visibly when `agency-swarm create-agent-template` fails.
 
 ### Trust-Safe Telemetry
 

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -182,9 +182,10 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** Missing selected Ollama models offer an Ollama download flow, and a dismissed download cannot later close a newer dialog.
 - **Happy-path proof:** In-flight Agency runs cancel through the bridge.
 - **Happy-path proof:** Codex OAuth is stripped from non-OpenAI LiteLLM agency runs.
-- **Happy-path proof:** Run mode hides Builder, Plan, `/editor`, `/variants`, `/init`, `/review`, and other disabled upstream-native surfaces.
+- **Happy-path proof:** Run mode hides Build, Plan, `/editor`, `/variants`, `/init`, `/review`, and other disabled upstream-native surfaces.
 - **Happy-path proof:** `/modes` remains available in Run so the user can switch to Build or Plan without leaving the project.
 - **Happy-path proof:** `/models` and `/auth` are limited to Agency-supported providers.
+- **Happy-path proof:** Starting with explicit `agency-swarm/...` model args stays in Run mode even before provider metadata is loaded.
 - **Happy-path proof:** Upstream provider/model state used for auth or LLM choice does not pull the user out of Run mode by accident.
 - **Happy-path proof:** `agency-swarm/default` stays active over stale stored model state until the user explicitly chooses another model.
 - **Happy-path proof:** Footer/status labels and completed run rows show actual Agent Swarm model labels when agency metadata exposes them, without changing the internal `agency-swarm/default` route.
@@ -198,16 +199,26 @@ For each failure scenario, capture the visible user result and cite the matching
 
 #### `/modes`, Build, and Plan
 
-- **Trigger:** The user runs `/modes` and chooses Build, Plan, or Run.
+- **Trigger:** The user runs `/modes` and chooses Plan, Build, or Run.
 - **Happy-path proof:** `/modes` is the product mode switch; `/build` and `/plan` slash commands do not exist.
-- **Happy-path proof:** Build uses native OpenCode build behavior with fork-specific Agent Swarm repo instructions and works without an Agency Swarm server.
-- **Happy-path proof:** Plan uses native OpenCode Plan mode with fork-specific Agent Swarm handoff instructions and works without an Agency Swarm server.
+- **Happy-path proof:** `/modes` lists the modes in work order: Plan, Build, Run.
+- **Happy-path proof:** Build uses native OpenCode Build behavior with added Agent Swarm Build instructions and works without an Agency Swarm server.
+- **Happy-path proof:** Plan uses native OpenCode Plan mode with added Agent Swarm Planner instructions and works without an Agency Swarm server.
+- **Happy-path proof:** The Build and Plan instruction payloads still include the native OpenCode system prompt, then add the Agent Swarm-specific guidance.
 - **Happy-path proof:** Build and Plan prompts use native local agent state, not the Agency Swarm backend target state.
+- **Happy-path proof:** Mixed sessions keep each completed turn's own mode label, including older Run turns saved before mode metadata existed.
 - **Happy-path proof:** Native OpenCode commands hidden in Run return in Build and Plan.
 - **Happy-path proof:** `/agents` uses the native OpenCode agent picker in Build and Plan.
 - **Happy-path proof:** Tab cycles native local agents in Build and Plan.
+- **Happy-path proof:** Plan mode submits the native Plan agent while Plan is selected; choosing another local agent moves the turn back to native Build behavior instead of silently ignoring the selected agent.
 - **Happy-path proof:** Switching from Run to Build or Plan stops treating prompts as server-backed Run prompts.
+- **Happy-path proof:** Sending a Build or Plan prompt after leaving Run does not erase the saved Run target for the session.
+- **Happy-path proof:** Shell commands in Build and Plan preserve native mode when the session is reopened.
+- **Happy-path proof:** In Build and Plan, `/compact` and auto-compaction keep prompts native and do not switch the session back to server-backed Run routing.
+- **Happy-path proof:** When Plan finishes and asks whether to switch to Build, pressing Enter on `Yes` switches the TUI to Build and creates the native approved-plan handoff turn.
+- **Happy-path proof:** The Plan approval question owns keyboard input while it is open, so session shortcuts do not fire at the same time.
 - **Happy-path proof:** Switching back to Run in the same project reconnects to or keeps using the Agency Swarm server and returns `/agents` to the swarm/agent picker.
+- **Happy-path proof:** Message actions use the selected turn's saved or legacy-inferred Run/native routing metadata, so Revert is shown or hidden for the selected turn even after switching modes.
 - **Failure scenarios to test:** Server failure in Run still lets the user switch to Build or Plan in the same project, make a plan or build a fix, then return to Run.
 - **Failure scenarios to test:** Run mode stays server-backed even when visible provider/model state is native.
 
@@ -251,9 +262,9 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** `connect` stores normalized backend config and optional bearer token.
 - **Happy-path proof:** `agencies` discovers available agencies.
 - **Happy-path proof:** `use` pins a default agency id.
-- **Happy-path proof:** `agent` provides Agent Builder scaffold helpers.
+- **Happy-path proof:** `agent new` is not promoted in help output because the non-natural-language scaffold helper is not the Build-mode user flow.
 - **Failure scenarios to test:** URL normalization and discovery failures surface in the CLI command.
-- **Failure scenarios to test:** `agentswarm agency agent new` fails visibly when `agency-swarm create-agent-template` fails.
+- **Failure scenarios to test:** Direct `agentswarm agency agent new` use, if invoked anyway, fails visibly when `agency-swarm create-agent-template` fails.
 
 ### Trust-Safe Telemetry
 

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -209,6 +209,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** Mixed sessions keep each completed turn's own mode label, including older Run turns saved before mode metadata existed.
 - **Happy-path proof:** Native OpenCode commands hidden in Run return in Build and Plan.
 - **Happy-path proof:** `/agents` uses the native OpenCode agent picker in Build and Plan.
+- **Happy-path proof:** Reopened Plan sessions keep Plan selected in `/agents` instead of defaulting back to Build.
 - **Happy-path proof:** Tab cycles native local agents in Build and Plan.
 - **Happy-path proof:** Plan mode submits the native Plan agent while Plan is selected; choosing another local agent moves the turn back to native Build behavior instead of silently ignoring the selected agent.
 - **Happy-path proof:** Switching from Run to Build or Plan stops treating prompts as server-backed Run prompts.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -251,8 +251,9 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** `connect` stores normalized backend config and optional bearer token.
 - **Happy-path proof:** `agencies` discovers available agencies.
 - **Happy-path proof:** `use` pins a default agency id.
-- **Happy-path proof:** `agent` scaffold helpers are not promoted in CLI help.
+- **Happy-path proof:** `agent` provides Agent Builder scaffold helpers.
 - **Failure scenarios to test:** URL normalization and discovery failures surface in the CLI command.
+- **Failure scenarios to test:** `agentswarm agency agent new` fails visibly when `agency-swarm create-agent-template` fails.
 
 ### Trust-Safe Telemetry
 

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -216,7 +216,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** Sending a Build or Plan prompt after leaving Run does not erase the saved Run target for the session.
 - **Happy-path proof:** Shell commands in Build and Plan preserve native mode when the session is reopened.
 - **Happy-path proof:** In Build and Plan, `/compact` and auto-compaction keep prompts native and do not switch the session back to server-backed Run routing.
-- **Happy-path proof:** When Plan finishes and asks whether to switch to Build, pressing Enter on `Yes` switches the TUI to Build and creates the native approved-plan handoff turn.
+- **Happy-path proof:** When Plan finishes and asks whether to switch to Build, pressing Enter on `Yes` follows the upstream OpenCode Plan approval flow, switches the TUI to Build, and creates the native approved-plan handoff turn.
 - **Happy-path proof:** The Plan approval question owns keyboard input while it is open, so session shortcuts do not fire at the same time.
 - **Happy-path proof:** Switching back to Run in the same project reconnects to or keeps using the Agency Swarm server and returns `/agents` to the swarm/agent picker.
 - **Happy-path proof:** Message actions use the selected turn's saved or legacy-inferred Run/native routing metadata, so Revert is shown or hidden for the selected turn even after switching modes.

--- a/bun.lock
+++ b/bun.lock
@@ -3319,7 +3319,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#20bd361", {}, "anomalyco-ghostty-web-20bd361", "sha512-dW0nwaiBBcun9y5WJSvm3HxDLe5o9V0xLCndQvWonRVubU8CS1PHxZpLffyPt1YujPWC13ez03aWxcuKBPYYGQ=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#513463a", {}, "anomalyco-ghostty-web-513463a", "sha512-GZR8LSmgGzViWnBJrqRI8MpAZRCJxhcr1Hi9Tyeh7YRooHZQjK9J97FQRD3tbBaM2wjq05gzGY2UEsG+JtZeBw=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -7,7 +7,7 @@
 - `USER_FLOWS.md` Detected Local Project: launcher mode shows startup project-file checking, the detected-project choice before `.venv` work begins, unreadable `agency.py` recovery choices, and Agent Swarm connect copy.
 - `USER_FLOWS.md` Startup `/auth` and In-TUI `/connect`: `/auth` and `/connect` stay separate in the real terminal UI.
 - `USER_FLOWS.md` Run Mode: native `/editor`, `/variants`, `/init`, and `/review` slash commands stay hidden.
-- `USER_FLOWS.md` `/modes`, Build, and Plan: `/modes` appears as the product switch, `/build` and `/plan` do not exist, Build and Plan restore native `/review` and `/init`, and switching back to Run hides native commands again.
+- `USER_FLOWS.md` `/modes`, Build, and Plan: `/modes` appears as the product switch, `/build` and `/plan` do not exist, Build and Plan restore native `/review` and `/init`, native `/review` execution stays server-free, and switching back to Run hides native commands again.
 - `USER_FLOWS.md` `/modes`, Build, and Plan: Tab cycles native local agents outside Run and Agency Swarm targets in Run.
 - `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/subagent counts; `/agents` uses Swarm and agent wording, live agency labels, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
 - `USER_FLOWS.md` Run Mode: prompt submit reaches a local Agency Swarm protocol server with the configured agent.

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -7,6 +7,8 @@
 - `USER_FLOWS.md` Detected Local Project: launcher mode shows startup project-file checking, the detected-project choice before `.venv` work begins, unreadable `agency.py` recovery choices, and Agent Swarm connect copy.
 - `USER_FLOWS.md` Startup `/auth` and In-TUI `/connect`: `/auth` and `/connect` stay separate in the real terminal UI.
 - `USER_FLOWS.md` Run Mode: native `/editor`, `/variants`, `/init`, and `/review` slash commands stay hidden.
+- `USER_FLOWS.md` `/modes`, Build, and Plan: `/modes` appears as the product switch, `/build` and `/plan` do not exist, Build and Plan restore native `/review` and `/init`, and switching back to Run hides native commands again.
+- `USER_FLOWS.md` `/modes`, Build, and Plan: Tab cycles native local agents outside Run and Agency Swarm targets in Run.
 - `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/subagent counts; `/agents` uses Swarm and agent wording, live agency labels, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
 - `USER_FLOWS.md` Run Mode: prompt submit reaches a local Agency Swarm protocol server with the configured agent.
 - `USER_FLOWS.md` Run Mode: simulated visible OpenAI model state does not pull prompts, slash-command `/new`, run-session local-project marking, `/connect`, or runtime auth recovery out of Agency Swarm routing.

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -20,8 +20,8 @@ export const agencyClientConfigModel = "gpt-4o-mini"
 const tuiDemoEntryAgentModel = "gpt-5.4-mini"
 const tuiDemoMathAgentModel = "claude-sonnet-4-5"
 
-type TuiManagedConfig = Pick<Config.Info, "$schema" | "enabled_providers" | "model" | "provider">
-export type TuiConfigOverride = Pick<Config.Info, "enabled_providers" | "model" | "provider">
+type TuiManagedConfig = Pick<Config.Info, "$schema" | "enabled_providers" | "model" | "provider" | "agent">
+export type TuiConfigOverride = Pick<Config.Info, "enabled_providers" | "model" | "provider" | "agent">
 type ProviderConfigMap = NonNullable<TuiManagedConfig["provider"]>
 type ProviderConfig = ProviderConfigMap[string]
 
@@ -62,6 +62,7 @@ export type NativeLLMServer = {
     body: Record<string, unknown>
   }>
   planExitNext(): void
+  taskNext(prompt: string): void
   stop(): void
 }
 
@@ -69,6 +70,7 @@ export async function startNativeLLMServer(): Promise<NativeLLMServer> {
   const requests: NativeLLMServer["requests"] = []
   let planExitUsed = false
   let planExitNext = false
+  let taskPrompt: string | undefined
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
@@ -82,9 +84,86 @@ export async function startNativeLLMServer(): Promise<NativeLLMServer> {
       const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
       requests.push({ path: url.pathname, body })
       const bodyText = JSON.stringify(body)
-      const shouldPlanExit = !planExitUsed && planExitNext && !bodyText.includes("title generator")
+      const title = bodyText.includes("title generator") || bodyText.includes("Generate a title for this conversation")
+      const shouldPlanExit = !planExitUsed && planExitNext && !title
+      const shouldTask = taskPrompt !== undefined && !title
+      const taskArguments = taskPrompt
+        ? JSON.stringify({
+            description: "native task bridge routing",
+            prompt: taskPrompt,
+            subagent_type: "general",
+          })
+        : ""
 
       if (url.pathname === "/v1/responses") {
+        if (shouldTask) {
+          taskPrompt = undefined
+          return new Response(
+            eventStream([
+              {
+                type: "response.created",
+                sequence_number: 1,
+                response: {
+                  id: `resp_native_${requests.length}`,
+                  created_at: Math.floor(Date.now() / 1000),
+                  model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+                  service_tier: null,
+                },
+              },
+              {
+                type: "response.output_item.added",
+                sequence_number: 2,
+                output_index: 0,
+                item: {
+                  type: "function_call",
+                  id: "fc_task",
+                  call_id: "call_task",
+                  name: "task",
+                  arguments: "",
+                  status: "in_progress",
+                },
+              },
+              {
+                type: "response.function_call_arguments.done",
+                sequence_number: 3,
+                output_index: 0,
+                item_id: "fc_task",
+                arguments: taskArguments,
+              },
+              {
+                type: "response.output_item.done",
+                sequence_number: 4,
+                output_index: 0,
+                item: {
+                  type: "function_call",
+                  id: "fc_task",
+                  call_id: "call_task",
+                  name: "task",
+                  arguments: taskArguments,
+                  status: "completed",
+                },
+              },
+              {
+                type: "response.completed",
+                sequence_number: 5,
+                response: {
+                  incomplete_details: null,
+                  service_tier: null,
+                  usage: {
+                    input_tokens: 1,
+                    input_tokens_details: { cached_tokens: null },
+                    output_tokens: 1,
+                    output_tokens_details: { reasoning_tokens: null },
+                  },
+                },
+              },
+            ]),
+            {
+              headers: { "Content-Type": "text/event-stream" },
+            },
+          )
+        }
+
         if (shouldPlanExit) {
           planExitUsed = true
           planExitNext = false
@@ -192,6 +271,79 @@ export async function startNativeLLMServer(): Promise<NativeLLMServer> {
                   output_tokens_details: { reasoning_tokens: null },
                 },
               },
+            },
+          ]),
+          {
+            headers: { "Content-Type": "text/event-stream" },
+          },
+        )
+      }
+
+      if (shouldTask) {
+        taskPrompt = undefined
+        return new Response(
+          eventStream([
+            {
+              id: `chatcmpl_native_${requests.length}`,
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+              choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+            },
+            {
+              id: `chatcmpl_native_${requests.length}`,
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+              choices: [
+                {
+                  index: 0,
+                  delta: {
+                    tool_calls: [
+                      {
+                        index: 0,
+                        id: "call_task",
+                        type: "function",
+                        function: {
+                          name: "task",
+                          arguments: "",
+                        },
+                      },
+                    ],
+                  },
+                  finish_reason: null,
+                },
+              ],
+            },
+            {
+              id: `chatcmpl_native_${requests.length}`,
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+              choices: [
+                {
+                  index: 0,
+                  delta: {
+                    tool_calls: [
+                      {
+                        index: 0,
+                        function: {
+                          arguments: taskArguments,
+                        },
+                      },
+                    ],
+                  },
+                  finish_reason: null,
+                },
+              ],
+            },
+            {
+              id: `chatcmpl_native_${requests.length}`,
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+              choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+              usage: { prompt_tokens: 1, completion_tokens: 1 },
             },
           ]),
           {
@@ -311,6 +463,9 @@ export async function startNativeLLMServer(): Promise<NativeLLMServer> {
     requests,
     planExitNext() {
       planExitNext = true
+    },
+    taskNext(prompt: string) {
+      taskPrompt = prompt
     },
     stop() {
       server.stop(true)

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -20,8 +20,8 @@ export const agencyClientConfigModel = "gpt-4o-mini"
 const tuiDemoEntryAgentModel = "gpt-5.4-mini"
 const tuiDemoMathAgentModel = "claude-sonnet-4-5"
 
-type TuiManagedConfig = Pick<Config.Info, "$schema" | "enabled_providers" | "model" | "provider" | "agent">
-export type TuiConfigOverride = Pick<Config.Info, "enabled_providers" | "model" | "provider" | "agent">
+type TuiManagedConfig = Pick<Config.Info, "$schema" | "enabled_providers" | "model" | "provider">
+export type TuiConfigOverride = Pick<Config.Info, "enabled_providers" | "model" | "provider">
 type ProviderConfigMap = NonNullable<TuiManagedConfig["provider"]>
 type ProviderConfig = ProviderConfigMap[string]
 

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -55,6 +55,269 @@ function fixturesForScenario(scenario: AgencyServerScenario) {
   return [qaAgencyFixture]
 }
 
+export type NativeLLMServer = {
+  baseURL: string
+  requests: Array<{
+    path: string
+    body: Record<string, unknown>
+  }>
+  planExitNext(): void
+  stop(): void
+}
+
+export async function startNativeLLMServer(): Promise<NativeLLMServer> {
+  const requests: NativeLLMServer["requests"] = []
+  let planExitUsed = false
+  let planExitNext = false
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: async (request) => {
+      const url = new URL(request.url)
+      if (request.method !== "POST") return new Response("not found", { status: 404 })
+      if (url.pathname !== "/v1/responses" && url.pathname !== "/v1/chat/completions") {
+        return new Response("not found", { status: 404 })
+      }
+
+      const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+      requests.push({ path: url.pathname, body })
+      const bodyText = JSON.stringify(body)
+      const shouldPlanExit = !planExitUsed && planExitNext && !bodyText.includes("title generator")
+
+      if (url.pathname === "/v1/responses") {
+        if (shouldPlanExit) {
+          planExitUsed = true
+          planExitNext = false
+          return new Response(
+            eventStream([
+              {
+                type: "response.created",
+                sequence_number: 1,
+                response: {
+                  id: `resp_native_${requests.length}`,
+                  created_at: Math.floor(Date.now() / 1000),
+                  model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+                  service_tier: null,
+                },
+              },
+              {
+                type: "response.output_item.added",
+                sequence_number: 2,
+                output_index: 0,
+                item: {
+                  type: "function_call",
+                  id: "fc_plan_exit",
+                  call_id: "call_plan_exit",
+                  name: "plan_exit",
+                  arguments: "",
+                  status: "in_progress",
+                },
+              },
+              {
+                type: "response.function_call_arguments.done",
+                sequence_number: 3,
+                output_index: 0,
+                item_id: "fc_plan_exit",
+                arguments: "{}",
+              },
+              {
+                type: "response.output_item.done",
+                sequence_number: 4,
+                output_index: 0,
+                item: {
+                  type: "function_call",
+                  id: "fc_plan_exit",
+                  call_id: "call_plan_exit",
+                  name: "plan_exit",
+                  arguments: "{}",
+                  status: "completed",
+                },
+              },
+              {
+                type: "response.completed",
+                sequence_number: 5,
+                response: {
+                  incomplete_details: null,
+                  service_tier: null,
+                  usage: {
+                    input_tokens: 1,
+                    input_tokens_details: { cached_tokens: null },
+                    output_tokens: 1,
+                    output_tokens_details: { reasoning_tokens: null },
+                  },
+                },
+              },
+            ]),
+            {
+              headers: { "Content-Type": "text/event-stream" },
+            },
+          )
+        }
+
+        return new Response(
+          eventStream([
+            {
+              type: "response.created",
+              sequence_number: 1,
+              response: {
+                id: `resp_native_${requests.length}`,
+                created_at: Math.floor(Date.now() / 1000),
+                model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+                service_tier: null,
+              },
+            },
+            {
+              type: "response.output_item.added",
+              sequence_number: 2,
+              output_index: 0,
+              item: { type: "message", id: "msg_native" },
+            },
+            {
+              type: "response.output_text.delta",
+              sequence_number: 3,
+              item_id: "msg_native",
+              delta: "native-mode-ok",
+              logprobs: null,
+            },
+            {
+              type: "response.completed",
+              sequence_number: 4,
+              response: {
+                incomplete_details: null,
+                service_tier: null,
+                usage: {
+                  input_tokens: 1,
+                  input_tokens_details: { cached_tokens: null },
+                  output_tokens: 1,
+                  output_tokens_details: { reasoning_tokens: null },
+                },
+              },
+            },
+          ]),
+          {
+            headers: { "Content-Type": "text/event-stream" },
+          },
+        )
+      }
+
+      if (shouldPlanExit) {
+        planExitUsed = true
+        planExitNext = false
+        return new Response(
+          eventStream([
+            {
+              id: `chatcmpl_native_${requests.length}`,
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+              choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+            },
+            {
+              id: `chatcmpl_native_${requests.length}`,
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+              choices: [
+                {
+                  index: 0,
+                  delta: {
+                    tool_calls: [
+                      {
+                        index: 0,
+                        id: "call_plan_exit",
+                        type: "function",
+                        function: {
+                          name: "plan_exit",
+                          arguments: "",
+                        },
+                      },
+                    ],
+                  },
+                  finish_reason: null,
+                },
+              ],
+            },
+            {
+              id: `chatcmpl_native_${requests.length}`,
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+              choices: [
+                {
+                  index: 0,
+                  delta: {
+                    tool_calls: [
+                      {
+                        index: 0,
+                        function: {
+                          arguments: "{}",
+                        },
+                      },
+                    ],
+                  },
+                  finish_reason: null,
+                },
+              ],
+            },
+            {
+              id: `chatcmpl_native_${requests.length}`,
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+              choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+              usage: { prompt_tokens: 1, completion_tokens: 1 },
+            },
+          ]),
+          {
+            headers: { "Content-Type": "text/event-stream" },
+          },
+        )
+      }
+
+      return new Response(
+        eventStream([
+          {
+            id: `chatcmpl_native_${requests.length}`,
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+            choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+          },
+          {
+            id: `chatcmpl_native_${requests.length}`,
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+            choices: [{ index: 0, delta: { content: "native-mode-ok" }, finish_reason: null }],
+          },
+          {
+            id: `chatcmpl_native_${requests.length}`,
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: typeof body.model === "string" ? body.model : "gpt-5.4-mini",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1 },
+          },
+        ]),
+        {
+          headers: { "Content-Type": "text/event-stream" },
+        },
+      )
+    },
+  })
+
+  return {
+    baseURL: `http://${server.hostname}:${server.port}/v1`,
+    requests,
+    planExitNext() {
+      planExitNext = true
+    },
+    stop() {
+      server.stop(true)
+    },
+  }
+}
+
 export async function startAgencyProtocolServer(
   input: { scenario?: AgencyServerScenario } = {},
 ): Promise<AgencyProtocolServer> {
@@ -210,6 +473,7 @@ function mergeSingleProviderConfig(base: ProviderConfig | undefined, override: P
 
 export async function startTui(input: {
   args?: string[]
+  binaryPath?: string
   cwd?: string
   env?: Record<string, string | undefined>
   cols?: number
@@ -260,7 +524,7 @@ export async function startTui(input: {
     ...(configContent && input.configSource !== "file" ? { OPENCODE_CONFIG_CONTENT: configContent } : {}),
     ...(input.env ?? {}),
   })
-  let proc = spawnTuiProcess({ args, cwd: input.cwd, env, cols, rows })
+  let proc = spawnTuiProcess({ args, binaryPath: input.binaryPath, cwd: input.cwd, env, cols, rows })
 
   let dataReceived = false
   let activeProc = proc
@@ -290,7 +554,7 @@ export async function startTui(input: {
       onRetry: async () => {
         await closeProcess(proc)
         await Bun.sleep(initialOutputRetryDelayMs)
-        proc = spawnTuiProcess({ args, cwd: input.cwd, env, cols, rows })
+        proc = spawnTuiProcess({ args, binaryPath: input.binaryPath, cwd: input.cwd, env, cols, rows })
         dataReceived = false
         exitCode = undefined
         attachProcess(proc)
@@ -349,12 +613,15 @@ export async function startTui(input: {
 
 function spawnTuiProcess(input: {
   args: string[]
+  binaryPath?: string
   cwd?: string
   env: Record<string, string | undefined>
   cols: number
   rows: number
 }) {
-  return spawn(process.execPath, ["--conditions=browser", "./src/index.ts", ...input.args], {
+  const command = input.binaryPath ?? process.execPath
+  const args = input.binaryPath ? input.args : ["--conditions=browser", "./src/index.ts", ...input.args]
+  return spawn(command, args, {
     cwd: input.cwd ?? packageRoot,
     cols: input.cols,
     rows: input.rows,
@@ -916,6 +1183,10 @@ const multiAgencyFixtures: AgencyFixture[] = [
 
 function sse(events: Array<[event: string, data: Record<string, unknown>]>) {
   return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("")
+}
+
+function eventStream(chunks: unknown[]) {
+  return chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("") + "data: [DONE]\n\n"
 }
 
 function controlledSse(

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -687,87 +687,6 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(currentServer.requests).toHaveLength(0)
   })
 
-  test("native /agents selection honors custom primary agents in Build mode", async () => {
-    const prompt = "custom native primary agent selected from build"
-    const buildPrompt = "default build turn before reopening custom agent"
-    const reopenedPrompt = "custom native primary agent after reopen"
-    currentServer = await startTuiDemoAgencyServer()
-    currentNativeServer = await startNativeLLMServer()
-    currentTui = await startTui({
-      baseURL: currentServer.baseURL,
-      agency: "tui-demo-agency",
-      recipientAgent: "UserSupportAgent",
-      config: {
-        model: latestOpenAITestModel,
-        enabled_providers: openAIProviderTestConfig.enabled_providers,
-        provider: {
-          openai: {
-            options: {
-              apiKey: "test-openai-key",
-              baseURL: currentNativeServer.baseURL,
-            },
-          },
-        },
-        agent: {
-          reviewer: {
-            mode: "primary",
-            model: latestOpenAITestModel,
-            prompt: "You are selected native reviewer.",
-            description: "Review native Build-mode routing.",
-          },
-        },
-      },
-    })
-
-    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
-    await selectProductMode(currentTui, "Build")
-    currentTui.write("/agents\r")
-    await currentTui.waitForText("Select agent", tuiInteractionTimeoutMs)
-    currentTui.write("reviewer")
-    await currentTui.waitForText("reviewer", tuiInteractionTimeoutMs)
-    currentTui.write("\r")
-
-    currentTui.write(`${prompt}\r`)
-    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
-    const request = await waitForNativeLLMRequest(currentTui, currentNativeServer, prompt)
-    const body = JSON.stringify(request.body)
-    expect(body).toContain("You are selected native reviewer.")
-    expect(body).not.toContain("Agent Swarm Build Instructions")
-    expect(currentServer.requests).toHaveLength(0)
-
-    currentTui.write("/new")
-    await currentTui.waitFor(
-      () => currentTui!.screen().includes("/new"),
-      "visible /new command",
-      tuiInteractionTimeoutMs,
-    )
-    currentTui.write("\r")
-    await currentTui.waitFor(
-      () => !currentTui!.screen().includes(prompt),
-      "new empty prompt after leaving custom agent session",
-      tuiInteractionTimeoutMs,
-    )
-
-    await selectProductMode(currentTui, "Build")
-    currentTui.write(`${buildPrompt}\r`)
-    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
-    const build = await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
-    expect(JSON.stringify(build.body)).toContain("Agent Swarm Build Instructions")
-
-    currentTui.write("/sessions\r")
-    await currentTui.waitForText("Sessions", tuiInteractionTimeoutMs)
-    currentTui.write("\x1b[B\r")
-    await currentTui.waitForText(prompt, tuiInteractionTimeoutMs)
-
-    currentTui.write(`${reopenedPrompt}\r`)
-    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
-    const reopened = await waitForNativeLLMRequest(currentTui, currentNativeServer, reopenedPrompt)
-    const reopenedBody = JSON.stringify(reopened.body)
-    expect(reopenedBody).toContain("You are selected native reviewer.")
-    expect(reopenedBody).not.toContain("Agent Swarm Build Instructions")
-    expect(currentServer.requests).toHaveLength(0)
-  })
-
   test("Build task tool calls stay native when launcher-style env config defaults to Run", async () => {
     const parentPrompt = "call native task tool from build mode"
     const childPrompt = "child-task-routing-sentinel"
@@ -1023,6 +942,66 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(screen).toContain("Run ·")
     expect(screen).toContain("Build ·")
     expect(currentServer.requests).toHaveLength(1)
+  })
+
+  test("/modes Build keeps undo hidden for a previous Run turn", async () => {
+    const runPrompt = "run before undo mode switch"
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    currentTui.write(`${runPrompt}\r`)
+    await currentTui.waitForText("TUI demo response complete.", tuiInteractionTimeoutMs)
+    await currentTui.waitForText("Run ·", tuiInteractionTimeoutMs)
+
+    await selectProductMode(currentTui, "Build")
+    currentTui.write("/und")
+    await currentTui.waitForText("/und", tuiInteractionTimeoutMs)
+    await Bun.sleep(100)
+    expect(hasCommand(currentTui.screen(), "/undo")).toBe(false)
+  })
+
+  test("/modes Run keeps redo visible for a previous Build turn", async () => {
+    const buildPrompt = "build before redo mode switch"
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    await selectProductMode(currentTui, "Build")
+    currentTui.write(`${buildPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
+
+    currentTui.write("/undo\r")
+    await currentTui.waitForText("message reverted", tuiInteractionTimeoutMs)
+
+    await selectProductMode(currentTui, "Run")
+    currentTui.write("/red")
+    const screen = await waitForCommand(currentTui, "/redo")
+    expect(hasCommand(screen, "/redo")).toBe(true)
   })
 
   test("legacy Run sessions without bridge metadata keep Run labels after mode switch", async () => {

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -565,7 +565,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     currentNativeServer.planExitNext()
     currentTui.write(`${planPrompt}\r`)
     await currentTui.waitFor(
-      () => currentTui!.screen().includes("Would you like to") && currentTui!.screen().includes("switch to the build"),
+      () => currentTui!.screen().includes("Would you like to") && currentTui!.screen().includes("switch to Build"),
       "Plan approval question",
       tuiInteractionTimeoutMs,
     )

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -11,15 +11,18 @@ import {
   openAIProviderTestConfig,
   startAgencyProtocolServer,
   startMultiAgencyServer,
+  startNativeLLMServer,
   startTui,
   startTuiDemoAgencyServer,
   writeAgencyProject,
+  type NativeLLMServer,
   type TuiProcess,
   type AgencyProtocolServer,
 } from "./harness"
 
 let currentTui: TuiProcess | undefined
 let currentServer: AgencyProtocolServer | undefined
+let currentNativeServer: NativeLLMServer | undefined
 let currentTelemetryServer: ReturnType<typeof startTelemetryServer> | undefined
 const tempDirs: string[] = []
 const tuiReadyTimeoutMs = process.env.CI ? 120_000 : 30_000
@@ -39,11 +42,39 @@ function hasCommand(screen: string, command: string) {
   return screen.split("\n").some((line) => new RegExp(`┃\\s+${command}\\b`).test(line))
 }
 
+async function waitForCommand(tui: TuiProcess, command: string) {
+  await tui.waitFor(() => hasCommand(tui.screen(), command), `${command} command`, tuiInteractionTimeoutMs)
+  return tui.screen()
+}
+
+function clearPrompt(tui: TuiProcess) {
+  tui.write("\b".repeat(80))
+}
+
+function hasModeDialog(screen: string) {
+  return (
+    screen.includes("Select mode") &&
+    screen.includes("Build") &&
+    screen.includes("Plan") &&
+    screen.includes("Run") &&
+    !screen.includes("Select model")
+  )
+}
+
+function footerHasMode(screen: string, mode: string) {
+  return screen
+    .split("\n")
+    .slice(-16)
+    .some((line) => line.includes(`${mode} ·`) && line.includes("OpenAI"))
+}
+
 afterEach(async () => {
   await currentTui?.close()
   currentTui = undefined
   currentServer?.stop()
   currentServer = undefined
+  currentNativeServer?.stop()
+  currentNativeServer = undefined
   currentTelemetryServer?.stop()
   currentTelemetryServer = undefined
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
@@ -357,6 +388,237 @@ describe("Agent Swarm terminal TUI e2e", () => {
       currentServer.stop()
       currentServer = undefined
     }
+  })
+
+  test("/modes is the product switch and does not add /build or /plan commands", async () => {
+    currentServer = await startAgencyProtocolServer()
+    currentTui = await startTui({ baseURL: currentServer.baseURL })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    currentTui.write("/")
+    const screen = await waitForCommand(currentTui, "/modes")
+
+    expect(hasCommand(screen, "/modes")).toBe(true)
+    expect(hasCommand(screen, "/agents")).toBe(true)
+    expect(hasCommand(screen, "/build")).toBe(false)
+    expect(hasCommand(screen, "/plan")).toBe(false)
+    expect(hasCommand(screen, "/review")).toBe(false)
+
+    currentTui.write("mode\r")
+    await currentTui.waitForText("Select mode", tuiInteractionTimeoutMs)
+  })
+
+  test("/modes Build and Plan restore native command visibility", async () => {
+    for (const mode of ["Build", "Plan"] as const) {
+      currentServer = await startAgencyProtocolServer()
+      currentTui = await startTui({ baseURL: currentServer.baseURL })
+
+      await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+      await selectProductMode(currentTui, mode)
+      currentTui.write("/rev")
+      const screen = await waitForCommand(currentTui, "/review")
+
+      expect(hasCommand(screen, "/review")).toBe(true)
+      expect(hasCommand(screen, "/build")).toBe(false)
+      expect(hasCommand(screen, "/plan")).toBe(false)
+
+      await currentTui.close()
+      currentTui = undefined
+      currentServer.stop()
+      currentServer = undefined
+    }
+  })
+
+  test("/modes Build and Plan stay native after a Run-mode Agency response", async () => {
+    for (const mode of ["Build", "Plan"] as const) {
+      currentServer = await startTuiDemoAgencyServer()
+      currentNativeServer = await startNativeLLMServer()
+      currentTui = await startTui({
+        baseURL: currentServer.baseURL,
+        agency: "tui-demo-agency",
+        recipientAgent: "UserSupportAgent",
+        configSource: "file",
+        config: {
+          enabled_providers: openAIProviderTestConfig.enabled_providers,
+          provider: {
+            openai: {
+              options: {
+                apiKey: "test-openai-key",
+                baseURL: currentNativeServer.baseURL,
+              },
+            },
+          },
+        },
+      })
+
+      await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+      currentTui.write(`run before ${mode.toLowerCase()} mode switch\r`)
+      await currentTui.waitForText("TUI demo response complete.", tuiInteractionTimeoutMs)
+      await currentTui.waitFor(
+        () => currentServer!.requests.length === 1,
+        `Run-mode Agency request before ${mode}`,
+        tuiInteractionTimeoutMs,
+      )
+      const agencyRequests = currentServer.requests.length
+
+      await selectProductMode(currentTui, mode)
+      currentTui.write("who are you\r")
+      await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+
+      const request = await waitForNativeLLMRequest(currentTui, currentNativeServer, "who are you")
+      const body = JSON.stringify(request.body)
+      expect(body).toContain("You are OpenCode")
+      expect(body).toContain(
+        mode === "Build" ? "Agent Swarm Agent Builder Instructions" : "Agent Swarm Planner Instructions",
+      )
+      if (mode === "Plan") expect(body).toContain("plan_exit")
+      expect(currentServer.requests).toHaveLength(agencyRequests)
+
+      await currentTui.close()
+      currentTui = undefined
+      currentServer.stop()
+      currentServer = undefined
+      currentNativeServer.stop()
+      currentNativeServer = undefined
+    }
+  })
+
+  test("/modes Build and Plan stay native when launcher-style env config defaults to Run", async () => {
+    for (const mode of ["Build", "Plan"] as const) {
+      currentServer = await startTuiDemoAgencyServer()
+      currentNativeServer = await startNativeLLMServer()
+      currentTui = await startTui({
+        baseURL: currentServer.baseURL,
+        agency: "tui-demo-agency",
+        recipientAgent: "UserSupportAgent",
+        config: {
+          enabled_providers: openAIProviderTestConfig.enabled_providers,
+          provider: {
+            openai: {
+              options: {
+                apiKey: "test-openai-key",
+                baseURL: currentNativeServer.baseURL,
+              },
+            },
+          },
+        },
+      })
+
+      await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+      await selectProductMode(currentTui, mode)
+      currentTui.write(`who are you from ${mode.toLowerCase()} env config\r`)
+      await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+
+      await waitForNativeLLMRequest(
+        currentTui,
+        currentNativeServer,
+        `who are you from ${mode.toLowerCase()} env config`,
+      )
+      const request = currentNativeServer.requests.find((item) =>
+        JSON.stringify(item.body).includes(
+          mode === "Build" ? "Agent Swarm Agent Builder Instructions" : "Agent Swarm Planner Instructions",
+        ),
+      )
+      expect(request).toBeDefined()
+      const body = JSON.stringify(request.body)
+      expect(body).toContain(
+        mode === "Build" ? "Agent Swarm Agent Builder Instructions" : "Agent Swarm Planner Instructions",
+      )
+      if (mode === "Plan") expect(body).toContain("plan_exit")
+      expect(currentServer.requests).toHaveLength(0)
+
+      await currentTui.close()
+      currentTui = undefined
+      currentServer.stop()
+      currentServer = undefined
+      currentNativeServer.stop()
+      currentNativeServer = undefined
+    }
+  })
+
+  test("approving native Plan handoff switches the TUI to Build", async () => {
+    const planPrompt = "finish test plan with native plan_exit"
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      config: {
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    await selectProductMode(currentTui, "Plan")
+    await currentTui.waitFor(() => footerHasMode(currentTui!.screen(), "Plan"), "Plan footer", tuiInteractionTimeoutMs)
+
+    currentNativeServer.planExitNext()
+    currentTui.write(`${planPrompt}\r`)
+    await currentTui.waitFor(
+      () => currentTui!.screen().includes("Would you like to") && currentTui!.screen().includes("switch to the build"),
+      "Plan approval question",
+      tuiInteractionTimeoutMs,
+    )
+    currentTui.write("\r")
+    await currentTui.waitFor(
+      () => footerHasMode(currentTui!.screen(), "Build"),
+      "Build footer after plan approval",
+      tuiInteractionTimeoutMs,
+    )
+    expect(currentServer.requests).toHaveLength(0)
+  })
+
+  test("/modes can return to server-backed Run after Build", async () => {
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    await selectProductMode(currentTui, "Build")
+    await selectProductMode(currentTui, "Run")
+    await currentTui.waitForText("Swarm Default", tuiInteractionTimeoutMs)
+
+    currentTui.write("/")
+    const screen = await waitForCommand(currentTui, "/agents")
+    expect(hasCommand(screen, "/agents")).toBe(true)
+    expect(hasCommand(screen, "/review")).toBe(false)
+  })
+
+  test("Tab cycles native agents outside Run and swarm targets in Run", async () => {
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+    })
+
+    await currentTui.waitForText("UserSupportAgent", tuiReadyTimeoutMs)
+    await selectProductMode(currentTui, "Build")
+    currentTui.write("\t")
+    await currentTui.waitFor(() => currentTui!.screen().includes("Plan"), "native Plan agent", tuiInteractionTimeoutMs)
+
+    await selectProductMode(currentTui, "Run")
+    currentTui.write("\t")
+    await currentTui.waitFor(
+      () => currentTui!.screen().includes("MathAgent · Swarm Default"),
+      "Run agent target",
+      tuiInteractionTimeoutMs,
+    )
   })
 
   test("run-target picker uses live agency labels instead of local-agency ids", async () => {
@@ -1108,6 +1370,35 @@ async function selectRunTarget(tui: TuiProcess, query: string, successMessage: s
   tui.write("\x1b[B")
   tui.write("\r")
   await tui.waitForText(successMessage, tuiInteractionTimeoutMs)
+}
+
+async function selectProductMode(tui: TuiProcess, mode: "Build" | "Plan" | "Run") {
+  clearPrompt(tui)
+  tui.write("/modes\r")
+  await tui.waitFor(() => hasModeDialog(tui.screen()), "current mode dialog", tuiInteractionTimeoutMs)
+  tui.write(mode)
+  await tui.waitFor(
+    () => hasModeDialog(tui.screen()) && tui.screen().includes(mode),
+    `${mode} mode option`,
+    tuiInteractionTimeoutMs,
+  )
+  tui.write("\x1b[B")
+  tui.write("\r")
+  await tui.waitFor(() => !tui.screen().includes("Select mode"), `${mode} mode selected`, tuiInteractionTimeoutMs)
+  clearPrompt(tui)
+}
+
+async function waitForNativeLLMRequest(tui: TuiProcess, server: NativeLLMServer, prompt: string) {
+  let request: NativeLLMServer["requests"][number] | undefined
+  await tui.waitFor(
+    () => {
+      request = server.requests.find((item) => JSON.stringify(item.body).includes(prompt))
+      return request !== undefined
+    },
+    `native LLM request containing ${prompt}`,
+    tuiInteractionTimeoutMs,
+  )
+  return request!
 }
 
 async function selectCurrentSwarm(tui: TuiProcess) {

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -536,6 +536,48 @@ describe("Agent Swarm terminal TUI e2e", () => {
     }
   })
 
+  test("/mode Build and Plan slash commands stay native when launcher-style env config defaults to Run", async () => {
+    for (const mode of ["Build", "Plan"] as const) {
+      const prompt = `agent-builder-command-route-${mode.toLowerCase()}`
+      currentServer = await startTuiDemoAgencyServer()
+      currentNativeServer = await startNativeLLMServer()
+      currentTui = await startTui({
+        baseURL: currentServer.baseURL,
+        agency: "tui-demo-agency",
+        recipientAgent: "UserSupportAgent",
+        config: {
+          enabled_providers: openAIProviderTestConfig.enabled_providers,
+          provider: {
+            openai: {
+              options: {
+                apiKey: "test-openai-key",
+                baseURL: currentNativeServer.baseURL,
+              },
+            },
+          },
+        },
+      })
+
+      await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+      await selectProductMode(currentTui, mode)
+      currentTui.write(`/review ${prompt}\r`)
+      await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+
+      const request = await waitForNativeLLMRequest(currentTui, currentNativeServer, prompt)
+      const body = JSON.stringify(request.body)
+      expect(body).toContain(prompt)
+      expect(body).toContain("You are a code reviewer")
+      expect(currentServer.requests).toHaveLength(0)
+
+      await currentTui.close()
+      currentTui = undefined
+      currentServer.stop()
+      currentServer = undefined
+      currentNativeServer.stop()
+      currentNativeServer = undefined
+    }
+  })
+
   test("approving native Plan handoff switches the TUI to Build", async () => {
     const planPrompt = "finish test plan with native plan_exit"
     currentServer = await startTuiDemoAgencyServer()
@@ -569,7 +611,9 @@ describe("Agent Swarm terminal TUI e2e", () => {
       "Plan approval question",
       tuiInteractionTimeoutMs,
     )
-    currentTui.write("\r")
+    currentTui.write("\x1b[B")
+    await currentTui.waitFor(() => currentTui!.screen().includes("2. No"), "No option visible", tuiInteractionTimeoutMs)
+    currentTui.write("1")
     await currentTui.waitFor(
       () => footerHasMode(currentTui!.screen(), "Build"),
       "Build footer after plan approval",

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { Database } from "bun:sqlite"
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import {
@@ -48,7 +49,9 @@ async function waitForCommand(tui: TuiProcess, command: string) {
 }
 
 function clearPrompt(tui: TuiProcess) {
-  tui.write("\b".repeat(80))
+  tui.write("\x15")
+  tui.write("\x7f".repeat(120))
+  tui.write("\b".repeat(120))
 }
 
 function hasModeDialog(screen: string) {
@@ -61,11 +64,74 @@ function hasModeDialog(screen: string) {
   )
 }
 
+function hasSelectedMode(screen: string, mode: "Build" | "Plan" | "Run") {
+  return screen.split("\n").some((line) => line.includes(`● ${mode}`))
+}
+
+function hasFilteredMode(screen: string, mode: "Build" | "Plan" | "Run") {
+  const options = {
+    Build: "Build Build or fix swarms and agents",
+    Plan: "Plan Plan work before building",
+    Run: "Run Run the connected swarm",
+  }
+  return (
+    screen.includes(options[mode]) &&
+    Object.entries(options).every(([key, label]) => key === mode || !screen.includes(label))
+  )
+}
+
+function hasModeOrder(screen: string) {
+  const plan = screen.indexOf("Plan Plan work before building")
+  const build = screen.indexOf("Build Build or fix swarms and agents")
+  const run = screen.indexOf("Run Run the connected swarm")
+  return plan >= 0 && build > plan && run > build
+}
+
 function footerHasMode(screen: string, mode: string) {
   return screen
     .split("\n")
     .slice(-16)
     .some((line) => line.includes(`${mode} ·`) && line.includes("OpenAI"))
+}
+
+async function waitForModelOption(tui: TuiProcess, model: string) {
+  await tui.waitFor(
+    () =>
+      tui
+        .screen()
+        .split("\n")
+        .some((line) => line.includes(model) && line.includes("OpenAI")),
+    `${model} model option`,
+    tuiInteractionTimeoutMs,
+  )
+}
+
+async function findOpenCodeDatabase(dataHome: string) {
+  const dir = path.join(dataHome, "agentswarm")
+  const entries = await readdir(dir)
+  const db = entries.find((entry) => /^opencode(?:-.+)?\.db$/.test(entry))
+  if (!db) throw new Error(`No opencode database found in ${dir}`)
+  return path.join(dir, db)
+}
+
+function stripAgencySwarmBridgeMetadata(dbPath: string) {
+  const db = new Database(dbPath)
+  try {
+    let count = 0
+    const rows = db.query<{ id: string; data: string }, []>("select id, data from part").all()
+    const update = db.query("update part set data = ? where id = ?")
+    for (const row of rows) {
+      const data = JSON.parse(row.data) as { metadata?: Record<string, unknown> }
+      if (data.metadata?.agencySwarmBridge === undefined) continue
+      delete data.metadata.agencySwarmBridge
+      if (Object.keys(data.metadata).length === 0) delete data.metadata
+      update.run(JSON.stringify(data), row.id)
+      count++
+    }
+    return count
+  } finally {
+    db.close()
+  }
 }
 
 afterEach(async () => {
@@ -404,8 +470,9 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(hasCommand(screen, "/plan")).toBe(false)
     expect(hasCommand(screen, "/review")).toBe(false)
 
-    currentTui.write("mode\r")
+    currentTui.write("modes\r")
     await currentTui.waitForText("Select mode", tuiInteractionTimeoutMs)
+    expect(hasModeOrder(currentTui.screen())).toBe(true)
   })
 
   test("/modes Build and Plan restore native command visibility", async () => {
@@ -439,6 +506,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
         recipientAgent: "UserSupportAgent",
         configSource: "file",
         config: {
+          model: latestOpenAITestModel,
           enabled_providers: openAIProviderTestConfig.enabled_providers,
           provider: {
             openai: {
@@ -468,9 +536,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
       const request = await waitForNativeLLMRequest(currentTui, currentNativeServer, "who are you")
       const body = JSON.stringify(request.body)
       expect(body).toContain("You are OpenCode")
-      expect(body).toContain(
-        mode === "Build" ? "Agent Swarm Agent Builder Instructions" : "Agent Swarm Planner Instructions",
-      )
+      expect(body).toContain(mode === "Build" ? "Agent Swarm Build Instructions" : "Agent Swarm Planner Instructions")
       if (mode === "Plan") expect(body).toContain("plan_exit")
       expect(currentServer.requests).toHaveLength(agencyRequests)
 
@@ -492,6 +558,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
         agency: "tui-demo-agency",
         recipientAgent: "UserSupportAgent",
         config: {
+          model: latestOpenAITestModel,
           enabled_providers: openAIProviderTestConfig.enabled_providers,
           provider: {
             openai: {
@@ -516,14 +583,12 @@ describe("Agent Swarm terminal TUI e2e", () => {
       )
       const request = currentNativeServer.requests.find((item) =>
         JSON.stringify(item.body).includes(
-          mode === "Build" ? "Agent Swarm Agent Builder Instructions" : "Agent Swarm Planner Instructions",
+          mode === "Build" ? "Agent Swarm Build Instructions" : "Agent Swarm Planner Instructions",
         ),
       )
       expect(request).toBeDefined()
       const body = JSON.stringify(request.body)
-      expect(body).toContain(
-        mode === "Build" ? "Agent Swarm Agent Builder Instructions" : "Agent Swarm Planner Instructions",
-      )
+      expect(body).toContain(mode === "Build" ? "Agent Swarm Build Instructions" : "Agent Swarm Planner Instructions")
       if (mode === "Plan") expect(body).toContain("plan_exit")
       expect(currentServer.requests).toHaveLength(0)
 
@@ -536,7 +601,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     }
   })
 
-  test("/mode Build and Plan slash commands stay native when launcher-style env config defaults to Run", async () => {
+  test("/modes Build and Plan slash commands stay native when launcher-style env config defaults to Run", async () => {
     for (const mode of ["Build", "Plan"] as const) {
       const prompt = `agent-builder-command-route-${mode.toLowerCase()}`
       currentServer = await startTuiDemoAgencyServer()
@@ -546,6 +611,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
         agency: "tui-demo-agency",
         recipientAgent: "UserSupportAgent",
         config: {
+          model: latestOpenAITestModel,
           enabled_providers: openAIProviderTestConfig.enabled_providers,
           provider: {
             openai: {
@@ -578,6 +644,164 @@ describe("Agent Swarm terminal TUI e2e", () => {
     }
   })
 
+  test("native /agents selection updates Build and Plan routing", async () => {
+    const prompt = "native agents picker selected plan"
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      args: ["--model", "agency-swarm/default", "--agent", "build"],
+      configSource: "file",
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    await selectProductMode(currentTui, "Build")
+    currentTui.write("/agents\r")
+    await currentTui.waitForText("Select agent", tuiInteractionTimeoutMs)
+    currentTui.write("Plan")
+    await currentTui.waitForText("Plan", tuiInteractionTimeoutMs)
+    currentTui.write("\r")
+    await currentTui.waitFor(() => footerHasMode(currentTui!.screen(), "Plan"), "Plan footer", tuiInteractionTimeoutMs)
+
+    currentTui.write(`${prompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    const request = await waitForNativeLLMRequest(currentTui, currentNativeServer, prompt)
+    const body = JSON.stringify(request.body)
+    expect(body).toContain("Agent Swarm Planner Instructions")
+    expect(body).toContain("plan_exit")
+    expect(body).not.toContain("Agent Swarm Build Instructions")
+    expect(currentServer.requests).toHaveLength(0)
+  })
+
+  test("native /agents selection honors custom primary agents in Build mode", async () => {
+    const prompt = "custom native primary agent selected from build"
+    const buildPrompt = "default build turn before reopening custom agent"
+    const reopenedPrompt = "custom native primary agent after reopen"
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+        agent: {
+          reviewer: {
+            mode: "primary",
+            model: latestOpenAITestModel,
+            prompt: "You are selected native reviewer.",
+            description: "Review native Build-mode routing.",
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    await selectProductMode(currentTui, "Build")
+    currentTui.write("/agents\r")
+    await currentTui.waitForText("Select agent", tuiInteractionTimeoutMs)
+    currentTui.write("reviewer")
+    await currentTui.waitForText("reviewer", tuiInteractionTimeoutMs)
+    currentTui.write("\r")
+
+    currentTui.write(`${prompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    const request = await waitForNativeLLMRequest(currentTui, currentNativeServer, prompt)
+    const body = JSON.stringify(request.body)
+    expect(body).toContain("You are selected native reviewer.")
+    expect(body).not.toContain("Agent Swarm Build Instructions")
+    expect(currentServer.requests).toHaveLength(0)
+
+    currentTui.write("/new")
+    await currentTui.waitFor(
+      () => currentTui!.screen().includes("/new"),
+      "visible /new command",
+      tuiInteractionTimeoutMs,
+    )
+    currentTui.write("\r")
+    await currentTui.waitFor(
+      () => !currentTui!.screen().includes(prompt),
+      "new empty prompt after leaving custom agent session",
+      tuiInteractionTimeoutMs,
+    )
+
+    await selectProductMode(currentTui, "Build")
+    currentTui.write(`${buildPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    const build = await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
+    expect(JSON.stringify(build.body)).toContain("Agent Swarm Build Instructions")
+
+    currentTui.write("/sessions\r")
+    await currentTui.waitForText("Sessions", tuiInteractionTimeoutMs)
+    currentTui.write("\x1b[B\r")
+    await currentTui.waitForText(prompt, tuiInteractionTimeoutMs)
+
+    currentTui.write(`${reopenedPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    const reopened = await waitForNativeLLMRequest(currentTui, currentNativeServer, reopenedPrompt)
+    const reopenedBody = JSON.stringify(reopened.body)
+    expect(reopenedBody).toContain("You are selected native reviewer.")
+    expect(reopenedBody).not.toContain("Agent Swarm Build Instructions")
+    expect(currentServer.requests).toHaveLength(0)
+  })
+
+  test("Build task tool calls stay native when launcher-style env config defaults to Run", async () => {
+    const parentPrompt = "call native task tool from build mode"
+    const childPrompt = "child-task-routing-sentinel"
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    await selectProductMode(currentTui, "Build")
+    currentNativeServer.taskNext(childPrompt)
+    currentTui.write(`${parentPrompt}\r`)
+
+    await waitForNativeLLMRequest(currentTui, currentNativeServer, parentPrompt)
+    const child = await waitForNativeLLMRequest(currentTui, currentNativeServer, childPrompt)
+    expect(JSON.stringify(child.body)).toContain(childPrompt)
+    expect(currentServer.requests).toHaveLength(0)
+  })
+
   test("approving native Plan handoff switches the TUI to Build", async () => {
     const planPrompt = "finish test plan with native plan_exit"
     currentServer = await startTuiDemoAgencyServer()
@@ -586,8 +810,8 @@ describe("Agent Swarm terminal TUI e2e", () => {
       baseURL: currentServer.baseURL,
       agency: "tui-demo-agency",
       recipientAgent: "UserSupportAgent",
-      configSource: "file",
       config: {
+        model: latestOpenAITestModel,
         enabled_providers: openAIProviderTestConfig.enabled_providers,
         provider: {
           openai: {
@@ -611,9 +835,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
       "Plan approval question",
       tuiInteractionTimeoutMs,
     )
-    currentTui.write("\x1b[B")
-    await currentTui.waitFor(() => currentTui!.screen().includes("2. No"), "No option visible", tuiInteractionTimeoutMs)
-    currentTui.write("1")
+    currentTui.write("\r")
     await currentTui.waitFor(
       () => footerHasMode(currentTui!.screen(), "Build"),
       "Build footer after plan approval",
@@ -622,24 +844,289 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(currentServer.requests).toHaveLength(0)
   })
 
+  test("reopened Plan sessions keep Plan routing after switching away", async () => {
+    const firstPlanPrompt = "first plan turn before reopening session"
+    const buildPrompt = "build turn before reopening plan session"
+    const secondPlanPrompt = "second plan turn after reopening session"
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    await selectProductMode(currentTui, "Plan")
+    currentTui.write(`${firstPlanPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    const first = await waitForNativeLLMRequest(currentTui, currentNativeServer, firstPlanPrompt)
+    expect(JSON.stringify(first.body)).toContain("Agent Swarm Planner Instructions")
+
+    currentTui.write("/new")
+    await currentTui.waitFor(
+      () => currentTui!.screen().includes("/new"),
+      "visible /new command",
+      tuiInteractionTimeoutMs,
+    )
+    currentTui.write("\r")
+    await currentTui.waitFor(
+      () => !currentTui!.screen().includes(firstPlanPrompt),
+      "new empty prompt after leaving Plan session",
+      tuiInteractionTimeoutMs,
+    )
+
+    await selectProductMode(currentTui, "Build")
+    currentTui.write(`${buildPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    const build = await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
+    expect(JSON.stringify(build.body)).toContain("Agent Swarm Build Instructions")
+
+    currentTui.write("/sessions\r")
+    await currentTui.waitForText("Sessions", tuiInteractionTimeoutMs)
+    currentTui.write("\x1b[B\r")
+    await currentTui.waitForText(firstPlanPrompt, tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => footerHasMode(currentTui!.screen(), "Plan"),
+      "reopened Plan footer",
+      tuiInteractionTimeoutMs,
+    )
+    currentTui.write("/models\r")
+    await currentTui.waitForText("Select model", tuiInteractionTimeoutMs)
+    currentTui.write("gpt-5.2")
+    await waitForModelOption(currentTui, "GPT-5.2")
+    currentTui.write("\r")
+    await currentTui.waitFor(
+      () => !currentTui!.screen().includes("Select model"),
+      "Plan model selected",
+      tuiInteractionTimeoutMs,
+    )
+    if (currentTui.screen().includes("Select variant")) {
+      currentTui.write("\r")
+      await currentTui.waitFor(
+        () => !currentTui!.screen().includes("Select variant"),
+        "Plan variant selected",
+        tuiInteractionTimeoutMs,
+      )
+    }
+    await currentTui.waitForText("Plan · GPT-5.2", tuiInteractionTimeoutMs)
+
+    currentTui.write(`${secondPlanPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    const second = await waitForNativeLLMRequest(currentTui, currentNativeServer, secondPlanPrompt)
+    const body = JSON.stringify(second.body)
+    expect(second.body.model).toBe("gpt-5.2")
+    expect(body).toContain("Agent Swarm Planner Instructions")
+    expect(body).toContain("plan_exit")
+    expect(body).not.toContain("Agent Swarm Build Instructions")
+    expect(currentServer.requests).toHaveLength(0)
+  })
+
   test("/modes can return to server-backed Run after Build", async () => {
+    const buildPrompt = "native build before run return"
+    const runPrompt = "run after native build return"
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    await selectProductMode(currentTui, "Build")
+    currentTui.write(`${buildPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
+    expect(currentServer.requests).toHaveLength(0)
+
+    await selectProductMode(currentTui, "Run")
+    await currentTui.waitForText("Swarm Default", tuiInteractionTimeoutMs)
+
+    currentTui.write(`${runPrompt}\r`)
+    await currentTui.waitFor(
+      () => currentServer!.requests.some((request) => request.body.message === runPrompt),
+      "Run request after native Build prompt",
+      tuiInteractionTimeoutMs,
+    )
+
+    currentTui.write("/")
+    const screen = await waitForCommand(currentTui, "/agents")
+    expect(hasCommand(screen, "/agents")).toBe(true)
+    expect(hasCommand(screen, "/review")).toBe(false)
+  })
+
+  test("mixed Run and Build sessions keep per-turn labels stable", async () => {
+    const runPrompt = "run before mixed mode label switch"
+    const buildPrompt = "build after mixed mode label switch"
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    currentTui.write(`${runPrompt}\r`)
+    await currentTui.waitForText("TUI demo response complete.", tuiInteractionTimeoutMs)
+    await currentTui.waitForText("Run ·", tuiInteractionTimeoutMs)
+
+    await selectProductMode(currentTui, "Build")
+    expect(currentTui.screen()).toContain("Run ·")
+    currentTui.write(`${buildPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
+    expect(currentTui.screen()).toContain("Build ·")
+
+    await selectProductMode(currentTui, "Run")
+    const screen = currentTui.screen()
+    expect(screen).toContain("Run ·")
+    expect(screen).toContain("Build ·")
+    expect(currentServer.requests).toHaveLength(1)
+  })
+
+  test("legacy Run sessions without bridge metadata keep Run labels after mode switch", async () => {
+    const runPrompt = "legacy run before bridge metadata"
+    const dataHome = await mkdtemp(path.join(os.tmpdir(), "agentswarm-legacy-mode-data-"))
+    tempDirs.push(dataHome)
     currentServer = await startTuiDemoAgencyServer()
     currentTui = await startTui({
       baseURL: currentServer.baseURL,
       agency: "tui-demo-agency",
       recipientAgent: "UserSupportAgent",
       configSource: "file",
+      env: {
+        XDG_DATA_HOME: dataHome,
+      },
     })
 
     await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
-    await selectProductMode(currentTui, "Build")
-    await selectProductMode(currentTui, "Run")
-    await currentTui.waitForText("Swarm Default", tuiInteractionTimeoutMs)
+    currentTui.write(`${runPrompt}\r`)
+    await currentTui.waitForText("TUI demo response complete.", tuiInteractionTimeoutMs)
+    await currentTui.waitForText("Run ·", tuiInteractionTimeoutMs)
+    await currentTui.close()
+    currentTui = undefined
 
-    currentTui.write("/")
-    const screen = await waitForCommand(currentTui, "/agents")
-    expect(hasCommand(screen, "/agents")).toBe(true)
-    expect(hasCommand(screen, "/review")).toBe(false)
+    const removed = stripAgencySwarmBridgeMetadata(await findOpenCodeDatabase(dataHome))
+    expect(removed).toBeGreaterThan(0)
+
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      env: {
+        XDG_DATA_HOME: dataHome,
+      },
+    })
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    if (!currentTui.screen().includes(runPrompt)) {
+      currentTui.write("/sessions\r")
+      await currentTui.waitForText("Sessions", tuiInteractionTimeoutMs)
+      currentTui.write("\r")
+      await currentTui.waitForText(runPrompt, tuiInteractionTimeoutMs)
+    }
+
+    await selectProductMode(currentTui, "Build")
+    await currentTui.waitFor(() => currentTui!.screen().includes("Build ·"), "Build footer", tuiInteractionTimeoutMs)
+    const screen = currentTui.screen()
+    expect(screen).toContain(runPrompt)
+    expect(screen).toContain("Run ·")
+    expect(currentServer.requests).toHaveLength(1)
+  })
+
+  test("/modes Run selection stays native when Agency Swarm provider is excluded", async () => {
+    const prompt = "prompt after excluded run selection"
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      config: {
+        enabled_providers: ["openai"],
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitFor(() => footerHasMode(currentTui!.screen(), "Build"), "Build footer", tuiReadyTimeoutMs)
+    currentTui.write("/models\r")
+    await currentTui.waitForText("Select model", tuiInteractionTimeoutMs)
+    currentTui.write("gpt-5.2")
+    await waitForModelOption(currentTui, "GPT-5.2")
+    currentTui.write("\r")
+    await currentTui.waitFor(
+      () => !currentTui!.screen().includes("Select model"),
+      "native model selected with Agency Swarm excluded",
+      tuiInteractionTimeoutMs,
+    )
+    if (currentTui.screen().includes("Select variant")) {
+      currentTui.write("\r")
+      await currentTui.waitFor(
+        () => !currentTui!.screen().includes("Select variant"),
+        "variant selected with Agency Swarm excluded",
+        tuiInteractionTimeoutMs,
+      )
+    }
+    await currentTui.waitForText("Build · GPT-5.2", tuiInteractionTimeoutMs)
+
+    await selectProductMode(currentTui, "Run")
+    await currentTui.waitForText("Model agency-swarm/default is not valid", tuiInteractionTimeoutMs)
+    expect(footerHasMode(currentTui.screen(), "Run")).toBe(false)
+    expect(footerHasMode(currentTui.screen(), "Build")).toBe(true)
+
+    currentTui.write(`${prompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    await waitForNativeLLMRequest(currentTui, currentNativeServer, prompt)
+    expect(currentServer.requests).toHaveLength(0)
   })
 
   test("Tab cycles native agents outside Run and swarm targets in Run", async () => {
@@ -658,11 +1145,17 @@ describe("Agent Swarm terminal TUI e2e", () => {
 
     await selectProductMode(currentTui, "Run")
     currentTui.write("\t")
+    await currentTui.waitForText("MathAgent", tuiInteractionTimeoutMs)
+    currentTui.write("tab-selected run target\r")
     await currentTui.waitFor(
-      () => currentTui!.screen().includes("MathAgent · Swarm Default"),
-      "Run agent target",
+      () => currentServer!.requests.length === 1,
+      "Run agent target request",
       tuiInteractionTimeoutMs,
     )
+    expect(currentServer.requests[0]?.body).toMatchObject({
+      message: "tab-selected run target",
+      recipient_agent: "MathAgent",
+    })
   })
 
   test("run-target picker uses live agency labels instead of local-agency ids", async () => {
@@ -901,6 +1394,115 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(Object.values(runSessionState)).toContainEqual({
       mode: "local-project",
       directory: runProject,
+    })
+  })
+
+  test("/models native model selection keeps Run prompts server-backed", async () => {
+    const prompt = "run after slash models native selection"
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      cols: 150,
+      config: openAIProviderTestConfig,
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    currentTui.write("/models\r")
+    await currentTui.waitForText("Select model", tuiInteractionTimeoutMs)
+    currentTui.write("gpt-5.2")
+    await waitForModelOption(currentTui, "GPT-5.2")
+    currentTui.write("\r")
+    await currentTui.waitFor(
+      () => !currentTui!.screen().includes("Select model"),
+      "model selected",
+      tuiInteractionTimeoutMs,
+    )
+    if (currentTui.screen().includes("Select variant")) {
+      currentTui.write("\r")
+      await currentTui.waitFor(
+        () => !currentTui!.screen().includes("Select variant"),
+        "variant selected",
+        tuiInteractionTimeoutMs,
+      )
+    }
+
+    await selectProductMode(currentTui, "Build")
+    await currentTui.waitForText("Build · GPT-5.2", tuiInteractionTimeoutMs)
+    await selectProductMode(currentTui, "Run")
+    await currentTui.waitForText("UserSupportAgent · GPT-5.2", tuiInteractionTimeoutMs)
+
+    currentTui.write(`${prompt}\r`)
+    await currentTui.waitFor(
+      () => currentServer!.requests.some((request) => request.body.message === prompt),
+      "Agency request after /models native selection",
+      tuiInteractionTimeoutMs,
+    )
+
+    const screen = currentTui.screen()
+    expect(screen).not.toContain("Build ·")
+    expect(currentServer.requests[0]?.body).toMatchObject({
+      message: prompt,
+      recipient_agent: "UserSupportAgent",
+      client_config: {
+        model: "gpt-5.2",
+      },
+    })
+  })
+
+  test("model cycle shortcut keeps Run prompts server-backed", async () => {
+    const prompt = "run after model cycle native selection"
+    const stateHome = await mkdtemp(path.join(os.tmpdir(), "agentswarm-model-cycle-state-"))
+    tempDirs.push(stateHome)
+    await mkdir(path.join(stateHome, "agentswarm"), { recursive: true })
+    await writeFile(
+      path.join(stateHome, "agentswarm", "model.json"),
+      JSON.stringify({
+        recent: [
+          {
+            providerID: "agency-swarm",
+            modelID: "default",
+          },
+          {
+            providerID: "openai",
+            modelID: "gpt-5.2",
+          },
+        ],
+        favorite: [],
+        variant: {},
+      }),
+    )
+
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      cols: 150,
+      env: {
+        XDG_STATE_HOME: stateHome,
+      },
+      config: openAIProviderTestConfig,
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    currentTui.write("\x1bOQ")
+    await currentTui.waitForText("GPT-5.2 OpenAI", tuiInteractionTimeoutMs)
+    currentTui.write(`${prompt}\r`)
+    await currentTui.waitFor(
+      () => currentServer!.requests.some((request) => request.body.message === prompt),
+      "Agency request after model cycle native selection",
+      tuiInteractionTimeoutMs,
+    )
+
+    const screen = currentTui.screen()
+    expect(screen).not.toContain("Build ·")
+    expect(currentServer.requests[0]?.body).toMatchObject({
+      message: prompt,
+      recipient_agent: "UserSupportAgent",
     })
   })
 
@@ -1420,13 +2022,13 @@ async function selectProductMode(tui: TuiProcess, mode: "Build" | "Plan" | "Run"
   clearPrompt(tui)
   tui.write("/modes\r")
   await tui.waitFor(() => hasModeDialog(tui.screen()), "current mode dialog", tuiInteractionTimeoutMs)
+  await Bun.sleep(100)
   tui.write(mode)
   await tui.waitFor(
-    () => hasModeDialog(tui.screen()) && tui.screen().includes(mode),
+    () => hasSelectedMode(tui.screen(), mode) || hasFilteredMode(tui.screen(), mode),
     `${mode} mode option`,
     tuiInteractionTimeoutMs,
   )
-  tui.write("\x1b[B")
   tui.write("\r")
   await tui.waitFor(() => !tui.screen().includes("Select mode"), `${mode} mode selected`, tuiInteractionTimeoutMs)
   clearPrompt(tui)
@@ -1436,7 +2038,10 @@ async function waitForNativeLLMRequest(tui: TuiProcess, server: NativeLLMServer,
   let request: NativeLLMServer["requests"][number] | undefined
   await tui.waitFor(
     () => {
-      request = server.requests.find((item) => JSON.stringify(item.body).includes(prompt))
+      request = server.requests.find((item) => {
+        const body = JSON.stringify(item.body)
+        return body.includes(prompt) && !body.includes("title generator")
+      })
       return request !== undefined
     },
     `native LLM request containing ${prompt}`,

--- a/packages/opencode/src/agency-swarm/run-mode.ts
+++ b/packages/opencode/src/agency-swarm/run-mode.ts
@@ -1,6 +1,7 @@
 import { AgencySwarmAdapter } from "./adapter"
 
 export type AgencySwarmRunModeInput = {
+  argModel?: string
   currentProviderID?: string
   configuredModel?: string
   agentModel?: { providerID: string; modelID: string }
@@ -11,6 +12,7 @@ export function isAgencySwarmModel(model?: string) {
 }
 
 export function resolveAgencySwarmRunMode(input: AgencySwarmRunModeInput) {
+  if (isAgencySwarmModel(input.argModel)) return { active: true, reason: "arg" as const }
   if (isAgencySwarmModel(input.configuredModel)) return { active: true, reason: "config" as const }
   if (input.agentModel?.providerID === AgencySwarmAdapter.PROVIDER_ID) {
     return { active: true, reason: "agent" as const }

--- a/packages/opencode/src/agent/display.ts
+++ b/packages/opencode/src/agent/display.ts
@@ -1,6 +1,5 @@
 import * as Locale from "@/util/locale"
 
 export function displayAgentName(name: string) {
-  if (name === "build") return "Agent Builder"
   return Locale.titlecase(name)
 }

--- a/packages/opencode/src/cli/cmd/agency.ts
+++ b/packages/opencode/src/cli/cmd/agency.ts
@@ -10,7 +10,7 @@ import path from "path"
 
 export const AgencyCommand = cmd({
   command: "agency",
-  describe: "Agency Swarm backend management: connect, discover swarms, set default swarm",
+  describe: "Agency Swarm backend management: connect, discover agencies, set default agency, Agent Builder helpers",
   builder: (yargs: Argv) =>
     yargs
       .command(AgencyConnectCommand)
@@ -165,14 +165,14 @@ const AgencyUseCommand = cmd({
 
 const AgencyAgentCommand = cmd({
   command: "agent",
-  describe: false,
+  describe: "Agency Swarm Agent Builder helpers",
   builder: (yargs: Argv) => yargs.command(AgencyAgentNewCommand).demandCommand(),
   async handler() {},
 })
 
 const AgencyAgentNewCommand = cmd({
   command: "new <name>",
-  describe: false,
+  describe: "create a new Agency Swarm agent scaffold via `agency-swarm create-agent-template`",
   builder: (yargs: Argv) =>
     yargs
       .positional("name", {

--- a/packages/opencode/src/cli/cmd/agency.ts
+++ b/packages/opencode/src/cli/cmd/agency.ts
@@ -10,7 +10,7 @@ import path from "path"
 
 export const AgencyCommand = cmd({
   command: "agency",
-  describe: "Agency Swarm backend management: connect, discover agencies, set default agency, Agent Builder helpers",
+  describe: "Agency Swarm backend management: connect, discover swarms, set default swarm",
   builder: (yargs: Argv) =>
     yargs
       .command(AgencyConnectCommand)
@@ -165,14 +165,14 @@ const AgencyUseCommand = cmd({
 
 const AgencyAgentCommand = cmd({
   command: "agent",
-  describe: "Agency Swarm Agent Builder helpers",
+  describe: false,
   builder: (yargs: Argv) => yargs.command(AgencyAgentNewCommand).demandCommand(),
   async handler() {},
 })
 
 const AgencyAgentNewCommand = cmd({
   command: "new <name>",
-  describe: "create a new Agency Swarm agent scaffold via `agency-swarm create-agent-template`",
+  describe: false,
   builder: (yargs: Argv) =>
     yargs
       .positional("name", {

--- a/packages/opencode/src/cli/cmd/agency.ts
+++ b/packages/opencode/src/cli/cmd/agency.ts
@@ -10,7 +10,7 @@ import path from "path"
 
 export const AgencyCommand = cmd({
   command: "agency",
-  describe: "Agency Swarm backend management: connect, discover agencies, set default agency, Agent Builder helpers",
+  describe: "Agency Swarm backend management: connect, discover agencies, set default agency",
   builder: (yargs: Argv) =>
     yargs
       .command(AgencyConnectCommand)
@@ -165,14 +165,14 @@ const AgencyUseCommand = cmd({
 
 const AgencyAgentCommand = cmd({
   command: "agent",
-  describe: "Agency Swarm Agent Builder helpers",
+  describe: false,
   builder: (yargs: Argv) => yargs.command(AgencyAgentNewCommand).demandCommand(),
   async handler() {},
 })
 
 const AgencyAgentNewCommand = cmd({
   command: "new <name>",
-  describe: "create a new Agency Swarm agent scaffold via `agency-swarm create-agent-template`",
+  describe: false,
   builder: (yargs: Argv) =>
     yargs
       .positional("name", {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -459,7 +459,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   const connected = useConnected()
   const frameworkMode = createMemo(() =>
     isAgencySwarmFrameworkMode({
-      productMode: local.product.current(),
+      productMode: local.product?.current(),
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -73,7 +73,13 @@ import type { RouteMap } from "@/cli/cmd/tui/plugin/api"
 import { createTuiAttention } from "@/cli/cmd/tui/attention"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 import { CommandPaletteProvider, useCommandPalette } from "./context/command-palette"
-import { OpencodeKeymapProvider, registerOpencodeKeymap, useBindings, useOpencodeKeymap } from "./keymap"
+import {
+  OPENCODE_BASE_MODE,
+  OpencodeKeymapProvider,
+  registerOpencodeKeymap,
+  useBindings,
+  useOpencodeKeymap,
+} from "./keymap"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { AgencySwarmOllama } from "@/agency-swarm/ollama"
 import { AgencyProduct } from "@/agency-swarm/product"
@@ -742,6 +748,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
             return
           }
           local.agent.move(1)
+          const agent = local.agent.current()
+          if (agent?.name === "build" || agent?.name === "plan") void local.product.set(agent.name)
         },
       },
       {
@@ -782,6 +790,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
             return
           }
           local.agent.move(-1)
+          const agent = local.agent.current()
+          if (agent?.name === "build" || agent?.name === "plan") void local.product.set(agent.name)
         },
       },
       {
@@ -993,10 +1003,12 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   )
 
   useBindings(() => ({
+    mode: OPENCODE_BASE_MODE,
     commands: appCommands(),
   }))
 
   useBindings(() => ({
+    mode: OPENCODE_BASE_MODE,
     enabled: command.matcher,
     bindings: tuiConfig.keybinds.gather(
       "app",
@@ -1009,6 +1021,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   }))
 
   useBindings(() => ({
+    mode: OPENCODE_BASE_MODE,
     enabled: () => {
       const ok = command.matcher.get()
       if (!ok) return false

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -39,6 +39,7 @@ import { SyncProvider, useSync } from "@tui/context/sync"
 import { SyncProviderV2 } from "@tui/context/sync-v2"
 import { LocalProvider, useLocal } from "@tui/context/local"
 import { DialogModel } from "@tui/component/dialog-model"
+import { DialogMode } from "@tui/component/dialog-mode"
 import { useConnected } from "@tui/component/use-connected"
 import { DialogMcp } from "@tui/component/dialog-mcp"
 import { DialogStatus } from "@tui/component/dialog-status"
@@ -109,6 +110,7 @@ const appBindingCommands = [
   "model.cycle_recent_reverse",
   "model.cycle_favorite",
   "model.cycle_favorite_reverse",
+  "product.mode",
   "agent.list",
   "mcp.list",
   "agent.cycle",
@@ -457,6 +459,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   const connected = useConnected()
   const frameworkMode = createMemo(() =>
     isAgencySwarmFrameworkMode({
+      productMode: local.product.current(),
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
@@ -644,6 +647,15 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
             })),
           ]
         : []),
+      {
+        name: "product.mode",
+        title: "Switch mode",
+        category: "Agent",
+        slashName: "modes",
+        run: () => {
+          dialog.replace(() => <DialogMode />)
+        },
+      },
       {
         name: "model.list",
         title: "Switch model",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -47,7 +47,7 @@ export function DialogAgent() {
       currentProviderID: currentModel()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
-      productMode: local.product.current(),
+      productMode: local.product?.current(),
     }),
   )
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -47,6 +47,7 @@ export function DialogAgent() {
       currentProviderID: currentModel()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
+      productMode: local.product.current(),
     }),
   )
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -190,9 +190,13 @@ export function DialogAgent() {
 
   const current = createMemo<AgentOptionValue | undefined>(() => {
     if (!agencySwarmEnabled()) {
+      const product = local.product?.current()
+      const agent = local.agent.current()?.name
       return {
         kind: "local",
-        agent: local.agent.current()?.name ?? "build",
+        agent: (product === "build" || product === "plan") && (!agent || agent === "build" || agent === "plan")
+          ? product
+          : (agent ?? "build"),
       }
     }
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -232,6 +232,13 @@ export function DialogAgent() {
       options={options()}
       onSelect={(option) => {
         if (option.value.kind === "local") {
+          if (option.value.agent === "build" || option.value.agent === "plan") {
+            void local.product.set(option.value.agent).then(
+              () => dialog.clear(),
+              () => dialog.clear(),
+            )
+            return
+          }
           local.agent.set(option.value.agent)
           dialog.clear()
           return

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx
@@ -1,0 +1,40 @@
+import { useLocal, type ProductMode } from "@tui/context/local"
+import { useDialog } from "@tui/ui/dialog"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
+
+export function DialogMode() {
+  const local = useLocal()
+  const dialog = useDialog()
+
+  const options: DialogSelectOption<ProductMode>[] = [
+    {
+      value: "build",
+      title: "Build",
+      description: "Build or fix swarms and agents",
+    },
+    {
+      value: "plan",
+      title: "Plan",
+      description: "Plan work before building",
+    },
+    {
+      value: "run",
+      title: "Run",
+      description: "Run the connected swarm",
+    },
+  ]
+
+  return (
+    <DialogSelect
+      title="Select mode"
+      current={local.product.current()}
+      options={options}
+      onSelect={(option) => {
+        void local.product.set(option.value).then(
+          () => dialog.clear(),
+          () => dialog.clear(),
+        )
+      }}
+    />
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx
@@ -8,14 +8,14 @@ export function DialogMode() {
 
   const options: DialogSelectOption<ProductMode>[] = [
     {
-      value: "build",
-      title: "Build",
-      description: "Build or fix swarms and agents",
-    },
-    {
       value: "plan",
       title: "Plan",
       description: "Plan work before building",
+    },
+    {
+      value: "build",
+      title: "Build",
+      description: "Build or fix swarms and agents",
     },
     {
       value: "run",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -33,7 +33,7 @@ export function DialogModel(props: { providerID?: string }) {
     currentProviderID: local.model.current()?.providerID,
     configuredModel: sync.data.config.model,
     agentModel: local.agent.current()?.model,
-    productMode: local.product.current(),
+    productMode: local.product?.current(),
   })
   const agencyOptions = createMemo(() =>
     readAgencyProviderOptions({

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -29,11 +29,12 @@ export function DialogModel(props: { providerID?: string }) {
   const [query, setQuery] = createSignal("")
 
   const rawConnected = useConnected()
+  const productMode = createMemo(() => local.product?.current())
   const frameworkMode = isAgencySwarmFrameworkMode({
     currentProviderID: local.model.current()?.providerID,
     configuredModel: sync.data.config.model,
     agentModel: local.agent.current()?.model,
-    productMode: local.product?.current(),
+    productMode: productMode(),
   })
   const agencyOptions = createMemo(() =>
     readAgencyProviderOptions({
@@ -79,7 +80,9 @@ export function DialogModel(props: { providerID?: string }) {
   const enabledProviders = createMemo(() =>
     frameworkMode
       ? sync.data.provider.filter((provider) => isAgencySupportedProvider(provider.id))
-      : sync.data.provider,
+      : productMode() === "build" || productMode() === "plan"
+        ? sync.data.provider.filter((provider) => provider.id !== AgencySwarmAdapter.PROVIDER_ID)
+        : sync.data.provider,
   )
   // Treat framework mode as "not connected" when no agency-supported provider is usable,
   // so the disconnected fallback (filtered popular providers) keeps `/models` actionable
@@ -257,7 +260,7 @@ export function DialogModel(props: { providerID?: string }) {
         return
       }
     }
-    local.model.set({ providerID, modelID }, { recent: true, explicit: true })
+    local.model.set({ providerID, modelID }, { recent: true, explicit: true, preserveRun: productMode() === "run" })
     const list = local.model.variant.list()
     const cur = local.model.variant.selected()
     if (cur === "default" || (cur && list.includes(cur))) {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -33,6 +33,7 @@ export function DialogModel(props: { providerID?: string }) {
     currentProviderID: local.model.current()?.providerID,
     configuredModel: sync.data.config.model,
     agentModel: local.agent.current()?.model,
+    productMode: local.product.current(),
   })
   const agencyOptions = createMemo(() =>
     readAgencyProviderOptions({

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -197,7 +197,7 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
-      productMode: local.product.current(),
+      productMode: local.product?.current(),
     }),
   )
 
@@ -454,7 +454,7 @@ export function DialogAuth() {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
-      productMode: local.product.current(),
+      productMode: local.product?.current(),
     }),
   )
   const providerIDs = frameworkMode()
@@ -987,7 +987,7 @@ function AutoMethod(props: AutoMethodProps) {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
-      productMode: local.product.current(),
+      productMode: local.product?.current(),
     }),
   )
 
@@ -1131,7 +1131,7 @@ function CodeMethod(props: CodeMethodProps) {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
-      productMode: local.product.current(),
+      productMode: local.product?.current(),
     }),
   )
 
@@ -1231,7 +1231,7 @@ function ApiMethod(props: ApiMethodProps) {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
-      productMode: local.product.current(),
+      productMode: local.product?.current(),
     }),
   )
   const description = () => {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -197,6 +197,7 @@ export function createDialogProviderOptionsWithFilter(props: DialogProviderProps
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
+      productMode: local.product.current(),
     }),
   )
 
@@ -453,6 +454,7 @@ export function DialogAuth() {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
+      productMode: local.product.current(),
     }),
   )
   const providerIDs = frameworkMode()
@@ -985,6 +987,7 @@ function AutoMethod(props: AutoMethodProps) {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
+      productMode: local.product.current(),
     }),
   )
 
@@ -1128,6 +1131,7 @@ function CodeMethod(props: CodeMethodProps) {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
+      productMode: local.product.current(),
     }),
   )
 
@@ -1227,6 +1231,7 @@ function ApiMethod(props: ApiMethodProps) {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
+      productMode: local.product.current(),
     }),
   )
   const description = () => {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -106,6 +106,7 @@ export function Autocomplete(props: {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
+      productMode: local.product.current(),
     }),
   )
 
@@ -663,7 +664,7 @@ export function Autocomplete(props: {
   function select() {
     if (store.visible === "/" && store.selected === 0) {
       const typed = "/" + props.input().getTextRange(store.index + 1, props.input().cursorOffset)
-      const exact = command.slashes().find((item) => [item.display, ...(item.aliases ?? [])].includes(typed))
+      const exact = command.slashes().find((item) => [item.display.trimEnd(), ...(item.aliases ?? [])].includes(typed))
       if (exact) {
         hide()
         exact.onSelect()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -106,7 +106,7 @@ export function Autocomplete(props: {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
-      productMode: local.product.current(),
+      productMode: local.product?.current(),
     }),
   )
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -99,7 +99,7 @@ import { useArgs } from "@tui/context/args"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { type WorkspaceStatus } from "../workspace-label"
 import { useCommandPalette } from "../../context/command-palette"
-import { useBindings, useCommandShortcut, useLeaderActive, useOpencodeKeymap } from "../../keymap"
+import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut, useLeaderActive, useOpencodeKeymap } from "../../keymap"
 import { useTuiConfig } from "../../context/tui-config"
 import { Telemetry } from "@/telemetry/telemetry"
 import { captureCommand } from "@/telemetry/command"
@@ -279,7 +279,31 @@ export function Prompt(props: PromptProps) {
     }
     return model
   }
-  const effectiveAgentName = createMemo(() => (frameworkMode() ? "build" : (local.agent.current()?.name ?? "build")))
+  function currentSessionUserMessage() {
+    if (!props.sessionID) return undefined
+    const messages = sync.data.message[props.sessionID]
+    if (!messages) return undefined
+    return messages.findLast((m): m is UserMessage => m.role === "user")
+  }
+  function currentSessionPrimaryAgentName() {
+    const name = currentSessionUserMessage()?.agent
+    if (!name) return undefined
+    if (!local.agent.list().some((agent) => agent.name === name)) return undefined
+    return name
+  }
+  const effectiveAgentName = createMemo(() => {
+    const mode = local.product?.current()
+    const current = local.agent.current()?.name
+    if (mode === "plan") return "plan"
+    if (mode === "build") {
+      if (props.sessionID && local.agent.sessionID() !== props.sessionID)
+        return currentSessionPrimaryAgentName() ?? mode
+      if (current === "build" || current === "plan") return "build"
+      return current ?? mode
+    }
+    if (frameworkMode()) return "build"
+    return current ?? "build"
+  })
   const agencyProviderOptions = createMemo(() =>
     readAgencyProviderOptions({
       configuredProvider: sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID],
@@ -733,12 +757,7 @@ export function Prompt(props: PromptProps) {
     if (!props.disabled) input.cursorColor = theme.text
   })
 
-  const lastUserMessage = createMemo(() => {
-    if (!props.sessionID) return undefined
-    const messages = sync.data.message[props.sessionID]
-    if (!messages) return undefined
-    return messages.findLast((m): m is UserMessage => m.role === "user")
-  })
+  const lastUserMessage = createMemo(currentSessionUserMessage)
 
   const usage = createMemo(() => {
     if (!props.sessionID) return
@@ -1052,10 +1071,12 @@ export function Prompt(props: PromptProps) {
   )
 
   useBindings(() => ({
+    mode: OPENCODE_BASE_MODE,
     commands: promptCommands(),
   }))
 
   useBindings(() => ({
+    mode: OPENCODE_BASE_MODE,
     enabled: command.matcher,
     bindings: tuiConfig.keybinds.gather("prompt.palette", [
       "prompt.submit",
@@ -1293,11 +1314,13 @@ export function Prompt(props: PromptProps) {
   )
 
   useBindings(() => ({
+    mode: OPENCODE_BASE_MODE,
     commands: stashCommands(),
   }))
 
   useBindings(() => {
     return {
+      mode: OPENCODE_BASE_MODE,
       target: inputTarget,
       enabled: inputTarget() !== undefined && !props.disabled,
       bindings: tuiConfig.keybinds.get("prompt.paste"),
@@ -1306,6 +1329,7 @@ export function Prompt(props: PromptProps) {
 
   useBindings(() => {
     return {
+      mode: OPENCODE_BASE_MODE,
       target: inputTarget,
       enabled: inputTarget() !== undefined && !props.disabled && store.prompt.input !== "",
       bindings: tuiConfig.keybinds.get("prompt.clear"),
@@ -1314,6 +1338,7 @@ export function Prompt(props: PromptProps) {
 
   useBindings(() => {
     return {
+      mode: OPENCODE_BASE_MODE,
       target: inputTarget,
       enabled: (() => {
         cursorVersion()
@@ -1341,6 +1366,7 @@ export function Prompt(props: PromptProps) {
 
   useBindings(() => {
     return {
+      mode: OPENCODE_BASE_MODE,
       target: inputTarget,
       enabled: inputTarget() !== undefined && store.mode === "shell",
       bindings: [{ key: "escape", desc: "Exit shell mode", group: "Prompt", cmd: () => setStore("mode", "normal") }],
@@ -1349,6 +1375,7 @@ export function Prompt(props: PromptProps) {
 
   useBindings(() => {
     return {
+      mode: OPENCODE_BASE_MODE,
       target: inputTarget,
       enabled: (() => {
         cursorVersion()
@@ -1360,6 +1387,7 @@ export function Prompt(props: PromptProps) {
 
   useBindings(() => {
     return {
+      mode: OPENCODE_BASE_MODE,
       target: inputTarget,
       enabled: (() => {
         cursorVersion()
@@ -1392,6 +1420,7 @@ export function Prompt(props: PromptProps) {
 
   useBindings(() => {
     return {
+      mode: OPENCODE_BASE_MODE,
       target: inputTarget,
       enabled: (() => {
         cursorVersion()
@@ -1593,7 +1622,7 @@ export function Prompt(props: PromptProps) {
     ) {
       toast.show({
         variant: "warning",
-        message: `/${serverSlashCommand.name} is available in Agent Builder or Plan mode.`,
+        message: `/${serverSlashCommand.name} is available in Build or Plan mode.`,
         duration: 4000,
       })
       return false
@@ -1690,11 +1719,14 @@ export function Prompt(props: PromptProps) {
     }
 
     const messageID = MessageID.ascending()
-    void AgencySwarmRunSession.sync({
-      sessionID,
-      providerID: productProviderID,
-      directory: process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV],
-    })
+    const productMode = local.product?.current()
+    if (productMode === "run") {
+      void AgencySwarmRunSession.sync({
+        sessionID,
+        providerID: productProviderID,
+        directory: process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV],
+      })
+    }
 
     const editorSelection = editorContext()
     const editorParts =
@@ -1736,6 +1768,7 @@ export function Prompt(props: PromptProps) {
           modelID: selectedModel.modelID,
         },
         command: inputText,
+        agencySwarmBridge: frameworkMode(),
       })
       setStore("mode", "normal")
     } else if (isServerSlashCommand) {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -248,11 +248,37 @@ export function Prompt(props: PromptProps) {
   const canSwitchOrgs = createMemo(() => sync.data.console_state.switchableOrgCount > 1)
   const frameworkMode = createMemo(() =>
     isAgencySwarmFrameworkMode({
+      productMode: local.product.current(),
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
     }),
   )
+  function firstNativeModel() {
+    const hasModel = (model: { providerID: string; modelID: string }) =>
+      Boolean(sync.data.provider.find((provider) => provider.id === model.providerID)?.models[model.modelID])
+
+    const recent = local.model
+      .recent()
+      .find((item) => item.providerID !== AgencySwarmAdapter.PROVIDER_ID && hasModel(item))
+    if (recent) return recent
+
+    for (const provider of sync.data.provider) {
+      if (provider.id === AgencySwarmAdapter.PROVIDER_ID) continue
+      const defaultModel = sync.data.provider_default[provider.id]
+      const firstModel = Object.values(provider.models)[0] as { id?: string } | undefined
+      const modelID = defaultModel ?? firstModel?.id
+      if (modelID) return { providerID: provider.id, modelID }
+    }
+  }
+  function promptModel() {
+    const model = local.model.current()
+    const mode = local.product.current()
+    if ((mode === "build" || mode === "plan") && model?.providerID === AgencySwarmAdapter.PROVIDER_ID) {
+      return firstNativeModel() ?? model
+    }
+    return model
+  }
   const effectiveAgentName = createMemo(() => (frameworkMode() ? "build" : (local.agent.current()?.name ?? "build")))
   const agencyProviderOptions = createMemo(() =>
     readAgencyProviderOptions({
@@ -1494,7 +1520,7 @@ export function Prompt(props: PromptProps) {
     }
 
     const currentMode = store.mode
-    const selectedModel = local.model.current()
+    const selectedModel = promptModel()
     if (!selectedModel) {
       void promptModelWarning()
       return false
@@ -1596,7 +1622,7 @@ export function Prompt(props: PromptProps) {
       return false
     }
 
-    if (currentMode !== "shell" && agencyConnection.requiresReconnect()) {
+    if (currentMode !== "shell" && frameworkMode() && agencyConnection.requiresReconnect()) {
       toast.show({
         variant: "warning",
         message: "Reconnect to a local agency-swarm server before sending a message",
@@ -1768,6 +1794,7 @@ export function Prompt(props: PromptProps) {
         $body_agencyRecipientAgent?: string
         $body_agencyLabelAgency?: string
         $body_agencyLabelRecipientAgent?: string
+        $body_agencySwarmBridge?: boolean
       } = {
         sessionID,
         ...selectedModel,
@@ -1778,6 +1805,7 @@ export function Prompt(props: PromptProps) {
         $body_agencyRecipientAgent: agencyRecipientAgent,
         $body_agencyLabelAgency: agencyLabelAgency,
         $body_agencyLabelRecipientAgent: agencyLabelRecipientAgent,
+        $body_agencySwarmBridge: frameworkMode(),
         parts: [
           ...editorParts,
           {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -248,7 +248,7 @@ export function Prompt(props: PromptProps) {
   const canSwitchOrgs = createMemo(() => sync.data.console_state.switchableOrgCount > 1)
   const frameworkMode = createMemo(() =>
     isAgencySwarmFrameworkMode({
-      productMode: local.product.current(),
+      productMode: local.product?.current(),
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
@@ -273,7 +273,7 @@ export function Prompt(props: PromptProps) {
   }
   function promptModel() {
     const model = local.model.current()
-    const mode = local.product.current()
+    const mode = local.product?.current()
     if ((mode === "build" || mode === "plan") && model?.providerID === AgencySwarmAdapter.PROVIDER_ID) {
       return firstNativeModel() ?? model
     }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1603,6 +1603,7 @@ export function Prompt(props: PromptProps) {
 
     if (
       shouldBlockAgencyPromptSubmit({
+        productMode: local.product?.current(),
         currentProviderID: selectedModel.providerID,
         configuredModel: sync.data.config.model,
         agentModel: local.agent.current()?.model,
@@ -1749,6 +1750,7 @@ export function Prompt(props: PromptProps) {
         sessionID,
         command: command.slice(1),
         arguments: args,
+        agencySwarmBridge: frameworkMode(),
         agent: effectiveAgentName(),
         model: `${selectedModel.providerID}/${selectedModel.modelID}`,
         messageID,

--- a/packages/opencode/src/cli/cmd/tui/context/agency-swarm-connection.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/agency-swarm-connection.tsx
@@ -245,7 +245,7 @@ export const { use: useAgencySwarmConnection, provider: AgencySwarmConnectionPro
         currentProviderID: local.model.current()?.providerID,
         configuredModel: sync.data.config.model,
         agentModel: local.agent.current()?.model,
-        productMode: local.product.current(),
+        productMode: local.product?.current(),
       }),
     )
 

--- a/packages/opencode/src/cli/cmd/tui/context/agency-swarm-connection.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/agency-swarm-connection.tsx
@@ -245,6 +245,7 @@ export const { use: useAgencySwarmConnection, provider: AgencySwarmConnectionPro
         currentProviderID: local.model.current()?.providerID,
         configuredModel: sync.data.config.model,
         agentModel: local.agent.current()?.model,
+        productMode: local.product.current(),
       }),
     )
 

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -18,6 +18,7 @@ import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
 import { Provider } from "@/provider/provider"
 import { Filesystem } from "@/util/filesystem"
+import type { Part } from "@opencode-ai/sdk/v2"
 
 export function parseModel(model: string) {
   const [providerID, ...rest] = model.split("/")
@@ -37,6 +38,73 @@ type StoredModelSelection = ModelSelection & {
 }
 
 export type ProductMode = "build" | "plan" | "run"
+const AGENCY_SWARM_BRIDGE_METADATA_KEY = "agencySwarmBridge"
+
+function isProviderEnabled(input: { providerID: string; enabledProviders?: string[]; disabledProviders?: string[] }) {
+  if (input.enabledProviders && !input.enabledProviders.includes(input.providerID)) return false
+  if (input.disabledProviders?.includes(input.providerID)) return false
+  return true
+}
+
+export function inferProductMode(input: {
+  storedMode?: ProductMode
+  storedModel?: StoredModelSelection
+  storedBridge?: boolean
+  agentName?: string
+  currentProviderID?: string
+  configuredModel?: string
+  hasAgencySwarmProvider?: boolean
+  enabledProviders?: string[]
+  disabledProviders?: string[]
+  argModel?: string
+  agentModel?: ModelSelection
+}) {
+  const agencySwarmEnabled = isProviderEnabled({
+    providerID: AgencySwarmAdapter.PROVIDER_ID,
+    enabledProviders: input.enabledProviders,
+    disabledProviders: input.disabledProviders,
+  })
+  if (input.storedMode === "plan" && input.agentName && input.agentName !== "plan") return "build"
+  if (input.storedMode) return input.storedMode
+  if (input.storedBridge === true) return agencySwarmEnabled ? "run" : "build"
+  if (input.agentName === "plan") return "plan"
+  if (input.storedBridge === false) return "build"
+  if (
+    input.agentName === "build" &&
+    !input.argModel &&
+    input.storedModel &&
+    input.currentProviderID &&
+    input.currentProviderID !== AgencySwarmAdapter.PROVIDER_ID
+  ) {
+    return "build"
+  }
+  if (input.hasAgencySwarmProvider && agencySwarmEnabled) return "run"
+  if (
+    agencySwarmEnabled &&
+    isAgencySwarmRunMode({
+      argModel: input.argModel,
+      currentProviderID: input.currentProviderID,
+      configuredModel: input.configuredModel,
+      agentModel: input.agentModel,
+    })
+  ) {
+    return "run"
+  }
+  return "build"
+}
+
+export function readAgencySwarmBridge(parts: Part[] | undefined) {
+  for (const part of parts ?? []) {
+    if (part.type !== "text" && part.type !== "subtask" && part.type !== "compaction") continue
+    const value = part.metadata?.[AGENCY_SWARM_BRIDGE_METADATA_KEY]
+    if (typeof value === "boolean") return value
+  }
+}
+
+function isAllowedProductModel(input: { model: ModelSelection; productMode?: ProductMode }) {
+  if (input.productMode !== "build" && input.productMode !== "plan") return true
+  return input.model.providerID !== AgencySwarmAdapter.PROVIDER_ID
+}
 
 export function isUsableModel(input: {
   model: ModelSelection
@@ -51,12 +119,20 @@ export function isUsableModel(input: {
   disabledProviders?: string[]
   productMode?: ProductMode
 }) {
+  if (!isAllowedProductModel(input)) return false
+  if (
+    !isProviderEnabled({
+      providerID: input.model.providerID,
+      enabledProviders: input.enabledProviders,
+      disabledProviders: input.disabledProviders,
+    })
+  ) {
+    return false
+  }
   const provider = input.providers.find((x) => x.id === input.model.providerID)
   if (provider?.models[input.model.modelID]) return true
   if (input.model.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
   if (input.model.modelID !== AgencySwarmAdapter.DEFAULT_MODEL_ID) return false
-  if (input.enabledProviders && !input.enabledProviders.includes(AgencySwarmAdapter.PROVIDER_ID)) return false
-  if (input.disabledProviders?.includes(AgencySwarmAdapter.PROVIDER_ID)) return false
   if (input.productMode === "run") return true
   const selectedAgencySwarmModel = [input.argModel, input.configModel].some(
     (value) => value === `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`,
@@ -80,7 +156,36 @@ export function selectCurrentModel(input: {
   enabledProviders?: string[]
   disabledProviders?: string[]
   productMode?: ProductMode
+  storedMode?: ProductMode
+  storedBridge?: boolean
+  agentName?: string
+  currentProviderID?: string
+  hasAgencySwarmProvider?: boolean
 }) {
+  const hasProductModeContext =
+    input.storedMode !== undefined ||
+    input.storedBridge !== undefined ||
+    input.agentName !== undefined ||
+    input.currentProviderID !== undefined ||
+    input.hasAgencySwarmProvider !== undefined
+  const productMode =
+    input.productMode ??
+    (hasProductModeContext
+      ? inferProductMode({
+          storedMode: input.storedMode,
+          storedModel: input.storedModel,
+          storedBridge: input.storedBridge,
+          agentName: input.agentName,
+          currentProviderID: input.currentProviderID ?? input.storedModel?.providerID ?? input.agentModel?.providerID,
+          configuredModel: input.configModel,
+          hasAgencySwarmProvider: input.hasAgencySwarmProvider,
+          enabledProviders: input.enabledProviders,
+          disabledProviders: input.disabledProviders,
+          argModel: input.argModel,
+          agentModel: input.agentModel,
+        })
+      : undefined)
+
   function isModelValid(model: ModelSelection) {
     return isUsableModel({
       model,
@@ -90,20 +195,15 @@ export function selectCurrentModel(input: {
       configuredProviders: input.configuredProviders,
       enabledProviders: input.enabledProviders,
       disabledProviders: input.disabledProviders,
-      productMode: input.productMode,
+      productMode,
     })
-  }
-
-  function isAllowedProductModel(model: ModelSelection) {
-    if (input.productMode !== "build" && input.productMode !== "plan") return true
-    return model.providerID !== AgencySwarmAdapter.PROVIDER_ID
   }
 
   function getFirstValidModel(...modelFns: (() => ModelSelection | undefined)[]) {
     for (const modelFn of modelFns) {
       const model = modelFn()
       if (!model) continue
-      if (!isAllowedProductModel(model)) continue
+      if (!isAllowedProductModel({ model, productMode })) continue
       if (isModelValid(model)) return { providerID: model.providerID, modelID: model.modelID }
     }
   }
@@ -111,7 +211,10 @@ export function selectCurrentModel(input: {
   const fallbackModel = () => {
     if (input.argModel) {
       const { providerID, modelID } = Provider.parseModel(input.argModel)
-      if (isAllowedProductModel({ providerID, modelID }) && isModelValid({ providerID, modelID })) {
+      if (
+        isAllowedProductModel({ model: { providerID, modelID }, productMode }) &&
+        isModelValid({ providerID, modelID })
+      ) {
         return {
           providerID,
           modelID,
@@ -121,7 +224,10 @@ export function selectCurrentModel(input: {
 
     if (input.configModel) {
       const { providerID, modelID } = Provider.parseModel(input.configModel)
-      if (isAllowedProductModel({ providerID, modelID }) && isModelValid({ providerID, modelID })) {
+      if (
+        isAllowedProductModel({ model: { providerID, modelID }, productMode }) &&
+        isModelValid({ providerID, modelID })
+      ) {
         return {
           providerID,
           modelID,
@@ -130,23 +236,21 @@ export function selectCurrentModel(input: {
     }
 
     for (const item of input.recentModels ?? []) {
-      if (isAllowedProductModel(item) && isModelValid(item)) {
+      if (isAllowedProductModel({ model: item, productMode }) && isModelValid(item)) {
         return item
       }
     }
 
-    const provider = input.providers.find((item) => {
-      if (input.productMode !== "build" && input.productMode !== "plan") return true
-      return item.id !== AgencySwarmAdapter.PROVIDER_ID
-    })
-    if (!provider) return undefined
-    const defaultModel = input.providerDefaults?.[provider.id]
-    const firstModel = Object.values(provider.models)[0] as { id?: string } | undefined
-    const model = defaultModel ?? firstModel?.id
-    if (!model) return undefined
-    return {
-      providerID: provider.id,
-      modelID: model,
+    for (const provider of input.providers) {
+      const firstModel = Object.values(provider.models)[0] as { id?: string } | undefined
+      for (const model of [input.providerDefaults?.[provider.id], firstModel?.id]) {
+        if (!model) continue
+        const item = {
+          providerID: provider.id,
+          modelID: model,
+        }
+        if (isModelValid(item)) return item
+      }
     }
   }
 
@@ -159,7 +263,12 @@ export function selectCurrentModel(input: {
     return explicitArgModel
   }
 
-  if (shouldPreferConfiguredAgencySwarmModel(input) && !input.storedModel?.explicit) {
+  if (
+    productMode !== "build" &&
+    productMode !== "plan" &&
+    shouldPreferConfiguredAgencySwarmModel(input) &&
+    !input.storedModel?.explicit
+  ) {
     return getFirstValidModel(fallbackModel, () => input.agentModel)
   }
 
@@ -187,10 +296,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sdk = useSDK()
     const toast = useToast()
     const args = useArgs()
+    const route = useRoute()
     const [productStore, setProductStore] = createStore<{
       mode: ProductMode | undefined
+      sessionID: string | undefined
     }>({
       mode: undefined,
+      sessionID: undefined,
     })
 
     function isModelValid(model: ModelSelection) {
@@ -205,7 +317,31 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         configuredProviders: sync.data.config.provider,
         enabledProviders: sync.data.config.enabled_providers,
         disabledProviders: sync.data.config.disabled_providers,
-        productMode: productStore.mode,
+        productMode: currentStoredMode(),
+      })
+    }
+
+    function isModelValidForMode(model: ModelSelection, mode: ProductMode) {
+      return isUsableModel({
+        model,
+        providers: sync.data.provider.map((item) => ({
+          id: item.id,
+          models: item.models,
+        })),
+        argModel: args.model,
+        configModel: sync.data.config.model,
+        configuredProviders: sync.data.config.provider,
+        enabledProviders: sync.data.config.enabled_providers,
+        disabledProviders: sync.data.config.disabled_providers,
+        productMode: mode,
+      })
+    }
+
+    function showInvalidModelToast(model: ModelSelection) {
+      toast.show({
+        message: `Model ${model.providerID}/${model.modelID} is not valid`,
+        variant: "warning",
+        duration: 3000,
       })
     }
 
@@ -214,6 +350,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const visibleAgents = createMemo(() => sync.data.agent.filter((x) => !x.hidden))
       const [agentStore, setAgentStore] = createStore({
         current: undefined as string | undefined,
+        sessionID: undefined as string | undefined,
       })
       const { theme } = useTheme()
       const colors = createMemo(() => [
@@ -240,6 +377,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               duration: 3000,
             })
           setAgentStore("current", name)
+          setAgentStore("sessionID", currentSessionID())
+        },
+        sessionID() {
+          return agentStore.sessionID
         },
         move(direction: 1 | -1) {
           batch(() => {
@@ -250,6 +391,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             if (next >= agents().length) next = 0
             const value = agents()[next]
             setAgentStore("current", value.name)
+            setAgentStore("sessionID", currentSessionID())
           })
         },
         color(name: string) {
@@ -316,9 +458,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const currentModel = createMemo(() => {
         const a = agent.current()
         if (!a) return
+        const agentName = currentModelAgentName(a)
+        const selectedAgent = agent.list().find((item) => item.name === agentName) ?? a
         return selectCurrentModel({
-          storedModel: modelStore.model[a.name],
-          agentModel: a.model,
+          storedModel: modelStore.model[agentName],
+          agentModel: selectedAgent.model,
           recentModels: modelStore.recent,
           providers: sync.data.provider.map((item) => ({
             id: item.id,
@@ -330,9 +474,29 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           configuredProviders: sync.data.config.provider,
           enabledProviders: sync.data.config.enabled_providers,
           disabledProviders: sync.data.config.disabled_providers,
-          productMode: productStore.mode,
+          storedMode: currentStoredMode(),
+          storedBridge: currentSessionAgencySwarmBridge(),
+          agentName,
+          hasAgencySwarmProvider: !!sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID],
         })
       })
+
+      function preserveRunMode(a: { name: string; model?: ModelSelection }, current?: ModelSelection) {
+        const mode = inferProductMode({
+          storedMode: currentStoredMode(),
+          storedModel: modelStore.model[a.name],
+          storedBridge: currentSessionAgencySwarmBridge(),
+          agentName: a.name,
+          currentProviderID: current?.providerID,
+          configuredModel: sync.data.config.model,
+          hasAgencySwarmProvider: !!sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID],
+          enabledProviders: sync.data.config.enabled_providers,
+          disabledProviders: sync.data.config.disabled_providers,
+          argModel: args.model,
+          agentModel: a.model,
+        })
+        if (mode === "run") setProductMode("run")
+      }
 
       return {
         current: currentModel,
@@ -368,7 +532,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         cycle(direction: 1 | -1) {
           const current = currentModel()
           if (!current) return
-          const recent = modelStore.recent
+          const recent = modelStore.recent.filter((item) => isModelValidForMode(item, product.current()))
           const index = recent.findIndex((x) => x.providerID === current.providerID && x.modelID === current.modelID)
           if (index === -1) return
           let next = index + direction
@@ -378,10 +542,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (!val) return
           const a = agent.current()
           if (!a) return
-          setModelStore("model", a.name, { ...val, explicit: true })
+          preserveRunMode(a, current)
+          setModelStore("model", modelStoreKey(a), { ...val, explicit: true })
         },
         cycleFavorite(direction: 1 | -1) {
-          const favorites = modelStore.favorite.filter((item) => isModelValid(item))
+          const favorites = modelStore.favorite.filter((item) => isModelValidForMode(item, product.current()))
           if (!favorites.length) {
             toast.show({
               variant: "info",
@@ -406,7 +571,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (!next) return
           const a = agent.current()
           if (!a) return
-          setModelStore("model", a.name, { ...next, explicit: true })
+          preserveRunMode(a, current)
+          setModelStore("model", modelStoreKey(a), { ...next, explicit: true })
           const uniq = uniqueBy([next, ...modelStore.recent], (x) => `${x.providerID}/${x.modelID}`)
           if (uniq.length > 10) uniq.pop()
           setModelStore(
@@ -415,19 +581,19 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           )
           save()
         },
-        set(model: ModelSelection, options?: { recent?: boolean; explicit?: boolean }) {
+        set(model: ModelSelection, options?: { recent?: boolean; explicit?: boolean; preserveRun?: boolean }) {
           batch(() => {
             if (!isModelValid(model)) {
-              toast.show({
-                message: `Model ${model.providerID}/${model.modelID} is not valid`,
-                variant: "warning",
-                duration: 3000,
-              })
+              showInvalidModelToast(model)
               return
             }
             const a = agent.current()
             if (!a) return
-            setModelStore("model", a.name, { ...model, explicit: options?.explicit })
+            if (options?.preserveRun) {
+              setProductMode("run")
+              agent.set("build")
+            }
+            setModelStore("model", modelStoreKey(a), { ...model, explicit: options?.explicit })
             if (options?.recent) {
               const uniq = uniqueBy([model, ...modelStore.recent], (x) => `${x.providerID}/${x.modelID}`)
               if (uniq.length > 10) uniq.pop()
@@ -442,11 +608,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         toggleFavorite(model: ModelSelection) {
           batch(() => {
             if (!isModelValid(model)) {
-              toast.show({
-                message: `Model ${model.providerID}/${model.modelID} is not valid`,
-                variant: "warning",
-                duration: 3000,
-              })
+              showInvalidModelToast(model)
               return
             }
             const exists = modelStore.favorite.some(
@@ -552,7 +714,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (state.pending) save()
         })
 
-      const route = useRoute()
       const event = useEvent()
       let cycling = false
 
@@ -735,36 +896,100 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       }
     })
 
+    function currentSessionUserMessage() {
+      if (route.data.type !== "session") return undefined
+      return sync.data.message[route.data.sessionID]?.findLast((item) => item.role === "user")
+    }
+
+    function currentSessionAgencySwarmBridge() {
+      if (route.data.type !== "session") return undefined
+      const messages = sync.data.message[route.data.sessionID] ?? []
+      for (let index = messages.length - 1; index >= 0; index--) {
+        const message = messages[index]
+        if (!message || message.role !== "user") continue
+        const bridge = readAgencySwarmBridge(sync.data.part[message.id])
+        if (bridge !== undefined) return bridge
+      }
+    }
+
+    function currentSessionID() {
+      return route.data.type === "session" ? route.data.sessionID : undefined
+    }
+
+    function currentStoredMode() {
+      const sessionID = currentSessionID()
+      if (!sessionID) return productStore.mode
+      if (productStore.sessionID !== sessionID) return undefined
+      return productStore.mode
+    }
+
+    function setProductMode(mode: ProductMode) {
+      batch(() => {
+        setProductStore("mode", mode)
+        setProductStore("sessionID", currentSessionID())
+      })
+    }
+
+    function currentModelAgentName(current: { name: string }) {
+      const mode = currentStoredMode()
+      if (mode === "run") return "build"
+      if (mode === "build" || mode === "plan") return current.name
+      if (agent.sessionID() === currentSessionID()) return current.name
+      return currentSessionUserMessage()?.agent ?? current.name
+    }
+
+    function modelStoreKey(current: { name: string }) {
+      return currentModelAgentName(current)
+    }
+
     const product = {
       current(): ProductMode {
-        if (productStore.mode) return productStore.mode
-        if (
-          isAgencySwarmRunMode({
-            currentProviderID: model.current()?.providerID,
-            configuredModel: sync.data.config.model,
-            agentModel: agent.current()?.model,
-          })
-        ) {
-          return "run"
-        }
-        return agent.current()?.name === "plan" ? "plan" : "build"
+        const value = model.current()
+        const current = agent.current()
+        const agentName = current ? currentModelAgentName(current) : currentSessionUserMessage()?.agent
+        const selectedAgent = agent.list().find((item) => item.name === agentName) ?? current
+        return inferProductMode({
+          storedMode: currentStoredMode(),
+          storedModel: agentName ? model.override(agentName) : undefined,
+          storedBridge: currentSessionAgencySwarmBridge(),
+          agentName,
+          currentProviderID: value?.providerID,
+          configuredModel: sync.data.config.model,
+          hasAgencySwarmProvider: !!sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID],
+          enabledProviders: sync.data.config.enabled_providers,
+          disabledProviders: sync.data.config.disabled_providers,
+          argModel: args.model,
+          agentModel: selectedAgent?.model,
+        })
       },
       async set(mode: ProductMode) {
-        setProductStore("mode", mode)
         if (mode === "build" || mode === "plan") {
+          const currentAgent = agent.current()
+          const currentOverride = currentAgent ? model.override(currentAgent.name) : undefined
+          const currentModel = model.current()
+          setProductMode(mode)
           agent.set(mode)
-          const value = model.current()
-          if (!value || value.providerID === AgencySwarmAdapter.PROVIDER_ID) return
-          model.set(value, { explicit: true })
+          if (!currentOverride?.explicit) return
+          if (!currentModel || currentModel.providerID === AgencySwarmAdapter.PROVIDER_ID) return
+          model.set(currentModel, { explicit: true })
           return
         }
-        model.set(
-          {
-            providerID: AgencySwarmAdapter.PROVIDER_ID,
-            modelID: AgencySwarmAdapter.DEFAULT_MODEL_ID,
-          },
-          { explicit: true },
-        )
+        const bridge = {
+          providerID: AgencySwarmAdapter.PROVIDER_ID,
+          modelID: AgencySwarmAdapter.DEFAULT_MODEL_ID,
+        }
+        if (!isModelValidForMode(bridge, "run")) {
+          showInvalidModelToast(bridge)
+          return
+        }
+        const current = model.override("build")
+        const value =
+          current?.explicit && isModelValidForMode(current, "run")
+            ? { providerID: current.providerID, modelID: current.modelID }
+            : bridge
+        setProductMode(mode)
+        agent.set("build")
+        model.set(value, { explicit: true })
       },
     }
 

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -57,6 +57,7 @@ export function isUsableModel(input: {
   if (input.model.modelID !== AgencySwarmAdapter.DEFAULT_MODEL_ID) return false
   if (input.enabledProviders && !input.enabledProviders.includes(AgencySwarmAdapter.PROVIDER_ID)) return false
   if (input.disabledProviders?.includes(AgencySwarmAdapter.PROVIDER_ID)) return false
+  if (input.productMode === "run") return true
   const selectedAgencySwarmModel = [input.argModel, input.configModel].some(
     (value) => value === `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`,
   )
@@ -89,6 +90,7 @@ export function selectCurrentModel(input: {
       configuredProviders: input.configuredProviders,
       enabledProviders: input.enabledProviders,
       disabledProviders: input.disabledProviders,
+      productMode: input.productMode,
     })
   }
 
@@ -203,6 +205,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         configuredProviders: sync.data.config.provider,
         enabledProviders: sync.data.config.enabled_providers,
         disabledProviders: sync.data.config.disabled_providers,
+        productMode: productStore.mode,
       })
     }
 
@@ -753,31 +756,16 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const value = model.current()
           if (!value || value.providerID === AgencySwarmAdapter.PROVIDER_ID) return
           model.set(value, { explicit: true })
-          await updateConfigModel(value)
           return
         }
-        const runModel = {
-          providerID: AgencySwarmAdapter.PROVIDER_ID,
-          modelID: AgencySwarmAdapter.DEFAULT_MODEL_ID,
-        }
-        await updateConfigModel(runModel)
-        model.set(runModel, { explicit: true })
-      },
-    }
-
-    async function updateConfigModel(value: ModelSelection) {
-      await sdk.client.global.config.update(
-        {
-          config: {
-            model: `${value.providerID}/${value.modelID}`,
+        model.set(
+          {
+            providerID: AgencySwarmAdapter.PROVIDER_ID,
+            modelID: AgencySwarmAdapter.DEFAULT_MODEL_ID,
           },
-        },
-        {
-          throwOnError: true,
-        },
-      )
-      await sdk.client.instance.dispose()
-      await sync.bootstrap()
+          { explicit: true },
+        )
+      },
     }
 
     const result = {

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -8,7 +8,7 @@ import { useEvent } from "@tui/context/event"
 import { uniqueBy } from "remeda"
 import path from "path"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
-import { isAgencySwarmModel } from "@/agency-swarm/run-mode"
+import { isAgencySwarmModel, isAgencySwarmRunMode } from "@/agency-swarm/run-mode"
 import { Global } from "@opencode-ai/core/global"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { iife } from "@/util/iife"
@@ -36,6 +36,8 @@ type StoredModelSelection = ModelSelection & {
   explicit?: boolean
 }
 
+export type ProductMode = "build" | "plan" | "run"
+
 export function isUsableModel(input: {
   model: ModelSelection
   providers: {
@@ -47,6 +49,7 @@ export function isUsableModel(input: {
   configuredProviders?: Record<string, unknown>
   enabledProviders?: string[]
   disabledProviders?: string[]
+  productMode?: ProductMode
 }) {
   const provider = input.providers.find((x) => x.id === input.model.providerID)
   if (provider?.models[input.model.modelID]) return true
@@ -75,6 +78,7 @@ export function selectCurrentModel(input: {
   configuredProviders?: Record<string, unknown>
   enabledProviders?: string[]
   disabledProviders?: string[]
+  productMode?: ProductMode
 }) {
   function isModelValid(model: ModelSelection) {
     return isUsableModel({
@@ -88,10 +92,16 @@ export function selectCurrentModel(input: {
     })
   }
 
+  function isAllowedProductModel(model: ModelSelection) {
+    if (input.productMode !== "build" && input.productMode !== "plan") return true
+    return model.providerID !== AgencySwarmAdapter.PROVIDER_ID
+  }
+
   function getFirstValidModel(...modelFns: (() => ModelSelection | undefined)[]) {
     for (const modelFn of modelFns) {
       const model = modelFn()
       if (!model) continue
+      if (!isAllowedProductModel(model)) continue
       if (isModelValid(model)) return { providerID: model.providerID, modelID: model.modelID }
     }
   }
@@ -99,7 +109,7 @@ export function selectCurrentModel(input: {
   const fallbackModel = () => {
     if (input.argModel) {
       const { providerID, modelID } = Provider.parseModel(input.argModel)
-      if (isModelValid({ providerID, modelID })) {
+      if (isAllowedProductModel({ providerID, modelID }) && isModelValid({ providerID, modelID })) {
         return {
           providerID,
           modelID,
@@ -109,7 +119,7 @@ export function selectCurrentModel(input: {
 
     if (input.configModel) {
       const { providerID, modelID } = Provider.parseModel(input.configModel)
-      if (isModelValid({ providerID, modelID })) {
+      if (isAllowedProductModel({ providerID, modelID }) && isModelValid({ providerID, modelID })) {
         return {
           providerID,
           modelID,
@@ -118,12 +128,15 @@ export function selectCurrentModel(input: {
     }
 
     for (const item of input.recentModels ?? []) {
-      if (isModelValid(item)) {
+      if (isAllowedProductModel(item) && isModelValid(item)) {
         return item
       }
     }
 
-    const provider = input.providers[0]
+    const provider = input.providers.find((item) => {
+      if (input.productMode !== "build" && input.productMode !== "plan") return true
+      return item.id !== AgencySwarmAdapter.PROVIDER_ID
+    })
     if (!provider) return undefined
     const defaultModel = input.providerDefaults?.[provider.id]
     const firstModel = Object.values(provider.models)[0] as { id?: string } | undefined
@@ -172,6 +185,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sdk = useSDK()
     const toast = useToast()
     const args = useArgs()
+    const [productStore, setProductStore] = createStore<{
+      mode: ProductMode | undefined
+    }>({
+      mode: undefined,
+    })
 
     function isModelValid(model: ModelSelection) {
       return isUsableModel({
@@ -309,6 +327,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           configuredProviders: sync.data.config.provider,
           enabledProviders: sync.data.config.enabled_providers,
           disabledProviders: sync.data.config.disabled_providers,
+          productMode: productStore.mode,
         })
       })
 
@@ -713,11 +732,60 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       }
     })
 
+    const product = {
+      current(): ProductMode {
+        if (productStore.mode) return productStore.mode
+        if (
+          isAgencySwarmRunMode({
+            currentProviderID: model.current()?.providerID,
+            configuredModel: sync.data.config.model,
+            agentModel: agent.current()?.model,
+          })
+        ) {
+          return "run"
+        }
+        return agent.current()?.name === "plan" ? "plan" : "build"
+      },
+      async set(mode: ProductMode) {
+        setProductStore("mode", mode)
+        if (mode === "build" || mode === "plan") {
+          agent.set(mode)
+          const value = model.current()
+          if (!value || value.providerID === AgencySwarmAdapter.PROVIDER_ID) return
+          model.set(value, { explicit: true })
+          await updateConfigModel(value)
+          return
+        }
+        const runModel = {
+          providerID: AgencySwarmAdapter.PROVIDER_ID,
+          modelID: AgencySwarmAdapter.DEFAULT_MODEL_ID,
+        }
+        await updateConfigModel(runModel)
+        model.set(runModel, { explicit: true })
+      },
+    }
+
+    async function updateConfigModel(value: ModelSelection) {
+      await sdk.client.global.config.update(
+        {
+          config: {
+            model: `${value.providerID}/${value.modelID}`,
+          },
+        },
+        {
+          throwOnError: true,
+        },
+      )
+      await sdk.client.instance.dispose()
+      await sync.bootstrap()
+    }
+
     const result = {
       model,
       agent,
       mcp,
       session,
+      product,
     }
     return result
   },

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -19,6 +19,7 @@ import { RGBA } from "@opentui/core"
 import { Provider } from "@/provider/provider"
 import { Filesystem } from "@/util/filesystem"
 import type { Part } from "@opencode-ai/sdk/v2"
+import { isAgencySupportedProvider } from "../session-error"
 
 export function parseModel(model: string) {
   const [providerID, ...rest] = model.split("/")
@@ -101,7 +102,34 @@ export function readAgencySwarmBridge(parts: Part[] | undefined) {
   }
 }
 
+type SessionBridgeMessage = {
+  id: string
+  role: "user" | "assistant"
+  parentID?: string
+  providerID?: string
+}
+
+export function readSessionAgencySwarmBridge(input: {
+  messages: SessionBridgeMessage[]
+  parts: Record<string, Part[] | undefined>
+}) {
+  const children = new Map<string, boolean>()
+  for (const item of input.messages) {
+    if (item.role !== "assistant" || !item.parentID) continue
+    children.set(item.parentID, item.providerID === AgencySwarmAdapter.PROVIDER_ID)
+  }
+  for (let index = input.messages.length - 1; index >= 0; index--) {
+    const message = input.messages[index]
+    if (!message || message.role !== "user") continue
+    const bridge = readAgencySwarmBridge(input.parts[message.id])
+    if (bridge !== undefined) return bridge
+    const child = children.get(message.id)
+    if (child !== undefined) return child
+  }
+}
+
 function isAllowedProductModel(input: { model: ModelSelection; productMode?: ProductMode }) {
+  if (input.productMode === "run") return isAgencySupportedProvider(input.model.providerID)
   if (input.productMode !== "build" && input.productMode !== "plan") return true
   return input.model.providerID !== AgencySwarmAdapter.PROVIDER_ID
 }
@@ -903,13 +931,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     function currentSessionAgencySwarmBridge() {
       if (route.data.type !== "session") return undefined
-      const messages = sync.data.message[route.data.sessionID] ?? []
-      for (let index = messages.length - 1; index >= 0; index--) {
-        const message = messages[index]
-        if (!message || message.role !== "user") continue
-        const bridge = readAgencySwarmBridge(sync.data.part[message.id])
-        if (bridge !== undefined) return bridge
-      }
+      return readSessionAgencySwarmBridge({
+        messages: sync.data.message[route.data.sessionID] ?? [],
+        parts: sync.data.part,
+      })
     }
 
     function currentSessionID() {

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx
@@ -26,6 +26,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: props.api.state.config.model,
       agentModel: local.agent.current()?.model,
+      productMode: local.product?.current(),
     })
     if (!framework) return undefined
     const configuredProvider = props.api.state.config.provider?.[AgencySwarmAdapter.PROVIDER_ID]

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -19,6 +19,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: props.api.state.config.model,
       agentModel: local.agent.current()?.model,
+      productMode: local.product?.current(),
     }),
   )
   const model = createMemo(() => {

--- a/packages/opencode/src/cli/cmd/tui/keymap.tsx
+++ b/packages/opencode/src/cli/cmd/tui/keymap.tsx
@@ -1,4 +1,4 @@
-import { type CliRenderer } from "@opentui/core"
+import { InputRenderable, TextareaRenderable, type CliRenderer } from "@opentui/core"
 import * as addons from "@opentui/keymap/addons/opentui"
 import { stringifyKeyStroke } from "@opentui/keymap"
 import {
@@ -18,6 +18,9 @@ import { useTuiConfig } from "./context/tui-config"
 import { TuiKeybind } from "./config/keybind"
 
 export const LEADER_TOKEN = "leader"
+export const OPENCODE_BASE_MODE = "base"
+
+const OPENCODE_MODE_KEY = "opencode.mode"
 
 export const OpencodeKeymapProvider = KeymapProvider
 export const useOpencodeKeymap = useKeymap
@@ -25,10 +28,74 @@ export const useOpencodeKeymap = useKeymap
 export { reactiveMatcherFromSignal, useBindings, useKeymapSelector }
 
 export type OpenTuiKeymap = ReturnType<typeof useKeymap>
+type OpencodeModeStack = ReturnType<typeof createOpencodeModeStack>
+
+const modeStacks = new WeakMap<OpenTuiKeymap, OpencodeModeStack>()
+
+export function createOpencodeModeStack(keymap: OpenTuiKeymap) {
+  keymap.setData(OPENCODE_MODE_KEY, OPENCODE_BASE_MODE)
+
+  const offFields = keymap.registerLayerFields({
+    mode(value, ctx) {
+      ctx.require(OPENCODE_MODE_KEY, value)
+    },
+  })
+
+  const stack: { id: symbol; mode: string }[] = []
+  let disposed = false
+
+  const update = () => {
+    keymap.setData(OPENCODE_MODE_KEY, stack.at(-1)?.mode ?? OPENCODE_BASE_MODE)
+  }
+
+  const api = {
+    current() {
+      return stack.at(-1)?.mode ?? OPENCODE_BASE_MODE
+    },
+    push(mode: string) {
+      if (disposed) return () => {}
+      const id = Symbol(mode)
+      let active = true
+      stack.push({ id, mode })
+      update()
+
+      return () => {
+        if (!active) return
+        active = false
+        const index = stack.findIndex((item) => item.id === id)
+        if (index !== -1) stack.splice(index, 1)
+        update()
+      }
+    },
+    dispose() {
+      if (disposed) return
+      disposed = true
+      stack.length = 0
+      offFields()
+      keymap.setData(OPENCODE_MODE_KEY, undefined)
+      modeStacks.delete(keymap)
+    },
+  }
+
+  modeStacks.set(keymap, api)
+  return api
+}
+
+export function useOpencodeModeStack() {
+  return getOpencodeModeStack(useOpencodeKeymap())
+}
+
+export function getOpencodeModeStack(keymap: OpenTuiKeymap) {
+  const value = modeStacks.get(keymap)
+  if (!value) throw new Error("OpenCode mode stack is not registered for this keymap")
+  return value
+}
 
 const KEY_ALIASES = {
   enter: "return",
   esc: "escape",
+  pgdown: "pagedown",
+  pgup: "pageup",
 } as const
 
 function expandKeyAliases(input: string) {
@@ -109,6 +176,11 @@ function formatOptions(config: TuiConfig.Resolved) {
   } as const
 }
 
+function hasManagedTextareaFocus(renderer: CliRenderer) {
+  const editor = renderer.currentFocusedEditor
+  return editor instanceof TextareaRenderable && !(editor instanceof InputRenderable)
+}
+
 export function formatKeySequence(parts: Parameters<typeof formatKeySequenceExtra>[0], config: TuiConfig.Resolved) {
   return formatKeySequenceExtra(parts, formatOptions(config))
 }
@@ -125,6 +197,7 @@ export function registerOpencodeKeymap(
   renderer: CliRenderer,
   config: Pick<TuiConfig.Resolved, "keybinds" | "leader_timeout">,
 ) {
+  const modeStack = createOpencodeModeStack(keymap)
   const offCommaBindings = addons.registerCommaBindings(keymap)
   const offAliasExpander = registerKeyAliases(keymap)
   const offBaseLayout = addons.registerBaseLayoutFallback(keymap)
@@ -136,7 +209,7 @@ export function registerOpencodeKeymap(
   const offEscape = addons.registerEscapeClearsPendingSequence(keymap)
   const offBackspace = addons.registerBackspacePopsPendingSequence(keymap)
   const offInputBindings = addons.registerManagedTextareaLayer(keymap, renderer, {
-    enabled: () => renderer.currentFocusedEditor !== null,
+    enabled: () => hasManagedTextareaFocus(renderer),
     bindings: config.keybinds.gather("input", inputCommands),
   })
 
@@ -148,6 +221,7 @@ export function registerOpencodeKeymap(
     offAliasExpander()
     offBaseLayout()
     offCommaBindings()
+    modeStack.dispose()
   }
 }
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -23,7 +23,7 @@ export function DialogMessage(props: {
     currentProviderID: local.model.current()?.providerID,
     configuredModel: sync.data.config.model,
     agentModel: local.agent.current()?.model,
-    productMode: local.product.current(),
+    productMode: local.product?.current(),
   })
 
   const revertOption: DialogSelectOption<string> = {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -23,6 +23,7 @@ export function DialogMessage(props: {
     currentProviderID: local.model.current()?.providerID,
     configuredModel: sync.data.config.model,
     agentModel: local.agent.current()?.model,
+    productMode: local.product.current(),
   })
 
   const revertOption: DialogSelectOption<string> = {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -2,12 +2,21 @@ import { createMemo } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
 import { useSDK } from "@tui/context/sdk"
-import { useLocal } from "@tui/context/local"
 import { useRoute } from "@tui/context/route"
 import * as Clipboard from "@tui/util/clipboard"
 import type { PromptInfo } from "@tui/component/prompt/history"
 import { strip } from "@tui/component/prompt/part"
-import { isAgencySwarmFrameworkMode } from "../../session-error"
+import { AGENCY_SWARM_BRIDGE_METADATA_KEY } from "@/session/message-v2"
+import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import type { Part, UserMessage } from "@opencode-ai/sdk/v2"
+
+function readAgencySwarmBridge(parts: Part[] | undefined) {
+  for (const part of parts ?? []) {
+    if (part.type !== "text" && part.type !== "subtask" && part.type !== "compaction") continue
+    const value = part.metadata?.[AGENCY_SWARM_BRIDGE_METADATA_KEY]
+    if (typeof value === "boolean") return value
+  }
+}
 
 export function DialogMessage(props: {
   messageID: string
@@ -16,14 +25,28 @@ export function DialogMessage(props: {
 }) {
   const sync = useSync()
   const sdk = useSDK()
-  const local = useLocal()
   const message = createMemo(() => sync.data.message[props.sessionID]?.find((x) => x.id === props.messageID))
+  const messages = createMemo(() => sync.data.message[props.sessionID] ?? [])
   const route = useRoute()
-  const frameworkMode = isAgencySwarmFrameworkMode({
-    currentProviderID: local.model.current()?.providerID,
-    configuredModel: sync.data.config.model,
-    agentModel: local.agent.current()?.model,
-    productMode: local.product?.current(),
+  const frameworkMode = createMemo(() => {
+    const msg = message()
+    if (!msg) return false
+    const user =
+      msg.role === "user"
+        ? msg
+        : messages().find((item): item is UserMessage => item.role === "user" && item.id === msg.parentID)
+    const bridge = readAgencySwarmBridge(user ? sync.data.part[user.id] : undefined)
+    if (typeof bridge === "boolean") return bridge
+    if (msg.role === "assistant" && msg.providerID === AgencySwarmAdapter.PROVIDER_ID) return true
+    if (
+      msg.role === "user" &&
+      messages().some(
+        (item) => item.role === "assistant" && item.parentID === msg.id && item.providerID === AgencySwarmAdapter.PROVIDER_ID,
+      )
+    ) {
+      return true
+    }
+    return false
   })
 
   const revertOption: DialogSelectOption<string> = {
@@ -62,7 +85,7 @@ export function DialogMessage(props: {
     <DialogSelect
       title="Message Actions"
       options={[
-        ...(frameworkMode ? [] : [revertOption]),
+        ...(frameworkMode() ? [] : [revertOption]),
         {
           title: "Copy",
           value: "message.copy",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -88,13 +88,14 @@ import { DialogRetryAction } from "../../component/dialog-retry-action"
 import { SessionRetry } from "@/session/retry"
 import { getRevertDiffFiles } from "../../util/revert-diff"
 import { useCommandPalette } from "../../context/command-palette"
-import { useBindings, useCommandShortcut } from "../../keymap"
+import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut } from "../../keymap"
 import { PathFormatterProvider, usePathFormatter } from "../../context/path-format"
 import { AgencyProduct } from "@/agency-swarm/product"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { describeStreamAuthError, isAgencySwarmFrameworkMode } from "../../session-error"
 import { displayRunOnlyModeLabel, readAgencyProviderOptions } from "../../util/agency-target"
 import { resolveAssistantModelLabel, type ModelLabelScope } from "../../util/model-label"
+import { AGENCY_SWARM_BRIDGE_METADATA_KEY } from "@/session/message-v2"
 
 addDefaultParsers(parsers.parsers)
 
@@ -118,6 +119,15 @@ function readAgencyLabelRecipient(message: UserMessage | undefined) {
   if (!message) return undefined
   return (message as AgencyLabelUserMessage).agencyLabelRecipientAgent ?? message.agencyRecipientAgent
 }
+
+function readAgencySwarmBridge(parts: Part[] | undefined) {
+  for (const part of parts ?? []) {
+    if (part.type !== "text" && part.type !== "subtask" && part.type !== "compaction") continue
+    const value = part.metadata?.[AGENCY_SWARM_BRIDGE_METADATA_KEY]
+    if (typeof value === "boolean") return value
+  }
+}
+
 const GO_UPSELL_PROVIDERS = new Set(["opencode", "opencode-go"])
 
 function goUpsellKeys(action: SessionRetry.Retryable["action"]) {
@@ -192,6 +202,7 @@ const context = createContext<{
     submittedModel?: { providerID: string; modelID: string }
     scope?: ModelLabelScope
     turnStartedAt?: number
+    frameworkMode?: boolean
   }) => string
   providers: () => ReadonlyMap<string, Provider>
   sync: ReturnType<typeof useSync>
@@ -316,6 +327,7 @@ export function Session() {
     submittedModel?: { providerID: string; modelID: string }
     scope?: ModelLabelScope
     turnStartedAt?: number
+    frameworkMode?: boolean
   }) => {
     const options = agencyProviderOptions()
     const configuredTargetChangedAfterTurn =
@@ -332,7 +344,7 @@ export function Session() {
       modelID: input.modelID,
       submittedModel: input.submittedModel,
       recipientAgent: input.recipientAgent ?? (configuredTargetChangedAfterTurn ? undefined : options.recipientAgent),
-      frameworkMode: frameworkMode(),
+      frameworkMode: input.frameworkMode ?? frameworkMode(),
       scope: input.scope,
     })
   }
@@ -659,6 +671,7 @@ export function Session() {
           sessionID: route.sessionID,
           modelID: selectedModel.modelID,
           providerID: selectedModel.providerID,
+          agencySwarmBridge: frameworkMode(),
         })
         dialog.clear()
       },
@@ -1156,10 +1169,12 @@ export function Session() {
   )
 
   useBindings(() => ({
+    mode: OPENCODE_BASE_MODE,
     commands: sessionCommands(),
   }))
 
   useBindings(() => ({
+    mode: OPENCODE_BASE_MODE,
     enabled: command.matcher,
     bindings: tuiConfig.keybinds.gather("session", sessionBindingCommands),
   }))
@@ -1523,6 +1538,16 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
       (message): message is UserMessage => message.role === "user" && message.id === props.message.parentID,
     ),
   )
+  const parentParts = createMemo(() => {
+    const msg = parent()
+    return msg ? (sync.data.part[msg.id] ?? []) : []
+  })
+  const turnFrameworkMode = createMemo(() => {
+    const bridge = readAgencySwarmBridge(parentParts())
+    if (typeof bridge === "boolean") return bridge
+    if (props.message.providerID === AgencySwarmAdapter.PROVIDER_ID) return true
+    return false
+  })
   const model = createMemo(() =>
     ctx.modelLabel({
       providerID: props.message.providerID,
@@ -1532,6 +1557,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
       recipientAgent: readAgencyLabelRecipient(parent()),
       submittedModel: parent()?.model,
       turnStartedAt: parent()?.time.created,
+      frameworkMode: turnFrameworkMode(),
     }),
   )
 
@@ -1606,7 +1632,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               </span>{" "}
               <span style={{ fg: theme.text }}>
                 {displayRunOnlyModeLabel({
-                  frameworkMode: ctx.frameworkMode(),
+                  frameworkMode: turnFrameworkMode(),
                   mode: props.message.mode,
                 })}
               </span>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -270,7 +270,7 @@ export function Session() {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
-      productMode: local.product.current(),
+      productMode: local.product?.current(),
     }),
   )
   const agencyProviderOptions = createMemo(() =>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -554,6 +554,32 @@ export function Session() {
     }
   }
 
+  const undoTarget = createMemo(() => {
+    const revert = session()?.revert?.messageID
+    return messages().findLast(
+      (message): message is UserMessage => (!revert || message.id < revert) && message.role === "user",
+    )
+  })
+
+  const redoTarget = createMemo(() => {
+    const messageID = session()?.revert?.messageID
+    if (!messageID) return undefined
+    return messages().find((message): message is UserMessage => message.role === "user" && message.id >= messageID)
+  })
+
+  const targetAgencySwarmBridge = (message: UserMessage | undefined) => {
+    if (!message) return frameworkMode()
+    const bridge = readAgencySwarmBridge(sync.data.part[message.id])
+    if (typeof bridge === "boolean") return bridge
+    return messages().some(
+      (item) =>
+        item.role === "assistant" && item.parentID === message.id && item.providerID === AgencySwarmAdapter.PROVIDER_ID,
+    )
+  }
+
+  const undoAgencySwarmBridge = createMemo(() => targetAgencySwarmBridge(undoTarget()))
+  const redoAgencySwarmBridge = createMemo(() => targetAgencySwarmBridge(redoTarget()))
+
   const sessionCommandList = createMemo(() => [
     {
       title: session()?.share?.url ? "Copy share link" : "Share session",
@@ -703,16 +729,15 @@ export function Session() {
       title: "Undo previous message",
       value: "session.undo",
       category: "Session",
-      enabled: !frameworkMode(),
-      hidden: frameworkMode(),
+      enabled: !undoAgencySwarmBridge(),
+      hidden: undoAgencySwarmBridge(),
       slash: {
         name: "undo",
       },
       run: async () => {
         const status = sync.data.session_status?.[route.sessionID]
         if (status?.type !== "idle") await sdk.client.session.abort({ sessionID: route.sessionID }).catch(() => {})
-        const revert = session()?.revert?.messageID
-        const message = messages().findLast((x) => (!revert || x.id < revert) && x.role === "user")
+        const message = undoTarget()
         if (!message) return
         void sdk.client.session
           .revert({
@@ -742,8 +767,8 @@ export function Session() {
       title: "Redo",
       value: "session.redo",
       category: "Session",
-      enabled: !!session()?.revert?.messageID && !frameworkMode(),
-      hidden: frameworkMode(),
+      enabled: !!session()?.revert?.messageID && !redoAgencySwarmBridge(),
+      hidden: redoAgencySwarmBridge(),
       slash: {
         name: "redo",
       },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -270,6 +270,7 @@ export function Session() {
       currentProviderID: local.model.current()?.providerID,
       configuredModel: sync.data.config.model,
       agentModel: local.agent.current()?.model,
+      productMode: local.product.current(),
     }),
   )
   const agencyProviderOptions = createMemo(() =>
@@ -390,10 +391,11 @@ export function Session() {
     if (part.id === lastSwitch) return
 
     if (part.tool === "plan_exit") {
-      local.agent.set("build")
+      void local.product.set("build")
       lastSwitch = part.id
     } else if (part.tool === "plan_enter") {
-      local.agent.set(frameworkMode() ? "build" : "plan")
+      if (frameworkMode()) local.agent.set("build")
+      else void local.product.set("plan")
       lastSwitch = part.id
     }
   })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store"
-import { createMemo, createSignal, For, Show } from "solid-js"
+import { createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js"
 import { useRenderer } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
@@ -8,13 +8,17 @@ import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../component/border"
 import { useDialog } from "../../ui/dialog"
 import { useTuiConfig } from "../../context/tui-config"
-import { useBindings } from "../../keymap"
+import { useBindings, useOpencodeModeStack } from "../../keymap"
+
+const QUESTION_MODE = "question"
 
 export function QuestionPrompt(props: { request: QuestionRequest }) {
   const sdk = useSDK()
   const { theme } = useTheme()
   const renderer = useRenderer()
   const tuiConfig = useTuiConfig()
+  const modeStack = useOpencodeModeStack()
+  const dialog = useDialog()
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
@@ -124,10 +128,14 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     pick(opt.label)
   }
 
-  const dialog = useDialog()
+  onMount(() => {
+    const popMode = modeStack.push(QUESTION_MODE)
+    onCleanup(popMode)
+  })
 
   useBindings(() => ({
-    enabled: store.editing && !confirm(),
+    mode: QUESTION_MODE,
+    enabled: dialog.stack.length === 0 && store.editing && !confirm(),
     commands: [
       {
         name: "prompt.clear",
@@ -207,6 +215,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     const max = Math.min(total, 9)
 
     return {
+      mode: QUESTION_MODE,
       enabled: dialog.stack.length === 0 && !store.editing,
       commands: [
         {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -97,9 +97,12 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     setStore("selected", 0)
   }
 
-  function selectOption() {
-    if (other()) {
+  function selectOption(selected = store.selected) {
+    const opts = options()
+    const customSelected = custom() && selected === opts.length
+    if (customSelected) {
       if (!multi()) {
+        setStore("selected", selected)
         setStore("editing", true)
         return
       }
@@ -111,8 +114,9 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
       setStore("editing", true)
       return
     }
-    const opt = options()[store.selected]
+    const opt = opts[selected]
     if (!opt) return
+    setStore("selected", selected)
     if (multi()) {
       toggle(opt.label)
       return
@@ -249,8 +253,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                 desc: `Select answer ${index + 1}`,
                 group: "Question",
                 cmd: () => {
-                  moveTo(index)
-                  selectOption()
+                  selectOption(index)
                 },
               })),
               {
@@ -361,7 +364,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                       onMouseDown={() => moveTo(i())}
                       onMouseUp={() => {
                         if (renderer.getSelection()?.getSelectedText()) return
-                        selectOption()
+                        selectOption(i())
                       }}
                     >
                       <box flexDirection="row">

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -204,6 +204,7 @@ export function shouldOpenStartupAuthDialog(input: {
 }
 
 export function shouldBlockAgencyPromptSend(input: {
+  productMode?: ProductMode
   currentProviderID?: string
   configuredModel?: string
   agentModel?: { providerID: string; modelID: string }
@@ -222,6 +223,7 @@ export function shouldBlockAgencyPromptSend(input: {
 }
 
 export function shouldBlockAgencyPromptSubmit(input: {
+  productMode?: ProductMode
   currentProviderID?: string
   configuredModel?: string
   agentModel?: { providerID: string; modelID: string }

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -7,6 +7,7 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { Log } from "@opencode-ai/core/util/log"
 import { hasStoredProviderCredential } from "@tui/util/provider-auth"
 import type { Provider, ProviderAuthMethod } from "@opencode-ai/sdk/v2"
+import type { ProductMode } from "./context/local"
 
 export const AGENCY_SWARM_PRIMARY_AUTH_PROVIDER_IDS = [
   "openai",
@@ -167,7 +168,9 @@ function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
  * but the configured or agent model still points at `agency-swarm/...`, framework mode stays on so auth and
  * provider UI stay aligned with Agent Swarm.
  */
-export function isAgencySwarmFrameworkMode(input: AgencySwarmRunModeInput) {
+export function isAgencySwarmFrameworkMode(input: AgencySwarmRunModeInput & { productMode?: ProductMode }) {
+  if (input.productMode === "run") return true
+  if (input.productMode === "build" || input.productMode === "plan") return false
   return isAgencySwarmRunMode(input)
 }
 

--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -168,7 +168,7 @@ function hasExplicitAgencyClientConfig(provider: Provider | undefined) {
  * but the configured or agent model still points at `agency-swarm/...`, framework mode stays on so auth and
  * provider UI stay aligned with Agent Swarm.
  */
-export function isAgencySwarmFrameworkMode(input: AgencySwarmRunModeInput & { productMode?: ProductMode }) {
+export function isAgencySwarmFrameworkMode(input: AgencySwarmRunModeInput & { productMode: ProductMode | undefined }) {
   if (input.productMode === "run") return true
   if (input.productMode === "build" || input.productMode === "plan") return false
   return isAgencySwarmRunMode(input)
@@ -204,7 +204,7 @@ export function shouldOpenStartupAuthDialog(input: {
 }
 
 export function shouldBlockAgencyPromptSend(input: {
-  productMode?: ProductMode
+  productMode: ProductMode | undefined
   currentProviderID?: string
   configuredModel?: string
   agentModel?: { providerID: string; modelID: string }
@@ -223,7 +223,7 @@ export function shouldBlockAgencyPromptSend(input: {
 }
 
 export function shouldBlockAgencyPromptSubmit(input: {
-  productMode?: ProductMode
+  productMode: ProductMode | undefined
   currentProviderID?: string
   configuredModel?: string
   agentModel?: { providerID: string; modelID: string }

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -192,6 +192,7 @@ export const TuiThreadCommand = cmd({
       const env = sanitizedProcessEnv({
         [OPENCODE_PROCESS_ROLE]: "worker",
         [OPENCODE_RUN_ID]: ensureRunID(),
+        OPENCODE_EXPERIMENTAL_PLAN_MODE: "1",
       })
 
       const worker = new Worker(file, {

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -62,6 +62,7 @@ export const SummarizePayload = Schema.Struct({
   providerID: ProviderID,
   modelID: ModelID,
   auto: Schema.optional(Schema.Boolean),
+  agencySwarmBridge: Schema.optional(Schema.Boolean),
 })
 export const PromptPayload = Schema.Struct(Struct.omit(SessionPrompt.PromptInput.fields, ["sessionID"]))
 export const CommandPayload = Schema.Struct(Struct.omit(SessionPrompt.CommandInput.fields, ["sessionID"]))

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -270,9 +270,10 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
           modelID: ctx.payload.modelID,
         },
         auto: ctx.payload.auto ?? false,
+        agencySwarmBridge: ctx.payload.agencySwarmBridge,
       })
       yield* promptSvc
-        .loop({ sessionID: ctx.params.sessionID })
+        .loop({ sessionID: ctx.params.sessionID, agencySwarmBridge: ctx.payload.agencySwarmBridge })
         .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
       return true
     })

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -199,6 +199,7 @@ export interface Interface {
     sessionID: SessionID
     auto: boolean
     overflow?: boolean
+    agencySwarmBridge?: boolean
   }) => Effect.Effect<"continue" | "stop">
   readonly create: (input: {
     sessionID: SessionID
@@ -206,6 +207,7 @@ export interface Interface {
     model: { providerID: ProviderID; modelID: ModelID }
     auto: boolean
     overflow?: boolean
+    agencySwarmBridge?: boolean
   }) => Effect.Effect<void>
 }
 
@@ -384,6 +386,7 @@ export const layer: Layer.Layer<
       sessionID: SessionID
       auto: boolean
       overflow?: boolean
+      agencySwarmBridge?: boolean
     }) {
       const parent = input.messages.findLast((m) => m.info.id === input.parentID)
       if (!parent || parent.info.role !== "user") {
@@ -616,7 +619,12 @@ export const layer: Layer.Layer<
               // Internal marker for auto-compaction followups so provider plugins
               // can distinguish them from manual post-compaction user prompts.
               // This is not a stable plugin contract and may change or disappear.
-              metadata: { compaction_continue: true },
+              metadata: {
+                compaction_continue: true,
+                ...(input.agencySwarmBridge === undefined
+                  ? {}
+                  : { [MessageV2.AGENCY_SWARM_BRIDGE_METADATA_KEY]: input.agencySwarmBridge }),
+              },
               synthetic: true,
               text,
               time: {
@@ -657,6 +665,7 @@ export const layer: Layer.Layer<
       model: { providerID: ProviderID; modelID: ModelID }
       auto: boolean
       overflow?: boolean
+      agencySwarmBridge?: boolean
     }) {
       const msg = yield* session.updateMessage({
         id: MessageID.ascending(),
@@ -673,6 +682,10 @@ export const layer: Layer.Layer<
         type: "compaction",
         auto: input.auto,
         overflow: input.overflow,
+        metadata:
+          input.agencySwarmBridge === undefined
+            ? undefined
+            : { [MessageV2.AGENCY_SWARM_BRIDGE_METADATA_KEY]: input.agencySwarmBridge },
       })
       if (flags.experimentalEventSystem) {
         yield* sync.run(SessionEvent.Compaction.Started.Sync, {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -36,6 +36,7 @@ interface FetchDecompressionError extends Error {
 }
 
 export const SYNTHETIC_ATTACHMENT_PROMPT = "Attached media from tool result:"
+export const AGENCY_SWARM_BRIDGE_METADATA_KEY = "agencySwarmBridge"
 export { isMedia }
 
 export const AbortedError = NamedError.create("MessageAbortedError", { message: Schema.String })
@@ -187,6 +188,7 @@ export const CompactionPart = Schema.Struct({
   auto: Schema.Boolean,
   overflow: Schema.optional(Schema.Boolean),
   tail_start_id: Schema.optional(MessageID),
+  metadata: Schema.optional(Schema.Record(Schema.String, Schema.Any)),
 }).annotate({ identifier: "CompactionPart" })
 export type CompactionPart = Types.DeepMutable<Schema.Schema.Type<typeof CompactionPart>>
 
@@ -203,6 +205,7 @@ export const SubtaskPart = Schema.Struct({
     }),
   ),
   command: Schema.optional(Schema.String),
+  metadata: Schema.optional(Schema.Record(Schema.String, Schema.Any)),
 }).annotate({ identifier: "SubtaskPart" })
 export type SubtaskPart = Types.DeepMutable<Schema.Schema.Type<typeof SubtaskPart>>
 
@@ -449,6 +452,7 @@ export const SubtaskPartInput = Schema.Struct({
     }),
   ),
   command: Schema.optional(Schema.String),
+  metadata: Schema.optional(Schema.Record(Schema.String, Schema.Any)),
 }).annotate({ identifier: "SubtaskPartInput" })
 export type SubtaskPartInput = Types.DeepMutable<Schema.Schema.Type<typeof SubtaskPartInput>>
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -96,17 +96,10 @@ export function shouldUseAgencySwarmBridge(input: {
   configuredModel?: string
   agentProviderID?: string
   lastAssistantProviderID?: string
-  agentName?: string
   agencySwarmBridge?: boolean
 }) {
   if (input.agencySwarmBridge === true) return true
   if (input.agencySwarmBridge === false) return false
-  if (
-    input.resolvedProviderID !== SessionAgencySwarm.PROVIDER_ID &&
-    (input.agentName === "build" || input.agentName === "plan")
-  ) {
-    return false
-  }
   return isAgencySwarmRunMode({
     currentProviderID:
       input.resolvedProviderID === SessionAgencySwarm.PROVIDER_ID ||
@@ -121,6 +114,48 @@ export function shouldUseAgencySwarmBridge(input: {
         }
       : undefined,
   })
+}
+
+function agencySwarmBridgeFromParts(parts: MessageV2.Part[] | undefined) {
+  for (const part of parts ?? []) {
+    if (part.type !== "text" && part.type !== "subtask" && part.type !== "compaction") continue
+    const value = part.metadata?.[MessageV2.AGENCY_SWARM_BRIDGE_METADATA_KEY]
+    if (typeof value === "boolean") return value
+  }
+}
+
+function markAgencySwarmBridge(
+  parts: MessageV2.Part[],
+  value: boolean | undefined,
+  fallback?: { sessionID: SessionID; messageID: MessageID },
+) {
+  if (value === undefined) return parts
+  const part = parts.find(
+    (item): item is MessageV2.TextPart | MessageV2.SubtaskPart => item.type === "text" || item.type === "subtask",
+  )
+  if (!part) {
+    const anchor = parts[0]
+    const sessionID = anchor?.sessionID ?? fallback?.sessionID
+    const messageID = anchor?.messageID ?? fallback?.messageID
+    if (!sessionID || !messageID) return parts
+    parts.push({
+      id: PartID.ascending(),
+      sessionID,
+      messageID,
+      type: "text",
+      synthetic: true,
+      text: "",
+      metadata: {
+        [MessageV2.AGENCY_SWARM_BRIDGE_METADATA_KEY]: value,
+      },
+    })
+    return parts
+  }
+  part.metadata = {
+    ...part.metadata,
+    [MessageV2.AGENCY_SWARM_BRIDGE_METADATA_KEY]: value,
+  }
+  return parts
 }
 
 type ReferencePromptMetadata = {
@@ -567,6 +602,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       processor: Pick<SessionProcessor.Handle, "message" | "updateToolCall" | "completeToolCall">
       bypassAgentCheck: boolean
       messages: MessageV2.WithParts[]
+      agencySwarmBridge: boolean
     }) {
       using _ = log.time("resolveTools")
       const tools: Record<string, AITool> = {}
@@ -578,7 +614,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         abort: options.abortSignal!,
         messageID: input.processor.message.id,
         callID: options.toolCallId,
-        extra: { model: input.model, bypassAgentCheck: input.bypassAgentCheck, promptOps },
+        extra: {
+          model: input.model,
+          bypassAgentCheck: input.bypassAgentCheck,
+          promptOps,
+          agencySwarmBridge: input.agencySwarmBridge,
+        },
         agent: input.agent.name,
         messages: input.messages,
         metadata: (val) =>
@@ -806,6 +847,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         throw error
       }
 
+      const taskUser = msgs.findLast((item) => item.info.role === "user" && item.info.id === lastUser.id)
+      const taskAgencySwarmBridge = agencySwarmBridgeFromParts([task]) ?? agencySwarmBridgeFromParts(taskUser?.parts)
       let error: Error | undefined
       const taskAbort = new AbortController()
       const result = yield* taskTool
@@ -815,7 +858,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           sessionID,
           abort: taskAbort.signal,
           callID: part.callID,
-          extra: { bypassAgentCheck: true, promptOps },
+          extra: { bypassAgentCheck: true, promptOps, agencySwarmBridge: taskAgencySwarmBridge },
           messages: msgs,
           metadata: (val: { title?: string; metadata?: Record<string, any> }) =>
             Effect.gen(function* () {
@@ -929,6 +972,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         type: "text",
         text: "Summarize the task tool output above and continue with your task.",
         synthetic: true,
+        metadata:
+          taskAgencySwarmBridge === undefined
+            ? undefined
+            : {
+                [MessageV2.AGENCY_SWARM_BRIDGE_METADATA_KEY]: taskAgencySwarmBridge,
+              },
       } satisfies MessageV2.TextPart)
     })
 
@@ -967,6 +1016,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               sessionID: input.sessionID,
               text: "The following tool was executed by the user",
               synthetic: true,
+              metadata:
+                input.agencySwarmBridge === undefined
+                  ? undefined
+                  : {
+                      [MessageV2.AGENCY_SWARM_BRIDGE_METADATA_KEY]: input.agencySwarmBridge,
+                    },
             }
             yield* sessions.updatePart(userPart)
 
@@ -1526,7 +1581,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         { message: info, parts: resolvedParts },
       )
 
-      const parts = yield* Effect.forEach(resolvedParts, (part) =>
+      const routedParts = markAgencySwarmBridge(resolvedParts, input.agencySwarmBridge, {
+        sessionID: input.sessionID,
+        messageID: info.id,
+      })
+      const parts = yield* Effect.forEach(routedParts, (part) =>
         part.type === "file" &&
         part.mime.startsWith("image/") &&
         info.model.providerID !== AgencySwarmAdapter.PROVIDER_ID
@@ -1743,6 +1802,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
           const task = tasks.pop()
+          const userMsg = msgs.findLast((item) => item.info.role === "user" && item.info.id === lastUser.id)
+          const currentAgencySwarmBridge = agencySwarmBridgeFromParts(userMsg?.parts) ?? input.agencySwarmBridge
 
           if (task?.type === "subtask") {
             yield* handleSubtask({ task, model, lastUser, sessionID, session, msgs })
@@ -1756,6 +1817,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               sessionID,
               auto: task.auto,
               overflow: task.overflow,
+              agencySwarmBridge: currentAgencySwarmBridge,
             })
             if (result === "stop") break
             continue
@@ -1766,7 +1828,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             lastFinished.summary !== true &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
           ) {
-            yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+            yield* compaction.create({
+              sessionID,
+              agent: lastUser.agent,
+              model: lastUser.model,
+              auto: true,
+              agencySwarmBridge: currentAgencySwarmBridge,
+            })
             continue
           }
 
@@ -1784,8 +1852,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             configuredModel: cfg.model,
             agentProviderID: agent.model?.providerID,
             lastAssistantProviderID: lastAssistant?.providerID,
-            agentName: agent.name,
-            agencySwarmBridge: input.agencySwarmBridge,
+            agencySwarmBridge: currentAgencySwarmBridge,
           })
           const processorModel = useAgencySwarmBridge
             ? yield* getModel(
@@ -1883,6 +1950,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   model: lastUser.model,
                   auto: true,
                   overflow: !handle.message.finish,
+                  agencySwarmBridge: useAgencySwarmBridge,
                 })
               }
               return "continue" as const
@@ -1896,6 +1964,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               processor: handle,
               bypassAgentCheck,
               messages: msgs,
+              agencySwarmBridge: useAgencySwarmBridge,
             })
 
             if (lastUser.format?.type === "json_schema") {
@@ -1938,7 +2007,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             ])
             const modeInstructions = [
               ...agentBuilderInstructions(agent.name, model.providerID),
-              ...agentPlannerInstructions(agent.name, model.providerID),
+              ...agentPlannerInstructions(agent.name, model.providerID, flags.experimentalPlanMode),
             ]
             const system = [...env, ...instructions, ...modeInstructions, ...(skills ? [skills] : [])]
             const format = lastUser.format ?? { type: "text" as const }
@@ -1983,6 +2052,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 model: lastUser.model,
                 auto: true,
                 overflow: !handle.message.finish,
+                agencySwarmBridge: useAgencySwarmBridge,
               })
             }
             return "continue" as const
@@ -2221,6 +2291,7 @@ export const ShellInput = Schema.Struct({
   agent: Schema.String,
   model: Schema.optional(ModelRef),
   command: Schema.String,
+  agencySwarmBridge: Schema.optional(Schema.Boolean),
 })
 export type ShellInput = Schema.Schema.Type<typeof ShellInput>
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -64,7 +64,9 @@ import * as Database from "@/storage/db"
 import { SessionTable } from "./session.sql"
 import { SessionAgencySwarm } from "./agency-swarm"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
-import { isAgencySwarmRunMode } from "@/agency-swarm/run-mode"
+import { isAgencySwarmModel, isAgencySwarmRunMode } from "@/agency-swarm/run-mode"
+import { agentBuilderInstructions } from "./agent-builder"
+import { agentPlannerInstructions } from "./agent-planner"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -94,7 +96,18 @@ export function shouldUseAgencySwarmBridge(input: {
   configuredModel?: string
   agentProviderID?: string
   lastAssistantProviderID?: string
+  agentName?: string
+  agencySwarmBridge?: boolean
 }) {
+  if (input.agencySwarmBridge === false) return false
+  const nativePrimary =
+    input.resolvedProviderID !== SessionAgencySwarm.PROVIDER_ID &&
+    (input.agentName === "build" || input.agentName === "plan")
+  const configuredRunMode =
+    isAgencySwarmModel(input.configuredModel) || input.agentProviderID === SessionAgencySwarm.PROVIDER_ID
+  if (nativePrimary && !configuredRunMode) {
+    return false
+  }
   return isAgencySwarmRunMode({
     currentProviderID:
       input.resolvedProviderID === SessionAgencySwarm.PROVIDER_ID ||
@@ -1667,6 +1680,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       return yield* loop({
         sessionID: input.sessionID,
         agencyRecipientAgent: input.agencyRecipientAgent,
+        agencySwarmBridge: input.agencySwarmBridge,
         promptMessageID: message.info.id,
       })
     })
@@ -1771,6 +1785,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             configuredModel: cfg.model,
             agentProviderID: agent.model?.providerID,
             lastAssistantProviderID: lastAssistant?.providerID,
+            agentName: agent.name,
+            agencySwarmBridge: input.agencySwarmBridge,
           })
           const processorModel = useAgencySwarmBridge
             ? yield* getModel(
@@ -1921,7 +1937,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               instruction.system().pipe(Effect.orDie),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])
-            const system = [...env, ...instructions, ...(skills ? [skills] : [])]
+            const modeInstructions = [
+              ...agentBuilderInstructions(agent.name, model.providerID),
+              ...agentPlannerInstructions(agent.name, model.providerID),
+            ]
+            const system = [...env, ...instructions, ...modeInstructions, ...(skills ? [skills] : [])]
             const format = lastUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
             const result = yield* handle.process({
@@ -2177,6 +2197,7 @@ export const PromptInput = Schema.Struct({
   agencyRecipientAgent: Schema.optional(Schema.String),
   agencyLabelAgency: Schema.optional(Schema.String),
   agencyLabelRecipientAgent: Schema.optional(Schema.String),
+  agencySwarmBridge: Schema.optional(Schema.Boolean),
   parts: Schema.Array(
     Schema.Union([
       MessageV2.TextPartInput,
@@ -2191,6 +2212,7 @@ export type PromptInput = Schema.Schema.Type<typeof PromptInput>
 export class LoopInput extends Schema.Class<LoopInput>("SessionPrompt.LoopInput")({
   sessionID: SessionID,
   agencyRecipientAgent: Schema.optional(Schema.String),
+  agencySwarmBridge: Schema.optional(Schema.Boolean),
 }) {}
 
 export const ShellInput = Schema.Struct({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -64,7 +64,7 @@ import * as Database from "@/storage/db"
 import { SessionTable } from "./session.sql"
 import { SessionAgencySwarm } from "./agency-swarm"
 import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
-import { isAgencySwarmModel, isAgencySwarmRunMode } from "@/agency-swarm/run-mode"
+import { isAgencySwarmRunMode } from "@/agency-swarm/run-mode"
 import { agentBuilderInstructions } from "./agent-builder"
 import { agentPlannerInstructions } from "./agent-planner"
 
@@ -99,13 +99,12 @@ export function shouldUseAgencySwarmBridge(input: {
   agentName?: string
   agencySwarmBridge?: boolean
 }) {
+  if (input.agencySwarmBridge === true) return true
   if (input.agencySwarmBridge === false) return false
-  const nativePrimary =
+  if (
     input.resolvedProviderID !== SessionAgencySwarm.PROVIDER_ID &&
     (input.agentName === "build" || input.agentName === "plan")
-  const configuredRunMode =
-    isAgencySwarmModel(input.configuredModel) || input.agentProviderID === SessionAgencySwarm.PROVIDER_ID
-  if (nativePrimary && !configuredRunMode) {
+  ) {
     return false
   }
   return isAgencySwarmRunMode({
@@ -2120,6 +2119,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         agent: userAgent,
         parts,
         variant: input.variant,
+        agencySwarmBridge: input.agencySwarmBridge,
       })
       yield* bus.publish(Command.Event.Executed, {
         name: input.command,
@@ -2232,6 +2232,7 @@ export const CommandInput = Schema.Struct({
   arguments: Schema.String,
   command: Schema.String,
   variant: Schema.optional(Schema.String),
+  agencySwarmBridge: Schema.optional(Schema.Boolean),
   // Inlined (no identifier annotation) to keep the original SDK output — the
   // PromptInput call site below references FilePartInput by ref via the
   // Schema export in message-v2.ts.

--- a/packages/opencode/src/session/prompt/agent-builder.txt
+++ b/packages/opencode/src/session/prompt/agent-builder.txt
@@ -1,16 +1,16 @@
-Apply these additional instructions when working as the local Agent Builder for an Agency Swarm project.
+Apply these additional instructions when working in local Build mode for an Agency Swarm project.
 Use the Agency Swarm starter template as the reference for project structure and the agent-creation workflow:
 https://github.com/agency-ai-solutions/agency-starter-template
 
-# Agent Swarm Agent Builder Instructions
+# Agent Swarm Build Instructions
 
-Agency Swarm is built on the OpenAI Agents SDK. Your job in Agent Builder mode is to create or improve an Agency Swarm project in the actual file system, not to describe hypothetical steps.
+Agency Swarm is built on the OpenAI Agents SDK. Your job in Build mode is to create or improve an Agency Swarm project in the actual file system, not to describe hypothetical steps.
 
 ## Workflow
 
 0. Create a todo list for the work before you start coding.
 1. If the latest system reminder or handoff mentions an approved session plan file, read it before you change code and treat it as the source of truth.
-2. Activate a virtual environment if one exists. If it does not exist, create one and install the project requirements.
+2. Reuse the existing `.venv` or `venv` for testing. It should already be present in Agency Swarm projects. If the environment is missing or broken, repair it before installing project requirements or running tests.
 3. Explore the project before changing it.
 4. Create or update agent folders and templates in the expected structure.
 5. Build robust tools in the correct agent tool folders.
@@ -66,7 +66,7 @@ Agency Swarm is built on the OpenAI Agents SDK. Your job in Agent Builder mode i
 
 ## Testing and Delivery
 
-- Install dependencies before testing.
+- Reuse the existing `.venv` or `venv` for testing. Repair it if activation, Python, uv, imports, or dependency installation fails.
 - Run the tool files you create or modify.
 - Test the agency end to end.
 - Do not hand off until the agency behaves consistently and the files are actually updated.

--- a/packages/opencode/src/session/prompt/agent-planner.txt
+++ b/packages/opencode/src/session/prompt/agent-planner.txt
@@ -4,7 +4,7 @@ https://github.com/agency-ai-solutions/agency-starter-template
 
 # Agent Swarm Planner Instructions
 
-The native session plan file for this conversation is the implementation brief for the next Agent Builder turn. Write and refine that file so Agent Builder can execute directly from it after approval.
+The native session plan file for this conversation is the implementation brief for the next Build turn. A system reminder supplies the exact file path for the current turn; use that path. Write and refine that file so Build can execute directly from it after approval.
 
 ## Workflow
 
@@ -27,12 +27,12 @@ Write the session plan file as a concise implementation brief with these section
 - Dependencies and required env keys
 - File-by-file implementation order
 - Verification plan
-- Agent Builder handoff notes
+- Build handoff notes
 
 ## Planning Rules
 
-- Treat the session plan file as the source of truth for the next Agent Builder turn.
+- Treat the session plan file as the source of truth for the next Build turn.
 - Stay on the native session plan file. Do not create separate planning artifacts unless the user explicitly asks.
 - Reuse existing project files and starter-template patterns when they help.
-- Make the plan concrete enough that Agent Builder can edit files immediately after approval.
+- Make the plan concrete enough that Build can edit files immediately after approval.
 - If the repo still contains example agents or placeholder wiring, call out the cleanup explicitly in the plan.

--- a/packages/opencode/src/tool/plan-exit.txt
+++ b/packages/opencode/src/tool/plan-exit.txt
@@ -1,6 +1,6 @@
 Use this tool when you have completed the planning phase and are ready to exit plan agent.
 
-This tool will ask the user if they want to switch to Agent Builder to start implementing the plan.
+This tool will ask the user if they want to switch to build agent to start implementing the plan.
 
 Call this tool:
 - After you have written a complete plan to the plan file

--- a/packages/opencode/src/tool/plan-exit.txt
+++ b/packages/opencode/src/tool/plan-exit.txt
@@ -1,6 +1,6 @@
 Use this tool when you have completed the planning phase and are ready to exit plan agent.
 
-This tool will ask the user if they want to switch to build agent to start implementing the plan.
+This tool will ask the user if they want to switch to Build mode to start implementing the plan.
 
 Call this tool:
 - After you have written a complete plan to the plan file

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -31,12 +31,15 @@ export const PlanExitTool = Tool.define(
             sessionID: ctx.sessionID,
             questions: [
               {
-                question: `Plan at ${plan} is complete. Would you like to switch to the build agent and start implementing?`,
+                question: `Plan at ${plan} is complete. Would you like to switch to Build and start implementing?`,
                 header: displayAgentName("build"),
                 custom: false,
                 options: [
-                  { label: "Yes", description: `Switch to ${displayAgentName("build")} and start implementing the plan` },
-                  { label: "No", description: "Stay with plan agent to continue refining the plan" },
+                  {
+                    label: "Yes",
+                    description: `Switch to ${displayAgentName("build")} and start implementing the plan`,
+                  },
+                  { label: "No", description: "Stay with Plan to continue refining the plan" },
                 ],
               },
             ],

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -69,6 +69,9 @@ export const PlanExitTool = Tool.define(
             type: "text",
             text: `The plan at ${plan} has been approved, you can now edit files. Execute the plan`,
             synthetic: true,
+            metadata: {
+              [MessageV2.AGENCY_SWARM_BRIDGE_METADATA_KEY]: false,
+            },
           } satisfies MessageV2.TextPart)
 
           return {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -173,6 +173,8 @@ export const TaskTool = Tool.define(
         model,
         ...(runInBackground ? { background: true } : {}),
       }
+      const agencySwarmBridge =
+        typeof ctx.extra?.agencySwarmBridge === "boolean" ? ctx.extra.agencySwarmBridge : undefined
 
       yield* ctx.metadata({
         title: params.description,
@@ -193,6 +195,7 @@ export const TaskTool = Tool.define(
             providerID: model.providerID,
           },
           agent: next.name,
+          agencySwarmBridge,
           tools: {
             ...(next.permission.some((rule) => rule.permission === "todowrite") ? {} : { todowrite: false }),
             ...(next.permission.some((rule) => rule.permission === id) ? {} : { task: false }),
@@ -244,6 +247,7 @@ export const TaskTool = Tool.define(
           sessionID: ctx.sessionID,
           noReply: true,
           agent: currentParent.agent ?? ctx.agent,
+          agencySwarmBridge,
           parts: [
             {
               type: "text",

--- a/packages/opencode/test/agency-swarm/product.test.ts
+++ b/packages/opencode/test/agency-swarm/product.test.ts
@@ -148,8 +148,6 @@ describe("AgencyProduct profile", () => {
       const proc = Bun.spawn([process.execPath, path.join(outdir, "entry.js")], {
         cwd: root,
         env: {
-          ...process.env,
-          HOME: process.env.HOME ?? os.homedir(),
           AGENTSWARM_PRODUCT_ADDONS: "",
         },
         stdout: "pipe",

--- a/packages/opencode/test/agency-swarm/product.test.ts
+++ b/packages/opencode/test/agency-swarm/product.test.ts
@@ -148,6 +148,8 @@ describe("AgencyProduct profile", () => {
       const proc = Bun.spawn([process.execPath, path.join(outdir, "entry.js")], {
         cwd: root,
         env: {
+          ...process.env,
+          HOME: process.env.HOME ?? os.homedir(),
           AGENTSWARM_PRODUCT_ADDONS: "",
         },
         stdout: "pipe",

--- a/packages/opencode/test/agent/display.test.ts
+++ b/packages/opencode/test/agent/display.test.ts
@@ -1,11 +1,8 @@
 import { expect, test } from "bun:test"
 import { displayAgentName } from "../../src/agent/display"
 
-test("displayAgentName brands build as Agent Builder", () => {
-  expect(displayAgentName("build")).toBe("Agent Builder")
-})
-
 test("displayAgentName titlecases other agent names", () => {
+  expect(displayAgentName("build")).toBe("Build")
   expect(displayAgentName("plan")).toBe("Plan")
   expect(displayAgentName("general")).toBe("General")
 })

--- a/packages/opencode/test/cli/tui/dialog-agent.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-agent.test.tsx
@@ -19,6 +19,65 @@ describe("DialogAgent agency selection", () => {
     mock.restore()
   })
 
+  test("reopened Plan sessions select Plan instead of stale Build default", async () => {
+    let selectProps: DialogSelectModule.DialogSelectProps<any> | undefined
+
+    spyOn(DialogSelectModule, "DialogSelect").mockImplementation((props: any) => {
+      selectProps = props
+      return <box />
+    })
+    spyOn(DialogContext, "useDialog").mockReturnValue({
+      clear: mock(() => undefined),
+      replace: mock(() => undefined),
+      stack: [],
+      size: "medium",
+      setSize: mock(() => undefined),
+    } as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: mock(() => undefined),
+      error: mock(() => undefined),
+      currentToast: null,
+    } as any)
+    spyOn(LocalContext, "useLocal").mockReturnValue({
+      product: {
+        current: () => "plan",
+      },
+      agent: {
+        current: () => ({ name: "build" }),
+        list: () => [{ name: "build" }, { name: "plan" }],
+        set: mock(() => undefined),
+        color: () => RGBA.fromHex("#38bdf8"),
+      },
+      model: {
+        current: () => ({
+          providerID: "openai",
+          modelID: "gpt-5.2",
+        }),
+        variant: {
+          current: () => undefined,
+          list: () => [],
+          set: mock(() => undefined),
+        },
+      },
+    } as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({ client: {} } as any)
+    spyOn(SyncContext, "useSync").mockReturnValue({
+      bootstrap: mock(async () => undefined),
+      data: {
+        config: {
+          model: "openai/gpt-5.2",
+        },
+        provider: [],
+      },
+    } as any)
+
+    const { DialogAgent } = await import("../../../src/cli/cmd/tui/component/dialog-agent")
+    await testRender(() => <DialogAgent />)
+    await flushEffects()
+
+    expect(selectProps?.current).toEqual({ kind: "local", agent: "plan" })
+  })
+
   test("selecting a swarm row uses live labels without forcing an agent", async () => {
     let selectProps: DialogSelectModule.DialogSelectProps<any> | undefined
     const configUpdate = mock(async (_input: unknown, _options?: unknown) => ({ data: undefined }))

--- a/packages/opencode/test/cli/tui/local-context.test.tsx
+++ b/packages/opencode/test/cli/tui/local-context.test.tsx
@@ -127,4 +127,443 @@ describe("tui local context model sync", () => {
     })
     expect(local.model.override("writer")).toBeUndefined()
   })
+
+  test("skips Run-only recent models when cycling in Build mode", async () => {
+    const [syncData] = createStore<any>({
+      agent: [
+        {
+          name: "build",
+          mode: "primary",
+          hidden: false,
+          model: {
+            providerID: "openai",
+            modelID: "gpt-5",
+          },
+        },
+      ],
+      provider: [
+        {
+          id: "openai",
+          name: "OpenAI",
+          models: {
+            "gpt-5": { id: "gpt-5", name: "GPT-5" },
+            "gpt-5.1": { id: "gpt-5.1", name: "GPT-5.1" },
+          },
+        },
+        {
+          id: "agency-swarm",
+          name: "Agency Swarm",
+          models: {
+            default: { id: "default", name: "Swarm Default" },
+          },
+        },
+      ],
+      provider_default: {
+        openai: "gpt-5",
+      },
+      session: [],
+      config: {
+        model: "agency-swarm/default",
+        provider: {
+          "agency-swarm": {
+            options: {},
+          },
+        },
+      },
+      mcp: {},
+    })
+
+    spyOn(SyncContext, "useSync").mockReturnValue({ data: syncData } as any)
+    spyOn(ArgsContext, "useArgs").mockReturnValue({} as any)
+    spyOn(RouteContext, "useRoute").mockReturnValue({
+      data: {
+        type: "home",
+      },
+      navigate: () => {},
+    } as any)
+    spyOn(EventContext, "useEvent").mockReturnValue({
+      on: () => () => {},
+      subscribe: () => () => {},
+    } as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({
+      client: {
+        mcp: {
+          disconnect: async () => {},
+          connect: async () => {},
+        },
+      },
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {
+        secondary: {},
+        accent: {},
+        success: {},
+        warning: {},
+        primary: {},
+        error: {},
+        info: {},
+      },
+    } as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: () => {},
+      error: () => {},
+      currentToast: null,
+    } as any)
+    spyOn(Filesystem, "readJson").mockResolvedValue({
+      recent: [
+        {
+          providerID: "openai",
+          modelID: "gpt-5",
+        },
+        {
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        {
+          providerID: "openai",
+          modelID: "gpt-5.1",
+        },
+      ],
+      favorite: [],
+      variant: {},
+    })
+    spyOn(Filesystem, "writeJson").mockResolvedValue(undefined)
+
+    let local!: ReturnType<typeof useLocal>
+
+    const Capture = () => {
+      local = useLocal()
+      return <box />
+    }
+
+    await testRender(() => (
+      <LocalProvider>
+        <Capture />
+      </LocalProvider>
+    ))
+
+    await flushEffects()
+    await local.product.set("build")
+    await flushEffects()
+
+    expect(local.model.current()).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    })
+
+    local.model.cycle(1)
+    await flushEffects()
+
+    expect(local.model.current()).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.1",
+    })
+  })
+
+  test("skips Run-only favorite models when cycling in reopened Build mode", async () => {
+    const [syncData] = createStore<any>({
+      agent: [
+        {
+          name: "build",
+          mode: "primary",
+          hidden: false,
+          model: {
+            providerID: "openai",
+            modelID: "gpt-5",
+          },
+        },
+      ],
+      provider: [
+        {
+          id: "openai",
+          name: "OpenAI",
+          models: {
+            "gpt-5": { id: "gpt-5", name: "GPT-5" },
+            "gpt-5.1": { id: "gpt-5.1", name: "GPT-5.1" },
+          },
+        },
+        {
+          id: "agency-swarm",
+          name: "Agency Swarm",
+          models: {
+            default: { id: "default", name: "Swarm Default" },
+          },
+        },
+      ],
+      provider_default: {
+        openai: "gpt-5",
+      },
+      session: [],
+      message: {
+        ses_reopened_build: [
+          {
+            id: "msg_build",
+            role: "user",
+            agent: "build",
+          },
+        ],
+      },
+      part: {
+        msg_build: [
+          {
+            id: "prt_build",
+            type: "text",
+            text: "continue build",
+            metadata: {
+              agencySwarmBridge: false,
+            },
+          },
+        ],
+      },
+      config: {
+        model: "agency-swarm/default",
+        provider: {
+          "agency-swarm": {
+            options: {},
+          },
+        },
+      },
+      mcp: {},
+    })
+
+    spyOn(SyncContext, "useSync").mockReturnValue({ data: syncData } as any)
+    spyOn(ArgsContext, "useArgs").mockReturnValue({} as any)
+    spyOn(RouteContext, "useRoute").mockReturnValue({
+      data: {
+        type: "session",
+        sessionID: "ses_reopened_build",
+      },
+      navigate: () => {},
+    } as any)
+    spyOn(EventContext, "useEvent").mockReturnValue({
+      on: () => () => {},
+      subscribe: () => () => {},
+    } as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({
+      client: {
+        mcp: {
+          disconnect: async () => {},
+          connect: async () => {},
+        },
+      },
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {
+        secondary: {},
+        accent: {},
+        success: {},
+        warning: {},
+        primary: {},
+        error: {},
+        info: {},
+      },
+    } as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: () => {},
+      error: () => {},
+      currentToast: null,
+    } as any)
+    spyOn(Filesystem, "readJson").mockResolvedValue({
+      recent: [],
+      favorite: [
+        {
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        {
+          providerID: "openai",
+          modelID: "gpt-5.1",
+        },
+      ],
+      variant: {},
+    })
+    spyOn(Filesystem, "writeJson").mockResolvedValue(undefined)
+
+    let local!: ReturnType<typeof useLocal>
+
+    const Capture = () => {
+      local = useLocal()
+      return <box />
+    }
+
+    await testRender(() => (
+      <LocalProvider>
+        <Capture />
+      </LocalProvider>
+    ))
+
+    await flushEffects()
+
+    expect(local.product.current()).toBe("build")
+    local.model.cycleFavorite(1)
+    await flushEffects()
+
+    expect(local.model.current()).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.1",
+    })
+  })
+
+  test("uses reopened session agent model instead of current local agent model", async () => {
+    const [syncData] = createStore<any>({
+      agent: [
+        {
+          name: "build",
+          mode: "primary",
+          hidden: false,
+          model: {
+            providerID: "openai",
+            modelID: "build-model",
+          },
+        },
+        {
+          name: "plan",
+          mode: "primary",
+          hidden: false,
+          model: {
+            providerID: "openai",
+            modelID: "plan-model",
+          },
+        },
+      ],
+      provider: [
+        {
+          id: "openai",
+          name: "OpenAI",
+          models: {
+            "build-model": { id: "build-model", name: "Build Model" },
+            "plan-model": { id: "plan-model", name: "Plan Model" },
+          },
+        },
+        {
+          id: "agency-swarm",
+          name: "Agency Swarm",
+          models: {
+            default: { id: "default", name: "Swarm Default" },
+          },
+        },
+      ],
+      provider_default: {
+        openai: "build-model",
+      },
+      session: [],
+      message: {
+        ses_reopened_plan: [
+          {
+            id: "msg_plan",
+            role: "user",
+            agent: "plan",
+          },
+        ],
+      },
+      part: {
+        msg_plan: [
+          {
+            id: "prt_plan",
+            type: "text",
+            text: "continue plan",
+            metadata: {
+              agencySwarmBridge: false,
+            },
+          },
+        ],
+      },
+      config: {
+        model: "agency-swarm/default",
+        provider: {
+          "agency-swarm": {
+            options: {},
+          },
+        },
+      },
+      mcp: {},
+    })
+
+    spyOn(SyncContext, "useSync").mockReturnValue({ data: syncData } as any)
+    spyOn(ArgsContext, "useArgs").mockReturnValue({} as any)
+    spyOn(RouteContext, "useRoute").mockReturnValue({
+      data: {
+        type: "session",
+        sessionID: "ses_reopened_plan",
+      },
+      navigate: () => {},
+    } as any)
+    spyOn(EventContext, "useEvent").mockReturnValue({
+      on: () => () => {},
+      subscribe: () => () => {},
+    } as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({
+      client: {
+        mcp: {
+          disconnect: async () => {},
+          connect: async () => {},
+        },
+      },
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {
+        secondary: {},
+        accent: {},
+        success: {},
+        warning: {},
+        primary: {},
+        error: {},
+        info: {},
+      },
+    } as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: () => {},
+      error: () => {},
+      currentToast: null,
+    } as any)
+    spyOn(Filesystem, "readJson").mockResolvedValue({})
+    spyOn(Filesystem, "writeJson").mockResolvedValue(undefined)
+
+    let local!: ReturnType<typeof useLocal>
+
+    const Capture = () => {
+      local = useLocal()
+      return <box />
+    }
+
+    await testRender(() => (
+      <LocalProvider>
+        <Capture />
+      </LocalProvider>
+    ))
+
+    await flushEffects()
+
+    expect(local.agent.current()?.name).toBe("build")
+    expect(local.product.current()).toBe("plan")
+    expect(local.model.current()).toEqual({
+      providerID: "openai",
+      modelID: "plan-model",
+    })
+
+    await local.product.set("build")
+    await flushEffects()
+
+    expect(local.product.current()).toBe("build")
+    expect(local.model.current()).toEqual({
+      providerID: "openai",
+      modelID: "build-model",
+    })
+
+    await local.product.set("plan")
+    await flushEffects()
+
+    expect(local.agent.current()?.name).toBe("plan")
+    await local.product.set("run")
+    await flushEffects()
+
+    expect(local.product.current()).toBe("run")
+    expect(local.agent.current()?.name).toBe("build")
+    expect(local.model.override("build")).toEqual({
+      providerID: "agency-swarm",
+      modelID: "default",
+      explicit: true,
+    })
+    expect(local.model.override("plan")).toBeUndefined()
+  })
 })

--- a/packages/opencode/test/cli/tui/local.test.ts
+++ b/packages/opencode/test/cli/tui/local.test.ts
@@ -3,6 +3,7 @@ import {
   inferProductMode,
   isUsableModel,
   readAgencySwarmBridge,
+  readSessionAgencySwarmBridge,
   selectCurrentModel,
   shouldSyncAgentModel,
 } from "../../../src/cli/cmd/tui/context/local"
@@ -223,6 +224,102 @@ describe("tui local model selection", () => {
     ).toBe(true)
   })
 
+  test("infers legacy bridge mode from assistant children", () => {
+    const messages: Parameters<typeof readSessionAgencySwarmBridge>[0]["messages"] = [
+      {
+        id: "msg_1",
+        role: "user",
+      },
+      {
+        id: "msg_2",
+        role: "assistant",
+        parentID: "msg_1",
+        providerID: "agency-swarm",
+      },
+    ]
+
+    expect(
+      readSessionAgencySwarmBridge({
+        messages,
+        parts: {},
+      }),
+    ).toBe(true)
+    expect(
+      readSessionAgencySwarmBridge({
+        messages,
+        parts: {
+          msg_1: [
+            {
+              id: "prt_1",
+              sessionID: "ses_1",
+              messageID: "msg_1",
+              type: "text",
+              text: "hello",
+              metadata: {
+                agencySwarmBridge: false,
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
+    expect(
+      readSessionAgencySwarmBridge({
+        messages: [
+          {
+            id: "msg_3",
+            role: "user",
+          },
+          {
+            id: "msg_4",
+            role: "assistant",
+            parentID: "msg_3",
+            providerID: "openai",
+          },
+        ],
+        parts: {},
+      }),
+    ).toBe(false)
+    expect(
+      readSessionAgencySwarmBridge({
+        messages: [
+          {
+            id: "msg_5",
+            role: "user",
+          },
+          {
+            id: "msg_6",
+            role: "assistant",
+            parentID: "msg_5",
+            providerID: "agency-swarm",
+          },
+          {
+            id: "msg_7",
+            role: "user",
+          },
+          {
+            id: "msg_8",
+            role: "assistant",
+            parentID: "msg_7",
+            providerID: "openai",
+          },
+        ],
+        parts: {},
+      }),
+    ).toBe(false)
+    expect(
+      readSessionAgencySwarmBridge({
+        messages: [
+          {
+            id: "msg_9",
+            role: "user",
+          },
+        ],
+        parts: {},
+      }),
+    ).toBeUndefined()
+  })
+
   test("keeps agency-swarm launcher model usable before provider metadata loads", () => {
     expect(
       isUsableModel({
@@ -313,6 +410,46 @@ describe("tui local model selection", () => {
         productMode: "run",
       }),
     ).toBe(true)
+  })
+
+  test("keeps Agency-supported provider models usable in Run mode", () => {
+    expect(
+      isUsableModel({
+        model: {
+          providerID: "openai",
+          modelID: "gpt-5",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        productMode: "run",
+      }),
+    ).toBe(true)
+  })
+
+  test("rejects Build-only provider models in Run mode", () => {
+    const input = {
+      model: {
+        providerID: "github-copilot",
+        modelID: "gpt-5",
+      },
+      providers: [
+        {
+          id: "github-copilot",
+          models: {
+            "gpt-5": {},
+          },
+        },
+      ],
+    }
+
+    expect(isUsableModel({ ...input, productMode: "build" })).toBe(true)
+    expect(isUsableModel({ ...input, productMode: "run" })).toBe(false)
   })
 
   test("rejects agency-swarm models in Build and Plan even when provider metadata is loaded", () => {

--- a/packages/opencode/test/cli/tui/local.test.ts
+++ b/packages/opencode/test/cli/tui/local.test.ts
@@ -74,6 +74,26 @@ describe("tui local model selection", () => {
     ).toBe(true)
   })
 
+  test("keeps Run mode agency-swarm model usable without global config", () => {
+    expect(
+      isUsableModel({
+        model: {
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        productMode: "run",
+      }),
+    ).toBe(true)
+  })
+
   test("does not keep agency-swarm usable when disabled_providers filters it out", () => {
     expect(
       isUsableModel({
@@ -90,6 +110,27 @@ describe("tui local model selection", () => {
           },
         ],
         configModel: "agency-swarm/default",
+        disabledProviders: ["agency-swarm"],
+      }),
+    ).toBe(false)
+  })
+
+  test("does not keep Run mode agency-swarm usable when disabled_providers filters it out", () => {
+    expect(
+      isUsableModel({
+        model: {
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        productMode: "run",
         disabledProviders: ["agency-swarm"],
       }),
     ).toBe(false)
@@ -114,6 +155,30 @@ describe("tui local model selection", () => {
         enabledProviders: ["openai"],
       }),
     ).toBe(false)
+  })
+
+  test("keeps local Run mode model state without global config", () => {
+    expect(
+      selectCurrentModel({
+        storedModel: {
+          providerID: "agency-swarm",
+          modelID: "default",
+          explicit: true,
+        },
+        providers: [
+          {
+            id: "openai",
+            models: {
+              "gpt-5": {},
+            },
+          },
+        ],
+        productMode: "run",
+      }),
+    ).toEqual({
+      providerID: "agency-swarm",
+      modelID: "default",
+    })
   })
 
   test("does not treat unrelated missing models as usable", () => {

--- a/packages/opencode/test/cli/tui/local.test.ts
+++ b/packages/opencode/test/cli/tui/local.test.ts
@@ -1,7 +1,228 @@
 import { describe, expect, test } from "bun:test"
-import { isUsableModel, selectCurrentModel, shouldSyncAgentModel } from "../../../src/cli/cmd/tui/context/local"
+import {
+  inferProductMode,
+  isUsableModel,
+  readAgencySwarmBridge,
+  selectCurrentModel,
+  shouldSyncAgentModel,
+} from "../../../src/cli/cmd/tui/context/local"
 
 describe("tui local model selection", () => {
+  test("infers reopened Build and Plan sessions before launcher Run config", () => {
+    const agentModel = {
+      providerID: "openai",
+      modelID: "gpt-5",
+    }
+
+    expect(
+      inferProductMode({
+        agentName: "plan",
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        agentModel,
+      }),
+    ).toBe("plan")
+    expect(
+      inferProductMode({
+        agentName: "build",
+        storedMode: "build",
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+          explicit: true,
+        },
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        hasAgencySwarmProvider: true,
+        agentModel,
+      }),
+    ).toBe("build")
+    expect(
+      inferProductMode({
+        agentName: "build",
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+          explicit: true,
+        },
+        storedBridge: true,
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        hasAgencySwarmProvider: true,
+        agentModel,
+      }),
+    ).toBe("run")
+    expect(
+      inferProductMode({
+        agentName: "build",
+        storedMode: "run",
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+          explicit: true,
+        },
+        storedBridge: false,
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        hasAgencySwarmProvider: true,
+        agentModel,
+      }),
+    ).toBe("run")
+    expect(
+      inferProductMode({
+        agentName: "plan",
+        storedMode: "build",
+        storedBridge: false,
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        hasAgencySwarmProvider: true,
+        agentModel,
+      }),
+    ).toBe("build")
+    expect(
+      inferProductMode({
+        agentName: "plan",
+        storedBridge: true,
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        hasAgencySwarmProvider: true,
+        agentModel,
+      }),
+    ).toBe("run")
+    expect(
+      inferProductMode({
+        agentName: "plan",
+        storedBridge: false,
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        hasAgencySwarmProvider: true,
+        agentModel,
+      }),
+    ).toBe("plan")
+    expect(
+      inferProductMode({
+        agentName: "ExampleAgent",
+        storedMode: "plan",
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+          explicit: true,
+        },
+        currentProviderID: "openai",
+        hasAgencySwarmProvider: true,
+        agentModel,
+      }),
+    ).toBe("build")
+    expect(
+      inferProductMode({
+        agentName: "ExampleAgent",
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+          explicit: true,
+        },
+        currentProviderID: "openai",
+        hasAgencySwarmProvider: true,
+        agentModel,
+      }),
+    ).toBe("run")
+    expect(
+      inferProductMode({
+        agentName: "build",
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+          explicit: true,
+        },
+        currentProviderID: "openai",
+        argModel: "openai/gpt-5",
+        hasAgencySwarmProvider: true,
+        agentModel,
+      }),
+    ).toBe("run")
+    expect(
+      inferProductMode({
+        agentName: "build",
+        argModel: "agency-swarm/default",
+        currentProviderID: "openai",
+        agentModel,
+      }),
+    ).toBe("run")
+    expect(
+      inferProductMode({
+        agentName: "build",
+        currentProviderID: "agency-swarm",
+        hasAgencySwarmProvider: true,
+        agentModel,
+      }),
+    ).toBe("run")
+    expect(
+      inferProductMode({
+        agentName: "build",
+        currentProviderID: "agency-swarm",
+        hasAgencySwarmProvider: true,
+        disabledProviders: ["agency-swarm"],
+        agentModel,
+      }),
+    ).toBe("build")
+    expect(
+      inferProductMode({
+        agentName: "build",
+        currentProviderID: "agency-swarm",
+        hasAgencySwarmProvider: true,
+        enabledProviders: ["openai"],
+        agentModel,
+      }),
+    ).toBe("build")
+  })
+
+  test("reads saved Agency Swarm bridge metadata from text, subtask, and compaction parts", () => {
+    expect(
+      readAgencySwarmBridge([
+        {
+          id: "prt_1",
+          sessionID: "ses_1",
+          messageID: "msg_1",
+          type: "text",
+          text: "hello",
+          metadata: {
+            agencySwarmBridge: true,
+          },
+        },
+      ]),
+    ).toBe(true)
+    expect(
+      readAgencySwarmBridge([
+        {
+          id: "prt_2",
+          sessionID: "ses_1",
+          messageID: "msg_1",
+          type: "subtask",
+          prompt: "hello",
+          description: "hello",
+          agent: "build",
+          metadata: {
+            agencySwarmBridge: false,
+          },
+        },
+      ]),
+    ).toBe(false)
+    expect(
+      readAgencySwarmBridge([
+        {
+          id: "prt_3",
+          sessionID: "ses_1",
+          messageID: "msg_1",
+          type: "compaction",
+          auto: false,
+          metadata: {
+            agencySwarmBridge: true,
+          },
+        },
+      ]),
+    ).toBe(true)
+  })
+
   test("keeps agency-swarm launcher model usable before provider metadata loads", () => {
     expect(
       isUsableModel({
@@ -92,6 +313,33 @@ describe("tui local model selection", () => {
         productMode: "run",
       }),
     ).toBe(true)
+  })
+
+  test("rejects agency-swarm models in Build and Plan even when provider metadata is loaded", () => {
+    const input = {
+      model: {
+        providerID: "agency-swarm",
+        modelID: "default",
+      },
+      providers: [
+        {
+          id: "agency-swarm",
+          models: {
+            default: {},
+          },
+        },
+        {
+          id: "openai",
+          models: {
+            "gpt-5": {},
+          },
+        },
+      ],
+      configModel: "agency-swarm/default",
+    }
+
+    expect(isUsableModel({ ...input, productMode: "build" })).toBe(false)
+    expect(isUsableModel({ ...input, productMode: "plan" })).toBe(false)
   })
 
   test("does not keep agency-swarm usable when disabled_providers filters it out", () => {
@@ -236,6 +484,86 @@ describe("tui local model selection", () => {
     })
   })
 
+  test("keeps Build and Plan agent models ahead of agency-swarm launcher fallback", () => {
+    const input = {
+      agentModel: {
+        providerID: "openai",
+        modelID: "gpt-5",
+      },
+      recentModels: [
+        {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4",
+        },
+      ],
+      providers: [
+        {
+          id: "openai",
+          models: {
+            "gpt-5": {},
+          },
+        },
+        {
+          id: "anthropic",
+          models: {
+            "claude-sonnet-4": {},
+          },
+        },
+      ],
+      configModel: "agency-swarm/default",
+      configuredProviders: {
+        "agency-swarm": {
+          name: "Agency Swarm",
+          options: {},
+        },
+      },
+    }
+
+    expect(selectCurrentModel({ ...input, productMode: "build" })).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    })
+    expect(selectCurrentModel({ ...input, productMode: "plan" })).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    })
+  })
+
+  test("uses inferred Build and Plan modes when selecting the current model", () => {
+    const input = {
+      agentModel: {
+        providerID: "openai",
+        modelID: "gpt-5",
+      },
+      providers: [
+        {
+          id: "openai",
+          models: {
+            "gpt-5": {},
+          },
+        },
+      ],
+      configModel: "agency-swarm/default",
+      configuredProviders: {
+        "agency-swarm": {
+          name: "Agency Swarm",
+          options: {},
+        },
+      },
+      hasAgencySwarmProvider: true,
+      storedBridge: false,
+    }
+
+    expect(selectCurrentModel({ ...input, agentName: "build" })).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    })
+    expect(selectCurrentModel({ ...input, agentName: "plan" })).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    })
+  })
+
   test("falls back when configured agency-swarm is filtered out", () => {
     expect(
       selectCurrentModel({
@@ -263,6 +591,47 @@ describe("tui local model selection", () => {
     ).toEqual({
       providerID: "openai",
       modelID: "gpt-5",
+    })
+  })
+
+  test("skips filtered and unusable provider-list fallbacks", () => {
+    expect(
+      selectCurrentModel({
+        providers: [
+          {
+            id: "agency-swarm",
+            models: {
+              default: {},
+            },
+          },
+          {
+            id: "openai",
+            models: {
+              "gpt-disabled": { id: "gpt-disabled" },
+            },
+          },
+          {
+            id: "anthropic",
+            models: {},
+          },
+          {
+            id: "openrouter",
+            models: {
+              "openrouter-default": { id: "openrouter-default" },
+            },
+          },
+        ],
+        providerDefaults: {
+          anthropic: "missing-default",
+          openrouter: "openrouter-default",
+        },
+        productMode: "build",
+        enabledProviders: ["anthropic", "openrouter"],
+        disabledProviders: ["openai"],
+      }),
+    ).toEqual({
+      providerID: "openrouter",
+      modelID: "openrouter-default",
     })
   })
 

--- a/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { RGBA } from "@opentui/core"
 import { testRender, useRenderer } from "@opentui/solid"
 import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
-import { type ParentProps } from "solid-js"
+import { onCleanup, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
 import * as AgencySwarmConnectionContext from "../../../src/cli/cmd/tui/context/agency-swarm-connection"
 import * as ArgsContext from "../../../src/cli/cmd/tui/context/args"
@@ -29,11 +29,14 @@ import * as AutocompleteModule from "../../../src/cli/cmd/tui/component/prompt/a
 import { DialogProvider } from "../../../src/cli/cmd/tui/ui/dialog"
 import { AgencySwarmAdapter } from "../../../src/agency-swarm/adapter"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2"
-import { OpencodeKeymapProvider } from "../../../src/cli/cmd/tui/keymap"
+import { createOpencodeModeStack, OpencodeKeymapProvider } from "../../../src/cli/cmd/tui/keymap"
 
 function TestKeymapProvider(props: ParentProps) {
   const renderer = useRenderer()
-  return <OpencodeKeymapProvider keymap={createDefaultOpenTuiKeymap(renderer)}>{props.children}</OpencodeKeymapProvider>
+  const keymap = createDefaultOpenTuiKeymap(renderer)
+  const stack = createOpencodeModeStack(keymap)
+  onCleanup(() => stack.dispose())
+  return <OpencodeKeymapProvider keymap={keymap}>{props.children}</OpencodeKeymapProvider>
 }
 
 const testTuiConfig = {

--- a/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
@@ -173,6 +173,9 @@ describe("prompt framework-mode footer", () => {
           set: () => {},
         },
       },
+      product: {
+        current: () => "run",
+      },
     } as any)
     spyOn(SDKContext, "useSDK").mockReturnValue({
       client: {

--- a/packages/opencode/test/cli/tui/prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt.test.tsx
@@ -104,6 +104,7 @@ describe("prompt auth rejection handling", () => {
     frameworkMode?: boolean
     openaiCredential?: boolean
     openrouterEnv?: string[]
+    productMode?: "build" | "plan" | "run"
     selectedModel?: { providerID: string; modelID: string }
     prompt: (input: { messageID: string; sessionID: string }) => Promise<unknown>
     sessionID: string
@@ -132,7 +133,8 @@ describe("prompt auth rejection handling", () => {
       "shell",
     )
 
-    spyOn(AgencySwarmRunSession, "sync").mockResolvedValue(undefined)
+    const syncRunSession = spyOn(AgencySwarmRunSession, "sync").mockResolvedValue(undefined)
+    const clearRunSession = spyOn(AgencySwarmRunSession, "clear").mockResolvedValue(undefined)
     spyOn(AutocompleteModule, "Autocomplete").mockImplementation((props: any) => {
       props.ref?.({
         onInput() {},
@@ -198,6 +200,7 @@ describe("prompt auth rejection handling", () => {
           },
         }),
         list: () => [{ name: "builder" }],
+        sessionID: () => input.sessionID,
         set: () => {},
         color: () => RGBA.fromHex("#38bdf8"),
       },
@@ -217,6 +220,13 @@ describe("prompt auth rejection handling", () => {
           set: () => {},
         },
       },
+      ...(input.productMode
+        ? {
+            product: {
+              current: () => input.productMode,
+            },
+          }
+        : {}),
     } as any)
     spyOn(SDKContext, "useSDK").mockReturnValue({
       client: {
@@ -345,8 +355,53 @@ describe("prompt auth rejection handling", () => {
     ))
 
     expect(promptRef).toBeDefined()
-    return { parts, promptRef: promptRef!, promptSession, shellSession }
+    return { clearRunSession, parts, promptRef: promptRef!, promptSession, shellSession, syncRunSession }
   }
+
+  test("keeps saved Run session state when submitting a Build prompt", async () => {
+    const { clearRunSession, promptRef, promptSession, syncRunSession } = await renderTelemetryPrompt({
+      events: createEventBus(),
+      frameworkMode: false,
+      productMode: "build",
+      prompt: async () => ({ data: {} }),
+      sessionID: "session_build_preserve_run_state",
+      workspaceID: "workspace",
+    })
+
+    promptRef.set({ input: "fix the swarm", parts: [] })
+    promptRef.submit()
+    await flushEffects()
+
+    expect(promptSession).toHaveBeenCalledTimes(1)
+    expect(syncRunSession).not.toHaveBeenCalled()
+    expect(clearRunSession).not.toHaveBeenCalled()
+    const payload = promptSession.mock.calls[0]?.[0] as { $body_agencySwarmBridge?: boolean } | undefined
+    expect(payload?.$body_agencySwarmBridge).toBe(false)
+  })
+
+  test("keeps saved Run session state when submitting a Plan prompt", async () => {
+    const { clearRunSession, promptRef, promptSession, syncRunSession } = await renderTelemetryPrompt({
+      events: createEventBus(),
+      frameworkMode: false,
+      productMode: "plan",
+      prompt: async () => ({ data: {} }),
+      sessionID: "session_plan_preserve_run_state",
+      workspaceID: "workspace",
+    })
+
+    promptRef.set({ input: "plan the swarm fix", parts: [] })
+    promptRef.submit()
+    await flushEffects()
+
+    expect(promptSession).toHaveBeenCalledTimes(1)
+    expect(syncRunSession).not.toHaveBeenCalled()
+    expect(clearRunSession).not.toHaveBeenCalled()
+    const payload = promptSession.mock.calls[0]?.[0] as
+      | { $body_agencySwarmBridge?: boolean; agent?: string }
+      | undefined
+    expect(payload?.$body_agencySwarmBridge).toBe(false)
+    expect(payload?.agent).toBe("plan")
+  })
 
   test("blocks selected OpenRouter prompts when only OpenAI env credentials exist", async () => {
     const { promptRef, promptSession } = await renderTelemetryPrompt({

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -479,6 +479,39 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
+  test("prompt submit auth gating honors explicit Build and Plan product modes", () => {
+    const input = {
+      currentProviderID: "openai",
+      configuredModel: "agency-swarm/default",
+      providers: [
+        {
+          id: "agency-swarm",
+          name: "Agency Swarm",
+          source: "config",
+          env: [],
+          options: {},
+          models: {},
+        },
+        {
+          id: "openai",
+          name: "OpenAI",
+          source: "config",
+          env: ["OPENAI_API_KEY"],
+          options: {},
+          models: {},
+        },
+      ] satisfies Provider[],
+      providerAuth: {},
+      mode: "normal",
+      isSlashCommand: false,
+      env: {},
+    } satisfies Omit<Parameters<typeof shouldBlockAgencyPromptSubmit>[0], "productMode">
+
+    expect(shouldBlockAgencyPromptSubmit({ ...input, productMode: "build" })).toBe(false)
+    expect(shouldBlockAgencyPromptSubmit({ ...input, productMode: "plan" })).toBe(false)
+    expect(shouldBlockAgencyPromptSubmit({ ...input, productMode: "run" })).toBe(true)
+  })
+
   test("framework mode skips auth when explicit client_config exists", () => {
     expect(
       shouldOpenStartupAuthDialog({

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -314,6 +314,7 @@ describe("agency session errors", () => {
     expect(shouldOpenStartupAuthDialog(input)).toBe(false)
     expect(
       shouldBlockAgencyPromptSubmit({
+        productMode: undefined,
         currentProviderID: "agency-swarm",
         configuredModel: "agency-swarm/default",
         providers: input.providers,
@@ -455,6 +456,7 @@ describe("agency session errors", () => {
   test("framework mode stays true when config default is agency-swarm even if session uses openai upstream", () => {
     expect(
       isAgencySwarmFrameworkMode({
+        productMode: undefined,
         currentProviderID: "openai",
         configuredModel: "agency-swarm/default",
       }),
@@ -464,6 +466,7 @@ describe("agency session errors", () => {
   test("framework mode is true when agent default is agency-swarm but session model is openai", () => {
     expect(
       isAgencySwarmFrameworkMode({
+        productMode: undefined,
         currentProviderID: "openai",
         configuredModel: undefined,
         agentModel: { providerID: "agency-swarm", modelID: "default" },
@@ -474,6 +477,7 @@ describe("agency session errors", () => {
   test("framework mode falls back to the configured agency-swarm model when no current provider is selected", () => {
     expect(
       isAgencySwarmFrameworkMode({
+        productMode: undefined,
         configuredModel: "agency-swarm/default",
       }),
     ).toBe(true)
@@ -977,6 +981,7 @@ describe("agency session errors", () => {
   test("blocks the first agency prompt when supported auth is missing", () => {
     expect(
       shouldBlockAgencyPromptSend({
+        productMode: undefined,
         currentProviderID: "agency-swarm",
         configuredModel: "agency-swarm/default",
         providers: [
@@ -1004,6 +1009,7 @@ describe("agency session errors", () => {
   test("does not block the first agency prompt when supported auth exists", () => {
     expect(
       shouldBlockAgencyPromptSend({
+        productMode: undefined,
         currentProviderID: "agency-swarm",
         configuredModel: "agency-swarm/default",
         providers: [
@@ -1031,6 +1037,7 @@ describe("agency session errors", () => {
 
   test("does not block shell mode or slash commands during agency auth gating", () => {
     const input = {
+      productMode: undefined,
       currentProviderID: "agency-swarm",
       configuredModel: "agency-swarm/default",
       providers: [

--- a/packages/opencode/test/cli/tui/transcript.test.ts
+++ b/packages/opencode/test/cli/tui/transcript.test.ts
@@ -144,12 +144,12 @@ describe("transcript", () => {
 
     test("includes metadata when enabled", () => {
       const result = formatAssistantHeader(baseMsg, true)
-      expect(result).toBe("## Assistant (Agent Builder · claude-sonnet-4-20250514 · 5.4s)\n\n")
+      expect(result).toBe("## Assistant (Build · claude-sonnet-4-20250514 · 5.4s)\n\n")
     })
 
     test("uses model display name when available", () => {
       const result = formatAssistantHeader(baseMsg, true, providers)
-      expect(result).toBe("## Assistant (Agent Builder · Claude Sonnet 4 · 5.4s)\n\n")
+      expect(result).toBe("## Assistant (Build · Claude Sonnet 4 · 5.4s)\n\n")
     })
 
     test("uses assistant agent model label for agency-swarm default", () => {
@@ -272,7 +272,7 @@ describe("transcript", () => {
     test("handles missing completed time", () => {
       const msg = { ...baseMsg, time: { created: 1000000 } }
       const result = formatAssistantHeader(msg as AssistantMessage, true)
-      expect(result).toBe("## Assistant (Agent Builder · claude-sonnet-4-20250514)\n\n")
+      expect(result).toBe("## Assistant (Build · claude-sonnet-4-20250514)\n\n")
     })
 
     test("titlecases agent name", () => {
@@ -465,7 +465,7 @@ describe("transcript", () => {
       }
       const parts: Part[] = [{ id: "p1", sessionID: "ses_123", messageID: "msg_123", type: "text", text: "Hi there" }]
       const result = formatMessage(msg, parts, options)
-      expect(result).toContain("## Assistant (Agent Builder · Claude Sonnet 4 · 5.4s)")
+      expect(result).toContain("## Assistant (Build · Claude Sonnet 4 · 5.4s)")
       expect(result).toContain("Hi there")
     })
   })
@@ -520,7 +520,7 @@ describe("transcript", () => {
       expect(result).toContain("**Session ID:** ses_abc123")
       expect(result).toContain("## User")
       expect(result).toContain("Hello")
-      expect(result).toContain("## Assistant (Agent Builder · Claude Sonnet 4 · 0.5s)")
+      expect(result).toContain("## Assistant (Build · Claude Sonnet 4 · 0.5s)")
       expect(result).toContain("Hi!")
       expect(result).toContain("---")
     })
@@ -994,7 +994,7 @@ describe("transcript", () => {
         assistantMetadata: true,
       })
 
-      expect(result).toContain("## Assistant (Agent Builder · claude-sonnet-4-20250514 · 0.5s)")
+      expect(result).toContain("## Assistant (Build · claude-sonnet-4-20250514 · 0.5s)")
     })
 
     test("formats transcript without assistant metadata", () => {

--- a/packages/opencode/test/cli/tui/transcript.test.ts
+++ b/packages/opencode/test/cli/tui/transcript.test.ts
@@ -223,7 +223,7 @@ describe("transcript", () => {
         ],
       })
 
-      expect(result).toBe("## Assistant (Agent Builder · claude-sonnet-4-5 · 5.4s)\n\n")
+      expect(result).toBe("## Assistant (Build · claude-sonnet-4-5 · 5.4s)\n\n")
       expect(result).not.toContain("Swarm Default")
       expect(result).not.toContain("Swarm models")
     })
@@ -261,7 +261,7 @@ describe("transcript", () => {
         ],
       })
 
-      expect(result).toBe("## Assistant (Agent Builder · Swarm models: gpt-5.4-mini +1 · 5.4s)\n\n")
+      expect(result).toBe("## Assistant (Build · Swarm models: gpt-5.4-mini +1 · 5.4s)\n\n")
     })
 
     test("excludes metadata when disabled", () => {
@@ -595,8 +595,8 @@ describe("transcript", () => {
         ],
       })
 
-      expect(result).toContain("## Assistant (Agent Builder · claude-sonnet-4-5 · 0.5s)")
-      expect(result).not.toContain("Agent Builder · gpt-5.4-mini")
+      expect(result).toContain("## Assistant (Build · claude-sonnet-4-5 · 0.5s)")
+      expect(result).not.toContain("Build · gpt-5.4-mini")
     })
 
     test("uses sole discovered agency when current config omits agency id", () => {
@@ -659,7 +659,7 @@ describe("transcript", () => {
         ],
       })
 
-      expect(result).toContain("## Assistant (Agent Builder · claude-sonnet-4-5 · 0.5s)")
+      expect(result).toContain("## Assistant (Build · claude-sonnet-4-5 · 0.5s)")
       expect(result).not.toContain("Swarm Default")
     })
 
@@ -733,8 +733,8 @@ describe("transcript", () => {
         ],
       })
 
-      expect(result).toContain("## Assistant (Agent Builder · claude-sonnet-4-5 · 0.5s)")
-      expect(result).not.toContain("Agent Builder · gpt-5.4-mini")
+      expect(result).toContain("## Assistant (Build · claude-sonnet-4-5 · 0.5s)")
+      expect(result).not.toContain("Build · gpt-5.4-mini")
     })
 
     test("uses the submitted agency for completed build-route labels after the current agency changes", () => {
@@ -814,8 +814,8 @@ describe("transcript", () => {
         ],
       })
 
-      expect(result).toContain("## Assistant (Agent Builder · claude-sonnet-4-5 · 0.5s)")
-      expect(result).not.toContain("Agent Builder · gpt-5.4-mini")
+      expect(result).toContain("## Assistant (Build · claude-sonnet-4-5 · 0.5s)")
+      expect(result).not.toContain("Build · gpt-5.4-mini")
     })
 
     test("keeps auto-resolved submitted agency after another agency appears", () => {
@@ -892,8 +892,8 @@ describe("transcript", () => {
         ],
       })
 
-      expect(result).toContain("## Assistant (Agent Builder · claude-sonnet-4-5 · 0.5s)")
-      expect(result).not.toContain("Agent Builder · gpt-5.4-mini")
+      expect(result).toContain("## Assistant (Build · claude-sonnet-4-5 · 0.5s)")
+      expect(result).not.toContain("Build · gpt-5.4-mini")
       expect(result).not.toContain("Swarm Default")
     })
 
@@ -957,8 +957,8 @@ describe("transcript", () => {
         ],
       })
 
-      expect(result).toContain("## Assistant (Agent Builder · Claude Sonnet 4 · 0.5s)")
-      expect(result).not.toContain("Agent Builder · gpt-5.4-mini")
+      expect(result).toContain("## Assistant (Build · Claude Sonnet 4 · 0.5s)")
+      expect(result).not.toContain("Build · gpt-5.4-mini")
       expect(result).not.toContain("Swarm Default")
     })
 
@@ -1027,7 +1027,7 @@ describe("transcript", () => {
       const result = formatTranscript(session, messages, options)
 
       expect(result).toContain("## Assistant\n\n")
-      expect(result).not.toContain("Agent Builder")
+      expect(result).not.toContain("Build")
       expect(result).not.toContain("claude-sonnet-4-20250514")
     })
   })

--- a/packages/opencode/test/session/agent-builder.test.ts
+++ b/packages/opencode/test/session/agent-builder.test.ts
@@ -4,7 +4,7 @@ import { agentBuilderInstructions } from "../../src/session/agent-builder"
 test("agentBuilderInstructions applies only to local build turns", () => {
   const local = agentBuilderInstructions("build", "openai")
   expect(local).toHaveLength(1)
-  expect(local[0]).toContain("Agent Swarm Agent Builder Instructions")
+  expect(local[0]).toContain("Agent Swarm Build Instructions")
   expect(local[0]).toContain("https://github.com/agency-ai-solutions/agency-starter-template")
   expect(local[0]).toContain(
     "If the latest system reminder or handoff mentions an approved session plan file, read it before you change code",

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -601,6 +601,7 @@ describe("session.compaction.create", () => {
           model: ref,
           auto: true,
           overflow: true,
+          agencySwarmBridge: false,
         })
 
         const msgs = yield* ssn.messages({ sessionID: info.id })
@@ -611,6 +612,7 @@ describe("session.compaction.create", () => {
           type: "compaction",
           auto: true,
           overflow: true,
+          metadata: { agencySwarmBridge: false },
         })
 
         const v2 = yield* SessionV2.Service.use((svc) => svc.messages({ sessionID: info.id })).pipe(
@@ -1066,6 +1068,7 @@ describe("session.compaction.process", () => {
         messages: msgs,
         sessionID: session.id,
         auto: true,
+        agencySwarmBridge: false,
       })
 
       const all = yield* ssn.messages({ sessionID: session.id })
@@ -1076,7 +1079,7 @@ describe("session.compaction.process", () => {
       expect(last?.parts[0]).toMatchObject({
         type: "text",
         synthetic: true,
-        metadata: { compaction_continue: true },
+        metadata: { compaction_continue: true, agencySwarmBridge: false },
       })
       if (last?.parts[0]?.type === "text") {
         expect(last.parts[0].text).toContain("Continue if you have next steps")

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1006,7 +1006,8 @@ planMode.instance(
       const plan = Session.plan(chat, ctx)
       const [input] = yield* llm.inputs
       const payload = JSON.stringify(input)
-      expect(payload).toContain(plan)
+      const serializedPlan = JSON.stringify(plan).slice(1, -1)
+      expect(payload).toContain(serializedPlan)
       expect(payload).toContain("Agent Swarm Planner Instructions")
       expect(payload).toContain("plan_exit")
     }),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -55,6 +55,7 @@ import { awaitWithTimeout, pollWithTimeout, testEffect } from "../lib/effect"
 import { reply, TestLLMServer } from "../lib/llm-server"
 import { SyncEvent } from "@/sync"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { InstanceState } from "@/effect/instance-state"
 
 void Log.init({ print: false })
 
@@ -192,6 +193,217 @@ function queuedAgencyRecipientScenario(input: {
   })
 }
 
+function queuedBridgeScenario(
+  secondParts:
+    | { type: "text"; text: string }[]
+    | { type: "file"; mime: string; filename: string; url: string }[] = [{ type: "text", text: "second" }],
+  expectedNativeHits = 1,
+) {
+  return Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => ({
+      ...agencyCfg,
+      provider: {
+        ...agencyCfg.provider,
+        test: {
+          ...cfg.provider.test,
+          options: {
+            ...cfg.provider.test.options,
+            baseURL: url,
+          },
+        },
+      },
+    }))
+    const originalMetadata = AgencySwarmAdapter.getMetadata
+    const originalStream = AgencySwarmAdapter.streamRun
+    const firstStarted = defer<void>()
+    const finishFirst = defer<void>()
+    const streams: (string | undefined)[] = []
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        finishFirst.resolve()
+        AgencySwarmAdapter.getMetadata = originalMetadata
+        AgencySwarmAdapter.streamRun = originalStream
+      }),
+    )
+    AgencySwarmAdapter.getMetadata = (async () => ({
+      metadata: {
+        agents: ["MathAgent"],
+      },
+    })) as typeof AgencySwarmAdapter.getMetadata
+    AgencySwarmAdapter.streamRun = async function* (args) {
+      streams.push(typeof args.message === "string" ? args.message : undefined)
+      firstStarted.resolve()
+      await finishFirst.promise
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({
+      title: "Queued bridge routing",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+
+    const first = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: {
+          providerID: ProviderID.make("agency-swarm"),
+          modelID: ModelID.make("default"),
+        },
+        agencySwarmBridge: true,
+        parts: [{ type: "text", text: "first" }],
+      })
+      .pipe(Effect.forkChild)
+    yield* awaitWithTimeout(
+      Effect.race(
+        Effect.promise(() => firstStarted.promise),
+        Fiber.await(first).pipe(
+          Effect.flatMap((exit) =>
+            Effect.fail(
+              new Error(
+                `first agency prompt exited before the stream started: ${
+                  Exit.isFailure(exit) ? Cause.pretty(exit.cause) : "success"
+                }`,
+              ),
+            ),
+          ),
+        ),
+      ),
+      "timed out waiting for first agency stream to start",
+      "5 seconds",
+    )
+
+    const second = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        agencySwarmBridge: false,
+        parts: secondParts,
+      })
+      .pipe(Effect.forkChild)
+    yield* awaitWithTimeout(waitForQueuedUser(), "timed out waiting for queued native user to persist", "3 seconds")
+    yield* llm.text("native second")
+    finishFirst.resolve()
+
+    const [firstExit, secondExit] = yield* awaitWithTimeout(
+      Effect.all([Fiber.await(first), Fiber.await(second)]),
+      "timed out waiting for mixed queued prompts to finish",
+      "5 seconds",
+    )
+    expect(Exit.isSuccess(firstExit)).toBe(true)
+    expect(Exit.isSuccess(secondExit)).toBe(true)
+    expect(streams).toEqual(["first"])
+    expect(yield* llm.hits).toHaveLength(expectedNativeHits)
+
+    function waitForQueuedUser() {
+      return Effect.gen(function* () {
+        for (let attempt = 0; attempt < 20; attempt++) {
+          const messages = yield* sessions.messages({ sessionID: chat.id })
+          if (messages.filter((item) => item.info.role === "user").length === 2) return
+          yield* Effect.sleep("10 millis")
+        }
+        throw new Error("Queued native prompt was not persisted before the active run completed")
+      })
+    }
+  })
+}
+
+function queuedBridgeReverseScenario() {
+  return Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => ({
+      ...agencyCfg,
+      provider: {
+        ...agencyCfg.provider,
+        test: {
+          ...cfg.provider.test,
+          options: {
+            ...cfg.provider.test.options,
+            baseURL: url,
+          },
+        },
+      },
+    }))
+    const originalMetadata = AgencySwarmAdapter.getMetadata
+    const originalStream = AgencySwarmAdapter.streamRun
+    const finishFirst = yield* Deferred.make<void>()
+    const streams: (string | undefined)[] = []
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        succeedVoid(finishFirst)
+        AgencySwarmAdapter.getMetadata = originalMetadata
+        AgencySwarmAdapter.streamRun = originalStream
+      }),
+    )
+    AgencySwarmAdapter.getMetadata = (async () => ({
+      metadata: {
+        agents: ["MathAgent"],
+      },
+    })) as typeof AgencySwarmAdapter.getMetadata
+    AgencySwarmAdapter.streamRun = async function* (args) {
+      streams.push(typeof args.message === "string" ? args.message : undefined)
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({
+      title: "Queued bridge reverse routing",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+
+    yield* llm.hold("native first", deferredAsPromise(finishFirst))
+    const first = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        agencySwarmBridge: false,
+        parts: [{ type: "text", text: "first" }],
+      })
+      .pipe(Effect.forkChild)
+    yield* awaitWithTimeout(llm.wait(1), "timed out waiting for native prompt to start", "5 seconds")
+
+    const second = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: {
+          providerID: ProviderID.make("agency-swarm"),
+          modelID: ModelID.make("default"),
+        },
+        agencySwarmBridge: true,
+        parts: [{ type: "text", text: "second" }],
+      })
+      .pipe(Effect.forkChild)
+    yield* awaitWithTimeout(waitForQueuedUser(), "timed out waiting for queued agency user to persist", "3 seconds")
+    yield* Deferred.succeed(finishFirst, void 0).pipe(Effect.ignore)
+
+    const [firstExit, secondExit] = yield* awaitWithTimeout(
+      Effect.all([Fiber.await(first), Fiber.await(second)]),
+      "timed out waiting for reversed mixed queued prompts to finish",
+      "5 seconds",
+    )
+    expect(Exit.isSuccess(firstExit)).toBe(true)
+    expect(Exit.isSuccess(secondExit)).toBe(true)
+    expect(streams).toEqual(["second"])
+    expect(yield* llm.hits).toHaveLength(1)
+
+    function waitForQueuedUser() {
+      return Effect.gen(function* () {
+        for (let attempt = 0; attempt < 20; attempt++) {
+          const messages = yield* sessions.messages({ sessionID: chat.id })
+          if (messages.filter((item) => item.info.role === "user").length === 2) return
+          yield* Effect.sleep("10 millis")
+        }
+        throw new Error("Queued agency prompt was not persisted before the active run completed")
+      })
+    }
+  })
+}
+
 function withSh<A, E, R>(fx: () => Effect.Effect<A, E, R>) {
   return Effect.acquireUseRelease(
     Effect.sync(() => {
@@ -284,7 +496,11 @@ const blockingProcessor = Layer.succeed(
   }),
 )
 
-function makeHttp(input?: { processor?: "blocking" }) {
+function makeHttp(input?: { processor?: "blocking"; experimentalPlanMode?: boolean }) {
+  const runtime = RuntimeFlags.layer({
+    experimentalEventSystem: true,
+    experimentalPlanMode: input?.experimentalPlanMode ?? false,
+  })
   const deps = Layer.mergeAll(
     Session.defaultLayer,
     Snapshot.defaultLayer,
@@ -313,7 +529,7 @@ function makeHttp(input?: { processor?: "blocking" }) {
     Layer.provide(Reference.defaultLayer),
     Layer.provide(Ripgrep.defaultLayer),
     Layer.provide(Format.defaultLayer),
-    Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+    Layer.provide(runtime),
     Layer.provideMerge(todo),
     Layer.provideMerge(question),
     Layer.provideMerge(deps),
@@ -325,11 +541,11 @@ function makeHttp(input?: { processor?: "blocking" }) {
       : SessionProcessor.layer.pipe(
           Layer.provide(summary),
           Layer.provide(Image.defaultLayer),
-          Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+          Layer.provide(runtime),
           Layer.provideMerge(deps),
         )
   const compact = SessionCompaction.layer.pipe(
-    Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+    Layer.provide(runtime),
     Layer.provideMerge(proc),
     Layer.provideMerge(deps),
   )
@@ -347,7 +563,7 @@ function makeHttp(input?: { processor?: "blocking" }) {
       Layer.provideMerge(trunc),
       Layer.provide(Instruction.defaultLayer),
       Layer.provide(SystemPrompt.defaultLayer),
-      Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+      Layer.provide(runtime),
       Layer.provideMerge(deps),
     ),
   ).pipe(Layer.provide(summary))
@@ -355,6 +571,7 @@ function makeHttp(input?: { processor?: "blocking" }) {
 
 const it = testEffect(makeHttp())
 const race = testEffect(makeHttp({ processor: "blocking" }))
+const planMode = testEffect(makeHttp({ experimentalPlanMode: true }))
 const unix = process.platform !== "win32" ? it.instance : it.instance.skip
 
 it.effect(
@@ -762,6 +979,71 @@ it.instance(
   { git: true },
 )
 
+planMode.instance(
+  "Plan prompt keeps the dynamic plan file path with Agent Swarm planner instructions",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Plan path",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "plan",
+        noReply: true,
+        parts: [{ type: "text", text: "make a plan" }],
+      })
+
+      yield* llm.text("planned")
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.role).toBe("assistant")
+
+      const ctx = yield* InstanceState.context
+      const plan = Session.plan(chat, ctx)
+      const [input] = yield* llm.inputs
+      const payload = JSON.stringify(input)
+      expect(payload).toContain(plan)
+      expect(payload).toContain("Agent Swarm Planner Instructions")
+      expect(payload).toContain("plan_exit")
+    }),
+  { git: true },
+)
+
+it.instance(
+  "legacy Plan prompt skips Agent Swarm planner instructions without native plan mode",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Legacy plan",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "plan",
+        noReply: true,
+        parts: [{ type: "text", text: "make a legacy plan" }],
+      })
+
+      yield* llm.text("planned")
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.role).toBe("assistant")
+
+      const [input] = yield* llm.inputs
+      const payload = JSON.stringify(input)
+      expect(payload).not.toContain("Agent Swarm Planner Instructions")
+      expect(payload).not.toContain("plan_exit")
+    }),
+  { git: true },
+)
+
 it.instance(
   "static loop consumes queued replies across turns",
   () =>
@@ -832,11 +1114,168 @@ it.instance(
 )
 
 it.instance(
+  "auto compaction keeps native bridge routing across direct loop",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig((url) => ({
+        ...agencyCfg,
+        provider: {
+          ...agencyCfg.provider,
+          test: {
+            ...cfg.provider.test,
+            options: {
+              ...cfg.provider.test.options,
+              baseURL: url,
+            },
+          },
+        },
+      }))
+      const originalStream = AgencySwarmAdapter.streamRun
+      const streams: (string | undefined)[] = []
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          AgencySwarmAdapter.streamRun = originalStream
+        }),
+      )
+      AgencySwarmAdapter.streamRun = async function* (args) {
+        streams.push(typeof args.message === "string" ? args.message : undefined)
+        yield { type: "end" }
+      } as typeof AgencySwarmAdapter.streamRun
+
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const compact = yield* SessionCompaction.Service
+      const chat = yield* sessions.create({
+        title: "Compaction bridge routing",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        agencySwarmBridge: false,
+        noReply: true,
+        parts: [{ type: "text", text: "native work before compact" }],
+      })
+      yield* compact.create({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        auto: true,
+        agencySwarmBridge: false,
+      })
+      yield* llm.text("compacted summary")
+      yield* llm.text("native continuation")
+
+      const result = yield* prompt.loop({ sessionID: chat.id })
+
+      expect(result.info.role).toBe("assistant")
+      expect(result.parts.some((part) => part.type === "text" && part.text === "native continuation")).toBe(true)
+      expect(streams).toEqual([])
+      expect(yield* llm.hits).toHaveLength(2)
+    }),
+  { git: true, config: agencyCfg },
+  10_000,
+)
+
+it.instance(
   "queued agency prompt without a recipient does not inherit the active recipient",
   () =>
     queuedAgencyRecipientScenario({
       expectedRecipients: ["MathAgent", undefined],
     }),
+  { git: true, config: agencyCfg },
+  8_000,
+)
+
+it.instance(
+  "slash command subtask follow-up keeps explicit native bridge routing",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig((url) => ({
+        ...agencyCfg,
+        provider: {
+          ...agencyCfg.provider,
+          test: {
+            ...cfg.provider.test,
+            options: {
+              ...cfg.provider.test.options,
+              baseURL: url,
+            },
+          },
+        },
+      }))
+      const originalMetadata = AgencySwarmAdapter.getMetadata
+      const originalStream = AgencySwarmAdapter.streamRun
+      const streams: (string | undefined)[] = []
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          AgencySwarmAdapter.getMetadata = originalMetadata
+          AgencySwarmAdapter.streamRun = originalStream
+        }),
+      )
+      AgencySwarmAdapter.getMetadata = (async () => ({
+        metadata: {
+          agents: ["UserSupportAgent"],
+        },
+      })) as typeof AgencySwarmAdapter.getMetadata
+      AgencySwarmAdapter.streamRun = async function* (args) {
+        streams.push(typeof args.message === "string" ? args.message : undefined)
+        yield { type: "end" }
+      } as typeof AgencySwarmAdapter.streamRun
+
+      const { prompt, chat } = yield* boot({ title: "Command subtask bridge routing" })
+      yield* llm.text("native child")
+      yield* llm.text("native summary")
+
+      yield* prompt.command({
+        sessionID: chat.id,
+        command: "review",
+        arguments: "agent-builder-command-route-build",
+        agent: "build",
+        model: "test/test-model",
+        agencySwarmBridge: false,
+      })
+
+      expect(streams).toEqual([])
+      expect(yield* llm.pending).toBe(0)
+      const native = JSON.stringify(yield* llm.inputs)
+      expect(native).toContain("agent-builder-command-route-build")
+      expect(native).toContain("Summarize the task tool output above")
+    }),
+  { git: true, config: agencyCfg },
+  30_000,
+)
+
+it.instance(
+  "queued native prompts keep their bridge override after an active agency run",
+  () => queuedBridgeScenario(),
+  { git: true, config: agencyCfg },
+  8_000,
+)
+
+it.instance(
+  "queued file-only native prompts keep their bridge override after an active agency run",
+  () =>
+    queuedBridgeScenario(
+      [
+        {
+          type: "file",
+          mime: "application/octet-stream",
+          filename: "payload.bin",
+          url: "data:application/octet-stream;base64,AAAA",
+        },
+      ],
+      0,
+    ),
+  { git: true, config: agencyCfg },
+  8_000,
+)
+
+it.instance(
+  "queued agency prompts keep their bridge override after an active native run",
+  () => queuedBridgeReverseScenario(),
   { git: true, config: agencyCfg },
   8_000,
 )
@@ -1560,6 +1999,26 @@ unix(
       expect(tool.state.metadata.output).toContain("out")
       expect(tool.state.metadata.output).toContain("err")
       yield* run.assertNotBusy(chat.id)
+    }),
+  { git: true, config: cfg },
+)
+
+unix(
+  "shell persists explicit native bridge routing metadata",
+  () =>
+    Effect.gen(function* () {
+      const { prompt, chat } = yield* boot()
+      yield* prompt.shell({
+        sessionID: chat.id,
+        agent: "build",
+        command: "printf shell-native",
+        agencySwarmBridge: false,
+      })
+
+      const messages = yield* Session.Service.use((session) => session.messages({ sessionID: chat.id }))
+      const user = messages.find((message) => message.info.role === "user")
+      const text = user?.parts.find((part) => part.type === "text")
+      expect(text?.metadata?.agencySwarmBridge).toBe(false)
     }),
   { git: true, config: cfg },
 )

--- a/packages/opencode/test/session/schema-decoding.test.ts
+++ b/packages/opencode/test/session/schema-decoding.test.ts
@@ -260,15 +260,13 @@ describe("Todo.Info", () => {
 })
 
 describe("SessionPrompt input schemas", () => {
-  test("Build and Plan agents stay native when config still defaults to Run", () => {
+  test("Build and Plan agent names do not override configured Run routing", () => {
     const input = {
       resolvedProviderID: "openai",
       configuredModel: "agency-swarm/default",
     }
 
-    expect(shouldUseAgencySwarmBridge({ ...input, agentName: "build" })).toBe(false)
-    expect(shouldUseAgencySwarmBridge({ ...input, agentName: "plan" })).toBe(false)
-    expect(shouldUseAgencySwarmBridge({ ...input, agentName: "general" })).toBe(true)
+    expect(shouldUseAgencySwarmBridge(input)).toBe(true)
   })
 
   test("explicit Run bridge override wins over visible native model state", () => {
@@ -276,13 +274,22 @@ describe("SessionPrompt input schemas", () => {
       shouldUseAgencySwarmBridge({
         resolvedProviderID: "openai",
         configuredModel: "openai/gpt-5",
-        agentName: "build",
         agencySwarmBridge: true,
       }),
     ).toBe(true)
   })
 
-  test("LoopInput is just sessionID", () => {
+  test("explicit native bridge override wins over configured Run routing", () => {
+    expect(
+      shouldUseAgencySwarmBridge({
+        resolvedProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        agencySwarmBridge: false,
+      }),
+    ).toBe(false)
+  })
+
+  test("LoopInput accepts minimal sessionID", () => {
     const decode = decodeUnknown(SessionPrompt.LoopInput)
     expect(decode({ sessionID })).toEqual({ sessionID })
   })

--- a/packages/opencode/test/session/schema-decoding.test.ts
+++ b/packages/opencode/test/session/schema-decoding.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Schema } from "effect"
 
 import { Session } from "@/session/session"
-import { SessionPrompt } from "../../src/session/prompt"
+import { SessionPrompt, shouldUseAgencySwarmBridge } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionStatus } from "../../src/session/status"
 import { SessionSummary } from "../../src/session/summary"
@@ -260,6 +260,28 @@ describe("Todo.Info", () => {
 })
 
 describe("SessionPrompt input schemas", () => {
+  test("Build and Plan agents stay native when config still defaults to Run", () => {
+    const input = {
+      resolvedProviderID: "openai",
+      configuredModel: "agency-swarm/default",
+    }
+
+    expect(shouldUseAgencySwarmBridge({ ...input, agentName: "build" })).toBe(false)
+    expect(shouldUseAgencySwarmBridge({ ...input, agentName: "plan" })).toBe(false)
+    expect(shouldUseAgencySwarmBridge({ ...input, agentName: "general" })).toBe(true)
+  })
+
+  test("explicit Run bridge override wins over visible native model state", () => {
+    expect(
+      shouldUseAgencySwarmBridge({
+        resolvedProviderID: "openai",
+        configuredModel: "openai/gpt-5",
+        agentName: "build",
+        agencySwarmBridge: true,
+      }),
+    ).toBe(true)
+  })
+
   test("LoopInput is just sessionID", () => {
     const decode = decodeUnknown(SessionPrompt.LoopInput)
     expect(decode({ sessionID })).toEqual({ sessionID })
@@ -303,6 +325,7 @@ describe("SessionPrompt input schemas", () => {
     const expected = {
       sessionID,
       arguments: "--flag",
+      agencySwarmBridge: false,
       command: "deploy",
     }
     const input: unknown = expected

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -549,6 +549,51 @@ describe("tool.task", () => {
     }),
   )
 
+  background.instance("background task resume preserves explicit native bridge routing", () =>
+    Effect.gen(function* () {
+      const jobs = yield* BackgroundJob.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const prompts: SessionPrompt.PromptInput[] = []
+
+      const result = yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+          background: true,
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: {
+            agencySwarmBridge: false,
+            promptOps: stubOps({
+              text: "background done",
+              onPrompt: (input) => {
+                prompts.push(input)
+              },
+            }),
+          },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      const waited = yield* jobs.wait({ id: result.metadata.sessionId, timeout: 1_000 })
+      expect(waited.timedOut).toBe(false)
+      expect(waited.info?.status).toBe("completed")
+      expect(prompts.map((input) => ({ noReply: input.noReply, agencySwarmBridge: input.agencySwarmBridge }))).toEqual([
+        { noReply: undefined, agencySwarmBridge: false },
+        { noReply: true, agencySwarmBridge: false },
+      ])
+    }),
+  )
+
   background.instance("background task completion does not wait for the parent resume loop", () =>
     Effect.gen(function* () {
       const jobs = yield* BackgroundJob.Service

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3654,6 +3654,7 @@ export class Session2 extends HeyApiClient {
       providerID?: string
       modelID?: string
       auto?: boolean
+      agencySwarmBridge?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3668,6 +3669,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "providerID" },
             { in: "body", key: "modelID" },
             { in: "body", key: "auto" },
+            { in: "body", key: "agencySwarmBridge" },
           ],
         },
       ],
@@ -3829,6 +3831,7 @@ export class Session2 extends HeyApiClient {
         modelID: string
       }
       command?: string
+      agencySwarmBridge?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3844,6 +3847,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "agent" },
             { in: "body", key: "model" },
             { in: "body", key: "command" },
+            { in: "body", key: "agencySwarmBridge" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3349,6 +3349,7 @@ export class Session2 extends HeyApiClient {
       agencyRecipientAgent?: string
       agencyLabelAgency?: string
       agencyLabelRecipientAgent?: string
+      agencySwarmBridge?: boolean
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -3372,6 +3373,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "agencyRecipientAgent" },
             { in: "body", key: "agencyLabelAgency" },
             { in: "body", key: "agencyLabelRecipientAgent" },
+            { in: "body", key: "agencySwarmBridge" },
             { in: "body", key: "parts" },
           ],
         },
@@ -3708,6 +3710,7 @@ export class Session2 extends HeyApiClient {
       agencyRecipientAgent?: string
       agencyLabelAgency?: string
       agencyLabelRecipientAgent?: string
+      agencySwarmBridge?: boolean
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -3731,6 +3734,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "agencyRecipientAgent" },
             { in: "body", key: "agencyLabelAgency" },
             { in: "body", key: "agencyLabelRecipientAgent" },
+            { in: "body", key: "agencySwarmBridge" },
             { in: "body", key: "parts" },
           ],
         },
@@ -3764,6 +3768,7 @@ export class Session2 extends HeyApiClient {
       arguments?: string
       command?: string
       variant?: string
+      agencySwarmBridge?: boolean
       parts?: Array<{
         id?: string
         type: "file"
@@ -3789,6 +3794,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "arguments" },
             { in: "body", key: "command" },
             { in: "body", key: "variant" },
+            { in: "body", key: "agencySwarmBridge" },
             { in: "body", key: "parts" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5759,6 +5759,7 @@ export type SessionPromptData = {
     agencyRecipientAgent?: string
     agencyLabelAgency?: string
     agencyLabelRecipientAgent?: string
+    agencySwarmBridge?: boolean
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
   path: {
@@ -6097,6 +6098,7 @@ export type SessionPromptAsyncData = {
     agencyRecipientAgent?: string
     agencyLabelAgency?: string
     agencyLabelRecipientAgent?: string
+    agencySwarmBridge?: boolean
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
   path: {
@@ -6139,6 +6141,7 @@ export type SessionCommandData = {
     arguments: string
     command: string
     variant?: string
+    agencySwarmBridge?: boolean
     parts?: Array<{
       id?: string
       type: "file"

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -488,6 +488,9 @@ export type SubtaskPart = {
     modelID: string
   }
   command?: string
+  metadata?: {
+    [key: string]: unknown
+  }
 }
 
 export type ReasoningPart = {
@@ -705,6 +708,9 @@ export type CompactionPart = {
   auto: boolean
   overflow?: boolean
   tail_start_id?: string
+  metadata?: {
+    [key: string]: unknown
+  }
 }
 
 export type Part =
@@ -1793,6 +1799,9 @@ export type SubtaskPartInput = {
     modelID: string
   }
   command?: string
+  metadata?: {
+    [key: string]: unknown
+  }
 }
 
 export type V2SessionsResponse = {
@@ -6047,6 +6056,7 @@ export type SessionSummarizeData = {
     providerID: string
     modelID: string
     auto?: boolean
+    agencySwarmBridge?: boolean
   }
   path: {
     sessionID: string
@@ -6195,6 +6205,7 @@ export type SessionShellData = {
       modelID: string
     }
     command: string
+    agencySwarmBridge?: boolean
   }
   path: {
     sessionID: string


### PR DESCRIPTION
### Issue for this PR

N/A. Feature PR; issue check is skipped for `feat:` titles.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Restores the Agent Swarm CLI product modes behind `/modes`:

- Build and Plan use native OpenCode behavior with Agent Swarm guidance.
- Run stays backed by the Agency Swarm server.
- Native Plan approval switches the TUI into Build.
- `/build` and `/plan` are not added as commands.
- User-flow docs explain the fork-specific mode behavior.

### How did you verify your code works?

Local checks on the latest branch head:

- `npx --yes bun@1.3.13 run typecheck`
- `npx --yes bun@1.3.13 test test/cli/tui/local.test.ts --timeout 120000`
- `npx --yes bun@1.3.13 test --timeout 180000 --max-concurrency=1 ../../e2e/agent-swarm-tui/terminal-tui.test.ts`
- `npx --yes bun@1.3.13 turbo test:ci`
- `npx --yes bun@1.3.13 run build --single --skip-install`
- `npx --yes bun@1.3.13 /tmp/agent-builder-binary-qa.ts`

Binary QA proves `/modes -> Plan -> Yes` switches to Build, Build gets Agent Swarm Build instructions, Plan and Build make zero Agency server requests, and Run still reaches the Agency server.

### Screenshots / recordings

Terminal TUI behavior is covered by automated PTY E2E and binary QA.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
