### PR TITLE
feat(opencode): show actual Agent Swarm model labels

### DIFF
--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -15,7 +15,8 @@ const configSchema = "https://opencode.ai/config.json"
 export const latestOpenAITestModel = "openai/gpt-5.4-mini"
 export const latestOpenAITestModelLabel = "GPT-5.4 mini OpenAI"
 export const agencyClientConfigModel = "gpt-4o-mini"
-const tuiDemoAgentModel = "gpt-5.4-mini"
+const tuiDemoEntryAgentModel = "gpt-5.4-mini"
+const tuiDemoMathAgentModel = "claude-sonnet-4-5"
 
 type TuiManagedConfig = Pick<Config.Info, "$schema" | "enabled_providers" | "model" | "provider">
 export type TuiConfigOverride = Pick<Config.Info, "enabled_providers" | "model" | "provider">
@@ -436,7 +437,7 @@ const tuiDemoAgencyFixture: AgencyFixture = {
           label: "UserSupportAgent",
           description: "Receives user requests and coordinates reasoning, search, and file work.",
           isEntryPoint: true,
-          model: tuiDemoAgentModel,
+          model: tuiDemoEntryAgentModel,
         },
       },
       {
@@ -445,7 +446,7 @@ const tuiDemoAgencyFixture: AgencyFixture = {
         data: {
           label: "MathAgent",
           description: "Handles arithmetic and calculation-heavy requests.",
-          model: tuiDemoAgentModel,
+          model: tuiDemoMathAgentModel,
         },
       },
     ],

--- a/e2e/agent-swarm-tui/metadata-outage-recipient.test.ts
+++ b/e2e/agent-swarm-tui/metadata-outage-recipient.test.ts
@@ -32,7 +32,7 @@ describe("Agent Swarm metadata outage recipient e2e", () => {
     currentTui.write("please live handoff this calculation\r")
     await currentTui.waitForText("Live agent update moved control to MathAgent.", tuiInteractionTimeoutMs)
     await currentTui.waitFor(
-      () => currentTui!.screen().includes("MathAgent · Swarm Default"),
+      () => currentTui!.screen().includes("MathAgent · gpt-5.4-mini"),
       "live handoff routed prompt",
       tuiInteractionTimeoutMs,
     )

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -313,6 +313,27 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(screen).not.toContain("local-agency")
   })
 
+  test("swarm-level agency default footer uses metadata model label without a recipient agent", async () => {
+    currentServer = await startAgencyProtocolServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      config: {
+        provider: {
+          "agency-swarm": {
+            options: {
+              recipientAgent: undefined,
+              recipientAgentSelectedAt: undefined,
+            },
+          },
+        },
+      },
+    })
+
+    const screen = await currentTui.waitForText(agencyClientConfigModel, tuiReadyTimeoutMs)
+    expect(screen).toContain(`Live QA Agency · ${agencyClientConfigModel}`)
+    expect(screen).not.toContain("Live QA Agency · Swarm Default")
+  })
+
   test("run-target picker uses Swarm and agent wording against the TUI demo swarm", async () => {
     currentServer = await startTuiDemoAgencyServer()
     currentTui = await startTui({
@@ -345,12 +366,14 @@ describe("Agent Swarm terminal TUI e2e", () => {
     await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
     await selectCurrentSwarm(currentTui)
     currentTui.write("route through the whole swarm\r")
+    const screen = await currentTui.waitForText("Run · gpt-5.4-mini", tuiInteractionTimeoutMs)
     await currentTui.waitFor(
       () => currentServer!.requests.length === 1,
       "swarm-routed request",
       tuiInteractionTimeoutMs,
     )
 
+    expect(screen).not.toContain("Run · Swarm Default")
     const body = currentServer.requests[0]?.body
     expect(body?.message).toContain("route through the whole swarm")
     expect(body).not.toHaveProperty("recipient_agent")
@@ -367,6 +390,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
 
     await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
     await selectRunTarget(currentTui, "MathAgent", "Selected MathAgent in swarm TuiDemoAgency")
+    await currentTui.waitForText("MathAgent · claude-sonnet-4-5", tuiInteractionTimeoutMs)
     currentTui.write("calculate through the selected agent\r")
     await currentTui.waitFor(
       () => currentServer!.requests.length === 1,
@@ -642,6 +666,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     await waitForConfiguredDemoRecipient(currentTui)
     currentTui.write("please handoff this calculation\r")
     await currentTui.waitForText("Math agent now has control.", tuiInteractionTimeoutMs)
+    await currentTui.waitForText("Run · claude-sonnet-4-5", tuiInteractionTimeoutMs)
     await currentTui.waitFor(() => currentServer!.requests.length === 1, "handoff request", tuiInteractionTimeoutMs)
 
     currentTui.write("continue after handoff\r")
@@ -727,7 +752,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
       tuiInteractionTimeoutMs,
     )
     await currentTui.waitFor(
-      () => currentTui!.screen().includes("MathAgent · Swarm Default"),
+      () => currentTui!.screen().includes("MathAgent · claude-sonnet-4-5"),
       "live handoff routed prompt",
       tuiInteractionTimeoutMs,
     )

--- a/packages/opencode/src/agency-swarm/adapter.ts
+++ b/packages/opencode/src/agency-swarm/adapter.ts
@@ -17,6 +17,7 @@ export namespace AgencySwarmAdapter {
     id: string
     name: string
     description?: string
+    model?: string
     isEntryPoint: boolean
   }
 
@@ -129,6 +130,13 @@ export namespace AgencySwarmAdapter {
     }
 
     return Array.from(result.values()).sort()
+  }
+
+  export function formatModelLabels(labels: string[]): string | undefined {
+    const first = labels[0]
+    if (!first) return undefined
+    if (labels.length === 1) return first
+    return `${first} +${labels.length - 1}`
   }
 
   export async function discover(input: {
@@ -496,15 +504,18 @@ export namespace AgencySwarmAdapter {
       const data = asRecord(nodeRecord["data"])
       const label = asString(data?.["label"]) ?? id
       const description = asString(data?.["description"])
+      const model = asString(data?.["model"])
       const dataEntryPoint = asBoolean(data?.["isEntryPoint"]) === true
       const knownAgent = result.get(id)
       const includeNode = nodeType === "agent" || !!knownAgent
       if (!includeNode) continue
+      const resolvedModel = model || knownAgent?.model
 
       result.set(id, {
         id,
         name: label,
         description: description || knownAgent?.description,
+        ...(resolvedModel ? { model: resolvedModel } : {}),
         isEntryPoint: entryPoints.has(id) || dataEntryPoint || knownAgent?.isEntryPoint === true,
       })
     }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -83,6 +83,7 @@ import {
   resolveAgencyTargetSelection,
   shouldAdoptAgencyHandoffRecipient,
 } from "../../util/agency-target"
+import { resolveModelLabel } from "../../util/model-label"
 import { hasAgencyHandoffEvidence } from "@/session/agency-swarm-utils"
 import {
   confirmWorkspaceFileChanges,
@@ -114,6 +115,7 @@ export type PromptProps = {
     normal?: string[]
     shell?: string[]
   }
+  agencyDiscovery?: () => AgencySwarmAdapter.AgencyDescriptor[]
 }
 
 export type PromptRef = {
@@ -262,15 +264,15 @@ export function Prompt(props: PromptProps) {
   )
   const frameworkRecipientDiscoveryInput = createMemo(() => {
     if (!frameworkMode()) return undefined
+    if (props.agencyDiscovery) return undefined
     const options = agencyProviderOptions()
-    if (!options.recipientAgent) return undefined
     return {
       baseURL: options.baseURL,
       token: options.token,
       timeoutMs: options.discoveryTimeoutMs,
     }
   })
-  const [frameworkRecipientDiscovery] = createResource(
+  const [localFrameworkRecipientDiscovery] = createResource(
     frameworkRecipientDiscoveryInput,
     async (input): Promise<AgencySwarmAdapter.AgencyDescriptor[]> => {
       try {
@@ -289,6 +291,7 @@ export function Prompt(props: PromptProps) {
       initialValue: [],
     },
   )
+  const frameworkRecipientDiscovery = createMemo(() => props.agencyDiscovery?.() ?? localFrameworkRecipientDiscovery())
   const sessionHandoffRecipient = createMemo(() => {
     if (!props.sessionID) return undefined
     const options = agencyProviderOptions()
@@ -525,6 +528,24 @@ export function Prompt(props: PromptProps) {
   const [workspaceCreatingDots, setWorkspaceCreatingDots] = createSignal(3)
   const [warpNotice, setWarpNotice] = createSignal<string>()
   const [cursorVersion, setCursorVersion] = createSignal(0)
+  const currentModelLabel = createMemo(() => {
+    const fallback = local.model.parsed().model
+    const current = local.model.current()
+    if (!current) return fallback
+    const options = agencyProviderOptions()
+    return resolveModelLabel({
+      providers: sync.data.provider,
+      agencies: frameworkRecipientDiscovery(),
+      agencyID: options.agency,
+      agentID: effectiveHandoffRecipient()?.agent ?? options.recipientAgent,
+      providerID: current.providerID,
+      modelID: current.modelID,
+      fallback,
+    })
+  })
+  const currentModelLabelDisplay = createMemo(() =>
+    Locale.truncateMiddle(currentModelLabel(), Math.max(12, Math.min(48, Math.floor(dimensions().width / 3)))),
+  )
   const currentProviderLabel = createMemo(() => {
     const current = local.model.current()
     const provider = local.model.parsed().provider
@@ -2171,7 +2192,7 @@ export function Prompt(props: PromptProps) {
                             flexShrink={0}
                             fg={fadeColor(leader() ? theme.textMuted : theme.text, modelMetaAlpha())}
                           >
-                            {local.model.parsed().model}
+                            {currentModelLabelDisplay()}
                           </text>
                           <text fg={fadeColor(theme.textMuted, modelMetaAlpha())}>{currentProviderLabel()}</text>
                           <Show when={showAgencyReconnect()}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   createEffect,
   createMemo,
+  createResource,
   createSignal,
   For,
   Match,
@@ -90,8 +91,10 @@ import { useCommandPalette } from "../../context/command-palette"
 import { useBindings, useCommandShortcut } from "../../keymap"
 import { PathFormatterProvider, usePathFormatter } from "../../context/path-format"
 import { AgencyProduct } from "@/agency-swarm/product"
+import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { describeStreamAuthError, isAgencySwarmFrameworkMode } from "../../session-error"
-import { displayRunOnlyModeLabel } from "../../util/agency-target"
+import { displayRunOnlyModeLabel, readAgencyProviderOptions } from "../../util/agency-target"
+import { resolveModelLabel } from "../../util/model-label"
 
 addDefaultParsers(parsers.parsers)
 
@@ -165,6 +168,7 @@ const context = createContext<{
   showGenericToolOutput: () => boolean
   diffWrapMode: () => "word" | "none"
   frameworkMode: () => boolean
+  modelLabel: (input: { providerID: string; modelID: string; agentID?: string }) => string
   providers: () => ReadonlyMap<string, Provider>
   sync: ReturnType<typeof useSync>
   tui: ReturnType<typeof useTuiConfig>
@@ -244,6 +248,49 @@ export function Session() {
       agentModel: local.agent.current()?.model,
     }),
   )
+  const agencyProviderOptions = createMemo(() =>
+    readAgencyProviderOptions({
+      configuredProvider: sync.data.config.provider?.[AgencySwarmAdapter.PROVIDER_ID],
+      connectedProvider: sync.data.provider.find((item) => item.id === AgencySwarmAdapter.PROVIDER_ID),
+    }),
+  )
+  const agencyDiscoveryInput = createMemo(() => {
+    if (!frameworkMode()) return undefined
+    const options = agencyProviderOptions()
+    return {
+      baseURL: options.baseURL,
+      token: options.token,
+      timeoutMs: options.discoveryTimeoutMs,
+    }
+  })
+  const [agencyDiscovery] = createResource(
+    agencyDiscoveryInput,
+    async (input): Promise<AgencySwarmAdapter.AgencyDescriptor[]> => {
+      try {
+        const result = await AgencySwarmAdapter.discover({
+          baseURL: input.baseURL,
+          token: input.token,
+          timeoutMs: input.timeoutMs,
+        })
+        return result.agencies
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") throw error
+        return []
+      }
+    },
+    {
+      initialValue: [],
+    },
+  )
+  const modelLabel = (input: { providerID: string; modelID: string; agentID?: string }) =>
+    resolveModelLabel({
+      providers: providers(),
+      agencies: agencyDiscovery(),
+      agencyID: agencyProviderOptions().agency,
+      agentID: input.agentID,
+      providerID: input.providerID,
+      modelID: input.modelID,
+    })
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
   const toast = useToast()
@@ -921,6 +968,8 @@ export function Session() {
               toolDetails: showDetails(),
               assistantMetadata: showAssistantMetadata(),
               providers: sync.data.provider,
+              agencies: agencyDiscovery(),
+              agencyID: agencyProviderOptions().agency,
             },
           )
           await Clipboard.copy(transcript)
@@ -965,6 +1014,8 @@ export function Session() {
               toolDetails: options.toolDetails,
               assistantMetadata: options.assistantMetadata,
               providers: sync.data.provider,
+              agencies: agencyDiscovery(),
+              agencyID: agencyProviderOptions().agency,
             },
           )
 
@@ -1104,6 +1155,7 @@ export function Session() {
           showGenericToolOutput,
           diffWrapMode,
           frameworkMode,
+          modelLabel,
           providers,
           sync,
           tui: tuiConfig,
@@ -1255,6 +1307,7 @@ export function Session() {
                         toBottom()
                       }}
                       sessionID={route.sessionID}
+                      agencyDiscovery={agencyDiscovery}
                       right={<TuiPluginRuntime.Slot name="session_prompt_right" session_id={route.sessionID} />}
                     />
                   </TuiPluginRuntime.Slot>
@@ -1415,7 +1468,13 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
     const msg = props.message.error?.data.message
     return typeof msg === "string" ? describeStreamAuthError(msg) : null
   })
-  const model = createMemo(() => Model.name(ctx.providers(), props.message.providerID, props.message.modelID))
+  const model = createMemo(() =>
+    ctx.modelLabel({
+      providerID: props.message.providerID,
+      modelID: props.message.modelID,
+      agentID: props.message.agent,
+    }),
+  )
 
   const final = createMemo(() => {
     return props.message.finish && !["tool-calls", "unknown"].includes(props.message.finish)

--- a/packages/opencode/src/cli/cmd/tui/util/model-label.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/model-label.ts
@@ -1,0 +1,65 @@
+import type { Provider } from "@opencode-ai/sdk/v2"
+import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import * as Model from "./model"
+
+export type ModelLabelContext = {
+  providers?: Provider[] | ReadonlyMap<string, Provider>
+  agencies?: readonly AgencySwarmAdapter.AgencyDescriptor[]
+  agencyID?: string
+  agentID?: string
+}
+
+export function resolveModelLabel(
+  input: ModelLabelContext & { providerID: string; modelID: string; fallback?: string },
+) {
+  const fallback = input.fallback ?? Model.name(input.providers, input.providerID, input.modelID)
+  if (input.providerID !== AgencySwarmAdapter.PROVIDER_ID) return fallback
+  if (input.modelID !== AgencySwarmAdapter.DEFAULT_MODEL_ID) return fallback
+  return resolveAgencyModelLabel(input) ?? fallback
+}
+
+export function resolveAgencyDefaultModelLabel(input: {
+  agencies?: readonly AgencySwarmAdapter.AgencyDescriptor[]
+  agencyID?: string
+}) {
+  const agency = resolveAgency(input.agencies ?? [], input.agencyID)
+  if (!agency) return undefined
+  return formatAgencyModelLabel(agency)
+}
+
+function resolveAgencyModelLabel(input: {
+  agencies?: readonly AgencySwarmAdapter.AgencyDescriptor[]
+  agencyID?: string
+  agentID?: string
+}) {
+  const agency = resolveAgency(input.agencies ?? [], input.agencyID)
+  if (!agency) return undefined
+  return resolveAgencyAgentModelLabel(agency, input.agentID) ?? formatAgencyModelLabel(agency)
+}
+
+function resolveAgencyAgentModelLabel(agency: AgencySwarmAdapter.AgencyDescriptor, agentID: string | undefined) {
+  if (!agentID) return undefined
+  const agent = agency.agents.find((item) => item.id === agentID) ?? agency.agents.find((item) => item.name === agentID)
+  return agent?.model
+}
+
+function formatAgencyModelLabel(agency: AgencySwarmAdapter.AgencyDescriptor) {
+  const seen = new Set<string>()
+  const agents = [
+    ...agency.agents.filter((agent) => agent.isEntryPoint),
+    ...agency.agents.filter((agent) => !agent.isEntryPoint),
+  ]
+  const labels = agents.flatMap((agent) => {
+    if (!agent.model) return []
+    if (seen.has(agent.model)) return []
+    seen.add(agent.model)
+    return [agent.model]
+  })
+  return AgencySwarmAdapter.formatModelLabels(labels)
+}
+
+function resolveAgency(agencies: readonly AgencySwarmAdapter.AgencyDescriptor[], agencyID: string | undefined) {
+  if (agencyID) return agencies.find((item) => item.id === agencyID)
+  if (agencies.length === 1) return agencies[0]
+  return undefined
+}

--- a/packages/opencode/src/cli/cmd/tui/util/transcript.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/transcript.ts
@@ -2,12 +2,15 @@ import type { AssistantMessage, Part, Provider, UserMessage } from "@opencode-ai
 import { displayAgentName } from "@/agent/display"
 import { Locale } from "@/util/locale"
 import * as Model from "./model"
+import { resolveModelLabel, type ModelLabelContext } from "./model-label"
 
 export type TranscriptOptions = {
   thinking: boolean
   toolDetails: boolean
   assistantMetadata: boolean
   providers?: Provider[]
+  agencies?: ModelLabelContext["agencies"]
+  agencyID?: string
 }
 
 export type SessionInfo = {
@@ -55,7 +58,11 @@ export function formatMessage(
   if (msg.role === "user") {
     result += `## User\n\n`
   } else {
-    result += formatAssistantHeader(msg, options.assistantMetadata, providers ?? options.providers)
+    result += formatAssistantHeader(msg, options.assistantMetadata, {
+      providers: providers ?? options.providers,
+      agencies: options.agencies,
+      agencyID: options.agencyID,
+    })
   }
 
   for (const part of parts) {
@@ -68,7 +75,7 @@ export function formatMessage(
 export function formatAssistantHeader(
   msg: AssistantMessage,
   includeMetadata: boolean,
-  providers?: Provider[] | ReadonlyMap<string, Provider>,
+  context?: Provider[] | ReadonlyMap<string, Provider> | ModelLabelContext,
 ): string {
   if (!includeMetadata) {
     return `## Assistant\n\n`
@@ -77,9 +84,29 @@ export function formatAssistantHeader(
   const duration =
     msg.time.completed && msg.time.created ? ((msg.time.completed - msg.time.created) / 1000).toFixed(1) + "s" : ""
 
-  const modelName = Model.name(providers, msg.providerID, msg.modelID)
+  const modelName = resolveModelLabel({
+    ...readModelLabelContext(context),
+    providerID: msg.providerID,
+    modelID: msg.modelID,
+    agentID: msg.agent,
+  })
 
   return `## Assistant (${displayAgentName(msg.agent)} · ${modelName}${duration ? ` · ${duration}` : ""})\n\n`
+}
+
+function readModelLabelContext(
+  context: Provider[] | ReadonlyMap<string, Provider> | ModelLabelContext | undefined,
+): ModelLabelContext {
+  if (!context) return {}
+  if (Array.isArray(context)) return { providers: context }
+  if (isProviderMap(context)) return { providers: context }
+  return context
+}
+
+function isProviderMap(
+  context: Provider[] | ReadonlyMap<string, Provider> | ModelLabelContext,
+): context is ReadonlyMap<string, Provider> {
+  return context instanceof Map
 }
 
 export function formatPart(part: Part, options: TranscriptOptions): string {

--- a/packages/opencode/test/agency-swarm/adapter.test.ts
+++ b/packages/opencode/test/agency-swarm/adapter.test.ts
@@ -62,6 +62,7 @@ describe("agency-swarm.adapter", () => {
                   label: "Project Manager",
                   description: "Planning agent",
                   isEntryPoint: true,
+                  model: "gpt-5.4-mini",
                 },
               },
               {
@@ -69,6 +70,7 @@ describe("agency-swarm.adapter", () => {
                 type: "agent",
                 data: {
                   description: "Research support",
+                  model: "claude-sonnet-4-5",
                 },
               },
             ],
@@ -93,12 +95,14 @@ describe("agency-swarm.adapter", () => {
         id: "PM",
         name: "Project Manager",
         description: "Planning agent",
+        model: "gpt-5.4-mini",
         isEntryPoint: true,
       },
       {
         id: "Researcher",
         name: "Researcher",
         description: "Research support",
+        model: "claude-sonnet-4-5",
         isEntryPoint: false,
       },
     ])

--- a/packages/opencode/test/cli/tui/model-label.test.ts
+++ b/packages/opencode/test/cli/tui/model-label.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test"
+import { AgencySwarmAdapter } from "../../../src/agency-swarm/adapter"
+import { resolveAgencyDefaultModelLabel, resolveModelLabel } from "../../../src/cli/cmd/tui/util/model-label"
+
+const agencies: AgencySwarmAdapter.AgencyDescriptor[] = [
+  {
+    id: "demo",
+    name: "Demo Agency",
+    agents: [
+      {
+        id: "orchestrator",
+        name: "Orchestrator",
+        model: "gpt-5.4-mini",
+        isEntryPoint: true,
+      },
+      {
+        id: "reviewer",
+        name: "Reviewer",
+        model: "claude-sonnet-4-5",
+        isEntryPoint: false,
+      },
+      {
+        id: "support",
+        name: "Support",
+        model: "gpt-5.4-mini",
+        isEntryPoint: false,
+      },
+    ],
+    metadata: {},
+  },
+]
+
+describe("model-label", () => {
+  test("formats unique agency default model labels", () => {
+    expect(
+      resolveAgencyDefaultModelLabel({
+        agencies,
+        agencyID: "demo",
+      }),
+    ).toBe("gpt-5.4-mini +1")
+  })
+
+  test("uses matched agent model before agency aggregate", () => {
+    const result = resolveModelLabel({
+      agencies,
+      agencyID: "demo",
+      agentID: "reviewer",
+      providerID: AgencySwarmAdapter.PROVIDER_ID,
+      modelID: AgencySwarmAdapter.DEFAULT_MODEL_ID,
+      fallback: "Swarm Default",
+    })
+
+    expect(result).toBe("claude-sonnet-4-5")
+  })
+
+  test("falls back to aggregate when the agent has no metadata model", () => {
+    const result = resolveModelLabel({
+      agencies,
+      agencyID: "demo",
+      agentID: "missing",
+      providerID: AgencySwarmAdapter.PROVIDER_ID,
+      modelID: AgencySwarmAdapter.DEFAULT_MODEL_ID,
+      fallback: "Swarm Default",
+    })
+
+    expect(result).toBe("gpt-5.4-mini +1")
+  })
+
+  test("falls back when configured agency does not match ambiguous discovery", () => {
+    const result = resolveModelLabel({
+      agencies: [
+        ...agencies,
+        {
+          id: "other",
+          name: "Other Agency",
+          agents: [
+            {
+              id: "other-agent",
+              name: "Other Agent",
+              model: "gpt-5.5-pro",
+              isEntryPoint: true,
+            },
+          ],
+          metadata: {},
+        },
+      ],
+      agencyID: "missing",
+      providerID: AgencySwarmAdapter.PROVIDER_ID,
+      modelID: AgencySwarmAdapter.DEFAULT_MODEL_ID,
+      fallback: "Swarm Default",
+    })
+
+    expect(result).toBe("Swarm Default")
+  })
+})

--- a/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt-framework-mode.test.tsx
@@ -58,31 +58,35 @@ describe("prompt framework-mode footer", () => {
     const prompt = mock(async () => ({}))
     let promptRef: import("../../../src/cli/cmd/tui/component/prompt").PromptRef | undefined
 
-    spyOn(AgencySwarmAdapter, "discover").mockResolvedValue({
-      agencies: [
-        {
-          id: "demo",
-          name: "Demo Agency",
-          agents: [
-            {
-              id: "orchestrator-slug",
-              name: "Orchestrator",
-              isEntryPoint: true,
-            },
-            {
-              id: "slides_agent",
-              name: "Slides Agent",
-              isEntryPoint: false,
-            },
-            {
-              id: "support_agent",
-              name: "Support Agent",
-              isEntryPoint: false,
-            },
-          ],
-          metadata: {},
-        },
-      ],
+    const agencies: AgencySwarmAdapter.AgencyDescriptor[] = [
+      {
+        id: "demo",
+        name: "Demo Agency",
+        agents: [
+          {
+            id: "orchestrator-slug",
+            name: "Orchestrator",
+            model: "gpt-5.4-mini",
+            isEntryPoint: true,
+          },
+          {
+            id: "slides_agent",
+            name: "Slides Agent",
+            model: "claude-sonnet-4-5",
+            isEntryPoint: false,
+          },
+          {
+            id: "support_agent",
+            name: "Support Agent",
+            model: "gpt-5.4-mini",
+            isEntryPoint: false,
+          },
+        ],
+        metadata: {},
+      },
+    ]
+    const discover = spyOn(AgencySwarmAdapter, "discover").mockResolvedValue({
+      agencies,
       rawOpenAPI: {},
     })
     spyOn(AutocompleteModule, "Autocomplete").mockImplementation((props: any) => {
@@ -311,7 +315,12 @@ describe("prompt framework-mode footer", () => {
           <RouteProvider>
             <DialogProvider>
               <CommandPaletteProvider>
-                <Prompt sessionID="session_1" showPlaceholder={false} ref={(ref) => (promptRef = ref)} />
+                <Prompt
+                  sessionID="session_1"
+                  showPlaceholder={false}
+                  agencyDiscovery={() => agencies}
+                  ref={(ref) => (promptRef = ref)}
+                />
               </CommandPaletteProvider>
             </DialogProvider>
           </RouteProvider>
@@ -325,12 +334,15 @@ describe("prompt framework-mode footer", () => {
 
     const frame = rendered.captureCharFrame()
     expect(frame).toContain("Orchestrator")
-    expect(frame).toContain("Swarm Default")
+    expect(frame).toContain("gpt-5.4-mini")
+    expect(frame).not.toContain("gpt-5.4-mini +1")
+    expect(frame).not.toContain("Swarm Default")
     expect(frame).not.toContain("Swarm Default Agency Swarm")
     expect(frame).toContain("agents")
     expect(frame).not.toContain("orchestrator-slug")
     expect(frame).not.toContain("Agent Builder")
     expect(frame).not.toContain("recipients")
+    expect(discover).not.toHaveBeenCalled()
 
     eventHandlers["message.updated"]?.({
       properties: {
@@ -369,6 +381,8 @@ describe("prompt framework-mode footer", () => {
 
     const handoffFrame = rendered.captureCharFrame()
     expect(handoffFrame).toContain("Slides Agent")
+    expect(handoffFrame).toContain("claude-sonnet-4-5")
+    expect(handoffFrame).not.toContain("gpt-5.4-mini +1")
     expect(updateGlobalConfig).not.toHaveBeenCalled()
 
     promptRef!.set({ input: "continue", parts: [] })

--- a/packages/opencode/test/cli/tui/transcript.test.ts
+++ b/packages/opencode/test/cli/tui/transcript.test.ts
@@ -66,6 +66,65 @@ const providers: Provider[] = [
   },
 ]
 
+const agencyProviders: Provider[] = [
+  {
+    id: "agency-swarm",
+    name: "Agency Swarm",
+    source: "config",
+    env: [],
+    options: {},
+    models: {
+      default: {
+        id: "default",
+        providerID: "agency-swarm",
+        api: {
+          id: "default",
+          url: "https://example.com/agency-swarm/default",
+          npm: "@ai-sdk/openai",
+        },
+        name: "Swarm Default",
+        capabilities: {
+          temperature: false,
+          reasoning: false,
+          attachment: false,
+          toolcall: false,
+          input: {
+            text: true,
+            audio: false,
+            image: false,
+            video: false,
+            pdf: false,
+          },
+          output: {
+            text: true,
+            audio: false,
+            image: false,
+            video: false,
+            pdf: false,
+          },
+          interleaved: false,
+        },
+        cost: {
+          input: 0,
+          output: 0,
+          cache: {
+            read: 0,
+            write: 0,
+          },
+        },
+        limit: {
+          context: 128_000,
+          output: 8_192,
+        },
+        status: "active",
+        options: {},
+        headers: {},
+        release_date: "2026-01-01",
+      },
+    },
+  },
+]
+
 describe("transcript", () => {
   describe("formatAssistantHeader", () => {
     const baseMsg: AssistantMessage = {
@@ -91,6 +150,78 @@ describe("transcript", () => {
     test("uses model display name when available", () => {
       const result = formatAssistantHeader(baseMsg, true, providers)
       expect(result).toBe("## Assistant (Agent Builder · Claude Sonnet 4 · 5.4s)\n\n")
+    })
+
+    test("uses assistant agent model label for agency-swarm default", () => {
+      const msg = {
+        ...baseMsg,
+        agent: "reviewer",
+        providerID: "agency-swarm",
+        modelID: "default",
+      }
+      const result = formatAssistantHeader(msg, true, {
+        providers: agencyProviders,
+        agencyID: "demo",
+        agencies: [
+          {
+            id: "demo",
+            name: "Demo Agency",
+            agents: [
+              {
+                id: "orchestrator",
+                name: "Orchestrator",
+                model: "gpt-5.4-mini",
+                isEntryPoint: true,
+              },
+              {
+                id: "reviewer",
+                name: "Reviewer",
+                model: "claude-sonnet-4-5",
+                isEntryPoint: false,
+              },
+            ],
+            metadata: {},
+          },
+        ],
+      })
+
+      expect(result).toBe("## Assistant (Reviewer · claude-sonnet-4-5 · 5.4s)\n\n")
+      expect(result).not.toContain("Swarm Default")
+    })
+
+    test("falls back to agency aggregate when assistant agent cannot be resolved", () => {
+      const msg = {
+        ...baseMsg,
+        providerID: "agency-swarm",
+        modelID: "default",
+      }
+      const result = formatAssistantHeader(msg, true, {
+        providers: agencyProviders,
+        agencyID: "demo",
+        agencies: [
+          {
+            id: "demo",
+            name: "Demo Agency",
+            agents: [
+              {
+                id: "orchestrator",
+                name: "Orchestrator",
+                model: "gpt-5.4-mini",
+                isEntryPoint: true,
+              },
+              {
+                id: "reviewer",
+                name: "Reviewer",
+                model: "claude-sonnet-4-5",
+                isEntryPoint: false,
+              },
+            ],
+            metadata: {},
+          },
+        ],
+      })
+
+      expect(result).toBe("## Assistant (Agent Builder · gpt-5.4-mini +1 · 5.4s)\n\n")
     })
 
     test("excludes metadata when disabled", () => {


### PR DESCRIPTION
## Summary

- Shows the actual Agent Swarm model in the TUI when `agency-swarm/default` is backed by agency metadata.
- Uses the selected or handoff agent model for prompt footers, completed run rows, and transcript headers.
- Keeps the swarm-level fallback as an agency aggregate, such as `gpt-5.4-mini +1`.

## Issue for this PR

N/A

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Verification

- Focused model-label, prompt, transcript, and adapter tests passed.
- Agent Swarm terminal TUI E2E passed.
- Metadata-outage recipient E2E passed.
- Typecheck passed.
- Diff check passed.

## Screenshots / Recordings

Terminal model-label states were captured locally during Agent Swarm TUI E2E.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested this change locally.
- [x] I have updated related coverage.

