### PR TITLE
refactor(app): align child store working state

### DIFF
--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -139,49 +139,4 @@ describe("createChildStoreManager", () => {
       dispose()
     })
   })
-
-  test("treats unfinished assistant messages as working before status loads", () => {
-    queries = [{ isLoading: false }, { isLoading: false }, { isLoading: false }, { isLoading: false }]
-
-    createRoot((dispose) => {
-      const owner = getOwner()
-      if (!owner) throw new Error("owner required")
-
-      const store = manager(owner)
-      const [state, setState] = store.ensureChild("/repo")
-      setState("message", "ses_1", [
-        {
-          role: "assistant",
-          time: {},
-        } as unknown as State["message"][string][number],
-      ])
-
-      expect(state.session_working("ses_1")).toBe(true)
-
-      dispose()
-    })
-  })
-
-  test("does not use unfinished assistant messages after idle status loads", () => {
-    queries = [{ isLoading: false }, { isLoading: false }, { isLoading: false }, { isLoading: false }]
-
-    createRoot((dispose) => {
-      const owner = getOwner()
-      if (!owner) throw new Error("owner required")
-
-      const store = manager(owner)
-      const [state, setState] = store.ensureChild("/repo")
-      setState("session_status", "ses_1", { type: "idle" })
-      setState("message", "ses_1", [
-        {
-          role: "assistant",
-          time: {},
-        } as unknown as State["message"][string][number],
-      ])
-
-      expect(state.session_working("ses_1")).toBe(false)
-
-      dispose()
-    })
-  })
 })

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -210,11 +210,8 @@ export function createChildStoreManager(input: {
             sessionTotal: 0,
             session_status: {},
             session_working(id: string) {
-              const status = this.session_status[id]
-              if (status) return status.type !== "idle"
-              return (this.message[id] ?? []).some(
-                (item) => item.role === "assistant" && typeof item.time.completed !== "number",
-              )
+              const type = this.session_status[id]?.type
+              return (type ?? "idle") !== "idle"
             },
             session_diff: {},
             todo: {},


### PR DESCRIPTION
### Issue for this PR

N/A - upstream-alignment refactor.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes a fork-only child-store fallback that treated unfinished assistant messages as session working state before `session_status` loaded. The behavior is not listed in `FORK_CHANGELOG.md` or `USER_FLOWS.md`, and the matching upstream `session_working` logic treats missing status as idle.

This restores the upstream hunk and removes the tests that only covered the fallback.

### How did you verify your code works?

- `npx --yes bun@1.3.13 x prettier --write packages/app/src/context/global-sync/child-store.ts packages/app/src/context/global-sync/child-store.test.ts`
- `npx --yes bun@1.3.13 test --preload ./happydom.ts ./src/context/global-sync/child-store.test.ts` from `packages/app`
- `npx --yes bun@1.3.13 run typecheck` from `packages/app`
- Pre-push hook ran `bun turbo typecheck` successfully with Bun 1.3.13 on PATH

### Screenshots / recordings

Not applicable; no visual layout change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR