### PR TITLE
feat(opencode): improve Agent Swarm startup recovery

### DIFF
--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -49,7 +49,7 @@ For each failure scenario, capture the visible user result and cite the matching
 #### Detected local project, venv, and uv
 
 - **Trigger:** Launch from a directory containing `agency.py` with `def create_agency` and an `agency_swarm` import.
-- **Happy-path proof:** Onboarding offers `Use detected Agency Swarm project` first.
+- **Happy-path proof:** Onboarding shows `Checking Agent Swarm project files...`, then offers `Use detected Agent Swarm project` first.
 - **Happy-path proof:** A healthy `.venv` is reused.
 - **Happy-path proof:** A broken `.venv` is rebuilt when Python 3.12+ is available.
 - **Happy-path proof:** Launcher-managed uv is installed or repaired inside `.venv`.
@@ -59,6 +59,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** Local `.venv` uv is used for launcher-managed fallback installs into `.venv`.
 - **Failure scenarios to test:** Missing Python 3.12+ produces a visible launcher failure.
 - **Failure scenarios to test:** Failed imports produce a visible launcher failure.
+- **Failure scenarios to test:** An unreadable existing `agency.py` shows `Could not read agency.py. Make sure the project files are downloaded and readable, then try again.` and offers only `Try again`, `Connect to a running Agent Swarm`, and `Cancel`.
 - **Failure scenarios to test:** uv install or repair failure produces a visible launcher failure.
 - **Failure scenarios to test:** Dependency setup failure produces a visible launcher failure.
 
@@ -77,7 +78,7 @@ For each failure scenario, capture the visible user result and cite the matching
 
 #### Starter project
 
-- **Trigger:** Launch without a detected project and choose `Create a new starter project`.
+- **Trigger:** Launch without a detected project and choose `Create a new Agent Swarm project`.
 - **Happy-path proof:** Empty, unsafe, or already-used project names are rejected.
 - **Happy-path proof:** The starter uses `agency-ai-solutions/agency-starter-template`.
 - **Happy-path proof:** GitHub template creation is used only when `gh` is present and authenticated.
@@ -99,10 +100,10 @@ For each failure scenario, capture the visible user result and cite the matching
 
 ### Connect, Bridge, And Server Failures
 
-#### Onboarding connect to existing agency
+#### Onboarding connect to running Agent Swarm
 
-- **Trigger:** Launch without a detected project and choose `Connect to an existing agency`.
-- **Happy-path proof:** The launcher prompts for Agency Swarm base URL and optional bearer token.
+- **Trigger:** Launch without a detected project and choose `Connect to a running Agent Swarm`.
+- **Happy-path proof:** The launcher prompts for Agent Swarm server URL and optional access token.
 - **Happy-path proof:** The launcher normalizes and validates the URL.
 - **Happy-path proof:** The launcher discovers agencies.
 - **Happy-path proof:** The launcher auto-picks one agency or asks for an agency id when several exist.

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -4,7 +4,7 @@
 
 ## Automated
 
-- `USER_FLOWS.md` Detected Local Project: launcher mode shows the detected-project choice before `.venv` work begins.
+- `USER_FLOWS.md` Detected Local Project: launcher mode shows startup project-file checking, the detected-project choice before `.venv` work begins, unreadable `agency.py` recovery choices, and Agent Swarm connect copy.
 - `USER_FLOWS.md` Startup `/auth` and In-TUI `/connect`: `/auth` and `/connect` stay separate in the real terminal UI.
 - `USER_FLOWS.md` Run Mode: native `/editor`, `/variants`, `/init`, and `/review` slash commands stay hidden.
 - `USER_FLOWS.md` Run Mode: `/agents` uses Swarm and agent wording, live agency labels, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
