### PR TITLE
refactor(compaction): trim generic event cleanup drift

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -391,15 +391,6 @@ export const layer: Layer.Layer<
       }
       const userMessage = parent.info
       const compactionPart = parent.parts.find((part): part is MessageV2.CompactionPart => part.type === "compaction")
-      const endCompaction = (text: string, include?: MessageID) =>
-        flags.experimentalEventSystem
-          ? sync.run(SessionEvent.Compaction.Ended.Sync, {
-              sessionID: input.sessionID,
-              timestamp: DateTime.makeUnsafe(Date.now()),
-              text,
-              include,
-            })
-          : Effect.void
 
       let messages = input.messages
       let replay:
@@ -637,20 +628,24 @@ export const layer: Layer.Layer<
         }
       }
 
-      const summary =
-        result === "continue"
-          ? summaryText(
-              (yield* session.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)).find(
-                (item) => item.info.id === msg.id,
-              ) ?? {
-                info: msg,
-                parts: [],
-              },
-            )
-          : undefined
       if (processor.message.error) return "stop"
       if (result === "continue") {
-        yield* endCompaction(summary ?? "", selected.tail_start_id)
+        const summary = summaryText(
+          (yield* session.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)).find(
+            (item) => item.info.id === msg.id,
+          ) ?? {
+            info: msg,
+            parts: [],
+          },
+        )
+        if (flags.experimentalEventSystem) {
+          yield* sync.run(SessionEvent.Compaction.Ended.Sync, {
+            sessionID: input.sessionID,
+            timestamp: DateTime.makeUnsafe(Date.now()),
+            text: summary ?? "",
+            include: selected.tail_start_id,
+          })
+        }
         yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
       }
       return result

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -30,7 +30,6 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { TestConfig } from "../fixture/config"
 import { SyncEvent } from "@/sync"
 import { RuntimeFlags } from "@/effect/runtime-flags"
-import { SessionEvent } from "@/v2/session-event"
 
 void Log.init({ print: false })
 
@@ -1029,17 +1028,10 @@ describe("session.compaction.process", () => {
   itCompaction.instance(
     "marks summary message as errored on compact result",
     Effect.gen(function* () {
-      const bus = yield* Bus.Service
       const ssn = yield* SessionNs.Service
       const session = yield* ssn.create({})
       const msg = yield* createUserMessage(session.id, "hello")
       const msgs = yield* ssn.messages({ sessionID: session.id })
-      let ended = false
-      const unsub = yield* bus.subscribeCallback(SessionEvent.Compaction.Ended.Sync, (evt) => {
-        if (evt.properties.sessionID !== session.id) return
-        ended = true
-      })
-      yield* Effect.addFinalizer(() => Effect.sync(unsub))
 
       const result = yield* SessionCompaction.use.process({
         parentID: msg.id,
@@ -1053,7 +1045,6 @@ describe("session.compaction.process", () => {
       )
 
       expect(result).toBe("stop")
-      expect(ended).toBe(false)
       expect(summary?.info.role).toBe("assistant")
       if (summary?.info.role === "assistant") {
         expect(summary.info.finish).toBe("error")


### PR DESCRIPTION
### Issue for this PR

N/A - refactor-only cleanup.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Restores the compaction-ended event publication to the existing inline shape after the processor error guard and removes the redundant failure-event assertion added around it. The documented Swarm Default compaction fallback behavior and tests remain unchanged.

### How did you verify your code works?

- `npx --yes bun@1.3.13 test --timeout 30000 test/session/compaction.test.ts` from `packages/opencode`
- `npx --yes bun@1.3.13 run typecheck` from `packages/opencode`
- Pre-push hook: `bun turbo typecheck`

### Screenshots / recordings

N/A - no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
