### PR TITLE
refactor(core): align filesystem containment helper

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -1,5 +1,5 @@
 import { NodeFileSystem } from "@effect/platform-node"
-import { dirname, isAbsolute, join, relative, resolve as pathResolve, sep } from "path"
+import { dirname, join, resolve as pathResolve, sep } from "path"
 import { realpathSync } from "fs"
 import * as NFS from "fs/promises"
 import { lookup } from "mime-types"
@@ -237,7 +237,11 @@ export namespace AppFileSystem {
   }
 
   export function contains(parent: string, child: string) {
-    const result = relative(parent, child)
-    return result === "" || (!isAbsolute(result) && result !== ".." && !result.startsWith(`..${sep}`))
+    const dir = pathResolve(parent)
+    const file = pathResolve(child)
+    const base = process.platform === "win32" ? dir.toLowerCase() : dir
+    const target = process.platform === "win32" ? file.toLowerCase() : file
+    const prefix = base.endsWith(sep) ? base : `${base}${sep}`
+    return target === base || target.startsWith(prefix)
   }
 }

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -233,9 +233,7 @@ export namespace AppFileSystem {
   }
 
   export function overlaps(a: string, b: string) {
-    const relA = relative(a, b)
-    const relB = relative(b, a)
-    return !relA || !relA.startsWith("..") || !relB || !relB.startsWith("..")
+    return contains(a, b) || contains(b, a)
   }
 
   export function contains(parent: string, child: string) {

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -1,5 +1,5 @@
 import { NodeFileSystem } from "@effect/platform-node"
-import { dirname, isAbsolute, join, relative, resolve as pathResolve } from "path"
+import { dirname, isAbsolute, join, relative, resolve as pathResolve, sep } from "path"
 import { realpathSync } from "fs"
 import * as NFS from "fs/promises"
 import { lookup } from "mime-types"
@@ -239,7 +239,7 @@ export namespace AppFileSystem {
   }
 
   export function contains(parent: string, child: string) {
-    const rel = relative(parent, child)
-    return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))
+    const result = relative(parent, child)
+    return result === "" || (!isAbsolute(result) && result !== ".." && !result.startsWith(`..${sep}`))
   }
 }

--- a/packages/core/test/filesystem/filesystem.test.ts
+++ b/packages/core/test/filesystem/filesystem.test.ts
@@ -354,7 +354,11 @@ describe("AppFileSystem", () => {
 
     test("contains checks path containment", () => {
       expect(AppFileSystem.contains("/a/b", "/a/b/c")).toBe(true)
+      expect(AppFileSystem.contains("/a/b", "/a/b")).toBe(true)
+      expect(AppFileSystem.contains("/a/b", "/a/b/..c")).toBe(true)
       expect(AppFileSystem.contains("/a/b", "/a/c")).toBe(false)
+      expect(AppFileSystem.contains("/a/b", "/a")).toBe(false)
+      expect(AppFileSystem.contains("/a/b", "/a/bc")).toBe(false)
     })
 
     test("overlaps detects overlapping paths", () => {

--- a/packages/core/test/filesystem/filesystem.test.ts
+++ b/packages/core/test/filesystem/filesystem.test.ts
@@ -363,8 +363,12 @@ describe("AppFileSystem", () => {
 
     test("overlaps detects overlapping paths", () => {
       expect(AppFileSystem.overlaps("/a/b", "/a/b/c")).toBe(true)
+      expect(AppFileSystem.overlaps("/a/b", "/a/b")).toBe(true)
+      expect(AppFileSystem.overlaps("/a/b", "/a/b/..c")).toBe(true)
       expect(AppFileSystem.overlaps("/a/b/c", "/a/b")).toBe(true)
+      expect(AppFileSystem.overlaps("/a/b", "/a")).toBe(true)
       expect(AppFileSystem.overlaps("/a", "/b")).toBe(false)
+      expect(AppFileSystem.overlaps("/a/b", "/a/bc")).toBe(false)
     })
   })
 })

--- a/packages/core/test/filesystem/filesystem.test.ts
+++ b/packages/core/test/filesystem/filesystem.test.ts
@@ -356,19 +356,39 @@ describe("AppFileSystem", () => {
       expect(AppFileSystem.contains("/a/b", "/a/b/c")).toBe(true)
       expect(AppFileSystem.contains("/a/b", "/a/b")).toBe(true)
       expect(AppFileSystem.contains("/a/b", "/a/b/..c")).toBe(true)
+      expect(AppFileSystem.contains("/a/b", "/a/b/..c/file")).toBe(true)
       expect(AppFileSystem.contains("/a/b", "/a/c")).toBe(false)
       expect(AppFileSystem.contains("/a/b", "/a")).toBe(false)
       expect(AppFileSystem.contains("/a/b", "/a/bc")).toBe(false)
+    })
+
+    test("contains rejects Windows root-relative prefix collisions", () => {
+      if (process.platform !== "win32") return
+
+      expect(AppFileSystem.contains("/project", "/project-other/file")).toBe(false)
+      expect(AppFileSystem.contains("/project", "/projectfile")).toBe(false)
+      expect(AppFileSystem.contains("/project", "/project/..config")).toBe(true)
+      expect(AppFileSystem.contains("/project", "/project/..config/file")).toBe(true)
     })
 
     test("overlaps detects overlapping paths", () => {
       expect(AppFileSystem.overlaps("/a/b", "/a/b/c")).toBe(true)
       expect(AppFileSystem.overlaps("/a/b", "/a/b")).toBe(true)
       expect(AppFileSystem.overlaps("/a/b", "/a/b/..c")).toBe(true)
+      expect(AppFileSystem.overlaps("/a/b", "/a/b/..c/file")).toBe(true)
       expect(AppFileSystem.overlaps("/a/b/c", "/a/b")).toBe(true)
       expect(AppFileSystem.overlaps("/a/b", "/a")).toBe(true)
       expect(AppFileSystem.overlaps("/a", "/b")).toBe(false)
       expect(AppFileSystem.overlaps("/a/b", "/a/bc")).toBe(false)
+    })
+
+    test("overlaps rejects Windows root-relative prefix collisions", () => {
+      if (process.platform !== "win32") return
+
+      expect(AppFileSystem.overlaps("/project", "/project-other/file")).toBe(false)
+      expect(AppFileSystem.overlaps("/project", "/projectfile")).toBe(false)
+      expect(AppFileSystem.overlaps("/project", "/project/..config")).toBe(true)
+      expect(AppFileSystem.overlaps("/project", "/project/..config/file")).toBe(true)
     })
   })
 })

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdir, readFile, stat as statFile, writeFile } from "fs/promises"
 import { createWriteStream, existsSync, statSync } from "fs"
 import { realpathSync } from "fs"
-import { dirname, isAbsolute, join, relative, resolve as pathResolve, sep, win32 } from "path"
+import { dirname, isAbsolute, join, resolve as pathResolve, sep, win32 } from "path"
 import { Readable } from "stream"
 import { pipeline } from "stream/promises"
 import { Glob } from "@opencode-ai/core/util/glob"
@@ -167,8 +167,12 @@ export function overlaps(a: string, b: string) {
 }
 
 export function contains(parent: string, child: string) {
-  const result = relative(parent, child)
-  return result === "" || (!isAbsolute(result) && result !== ".." && !result.startsWith(`..${sep}`))
+  const dir = pathResolve(parent)
+  const file = pathResolve(child)
+  const base = process.platform === "win32" ? dir.toLowerCase() : dir
+  const target = process.platform === "win32" ? file.toLowerCase() : file
+  const prefix = base.endsWith(sep) ? base : `${base}${sep}`
+  return target === base || target.startsWith(prefix)
 }
 
 export async function findUp(

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdir, readFile, stat as statFile, writeFile } from "fs/promises"
 import { createWriteStream, existsSync, statSync } from "fs"
 import { realpathSync } from "fs"
-import { dirname, isAbsolute, join, relative, resolve as pathResolve, win32 } from "path"
+import { dirname, isAbsolute, join, relative, resolve as pathResolve, sep, win32 } from "path"
 import { Readable } from "stream"
 import { pipeline } from "stream/promises"
 import { Glob } from "@opencode-ai/core/util/glob"
@@ -163,13 +163,12 @@ export function windowsPath(p: string): string {
   )
 }
 export function overlaps(a: string, b: string) {
-  const relA = relative(a, b)
-  const relB = relative(b, a)
-  return !relA || !relA.startsWith("..") || !relB || !relB.startsWith("..")
+  return contains(a, b) || contains(b, a)
 }
 
 export function contains(parent: string, child: string) {
-  return !relative(parent, child).startsWith("..")
+  const result = relative(parent, child)
+  return result === "" || (!isAbsolute(result) && result !== ".." && !result.startsWith(`..${sep}`))
 }
 
 export async function findUp(

--- a/packages/opencode/test/file/path-traversal.test.ts
+++ b/packages/opencode/test/file/path-traversal.test.ts
@@ -25,6 +25,7 @@ describe("Filesystem.contains", () => {
       expect(Filesystem.contains("/project", "/project/src")).toBe(true)
       expect(Filesystem.contains("/project", "/project/src/file.ts")).toBe(true)
       expect(Filesystem.contains("/project", "/project")).toBe(true)
+      expect(Filesystem.contains("/project", "/project/..config")).toBe(true)
     }),
   )
 
@@ -33,6 +34,7 @@ describe("Filesystem.contains", () => {
       expect(Filesystem.contains("/project", "/project/../etc")).toBe(false)
       expect(Filesystem.contains("/project", "/project/src/../../etc")).toBe(false)
       expect(Filesystem.contains("/project", "/etc/passwd")).toBe(false)
+      expect(Filesystem.contains("/project", "/")).toBe(false)
     }),
   )
 
