### PR TITLE
feat(opencode): simplify Agent Swarm startup copy

### DIFF
--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -49,7 +49,7 @@ For each failure scenario, capture the visible user result and cite the matching
 #### Detected local project, venv, and uv
 
 - **Trigger:** Launch from a directory containing `agency.py` with `def create_agency` and an `agency_swarm` import.
-- **Happy-path proof:** Onboarding offers `Use detected Agency Swarm project` first.
+- **Happy-path proof:** Onboarding offers `Use detected Agent Swarm project` first.
 - **Happy-path proof:** A healthy `.venv` is reused.
 - **Happy-path proof:** A broken `.venv` is rebuilt when Python 3.12+ is available.
 - **Happy-path proof:** Launcher-managed uv is installed or repaired inside `.venv`.
@@ -57,6 +57,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** No second unpinned `agency-swarm` upgrade runs after manifest install.
 - **Happy-path proof:** Launcher-managed `agency-swarm[fastapi,litellm]` is used only when no manifest exists.
 - **Happy-path proof:** Local `.venv` uv is used for launcher-managed fallback installs into `.venv`.
+- **Happy-path proof:** Happy-path setup collapses internal Python, dependency, and package-check work into `Setting up Agent Swarm. This can take 1-2 minutes.` followed by `Agent Swarm ready`; downstream products use their configured product name.
 - **Failure scenarios to test:** Missing Python 3.12+ produces a visible launcher failure.
 - **Failure scenarios to test:** Failed imports produce a visible launcher failure.
 - **Failure scenarios to test:** uv install or repair failure produces a visible launcher failure.
@@ -77,12 +78,13 @@ For each failure scenario, capture the visible user result and cite the matching
 
 #### Starter project
 
-- **Trigger:** Launch without a detected project and choose `Create a new starter project`.
+- **Trigger:** Launch without a detected project and choose `Create a new Agent Swarm project`.
 - **Happy-path proof:** Empty, unsafe, or already-used project names are rejected.
 - **Happy-path proof:** The starter uses `agency-ai-solutions/agency-starter-template`.
 - **Happy-path proof:** GitHub template creation is used only when `gh` is present and authenticated.
 - **Happy-path proof:** Local clone mode is used when GitHub template creation is unavailable.
 - **Happy-path proof:** The new project then enters the local project setup flow.
+- **Happy-path proof:** Template clone and ready detail messages do not appear on the happy path; the user sees `Creating Agent Swarm project...` before compact setup status.
 - **Failure scenarios to test:** Clone failure is visible and does not leave the user in a partial TUI launch.
 - **Failure scenarios to test:** Template creation failure is visible and does not leave the user in a partial TUI launch.
 - **Failure scenarios to test:** Later local setup failure is visible and does not leave the user in a partial TUI launch.
@@ -99,10 +101,10 @@ For each failure scenario, capture the visible user result and cite the matching
 
 ### Connect, Bridge, And Server Failures
 
-#### Onboarding connect to existing agency
+#### Onboarding connect to running server
 