@@ -27,4 +27,4 @@ Manual QA command from a clean detected Agency project with no `.venv`:
 AGENTSWARM_LAUNCHER=1 bun --cwd packages/opencode --conditions=browser ./src/index.ts /absolute/path/to/project
 ```
 
-Expected result: choose `Use detected Agency Swarm project`, approve `.venv` creation, verify the local FastAPI bridge starts, and verify the TUI opens in Run mode against the detected project.
+Expected result: choose `Use detected Agent Swarm project`, approve `.venv` creation, verify the local FastAPI bridge starts, and verify the TUI opens in Run mode against the detected project.

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import {
@@ -63,9 +63,60 @@ describe("Agent Swarm terminal TUI e2e", () => {
       args: [project],
     })
 
-    await currentTui.waitForText("Use detected Agency Swarm project", 10_000)
+    await currentTui.waitForText("Checking Agent Swarm project files...", 10_000)
+    await currentTui.waitForText("Use detected Agent Swarm project", 10_000)
     expect(currentTui.history()).toContain(project)
     expect(currentTui.history()).not.toContain("Creating virtual environment")
+  })
+
+  test("launcher recovers when agency.py cannot be read", async () => {
+    const project = await mkdtemp(path.join(os.tmpdir(), "agentswarm-unreadable-project-"))
+    tempDirs.push(project)
+    await mkdir(path.join(project, "agency.py"))
+
+    currentTui = await startTui({
+      cwd: packageRoot,
+      env: {
+        AGENTSWARM_LAUNCHER: "1",
+        OPENCODE_CONFIG_CONTENT: undefined,
+      },
+      args: [project],
+    })
+
+    await currentTui.waitForText("Could not read agency.py", 10_000)
+    const screen = await currentTui.waitForText("Try again", tuiInteractionTimeoutMs)
+    const normalized = screen.replace(/\s+/g, " ").replace(/\s+\./g, ".")
+
+    expect(normalized).toContain(
+      "Could not read agency.py. Make sure the project files are downloaded and readable, then try again.",
+    )
+    expect(screen).toContain("Try again")
+    expect(screen).toContain("Connect to a running Agent Swarm")
+    expect(screen).toContain("Cancel")
+    expect(screen).not.toContain("Create a new Agent Swarm project")
+  })
+
+  test("launcher uses Agent Swarm connect copy without stale hints", async () => {
+    const project = await mkdtemp(path.join(os.tmpdir(), "agentswarm-connect-launch-"))
+    tempDirs.push(project)
+
+    currentTui = await startTui({
+      cwd: packageRoot,
+      env: {
+        AGENTSWARM_LAUNCHER: "1",
+        OPENCODE_CONFIG_CONTENT: undefined,
+      },
+      args: [project],
+    })
+
+    await currentTui.waitForText("How do you want to start?", 10_000)
+    currentTui.write("\x1b[B\r")
+    const screen = await currentTui.waitForText("Agent Swarm server URL", tuiInteractionTimeoutMs)
+
+    expect(screen).toContain("Connect to a running Agent Swarm")
+    expect(screen).toContain("Connect Agent Swarm to a running Agent Swarm.")
+    expect(screen).not.toContain("recommended for a fresh setup")
+    expect(screen).not.toContain("local or remote Agency Swarm server")
   })
 
   test("run-mode slash commands keep /auth and /connect separate and hide native commands", async () => {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -3,7 +3,7 @@ import net from "node:net"
 import os from "node:os"
 import path from "node:path"
 import { createWriteStream, existsSync, statSync } from "node:fs"
-import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises"
 import { AgencySwarmAdapter } from "./adapter"
 import { AgencySwarmRunSession } from "./run-session"
 import { SERVER_LAUNCHER_SCRIPT } from "./server-launcher"
@@ -113,6 +113,14 @@ interface VenvCanaryResult {
   timedOut: boolean
 }
 
+class ProjectEntryReadError extends Error {
+  constructor(readonly file: string) {
+    super(
+      `Could not read ${path.basename(file)}. Make sure the project files are downloaded and readable, then try again.`,
+    )
+  }
+}
+
 interface DependencyInstallResult extends CommandResult {
   hadManifests: boolean
 }
@@ -137,6 +145,7 @@ interface ServerStderrCollector {
 }
 
 const MIN_AGENCY_SWARM_VERSION = "1.10.1"
+const PROJECT_ENTRY_READ_TIMEOUT_MS = 1_000
 function buildVenvCanaryScript(minimumAgencySwarmVersion?: string) {
   const imports = ["import agency_swarm", "from agency_swarm.integrations.fastapi import run_fastapi"]
   if (!minimumAgencySwarmVersion) return imports.join("\n")
@@ -502,7 +511,7 @@ export async function detectAgencyProject(
   for (const entryFile of profile.agencyEntryFiles) {
     const agencyFile = path.join(dir, entryFile)
     if (!(await Filesystem.exists(agencyFile))) continue
-    const source = await Filesystem.readText(agencyFile).catch(() => "")
+    const source = await readProjectEntryFile(agencyFile)
     if (!source.includes("def create_agency")) continue
     if (!source.includes("agency_swarm")) continue
     return {
@@ -510,6 +519,21 @@ export async function detectAgencyProject(
       agencyFile,
       moduleName: agencyEntryModuleName(entryFile),
     } satisfies AgencyProject
+  }
+}
+
+async function readProjectEntryFile(file: string) {
+  const stat = await Filesystem.statAsync(file).catch(() => undefined)
+  if (!stat?.isFile()) throw new ProjectEntryReadError(file)
+
+  const abort = new AbortController()
+  const timeout = nativeSetTimeout(() => abort.abort(), PROJECT_ENTRY_READ_TIMEOUT_MS)
+  try {
+    return await readFile(file, { encoding: "utf8", signal: abort.signal })
+  } catch {
+    throw new ProjectEntryReadError(file)
+  } finally {
+    clearTimeout(timeout)
   }
 }
 
@@ -536,8 +560,7 @@ export function formatProjectLabel(
   project: AgencyProject,
   profile: Pick<ProductProfile, "custom" | "name"> = AgencyProduct,
 ) {
-  const label = profile.custom ? profile.name : "Agency Swarm"
-  return `Use detected ${label} project (${project.directory})`
+  return `Use detected ${profile.name} project (${project.directory})`
 }
 
 export function validateStarterName(base: string, value?: string) {
@@ -562,6 +585,7 @@ export async function prepareNpxLaunch(
   profile: ProductProfile = AgencyProduct,
 ): Promise<PreparedNpxLaunch | undefined> {
   prompts.intro(profile.name)
+  prompts.log.info(`Checking ${profile.name} project files...`)
   const stateRoot = normalizeProductStateRootEnv(profile)
   const projectDirectory = stateRoot ? path.join(stateRoot, "project") : undefined
   const launchDirectory = projectDirectory ?? directory
@@ -588,7 +612,20 @@ export async function prepareNpxLaunch(
     return launch
   }
 
-  const project = await detectAgencyProject(launchDirectory, profile)
+  const project = await detectLaunchProject(launchDirectory, profile)
+  if (project === "connect") {
+    const launch = await prepareRemoteLaunch(launchDirectory, profile)
+    if (!launch) {
+      prompts.outro("Cancelled")
+      return
+    }
+    prompts.outro(`Opening ${profile.name}`)
+    return launch
+  }
+  if (project === "cancel") {
+    prompts.outro("Cancelled")
+    return
+  }
   const choice = await chooseLaunchChoice(project, profile)
   if (!choice) {
     prompts.outro("Cancelled")
@@ -597,7 +634,7 @@ export async function prepareNpxLaunch(
   if (projectDirectory) await mkdir(projectDirectory, { recursive: true })
 
   if (choice === "connect") {
-    const launch = await prepareRemoteLaunch(launchDirectory)
+    const launch = await prepareRemoteLaunch(launchDirectory, profile)
     if (!launch) {
       prompts.outro("Cancelled")
       return
@@ -629,6 +666,45 @@ export async function prepareNpxLaunch(
   return launch
 }
 
+async function detectLaunchProject(
+  directory: string,
+  profile: ProductProfile,
+): Promise<AgencyProject | undefined | "connect" | "cancel"> {
+  while (true) {
+    try {
+      return await detectAgencyProject(directory, profile)
+    } catch (error) {
+      if (!(error instanceof ProjectEntryReadError)) throw error
+      const choice = await chooseProjectReadRecovery(error)
+      if (choice === "retry") continue
+      return choice
+    }
+  }
+}
+
+async function chooseProjectReadRecovery(error: ProjectEntryReadError) {
+  prompts.log.warn(error.message)
+  const choice = await prompts.select<"retry" | "connect" | "cancel">({
+    message: "How do you want to continue?",
+    options: [
+      {
+        value: "retry",
+        label: "Try again",
+      },
+      {
+        value: "connect",
+        label: "Connect to a running Agent Swarm",
+      },
+      {
+        value: "cancel",
+        label: "Cancel",
+      },
+    ],
+  })
+  if (prompts.isCancel(choice)) return "cancel"
+  return choice
+}
+
 async function chooseLaunchChoice(
   project: AgencyProject | undefined,
   profile: Pick<ProductProfile, "custom" | "name" | "stateRoot"> = AgencyProduct,
@@ -654,14 +730,12 @@ async function chooseLaunchChoice(
         : [
             {
               value: "starter" as const,
-              label: "Create a new starter project",
-              hint: "recommended for a fresh setup",
+              label: `Create a new ${profile.name} project`,
             },
           ]),
       {
         value: "connect" as const,
-        label: "Connect to an existing agency",
-        hint: "local or remote Agency Swarm server",
+        label: "Connect to a running Agent Swarm",
       },
     ],
   })
@@ -669,12 +743,14 @@ async function chooseLaunchChoice(
   return result
 }
 
-async function prepareRemoteLaunch(directory: string): Promise<PreparedNpxLaunch | undefined> {
-  prompts.log.info("2. Configure the Agency Swarm server.")
-  prompts.log.info("   This path is for an agency that is already running somewhere else.")
+async function prepareRemoteLaunch(
+  directory: string,
+  profile: Pick<ProductProfile, "name"> = AgencyProduct,
+): Promise<PreparedNpxLaunch | undefined> {
+  prompts.log.info(`Connect ${profile.name} to a running Agent Swarm.`)
 
   const url = await prompts.text({
-    message: "Agency Swarm base URL",
+    message: "Agent Swarm server URL",
     placeholder: AgencySwarmAdapter.DEFAULT_BASE_URL,
     defaultValue: AgencySwarmAdapter.DEFAULT_BASE_URL,
     validate(value) {
@@ -690,7 +766,7 @@ async function prepareRemoteLaunch(directory: string): Promise<PreparedNpxLaunch
   if (prompts.isCancel(url)) return
 
   const tokenConfirm = await prompts.confirm({
-    message: "Does this server need a bearer token?",
+    message: "Does this server need an access token?",
     initialValue: false,
   })
   if (prompts.isCancel(tokenConfirm)) return
@@ -698,7 +774,7 @@ async function prepareRemoteLaunch(directory: string): Promise<PreparedNpxLaunch
   let token: string | undefined
   if (tokenConfirm) {
     const entered = await prompts.password({
-      message: "Bearer token",
+      message: "Access token",
       mask: "•",
     })
     if (prompts.isCancel(entered)) return

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -3346,6 +3346,47 @@ describe("agency-swarm npx onboarding", () => {
     expect(project).toBeUndefined()
   })
 
+  test("prepareNpxLaunch offers recovery when agency.py cannot be read", async () => {
+    await using dir = await tmpdir()
+    await mkdir(path.join(dir.path, "agency.py"))
+    const labels: string[][] = []
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const warn = spyOn(prompts.log, "warn").mockImplementation(() => undefined as never)
+
+    spyOn(prompts, "outro").mockImplementation(() => undefined as never)
+    spyOn(prompts, "select").mockImplementation((input) => {
+      labels.push(input.options.map((option) => String(option.label)))
+      return Promise.resolve("connect" as never)
+    })
+    spyOn(prompts, "text").mockResolvedValue("http://127.0.0.1:8123" as never)
+    spyOn(prompts, "confirm").mockResolvedValue(false as never)
+    const rawFetch = globalThis.fetch
+    spyOn(globalThis, "fetch").mockImplementation(
+      Object.assign(
+        async (input: URL | RequestInfo) => {
+          const url = String(input)
+          const body = url.endsWith("/openapi.json")
+            ? { paths: { "/local-agency/get_metadata": { get: {} } } }
+            : { name: "Local Agency" }
+          return Response.json(body)
+        },
+        {
+          preconnect: rawFetch.preconnect?.bind(rawFetch),
+        },
+      ) as typeof globalThis.fetch,
+    )
+
+    const launch = await prepareNpxLaunch(dir.path)
+
+    expect(info).toHaveBeenCalledWith("Checking Agent Swarm project files...")
+    expect(warn).toHaveBeenCalledWith(
+      "Could not read agency.py. Make sure the project files are downloaded and readable, then try again.",
+    )
+    expect(labels[0]).toEqual(["Try again", "Connect to a running Agent Swarm", "Cancel"])
+    expect(labels.flat()).not.toContain("Create a new Agent Swarm project")
+    expect(launch?.directory).toBe(dir.path)
+  })
+
   test("product state root is the launcher project and state directory", async () => {
     await using caller = await tmpdir()
     await using root = await tmpdir()
@@ -3987,7 +4028,7 @@ describe("agency-swarm npx onboarding", () => {
       moduleName: "agency",
     }
 
-    expect(formatProjectLabel(project)).toBe(`Use detected Agency Swarm project (${root})`)
+    expect(formatProjectLabel(project)).toBe(`Use detected Agent Swarm project (${root})`)
     expect(formatProjectLabel(project, downstreamProfile)).toBe(`Use detected Example Product project (${root})`)
   })
 


### PR DESCRIPTION
### Issue for this PR

N/A - feature-scoped PR.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Improves Agent Swarm startup when project detection finds an unreadable `agency.py`.

The launcher now shows project-file checking before detection, then gives a recovery prompt instead of offering starter creation inside a folder that already looks like an Agent Swarm project. The recovery choices are retry, connect to a running Agent Swarm, or cancel.

This also updates the detected-project and connect wording to use Agent Swarm consistently, and adds unit plus terminal TUI coverage for the startup recovery path.

### How did you verify your code works?

- `git diff --check`
- `bun test test/agency-swarm/npx.test.ts`
- `bun test --timeout 180000 --max-concurrency=1 ../../e2e/agent-swarm-tui/terminal-tui.test.ts`
- `bun typecheck`
- `MODELS_DEV_API_JSON="$PWD/test/tool/fixtures/models-api.json" bun run build --single --skip-install`
- Compiled-binary terminal QA for a readable project and an unreadable `agency.py` project.
- Push hook: `bun turbo typecheck`

### Screenshots / recordings

Terminal screenshot captured from the compiled binary for the unreadable `agency.py` recovery prompt. The screen shows project-file checking, the readable/downloaded-files recovery message, and the three safe choices: retry, connect, or cancel.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