@@ -48,6 +50,29 @@ describe("Filesystem.contains", () => {
     Effect.sync(() => {
       expect(Filesystem.contains("/project", "/project-other/file")).toBe(false)
       expect(Filesystem.contains("/project", "/projectfile")).toBe(false)
+    }),
+  )
+})
+
+describe("Filesystem.overlaps", () => {
+  it.effect("detects containment in either direction", () =>
+    Effect.sync(() => {
+      expect(Filesystem.overlaps("/project", "/project/src")).toBe(true)
+      expect(Filesystem.overlaps("/project/src", "/project")).toBe(true)
+      expect(Filesystem.overlaps("/project", "/project")).toBe(true)
+    }),
+  )
+
+  it.effect("keeps child names beginning with .. inside the parent", () =>
+    Effect.sync(() => {
+      expect(Filesystem.overlaps("/project", "/project/..config")).toBe(true)
+    }),
+  )
+
+  it.effect("rejects unrelated sibling and parent-only paths", () =>
+    Effect.sync(() => {
+      expect(Filesystem.overlaps("/project", "/project-other")).toBe(false)
+      expect(Filesystem.overlaps("/project/src", "/etc")).toBe(false)
     }),
   )
 })

--- a/packages/opencode/test/file/path-traversal.test.ts
+++ b/packages/opencode/test/file/path-traversal.test.ts
@@ -26,6 +26,7 @@ describe("Filesystem.contains", () => {
       expect(Filesystem.contains("/project", "/project/src/file.ts")).toBe(true)
       expect(Filesystem.contains("/project", "/project")).toBe(true)
       expect(Filesystem.contains("/project", "/project/..config")).toBe(true)
+      expect(Filesystem.contains("/project", "/project/..config/file")).toBe(true)
     }),
   )
 
@@ -52,6 +53,17 @@ describe("Filesystem.contains", () => {
       expect(Filesystem.contains("/project", "/projectfile")).toBe(false)
     }),
   )
+
+  it.effect("handles Windows root-relative prefix collisions", () =>
+    Effect.sync(() => {
+      if (process.platform !== "win32") return
+
+      expect(Filesystem.contains("/project", "/project-other/file")).toBe(false)
+      expect(Filesystem.contains("/project", "/projectfile")).toBe(false)
+      expect(Filesystem.contains("/project", "/project/..config")).toBe(true)
+      expect(Filesystem.contains("/project", "/project/..config/file")).toBe(true)
+    }),
+  )
 })
 
 describe("Filesystem.overlaps", () => {
@@ -66,6 +78,7 @@ describe("Filesystem.overlaps", () => {
   it.effect("keeps child names beginning with .. inside the parent", () =>
     Effect.sync(() => {
       expect(Filesystem.overlaps("/project", "/project/..config")).toBe(true)
+      expect(Filesystem.overlaps("/project", "/project/..config/file")).toBe(true)
     }),
   )
 
@@ -73,6 +86,17 @@ describe("Filesystem.overlaps", () => {
     Effect.sync(() => {
       expect(Filesystem.overlaps("/project", "/project-other")).toBe(false)
       expect(Filesystem.overlaps("/project/src", "/etc")).toBe(false)
+    }),
+  )
+
+  it.effect("rejects Windows root-relative sibling paths", () =>
+    Effect.sync(() => {
+      if (process.platform !== "win32") return
+
+      expect(Filesystem.overlaps("/project", "/project-other")).toBe(false)
+      expect(Filesystem.overlaps("/project", "/projectfile")).toBe(false)
+      expect(Filesystem.overlaps("/project", "/project/..config")).toBe(true)
+      expect(Filesystem.overlaps("/project", "/project/..config/file")).toBe(true)
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

N/A - upstream-alignment cleanup for filesystem containment. Review found and fixed a Windows sibling-boundary bug in the helper.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Aligns the fork filesystem containment helpers around resolved path-boundary checks instead of broad string prefix checks.

This covers `AppFileSystem.contains`, `Filesystem.contains`, and overlap checks so parent/sibling escapes are rejected while valid child names beginning with two dots, such as `..config`, still stay inside the parent. The latest update also rejects Windows root-relative sibling prefix collisions such as `/project` versus `/project-other/file`.

### How did you verify your code works?

- `cd packages/core && bun test test/filesystem/filesystem.test.ts`
- `cd packages/opencode && bun test --timeout 30000 test/file/path-traversal.test.ts`
- `cd packages/core && bun run typecheck`
- `cd packages/opencode && bun run typecheck`
- `git diff --check`
- Local `path.win32` simulation reproduced the old `/project` versus `/project-other/file` false positive and confirmed the new boundary predicate rejects it while preserving `/project/..config` children.
- Pre-push hook: `bun turbo typecheck`

### Screenshots / recordings

N/A - no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR