### PR TITLE
feat(opencode): show Agent Swarm agent counts

### DIFF
--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -185,7 +185,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** `/models` and `/auth` are limited to Agency-supported providers.
 - **Happy-path proof:** Upstream provider/model state used for auth or LLM choice does not pull the user out of Run mode by accident.
 - **Happy-path proof:** `agency-swarm/default` stays active over stale stored model state until the user explicitly chooses another model.
-- **Happy-path proof:** Live agency names appear in run-target labels.
+- **Happy-path proof:** Live agency names and metadata-derived main-agent and subagent counts appear in run-target labels.
 - **Happy-path proof:** Tab cycles run targets.
 - **Failure scenarios to test:** Agent discovery failure offers `/connect`.
 - **Failure scenarios to test:** Server reachability or authorization failure opens `/connect`.

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -7,7 +7,7 @@
 - `USER_FLOWS.md` Detected Local Project: launcher mode shows the detected-project choice before `.venv` work begins.
 - `USER_FLOWS.md` Startup `/auth` and In-TUI `/connect`: `/auth` and `/connect` stay separate in the real terminal UI.
 - `USER_FLOWS.md` Run Mode: native `/editor`, `/variants`, `/init`, and `/review` slash commands stay hidden.
-- `USER_FLOWS.md` Run Mode: `/agents` uses Swarm and agent wording, live agency labels, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
+- `USER_FLOWS.md` Run Mode: `/agents` uses Swarm and agent wording, live agency labels, main-agent and subagent counts, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
 - `USER_FLOWS.md` Run Mode: prompt submit reaches a local Agency Swarm protocol server with the configured agent.
 - `USER_FLOWS.md` Run Mode: simulated visible OpenAI model state does not pull prompts, slash-command `/new`, run-session local-project marking, `/connect`, or runtime auth recovery out of Agency Swarm routing.
 - `USER_FLOWS.md` Run Mode: bracketed-paste image paths reach the local Agency Swarm protocol server as structured Responses `message` content.

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -194,6 +194,8 @@ export async function startTui(input: {
   args?: string[]
   cwd?: string
   env?: Record<string, string | undefined>
+  cols?: number
+  rows?: number
   baseURL?: string
   agency?: string
   recipientAgent?: string
@@ -207,7 +209,9 @@ export async function startTui(input: {
   await mkdir(path.join(root, "data"), { recursive: true })
   await mkdir(path.join(root, "managed"), { recursive: true })
 
-  const screen = new TerminalScreen(100, 30)
+  const cols = input.cols ?? 100
+  const rows = input.rows ?? 30
+  const screen = new TerminalScreen(cols, rows)
   let raw = ""
   let exitCode: number | undefined
   const configContent = input.baseURL ? JSON.stringify(buildTuiConfig(input)) : undefined
@@ -238,7 +242,7 @@ export async function startTui(input: {
     ...(configContent && input.configSource !== "file" ? { OPENCODE_CONFIG_CONTENT: configContent } : {}),
     ...(input.env ?? {}),
   })
-  let proc = spawnTuiProcess({ args, cwd: input.cwd, env })
+  let proc = spawnTuiProcess({ args, cwd: input.cwd, env, cols, rows })
 
   let dataReceived = false
   let activeProc = proc
@@ -268,7 +272,7 @@ export async function startTui(input: {
       onRetry: async () => {
         await closeProcess(proc)
         await Bun.sleep(initialOutputRetryDelayMs)
-        proc = spawnTuiProcess({ args, cwd: input.cwd, env })
+        proc = spawnTuiProcess({ args, cwd: input.cwd, env, cols, rows })
         dataReceived = false
         exitCode = undefined
         attachProcess(proc)
@@ -325,11 +329,17 @@ export async function startTui(input: {
   }
 }
 
-function spawnTuiProcess(input: { args: string[]; cwd?: string; env: Record<string, string | undefined> }) {
+function spawnTuiProcess(input: {
+  args: string[]
+  cwd?: string
+  env: Record<string, string | undefined>
+  cols: number
+  rows: number
+}) {
   return spawn(process.execPath, ["--conditions=browser", "./src/index.ts", ...input.args], {
     cwd: input.cwd ?? packageRoot,
-    cols: 100,
-    rows: 30,
+    cols: input.cols,
+    rows: input.rows,
     name: "xterm-256color",
     env: cleanEnv(input.env),
   })

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -308,6 +308,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     currentTui.write("/agents\r")
     const screen = await currentTui.waitForText("Live QA Agency")
 
+    expect(screen).toContain("Swarm: Live QA Agency (1 main / 1 sub)")
     expect(screen).toContain("Entry Agent")
     expect(screen).toContain("Review Agent")
     expect(screen).not.toContain("local-agency")
@@ -327,7 +328,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     const screen = await currentTui.waitForText("TuiDemoAgency")
 
     expect(screen).toContain("Select swarm")
-    expect(screen).toContain("Swarm: TuiDemoAgency")
+    expect(screen).toContain("Swarm: TuiDemoAgency (1 main / 1 sub)")
     expect(screen).toContain("UserSupportAgent")
     expect(screen).toContain("MathAgent")
     expect(screen.toLowerCase()).not.toContain("recipient")

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -144,7 +144,7 @@ export function DialogAgent() {
 
     const agencies = discovered?.agencies ?? []
     for (const agency of agencies) {
-      const category = `Swarm: ${agency.name}`
+      const category = formatAgencyCategory(agency)
       const entry = agency.agents.find((agent) => agent.isEntryPoint) ?? agency.agents[0]
       const description =
         agency.description && agency.description !== entry?.description ? agency.description : undefined
@@ -296,4 +296,10 @@ export function DialogAgent() {
       duration: 3000,
     })
   }
+}
+
+function formatAgencyCategory(agency: AgencySwarmAdapter.AgencyDescriptor) {
+  const main = agency.agents.filter((agent) => agent.isEntryPoint).length
+  const sub = agency.agents.length - main
+  return `Swarm: ${agency.name} (${main} main / ${sub} sub)`
 }

--- a/packages/opencode/test/cli/tui/dialog-agent.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-agent.test.tsx
@@ -134,7 +134,7 @@ describe("DialogAgent agency selection", () => {
 
     const agencyOption = selectProps?.options.find((option) => option.title === "Live Agency")
     expect(agencyOption).toBeDefined()
-    expect(agencyOption?.category).toBe("Swarm: Live Agency")
+    expect(agencyOption?.category).toBe("Swarm: Live Agency (1 main / 1 sub)")
     expect(agencyOption?.description).toBeUndefined()
 
     selectProps!.onSelect!(agencyOption!)


### PR DESCRIPTION
## Summary

- Adds metadata-derived main-agent and subagent counts to Agent Swarm `/agents` swarm section labels.
- Keeps the label generic and based on live agency metadata.
- Preserves configured terminal dimensions across TUI harness retry launches.

## Issue for this PR

N/A

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Verification

- Dialog agent unit test passed.
- Agent Swarm terminal TUI run-target picker E2E passed.
- Narrow `/agents` terminal proof passed.
- Typecheck passed.
- Diff check passed.

## Screenshots / Recordings

Narrow terminal frame captured locally: `/tmp/agentswarm-narrow-agents-screen.txt`.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested this change locally.
- [x] I have updated related user-flow docs.