-- **Trigger:** Launch without a detected project and choose `Connect to an existing agency`.
-- **Happy-path proof:** The launcher prompts for Agency Swarm base URL and optional bearer token.
+- **Trigger:** Launch without a detected project and choose `Connect to a running server`.
+- **Happy-path proof:** The launcher prompts for server URL and optional access token.
 - **Happy-path proof:** The launcher normalizes and validates the URL.
 - **Happy-path proof:** The launcher discovers agencies.
 - **Happy-path proof:** The launcher auto-picks one agency or asks for an agency id when several exist.

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -27,4 +27,4 @@ Manual QA command from a clean detected Agency project with no `.venv`:
 AGENTSWARM_LAUNCHER=1 bun --cwd packages/opencode --conditions=browser ./src/index.ts /absolute/path/to/project
 ```
 
-Expected result: choose `Use detected Agency Swarm project`, approve `.venv` creation, verify the local FastAPI bridge starts, and verify the TUI opens in Run mode against the detected project.
+Expected result: choose `Use detected Agent Swarm project`, approve `Create a Python environment for this project?`, see `Setting up Agent Swarm. This can take 1-2 minutes.` followed by `Agent Swarm ready`, and verify the TUI opens in Run mode against the detected project. The happy path should not print the Python path, `.venv` creation steps, dependency install steps, package checks, or local server startup line.

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -326,7 +326,7 @@ export async function startTui(input: {
 }
 
 function spawnTuiProcess(input: { args: string[]; cwd?: string; env: Record<string, string | undefined> }) {
-  return spawn(process.execPath, ["--conditions=browser", "./src/index.ts", ...input.args], {
+  return spawn(process.execPath, ["--conditions=browser", path.join(packageRoot, "src", "index.ts"), ...input.args], {
     cwd: input.cwd ?? packageRoot,
     cols: 100,
     rows: 30,

--- a/e2e/agent-swarm-tui/real-project-handoff.test.ts
+++ b/e2e/agent-swarm-tui/real-project-handoff.test.ts
@@ -34,7 +34,7 @@ describe("Agent Swarm real project TUI handoff e2e", () => {
 
     await currentTui.waitForText("Swarm Default", timeoutMs)
     await currentTui.waitForText("UserSupportAgent", timeoutMs)
-    expect(currentTui.history()).not.toContain("Use detected Agency Swarm project")
+    expect(currentTui.history()).not.toContain("Use detected Agent Swarm project")
 
     const imagePath = path.join(project, "handoff-proof.png")
     await writeFile(

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -178,7 +178,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
 
     const screen = await currentTui.waitForText("Use /models for local models or /auth for sign-in.", tuiReadyTimeoutMs)
 
-    expect(screen).toContain("Manage provider auth")
+    expect(screen).toContain("Tip Use /models for local models or /auth for sign-in.")
     expect(screen).not.toContain("Run /connect to add an AI provider")
   })
 

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import {
@@ -63,9 +63,123 @@ describe("Agent Swarm terminal TUI e2e", () => {
       args: [project],
     })
 
-    await currentTui.waitForText("Use detected Agency Swarm project", 10_000)
+    await currentTui.waitForText("Use detected Agent Swarm project", 10_000)
     expect(currentTui.history()).toContain(project)
     expect(currentTui.history()).not.toContain("Creating virtual environment")
+  })
+
+  test("launcher detects an Agent Swarm project from cwd", async () => {
+    const project = await mkdtemp(path.join(os.tmpdir(), "agentswarm-cwd-project-"))
+    tempDirs.push(project)
+    await writeAgencyProject(project)
+
+    currentTui = await startTui({
+      cwd: project,
+      env: {
+        AGENTSWARM_LAUNCHER: "1",
+        OPENCODE_CONFIG_CONTENT: undefined,
+      },
+      args: [],
+    })
+
+    await currentTui.waitForText("Use detected Agent Swarm project", 10_000)
+    expect(currentTui.history()).toContain(project)
+    expect(currentTui.history()).not.toContain("Creating virtual environment")
+  })
+
+  test("launcher resolves relative project arguments from cwd when PWD is stale", async () => {
+    const parent = await mkdtemp(path.join(os.tmpdir(), "agentswarm-relative-parent-"))
+    tempDirs.push(parent)
+    const stale = await mkdtemp(path.join(os.tmpdir(), "agentswarm-stale-pwd-"))
+    tempDirs.push(stale)
+    const project = path.join(parent, "my-agency")
+    await mkdir(project)
+    await writeAgencyProject(project)
+
+    currentTui = await startTui({
+      cwd: parent,
+      env: {
+        AGENTSWARM_LAUNCHER: "1",
+        OPENCODE_CONFIG_CONTENT: undefined,
+        PWD: stale,
+      },
+      args: ["my-agency"],
+    })
+
+    await currentTui.waitForText("Use detected Agent Swarm project", 10_000)
+    const history = currentTui.history().replace(/\s+/g, "")
+    expect(history).toContain((await realpath(project)).replace(/\s+/g, ""))
+    expect(history).not.toContain((await realpath(stale)).replace(/\s+/g, ""))
+    expect(currentTui.history()).not.toContain("Creating virtual environment")
+  })
+
+  test("launcher keeps the connect selection history free of stale option hints", async () => {
+    const project = await mkdtemp(path.join(os.tmpdir(), "agentswarm-connect-launch-"))
+    tempDirs.push(project)
+
+    currentTui = await startTui({
+      cwd: packageRoot,
+      env: {
+        AGENTSWARM_LAUNCHER: "1",
+        OPENCODE_CONFIG_CONTENT: undefined,
+      },
+      args: [project],
+    })
+
+    await currentTui.waitForText("How do you want to start?", 10_000)
+    currentTui.write("\x1b[B\r")
+    const screen = await currentTui.waitForText("Server URL", tuiInteractionTimeoutMs)
+
+    expect(screen).toContain("Connect to a running server")
+    expect(screen).toContain("Connect Agent Swarm to a running server.")
+    expect(screen).not.toContain("Connect to a running server(recommended for a fresh setup)")
+    expect(screen).not.toContain("recommended for a fresh setup")
+    expect(screen).not.toContain("local or remote server")
+  })
+
+  test("first-run no-models tip points users to local models or auth", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "agentswarm-first-run-models-"))
+    tempDirs.push(root)
+    const models = path.join(root, "models.json")
+    await writeFile(
+      models,
+      JSON.stringify({
+        opencode: {
+          id: "opencode",
+          name: "OpenCode",
+          env: ["OPENCODE_API_KEY"],
+          npm: "@ai-sdk/openai-compatible",
+          api: "https://example.invalid/v1",
+          models: {
+            free: {
+              id: "free",
+              name: "Free",
+              attachment: false,
+              reasoning: false,
+              tool_call: true,
+              temperature: true,
+              cost: { input: 0, output: 0 },
+              limit: { context: 128000, output: 4096 },
+              modalities: { input: ["text"], output: ["text"] },
+            },
+          },
+        },
+      }),
+    )
+
+    currentTui = await startTui({
+      cwd: packageRoot,
+      env: {
+        AGENTSWARM_LAUNCHER: "0",
+        OPENCODE_MODELS_PATH: models,
+      },
+      args: [],
+    })
+
+    const screen = await currentTui.waitForText("Use /models for local models or /auth for sign-in.", tuiReadyTimeoutMs)
+
+    expect(screen).toContain("Manage provider auth")
+    expect(screen).not.toContain("Run /connect to add an AI provider")
   })
 
   test("run-mode slash commands keep /auth and /connect separate and hide native commands", async () => {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -15,7 +15,6 @@ import { AgencyProduct } from "./product"
 import {
   collectUnixPythonCandidates,
   findPythonExecutable,
-  formatPython,
   inspectPython,
   isCondaPython,
   type PythonInfo,
@@ -526,7 +525,7 @@ async function requireDetectedStarterProject(directory: string, profile: Pick<Pr
   const project = await detectAgencyProject(directory, profile)
   if (!project) {
     throw new Error(
-      `Starter template did not contain a configured Agency Swarm entry file: ${profile.agencyEntryFiles.join(", ")}`,
+      `Starter template did not contain a configured project entry file: ${profile.agencyEntryFiles.join(", ")}`,
     )
   }
   return project
@@ -536,8 +535,7 @@ export function formatProjectLabel(
   project: AgencyProject,
   profile: Pick<ProductProfile, "custom" | "name"> = AgencyProduct,
 ) {
-  const label = profile.custom ? profile.name : "Agency Swarm"
-  return `Use detected ${label} project (${project.directory})`
+  return `Use detected ${profile.name} project (${project.directory})`
 }
 
 export function validateStarterName(base: string, value?: string) {
@@ -597,7 +595,7 @@ export async function prepareNpxLaunch(
   if (projectDirectory) await mkdir(projectDirectory, { recursive: true })
 
   if (choice === "connect") {
-    const launch = await prepareRemoteLaunch(launchDirectory)
+    const launch = await prepareRemoteLaunch(launchDirectory, profile)
     if (!launch) {
       prompts.outro("Cancelled")
       return
@@ -633,11 +631,6 @@ async function chooseLaunchChoice(
   project: AgencyProject | undefined,
   profile: Pick<ProductProfile, "custom" | "name" | "stateRoot"> = AgencyProduct,
 ) {
-  prompts.log.info("1. Choose how to start the terminal UI.")
-  prompts.log.info(
-    "   The launcher can use a detected project, create a starter project, or connect to an existing server.",
-  )
-
   const result = await prompts.select<LaunchChoice>({
     message: "How do you want to start?",
     options: [
@@ -654,14 +647,12 @@ async function chooseLaunchChoice(
         : [
             {
               value: "starter" as const,
-              label: "Create a new starter project",
-              hint: "recommended for a fresh setup",
+              label: `Create a new ${profile.name} project`,
             },
           ]),
       {
         value: "connect" as const,
-        label: "Connect to an existing agency",
-        hint: "local or remote Agency Swarm server",
+        label: "Connect to a running server",
       },
     ],
   })
@@ -669,12 +660,14 @@ async function chooseLaunchChoice(
   return result
 }
 
-async function prepareRemoteLaunch(directory: string): Promise<PreparedNpxLaunch | undefined> {
-  prompts.log.info("2. Configure the Agency Swarm server.")
-  prompts.log.info("   This path is for an agency that is already running somewhere else.")
+async function prepareRemoteLaunch(
+  directory: string,
+  profile: Pick<ProductProfile, "name"> = AgencyProduct,
+): Promise<PreparedNpxLaunch | undefined> {
+  prompts.log.info(`Connect ${profile.name} to a running server.`)
 
   const url = await prompts.text({
-    message: "Agency Swarm base URL",
+    message: "Server URL",
     placeholder: AgencySwarmAdapter.DEFAULT_BASE_URL,
     defaultValue: AgencySwarmAdapter.DEFAULT_BASE_URL,
     validate(value) {
@@ -690,7 +683,7 @@ async function prepareRemoteLaunch(directory: string): Promise<PreparedNpxLaunch
   if (prompts.isCancel(url)) return
 
   const tokenConfirm = await prompts.confirm({
-    message: "Does this server need a bearer token?",
+    message: "Does this server need an access token?",
     initialValue: false,
   })
   if (prompts.isCancel(tokenConfirm)) return
@@ -698,7 +691,7 @@ async function prepareRemoteLaunch(directory: string): Promise<PreparedNpxLaunch
   let token: string | undefined
   if (tokenConfirm) {
     const entered = await prompts.password({
-      message: "Bearer token",
+      message: "Access token",
       mask: "•",
     })
     if (prompts.isCancel(entered)) return
@@ -758,9 +751,6 @@ async function createStarterProject(input: {
   baseDirectory: string
   profile: ProductProfile
 }): Promise<AgencyProject | undefined> {
-  prompts.log.info("2. Create the starter project.")
-  prompts.log.info(`   This gives the terminal UI a ready-to-run ${input.profile.name} project to launch.`)
-
   const starterProfile = input.profile.customStarter ? input.profile : AgencyProduct
 
   if (input.profile.customStarter) {
@@ -769,7 +759,7 @@ async function createStarterProject(input: {
     if (await Filesystem.exists(targetDirectory)) {
       throw new Error(`Target directory already exists: ${targetDirectory}`)
     }
-    prompts.log.step(`Creating starter project in \`${name}/\``)
+    prompts.log.info(`Creating ${input.profile.name} project...`)
     const clone = await runCommand(["git", "clone", "--depth=1", starterTemplateUrl(input.profile), targetDirectory])
     if (clone.code !== 0) {
       throw new Error(clone.stderr.trim() || clone.stdout.trim() || "Starter template clone failed")
@@ -783,7 +773,7 @@ async function createStarterProject(input: {
   }
 
   const repoName = await prompts.text({
-    message: "Project or repository name",
+    message: "Project name",
     placeholder: input.profile.starterProjectName,
     validate(value) {
       return validateStarterName(input.baseDirectory, value)
@@ -795,17 +785,15 @@ async function createStarterProject(input: {
   let mode: StarterMode = "local"
   if (ghReady) {
     const selected = await prompts.select<StarterMode>({
-      message: "How should the starter be created?",
+      message: "Where should we create it?",
       options: [
         {
           value: "github",
-          label: "Create a GitHub repository from the template",
-          hint: "recommended",
+          label: "GitHub - backed up and shareable",
         },
         {
           value: "local",
-          label: "Create a local folder from the template",
-          hint: "skip GitHub for now",
+          label: "This computer - no GitHub",
         },
       ],
     })
@@ -819,7 +807,6 @@ async function createStarterProject(input: {
     throw new Error(`Target directory already exists: ${targetDirectory}`)
   }
 
-  prompts.log.step(mode === "github" ? "Creating repository from the starter template" : "Cloning the starter template")
   try {
     if (mode === "github") {
       const visibility = await prompts.select<"private" | "public">({
@@ -840,6 +827,7 @@ async function createStarterProject(input: {
         return
       }
 
+      prompts.log.info(`Creating ${input.profile.name} project...`)
       const result = await runCommand(
         ["gh", "repo", "create", name, "--template", input.profile.starterTemplateRepo, "--clone", `--${visibility}`],
         {
@@ -850,6 +838,7 @@ async function createStarterProject(input: {
         throw new Error(result.stderr.trim() || result.stdout.trim() || "GitHub template creation failed")
       }
     } else {
+      prompts.log.info(`Creating ${input.profile.name} project...`)
       const clone = await runCommand(["git", "clone", "--depth=1", starterTemplateUrl(input.profile), targetDirectory])
       if (clone.code !== 0) {
         throw new Error(clone.stderr.trim() || clone.stdout.trim() || "Starter template clone failed")
@@ -860,7 +849,6 @@ async function createStarterProject(input: {
       }).catch(() => undefined)
       await runCommand(["git", "init", "-b", "main"], { cwd: targetDirectory })
     }
-    prompts.log.step("Starter project ready")
   } catch (error) {
     prompts.log.error("Starter project setup failed")
     throw error
@@ -873,13 +861,10 @@ async function createProductStateRootProject(input: {
   directory: string
   profile: ProductProfile
 }): Promise<AgencyProject | undefined> {
-  prompts.log.info("2. Create the product state project.")
-  prompts.log.info(`   This keeps ${input.profile.name} launcher state in one user folder.`)
-
   const starterProfile = input.profile.customStarter ? input.profile : AgencyProduct
 
   await mkdir(path.dirname(input.directory), { recursive: true })
-  prompts.log.step(`Creating starter project in \`${input.directory}\``)
+  prompts.log.info(`Creating ${input.profile.name} project...`)
   const clone = await runCommand(["git", "clone", "--depth=1", starterTemplateUrl(input.profile), input.directory])
   if (clone.code !== 0) {
     throw new Error(clone.stderr.trim() || clone.stdout.trim() || "Starter template clone failed")
@@ -896,16 +881,13 @@ export async function prepareProjectLaunch(
   project: AgencyProject,
   profile: LaunchProfile = AgencyProduct,
 ): Promise<PreparedNpxLaunch | undefined> {
-  prompts.log.info(`Starting the ${profile.name} project.`)
-  prompts.log.info(
-    "The launcher will reuse a project `.venv`, start a local FastAPI server, and connect the terminal UI to it.",
-  )
+  prompts.log.info(`Setting up ${profile.name}. This can take 1-2 minutes.`)
 
   const python = await ensureProjectPython(project.directory, profile)
   if (!python) return
 
-  prompts.log.info("Starting your agency project.")
   const server = await startProjectServer(project.directory, python, project.moduleName, project.agencyFile)
+  prompts.log.success(`${profile.name} ready`)
   return {
     directory: project.directory,
     runProjectDirectory: project.directory,
@@ -946,8 +928,6 @@ async function ensureProjectPython(
       prompts.log.warn("Project `.venv` uses a Conda-family Python. Rebuilding with a standalone Python...")
       corruptedVenv = true
     } else {
-      prompts.log.info(`Using project Python: ${formatPython(info, [venvPython])}`)
-      prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
       let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
       try {
         canary = await venvCanaryPasses([venvPython], {
@@ -959,7 +939,6 @@ async function ensureProjectPython(
         canary = { healthy: false, stderr: "", timedOut: false }
       }
       if (canary.healthy) {
-        prompts.log.success("Agency Swarm packages ready")
         return [venvPython]
       }
       const refreshLogFile = await tryCreateProjectCommandLogFile(
@@ -968,7 +947,6 @@ async function ensureProjectPython(
         "launcher refresh",
         profile,
       )
-      prompts.log.info("Refreshing project dependencies...")
       let localUv: string | undefined
       try {
         localUv = await ensureLocalUv(directory, venvPython, {
@@ -988,7 +966,6 @@ async function ensureProjectPython(
         if (refresh.installerFailed) corruptedVenv = true
       }
       if (!corruptedVenv) {
-        prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
         let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
         try {
           canary = await venvCanaryPasses([venvPython], {
@@ -999,7 +976,6 @@ async function ensureProjectPython(
           canary = { healthy: false, stderr: "", timedOut: false }
         }
         if (canary.healthy) {
-          prompts.log.success("Agency Swarm packages ready")
           return [venvPython]
         }
         corruptedVenv = true
@@ -1028,7 +1004,6 @@ async function ensureProjectPython(
   // (python3 etc.) resolves via PATH and, in an activated broken venv, still points at
   // the .venv binary we are about to delete.
   const rebuildCmd = corruptedVenv ? [detected.executable] : detected.cmd
-  prompts.log.info(`Detected Python: ${formatPython(detected, rebuildCmd)}`)
 
   if (corruptedVenv) {
     prompts.log.warn("Project `.venv` is incomplete or corrupted. Rebuilding...")
@@ -1038,7 +1013,7 @@ async function ensureProjectPython(
 
   if (!selfHealing) {
     const createVenv = await prompts.confirm({
-      message: "Create a local `.venv` in this project?",
+      message: "Create a Python environment for this project?",
       initialValue: true,
     })
     if (prompts.isCancel(createVenv)) {
@@ -1055,7 +1030,6 @@ async function ensureProjectPython(
     }
   }
 
-  prompts.log.step("Creating `.venv`")
   const created = await runCommand([...rebuildCmd, "-m", "venv", ".venv"], {
     cwd: directory,
   })
@@ -1064,14 +1038,12 @@ async function ensureProjectPython(
     throw new Error(created.stderr.trim() || created.stdout.trim() || "Virtual environment creation failed")
   }
 
-  prompts.log.step("`.venv` created")
   const installLogFile = await tryCreateProjectCommandLogFile(
     directory,
     "launcher-rebuild",
     "launcher rebuild",
     profile,
   )
-  prompts.log.info("Installing project dependencies...")
   const localUv = await ensureLocalUv(directory, venvPython, {
     forceInstall: true,
     logFile: installLogFile,
@@ -1087,7 +1059,6 @@ async function ensureProjectPython(
   if (install.code !== 0) {
     throw new Error(formatCommandFailure(install, "Dependency install failed"))
   }
-  prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
   const canary = await venvCanaryPasses([venvPython], {
     cwd: directory,
     includeStderr: true,
@@ -1101,7 +1072,6 @@ async function ensureProjectPython(
       await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr, install.logFile),
     )
   }
-  prompts.log.success("Agency Swarm packages ready")
   return [venvPython]
 }
 
@@ -1191,9 +1161,9 @@ async function formatPostInstallCanaryFailure(
   const detail = summary ? ` Details: ${summary}` : ""
   if (isImportLikeCanaryFailure(stderr)) {
     if (hadManifests) {
-      return `The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint}${logHint}${detail}`
+      return `The launcher recreated the local Python environment, but it still could not import required packages. Check requirements.txt/pyproject.toml for agency-swarm version compatibility.${shadowingHint}${logHint}${detail}`
     }
-    return `The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages. Check for project-local fastapi.py/agency_swarm.py files that may shadow installed packages.${shadowingHint}${logHint}${detail}`
+    return `The launcher recreated the local Python environment, but it still could not import required packages. Check for project-local fastapi.py/agency_swarm.py files that may shadow installed packages.${shadowingHint}${logHint}${detail}`
   }
   return `The launcher recreated the local Python environment, but it still could not repair it.${shadowingHint}${logHint}${detail}`
 }
@@ -1202,8 +1172,8 @@ async function formatCanaryTimeoutFailure(directory: string, stderr: string) {
   const summary = summarizeBridgeStderr(stderr)
   const shadowingHint = await formatShadowingHint(directory)
   return summary
-    ? `Agency Swarm import canary timed out after ${formatInstallDuration(VENV_CANARY_TIMEOUT_MS)}. Startup stopped instead of waiting indefinitely.${shadowingHint} Canary stderr: ${summary}`
-    : `Agency Swarm import canary timed out after ${formatInstallDuration(VENV_CANARY_TIMEOUT_MS)}. Startup stopped instead of waiting indefinitely.${shadowingHint}`
+    ? `Package check timed out after ${formatInstallDuration(VENV_CANARY_TIMEOUT_MS)}. Startup stopped instead of waiting indefinitely.${shadowingHint} Check stderr: ${summary}`
+    : `Package check timed out after ${formatInstallDuration(VENV_CANARY_TIMEOUT_MS)}. Startup stopped instead of waiting indefinitely.${shadowingHint}`
 }
 
 function isImportLikeCanaryFailure(stderr: string) {
@@ -1503,10 +1473,10 @@ async function waitForServer(input: {
   const warningSummary = summary ? "" : summarizeBridgeStderr(stderr)
   throw new Error(
     summary
-      ? `Timed out waiting for the Agency Swarm server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}. Last bridge output: ${summary}`
+      ? `Timed out waiting for the local server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}. Last bridge output: ${summary}`
       : warningSummary
-        ? `Timed out waiting for the Agency Swarm server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}. Bridge output only contained non-fatal startup warnings: ${warningSummary}`
-        : `Timed out waiting for the Agency Swarm server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}`,
+        ? `Timed out waiting for the local server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}. Bridge output only contained non-fatal startup warnings: ${warningSummary}`
+        : `Timed out waiting for the local server to start after ${formatInstallDuration(SERVER_START_TIMEOUT_MS)}`,
   )
 }
 
@@ -1514,9 +1484,7 @@ function formatAgencyServerExitFailure(exited: number, stderr: string, entryFile
   const projectFailure = formatAgencyProjectStartupFailure(stderr, entryFile)
   if (projectFailure) return projectFailure
   const summary = summarizeBridgeStderr(stderr)
-  return summary
-    ? `Agency Swarm server exited with code ${exited}: ${summary}`
-    : `Agency Swarm server exited with code ${exited}`
+  return summary ? `Local server exited with code ${exited}: ${summary}` : `Local server exited with code ${exited}`
 }
 
 function formatAgencyProjectStartupFailure(stderr: string, entryFile: string) {
@@ -1524,7 +1492,7 @@ function formatAgencyProjectStartupFailure(stderr: string, entryFile: string) {
   if (!exception) return
   const frame = findProjectEntryFrame(stderr, entryFile)
   const importFailure = /^(?:[\w.]+\.)?(?:ImportError|ModuleNotFoundError):/.test(exception)
-  const title = importFailure ? "Your agency project could not load." : "Your agency project failed to start."
+  const title = importFailure ? "Your project could not load." : "Your project failed to start."
   const entryName = path.basename(entryFile)
   const location = frame ? `\nAt: ${entryName}:${frame.line}${frame.source ? `\n${frame.source}` : ""}` : ""
   const recovery = importFailure

--- a/packages/opencode/src/agency-swarm/product.ts
+++ b/packages/opencode/src/agency-swarm/product.ts
@@ -308,11 +308,10 @@ export namespace AgencyProduct {
   export const wordmarkLines = current.wordmarkLines
   export const pythonEnvironment = current.pythonEnvironment
   export const stateRoot = current.stateRoot
-  export const connect = "Authenticate providers"
-  export const start = [
-    "Authenticate providers and connect to a local agency-swarm server before sending prompts.",
-    "Use /auth for provider credentials, then /connect to choose the server and store a token.",
-  ]
+  export const connect = "Connect to a running server"
+  export const start = current.hideModelSelection
+    ? ["Set up model access to start.", "Use /auth for provider sign-in."]
+    : ["Choose a model or set up access to start.", "Use /models for local models or /auth for sign-in."]
 
   export function shouldShowPostAuthModelSelection(profile: Pick<Profile, "skipPostAuthModelSelection"> = current) {
     return !profile.skipPostAuthModelSelection
@@ -371,7 +370,7 @@ export namespace AgencyProduct {
   ]
 
   const add = [
-    "Use {highlight}/auth{/highlight} to sign in to OpenAI or add API keys for supported providers",
+    "Use {highlight}/auth{/highlight} to set up provider access",
     "Use {highlight}/connect{/highlight} to choose the local agency-swarm server you want to use",
     "Use {highlight}/agents{/highlight} to pick the active swarm or agent from live metadata",
     "Set {highlight}provider.agency-swarm.options.baseURL{/highlight} in config to pin a default local server",

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -68,7 +68,9 @@ function parse(tip: string): TipPart[] {
   return parts
 }
 
-const NO_MODELS_TIP = "Run {highlight}/connect{/highlight} to add an AI provider and start coding"
+const NO_MODELS_TIP = AgencyProduct.shouldShowModelSelection()
+  ? "Use {highlight}/models{/highlight} for local models or {highlight}/auth{/highlight} for sign-in."
+  : "Use {highlight}/auth{/highlight} for sign-in."
 
 function shortcutText(value: string) {
   return `{highlight}${value}{/highlight}`
@@ -187,7 +189,7 @@ const TIPS: Tip[] = AgencyProduct.tips<Tip>([
   (shortcuts) => `Use ${commandText("/export", shortcuts.sessionExport())} to save the conversation as Markdown`,
   (shortcuts) => press(shortcuts.messagesCopy(), "to copy the assistant's last message to clipboard"),
   (shortcuts) => press(shortcuts.commandList(), "to see all available actions and commands"),
-  "Run {highlight}/auth{/highlight} to add API keys for supported LLM providers",
+  "Run {highlight}/auth{/highlight} to set up provider access",
   (shortcuts) => `The leader key is ${shortcutText(shortcuts.leader())}; combine with other keys for quick actions`,
   (shortcuts) => press(shortcuts.modelCycleRecent(), "to quickly switch between recently used models"),
   (shortcuts) => press(shortcuts.sessionSidebarToggle(), "in a session to show or hide the sidebar panel"),

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/footer.tsx
@@ -52,10 +52,6 @@ function View(props: { api: TuiPluginApi }) {
             </box>
             <text fg={theme().textMuted}>{AgencyProduct.start[0]}</text>
             <text fg={theme().textMuted}>{AgencyProduct.start[1]}</text>
-            <box flexDirection="row" gap={1} justifyContent="space-between">
-              <text fg={theme().text}>{AgencyProduct.connect}</text>
-              <text fg={theme().textMuted}>/auth</text>
-            </box>
           </box>
         </box>
       </Show>

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -81,9 +81,10 @@ async function input(value?: string) {
 }
 
 export function resolveThreadDirectory(project?: string, envPWD = process.env.PWD, cwd = process.cwd()) {
-  const root = Filesystem.resolve(envPWD ?? cwd)
+  const resolvedCwd = Filesystem.resolve(cwd)
+  const root = resolvedCwd
   if (project) return Filesystem.resolve(path.isAbsolute(project) ? project : path.join(root, project))
-  return Filesystem.resolve(cwd)
+  return resolvedCwd
 }
 
 export const TuiThreadCommand = cmd({

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -244,7 +244,7 @@ describe("agency-swarm npx onboarding", () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
 
-    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    const confirm = spyOn(prompts, "confirm").mockResolvedValue(true as never)
     spyOn(prompts, "spinner").mockReturnValue({
       start() {},
       stop() {},
@@ -293,6 +293,9 @@ describe("agency-swarm npx onboarding", () => {
       }),
     ).rejects.toThrow("fallback install failed")
 
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Create a Python environment for this project?" }),
+    )
     const installCommand = commands.find(isUvPipInstallCommand)
 
     const venvCommand = commands.find(isPythonVenvCommand)
@@ -533,7 +536,7 @@ describe("agency-swarm npx onboarding", () => {
     await Bun.write(path.join(dir.path, "requirements.txt"), "agency-swarm==1.9.6\n")
     await writeVenvPython(dir.path)
 
-    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
 
     const commands: string[][] = []
@@ -622,7 +625,7 @@ describe("agency-swarm npx onboarding", () => {
     await Bun.write(path.join(dir.path, "pyproject.toml"), "[project]\ndependencies = ['agency-swarm==1.9.6']\n")
     await writeVenvPython(dir.path)
 
-    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
 
     const commands: string[][] = []
@@ -701,8 +704,13 @@ describe("agency-swarm npx onboarding", () => {
     await writeAgency(dir.path)
     await writeVenvPython(dir.path)
 
-    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const profile = {
+      ...AgencyProduct.resolve({}),
+      name: "Example Product",
+    }
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+    const success = spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
     spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
 
     const commands: string[][] = []
@@ -758,13 +766,24 @@ describe("agency-swarm npx onboarding", () => {
       throw new Error(`Unexpected command: ${cmd.join(" ")}`)
     })
 
-    const launch = await prepareProjectLaunch({
-      directory: dir.path,
-      agencyFile: path.join(dir.path, "agency.py"),
-      moduleName: "agency",
-    })
+    const launch = await prepareProjectLaunch(
+      {
+        directory: dir.path,
+        agencyFile: path.join(dir.path, "agency.py"),
+        moduleName: "agency",
+      },
+      profile,
+    )
 
     expect(warn).not.toHaveBeenCalled()
+    expect(info).toHaveBeenCalledWith("Setting up Example Product. This can take 1-2 minutes.")
+    expect(success).toHaveBeenCalledWith("Example Product ready")
+    const visible = info.mock.calls.map((call) => String(call[0])).join("\n")
+    expect(visible).not.toContain("Starting Example Product.")
+    expect(visible).not.toContain("Checking project setup.")
+    expect(visible).not.toContain("Checking packages.")
+    expect(visible).not.toContain("Using project Python")
+    expect(visible).not.toContain("First launch can take a minute")
     expect(commands.some(isPythonPipInstallUvCommand)).toBe(false)
     expect(commands.some(isUvPipInstallCommand)).toBe(false)
     expect(commands.some(isPythonVenvCommand)).toBe(false)
@@ -1443,7 +1462,7 @@ describe("agency-swarm npx onboarding", () => {
     expect(error).toBeInstanceOf(Error)
     if (!error) throw new Error("Expected prepareProjectLaunch to fail")
     expect(error.message).toContain(
-      "The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages.",
+      "The launcher recreated the local Python environment, but it still could not import required packages.",
     )
     expect(error.message).toContain("Check requirements.txt/pyproject.toml for agency-swarm version compatibility.")
     expect(error.message).toContain("Check the log file at")
@@ -1530,7 +1549,10 @@ describe("agency-swarm npx onboarding", () => {
       moduleName: "agency",
     })
 
-    expect(info).toHaveBeenCalledWith("Installing project dependencies...")
+    expect(info).toHaveBeenCalledWith("Setting up Agent Swarm. This can take 1-2 minutes.")
+    expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
+      "Installing project dependencies...",
+    )
     expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain("Full log")
     expect(stderrWrite.mock.calls.map((call) => call[0]).join("")).not.toContain("Resolving packages")
     const logContent = await Bun.file(launcherLogFilePath(dir.path, "launcher-rebuild", iso)).text()
@@ -2004,7 +2026,10 @@ describe("agency-swarm npx onboarding", () => {
       moduleName: "agency",
     })
 
-    expect(info).toHaveBeenCalledWith("Refreshing project dependencies...")
+    expect(info).toHaveBeenCalledWith("Setting up Agent Swarm. This can take 1-2 minutes.")
+    expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
+      "Refreshing project dependencies...",
+    )
     expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain("Full log")
     expect(stderrWrite.mock.calls.map((call) => call[0]).join("")).not.toContain("Collecting agency-swarm")
     expect(warn).toHaveBeenCalledWith(
@@ -2501,7 +2526,7 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(outcome).toBeInstanceOf(Error)
     if (!(outcome instanceof Error)) throw new Error("Expected prepareProjectLaunch to fail")
-    expect(outcome.message).toContain("Your agency project could not load.")
+    expect(outcome.message).toContain("Your project could not load.")
     expect(outcome.message).toContain("ModuleNotFoundError: No module named 'codex_missing_import_for_canary_test'")
     expect(outcome.message).toContain("At: agency.py:2")
     expect(outcome.message).not.toContain("agency.py:99")
@@ -2509,9 +2534,10 @@ describe("agency-swarm npx onboarding", () => {
     expect(outcome.message).toContain(
       "Fix the missing import or dependency in this project, then run agentswarm again.",
     )
-    expect(outcome.message).not.toContain("Agency Swarm server exited with code 1")
-    expect(success).toHaveBeenCalledWith("Agency Swarm packages ready")
-    expect(info).toHaveBeenCalledWith("Starting your agency project.")
+    expect(outcome.message).not.toContain("Local server exited with code 1")
+    expect(success).not.toHaveBeenCalled()
+    expect(info).toHaveBeenCalledWith("Setting up Agent Swarm. This can take 1-2 minutes.")
+    expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain("Starting local server.")
   })
 
   test("prepareProjectLaunch points startup import failures at the active entry file", async () => {
@@ -2830,7 +2856,7 @@ describe("agency-swarm npx onboarding", () => {
     if (!(outcome instanceof Error)) throw new Error("Expected prepareProjectLaunch to fail")
     expect(killSignals).toEqual([undefined, undefined])
     expect(outcome.message).toContain(
-      "Timed out waiting for the Agency Swarm server to start after 2 minutes. Last bridge output: bridge still starting",
+      "Timed out waiting for the local server to start after 2 minutes. Last bridge output: bridge still starting",
     )
   })
 
@@ -2928,7 +2954,7 @@ describe("agency-swarm npx onboarding", () => {
     expect(outcome).toBeInstanceOf(Error)
     if (!(outcome instanceof Error)) throw new Error("Expected prepareProjectLaunch to fail")
     expect(killSignals).toEqual([undefined, undefined])
-    expect(outcome.message).toContain("Timed out waiting for the Agency Swarm server to start after 2 minutes.")
+    expect(outcome.message).toContain("Timed out waiting for the local server to start after 2 minutes.")
     expect(outcome.message).toContain("Bridge output only contained non-fatal startup warnings")
     expect(outcome.message).not.toContain("Last bridge output")
   })
@@ -3262,7 +3288,7 @@ describe("agency-swarm npx onboarding", () => {
         moduleName: "agency",
       }),
     ).rejects.toThrow(
-      "The launcher recreated the local Python environment, but it still could not import required Agency Swarm packages. Check for project-local fastapi.py/agency_swarm.py files that may shadow installed packages.",
+      "The launcher recreated the local Python environment, but it still could not import required packages. Check for project-local fastapi.py/agency_swarm.py files that may shadow installed packages.",
     )
   })
 
@@ -3572,13 +3598,17 @@ describe("agency-swarm npx onboarding", () => {
     const project = path.join(root.path, "project")
     const nested = path.join(project, profile.starterProjectName)
     const calls: { cmd: string[]; cwd?: string }[] = []
+    const choices: { label: string; hint: string | undefined }[] = []
     const text = spyOn(prompts, "text").mockResolvedValue(profile.starterProjectName as never)
 
-    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
     spyOn(prompts, "outro").mockImplementation(() => undefined as never)
-    spyOn(prompts, "select").mockResolvedValue("starter" as never)
+    spyOn(prompts, "select").mockImplementation((input) => {
+      choices.push(...input.options.map((option) => ({ label: String(option.label), hint: option.hint })))
+      return Promise.resolve("starter" as never)
+    })
     spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
       const cmd = options?.cmd as string[] | undefined
@@ -3649,6 +3679,9 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(profile.customStarter).toBe(false)
     expect(text).not.toHaveBeenCalled()
+    expect(choices).toContainEqual({ label: "Create a new Agent Swarm project", hint: undefined })
+    expect(choices).toContainEqual({ label: "Connect to a running server", hint: undefined })
+    expect(info).toHaveBeenCalledWith("Creating Agent Swarm project...")
     expect(calls).toContainEqual({ cmd: ["git", "clone", "--depth=1", starterTemplateUrl(profile), project] })
     expect(launch?.directory).toBe(project)
     expect(launch?.runProjectDirectory).toBe(project)
@@ -3726,7 +3759,7 @@ describe("agency-swarm npx onboarding", () => {
     const target = path.join(dir.path, downstreamProfile.starterProjectName)
     const commands: string[][] = []
 
-    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
     spyOn(prompts, "outro").mockImplementation(() => undefined as never)
@@ -3781,6 +3814,11 @@ describe("agency-swarm npx onboarding", () => {
 
     const launch = await prepareNpxLaunch(dir.path, downstreamProfile)
 
+    expect(info).toHaveBeenCalledWith("Creating Example Product project...")
+    expect(info).toHaveBeenCalledWith("Setting up Example Product. This can take 1-2 minutes.")
+    expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
+      "Create a new Example Product project.",
+    )
     expect(commands).toContainEqual(["git", "clone", "--depth=1", starterTemplateUrl(downstreamProfile), target])
     expect(launch?.directory).toBe(target)
     expect(launch?.runProjectDirectory).toBe(target)
@@ -3803,13 +3841,24 @@ describe("agency-swarm npx onboarding", () => {
     const name = "entry-only-starter"
     const target = path.join(dir.path, name)
     const commands: string[][] = []
+    const choices: { label: string; hint: string | undefined }[] = []
+    const messages: string[] = []
 
-    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
     spyOn(prompts, "outro").mockImplementation(() => undefined as never)
-    spyOn(prompts, "select").mockResolvedValue("starter" as never)
-    spyOn(prompts, "text").mockResolvedValue(name as never)
+    spyOn(prompts, "select").mockImplementation((input) => {
+      messages.push(String(input.message))
+      choices.push(...input.options.map((option) => ({ label: String(option.label), hint: option.hint })))
+      if (input.options.some((option) => option.value === "starter")) return Promise.resolve("starter" as never)
+      if (input.options.some((option) => option.value === "local")) return Promise.resolve("local" as never)
+      throw new Error(`Unexpected select prompt: ${input.message}`)
+    })
+    spyOn(prompts, "text").mockImplementation((input) => {
+      messages.push(String(input.message))
+      return Promise.resolve(name as never)
+    })
     spyOn(prompts, "spinner").mockReturnValue({
       start() {},
       stop() {},
@@ -3821,7 +3870,7 @@ describe("agency-swarm npx onboarding", () => {
       commands.push(cmd)
 
       if (cmd[0] === "gh") {
-        return { exited: Promise.resolve(1), stdout: "", stderr: "gh unavailable" } as never
+        return { exited: Promise.resolve(0), stdout: "", stderr: "" } as never
       }
 
       if (cmd[0] === "git" && cmd[1] === "clone") {
@@ -3869,6 +3918,11 @@ describe("agency-swarm npx onboarding", () => {
 
     const launch = await prepareNpxLaunch(dir.path, profile)
 
+    expect(messages).toContain("Project name")
+    expect(messages).toContain("Where should we create it?")
+    expect(choices).toContainEqual({ label: "GitHub - backed up and shareable", hint: undefined })
+    expect(choices).toContainEqual({ label: "This computer - no GitHub", hint: undefined })
+    expect(info).toHaveBeenCalledWith("Creating Example Product project...")
     expect(commands).toContainEqual(["git", "clone", "--depth=1", starterTemplateUrl(), target])
     expect(launch?.runProjectDirectory).toBe(target)
     expect(commands.find((cmd) => cmd[1]?.endsWith("launch_agency.py"))?.at(-1)).toBe("agency")
@@ -3987,7 +4041,7 @@ describe("agency-swarm npx onboarding", () => {
       moduleName: "agency",
     }
 
-    expect(formatProjectLabel(project)).toBe(`Use detected Agency Swarm project (${root})`)
+    expect(formatProjectLabel(project)).toBe(`Use detected Agent Swarm project (${root})`)
     expect(formatProjectLabel(project, downstreamProfile)).toBe(`Use detected Example Product project (${root})`)
   })
 

--- a/packages/opencode/test/agency-swarm/product.test.ts
+++ b/packages/opencode/test/agency-swarm/product.test.ts
@@ -291,6 +291,13 @@ describe("AgencyProduct profile", () => {
       hidden: true,
     })
   })
+
+  test("uses first-run provider access copy", () => {
+    expect(AgencyProduct.start).toEqual([
+      "Choose a model or set up access to start.",
+      "Use /models for local models or /auth for sign-in.",
+    ])
+  })
 })
 
 describe("AgencyProduct.tips", () => {

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -99,6 +99,14 @@ describe("tui thread", () => {
     await check(".")
   })
 
+  test("uses the real cwd when PWD is stale", async () => {
+    await using cwd = await tmpdir({ git: true })
+    await using stale = await tmpdir()
+    const project = path.join(cwd.path, "my-agency")
+
+    expect(resolveThreadDirectory("my-agency", stale.path, cwd.path)).toBe(project)
+  })
+
   test("uses cwd-only npx launches without preparing local projects", async () => {
     setup()
     await using caller = await tmpdir({ git: true })


### PR DESCRIPTION
## Summary

- Simplifies Agent Swarm launcher copy so normal startup shows one setup line and a ready state instead of low-level Python, package, and server steps.
- Uses product-profile names for downstream products while keeping Agent Swarm defaults generic.
- Fixes project path resolution when the shell has a stale `PWD` and the user passes a relative project path.

## Issue for this PR

N/A

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Verification

- Focused onboarding and thread unit tests passed.
- Agent Swarm terminal TUI E2E passed.
- Typecheck passed.
- Diff check passed.

## Screenshots / Recordings

Terminal launcher output was captured locally during Agent Swarm TUI E2E.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested this change locally.
- [x] I have updated related user-flow docs.

