### PR TITLE
feat(opencode): quiet Agent Swarm setup output

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -980,7 +980,7 @@ export async function prepareProjectLaunch(
   const python = await ensureProjectPython(project.directory, profile)
   if (!python) return
 
-  prompts.log.info("Starting your agency project.")
+  prompts.log.info("Starting your Agent Swarm project.")
   const server = await startProjectServer(project.directory, python, project.moduleName, project.agencyFile)
   return {
     directory: project.directory,

--- a/packages/opencode/src/agency-swarm/server-launcher.ts
+++ b/packages/opencode/src/agency-swarm/server-launcher.ts
@@ -1,5 +1,4 @@
 export const SERVER_LAUNCHER_SCRIPT = `import importlib
-import inspect
 import os
 import sys
 
@@ -7,29 +6,7 @@ port = int(sys.argv[1])
 agency_id = sys.argv[2]
 module_name = sys.argv[3]
 sys.path.insert(0, os.getcwd())
-project_create_agency = importlib.import_module(module_name).create_agency
-
-def accepts_load_threads_callback(factory):
-    try:
-        parameters = inspect.signature(factory).parameters.values()
-    except (TypeError, ValueError):
-        return True
-
-    return any(
-        parameter.kind == inspect.Parameter.VAR_KEYWORD
-        or (
-            parameter.name == "load_threads_callback"
-            and parameter.kind != inspect.Parameter.POSITIONAL_ONLY
-        )
-        for parameter in parameters
-    )
-
-project_accepts_load_threads_callback = accepts_load_threads_callback(project_create_agency)
-
-def create_agency(load_threads_callback=None):
-    if project_accepts_load_threads_callback:
-        return project_create_agency(load_threads_callback=load_threads_callback)
-    return project_create_agency()
+create_agency = importlib.import_module(module_name).create_agency
 
 from agency_swarm.integrations.fastapi import run_fastapi
 

--- a/packages/opencode/src/agency-swarm/server-launcher.ts
+++ b/packages/opencode/src/agency-swarm/server-launcher.ts
@@ -1,4 +1,5 @@
 export const SERVER_LAUNCHER_SCRIPT = `import importlib
+import inspect
 import os
 import sys
 
@@ -6,7 +7,29 @@ port = int(sys.argv[1])
 agency_id = sys.argv[2]
 module_name = sys.argv[3]
 sys.path.insert(0, os.getcwd())
-create_agency = importlib.import_module(module_name).create_agency
+project_create_agency = importlib.import_module(module_name).create_agency
+
+def accepts_load_threads_callback(factory):
+    try:
+        parameters = inspect.signature(factory).parameters.values()
+    except (TypeError, ValueError):
+        return True
+
+    return any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        or (
+            parameter.name == "load_threads_callback"
+            and parameter.kind != inspect.Parameter.POSITIONAL_ONLY
+        )
+        for parameter in parameters
+    )
+
+project_accepts_load_threads_callback = accepts_load_threads_callback(project_create_agency)
+
+def create_agency(load_threads_callback=None):
+    if project_accepts_load_threads_callback:
+        return project_create_agency(load_threads_callback=load_threads_callback)
+    return project_create_agency()
 
 from agency_swarm.integrations.fastapi import run_fastapi
 

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -25,7 +25,6 @@ import {
 } from "../../src/agency-swarm/npx"
 import { AgencyProduct } from "../../src/agency-swarm/product"
 import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
-import { SERVER_LAUNCHER_SCRIPT } from "../../src/agency-swarm/server-launcher"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session/index"
 import { SessionID } from "../../src/session/schema"
@@ -2601,58 +2600,6 @@ describe("agency-swarm npx onboarding", () => {
     expect(outcome.message).not.toContain("agency.py:99")
   })
 
-  test.skipIf(!findCanaryTestPython())("server launcher supports no-arg create_agency factories", async () => {
-    await using dir = await tmpdir()
-    await writeServerLauncherFixture(
-      dir.path,
-      ["from agency_swarm import Agency", "", "def create_agency():", "    return Agency('no-arg')"].join("\n"),
-      [
-        "def run_fastapi(*, agencies, host, port, server_url, app_token_env):",
-        "    agency = agencies['local-agency'](load_threads_callback=lambda: None)",
-        "    assert agency.name == 'no-arg'",
-        "    print('ok:no-arg')",
-      ].join("\n"),
-    )
-
-    const result = runServerLauncherScript(dir.path)
-
-    expect(readSpawnText(result.stderr)).toBe("")
-    expect(result.exitCode).toBe(0)
-    expect(readSpawnText(result.stdout)).toContain("ok:no-arg")
-  })
-
-  test.skipIf(!findCanaryTestPython())(
-    "server launcher forwards thread callbacks when create_agency supports them",
-    async () => {
-      await using dir = await tmpdir()
-      await writeServerLauncherFixture(
-        dir.path,
-        [
-          "from agency_swarm import Agency",
-          "",
-          "def create_agency(load_threads_callback=None):",
-          "    return Agency('threaded', load_threads_callback)",
-        ].join("\n"),
-        [
-          "def run_fastapi(*, agencies, host, port, server_url, app_token_env):",
-          "    def load_threads_callback():",
-          "        return 'threads'",
-          "    agency = agencies['local-agency'](load_threads_callback=load_threads_callback)",
-          "    assert agency.name == 'threaded'",
-          "    assert agency.callback is load_threads_callback",
-          "    assert agency.callback() == 'threads'",
-          "    print('ok:threaded')",
-        ].join("\n"),
-      )
-
-      const result = runServerLauncherScript(dir.path)
-
-      expect(readSpawnText(result.stderr)).toBe("")
-      expect(result.exitCode).toBe(0)
-      expect(readSpawnText(result.stdout)).toContain("ok:threaded")
-    },
-  )
-
   test("prepareProjectLaunch refreshes an existing venv when the import canary hangs", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -4974,39 +4921,6 @@ async function writeVenvPython(dir: string) {
   const venvPython = getTestVenvPython(dir)
   await mkdir(path.dirname(venvPython), { recursive: true })
   await Bun.write(venvPython, "")
-}
-
-async function writeServerLauncherFixture(dir: string, agency: string, fastapi: string) {
-  await Bun.write(path.join(dir, "launch_agency.py"), SERVER_LAUNCHER_SCRIPT)
-  await Bun.write(path.join(dir, "agency.py"), agency)
-  await mkdir(path.join(dir, "agency_swarm", "integrations"), { recursive: true })
-  await Bun.write(
-    path.join(dir, "agency_swarm", "__init__.py"),
-    [
-      "class Agency:",
-      "    def __init__(self, name=None, callback=None):",
-      "        self.name = name",
-      "        self.callback = callback",
-    ].join("\n"),
-  )
-  await Bun.write(path.join(dir, "agency_swarm", "integrations", "__init__.py"), "")
-  await Bun.write(path.join(dir, "agency_swarm", "integrations", "fastapi.py"), fastapi)
-}
-
-function runServerLauncherScript(dir: string) {
-  const python = findCanaryTestPython()
-  if (!python) throw new Error("Python is required to verify the generated Agency Swarm server launcher script")
-  return Bun.spawnSync({
-    cmd: [...python, path.join(dir, "launch_agency.py"), "8765", "local-agency", "agency"],
-    cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-}
-
-function readSpawnText(value: Uint8Array | string | undefined) {
-  if (typeof value === "string") return value
-  return new TextDecoder().decode(value)
 }
 
 function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1487,11 +1487,18 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
+      if (isPythonVenvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
           stderr: "",
+        } as never
+      }
+      if (isPythonPipInstallUvCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "Collecting uv...\n",
+          stderr: "Installing uv...\n",
         } as never
       }
       if (isUvPipInstallCommand(cmd)) {
@@ -1532,8 +1539,13 @@ describe("agency-swarm npx onboarding", () => {
 
     expect(info).toHaveBeenCalledWith("Installing project dependencies...")
     expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain("Full log")
-    expect(stderrWrite.mock.calls.map((call) => call[0]).join("")).not.toContain("Resolving packages")
+    const mirrored = stderrWrite.mock.calls.map((call) => call[0]).join("")
+    expect(mirrored).not.toContain("Collecting uv")
+    expect(mirrored).not.toContain("Installing uv")
+    expect(mirrored).not.toContain("Resolving packages")
     const logContent = await Bun.file(launcherLogFilePath(dir.path, "launcher-rebuild", iso)).text()
+    expect(logContent).toContain("Collecting uv...")
+    expect(logContent).toContain("Installing uv...")
     expect(logContent).toContain("Resolving packages...")
     expect(logContent).toContain("Downloading wheels...")
 
@@ -2511,7 +2523,7 @@ describe("agency-swarm npx onboarding", () => {
     )
     expect(outcome.message).not.toContain("Agency Swarm server exited with code 1")
     expect(success).toHaveBeenCalledWith("Agency Swarm packages ready")
-    expect(info).toHaveBeenCalledWith("Starting your agency project.")
+    expect(info).toHaveBeenCalledWith("Starting your Agent Swarm project.")
   })
 
   test("prepareProjectLaunch points startup import failures at the active entry file", async () => {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../../src/agency-swarm/npx"
 import { AgencyProduct } from "../../src/agency-swarm/product"
 import { AgencySwarmRunSession } from "../../src/agency-swarm/run-session"
+import { SERVER_LAUNCHER_SCRIPT } from "../../src/agency-swarm/server-launcher"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session/index"
 import { SessionID } from "../../src/session/schema"
@@ -2600,6 +2601,58 @@ describe("agency-swarm npx onboarding", () => {
     expect(outcome.message).not.toContain("agency.py:99")
   })
 
+  test.skipIf(!findCanaryTestPython())("server launcher supports no-arg create_agency factories", async () => {
+    await using dir = await tmpdir()
+    await writeServerLauncherFixture(
+      dir.path,
+      ["from agency_swarm import Agency", "", "def create_agency():", "    return Agency('no-arg')"].join("\n"),
+      [
+        "def run_fastapi(*, agencies, host, port, server_url, app_token_env):",
+        "    agency = agencies['local-agency'](load_threads_callback=lambda: None)",
+        "    assert agency.name == 'no-arg'",
+        "    print('ok:no-arg')",
+      ].join("\n"),
+    )
+
+    const result = runServerLauncherScript(dir.path)
+
+    expect(readSpawnText(result.stderr)).toBe("")
+    expect(result.exitCode).toBe(0)
+    expect(readSpawnText(result.stdout)).toContain("ok:no-arg")
+  })
+
+  test.skipIf(!findCanaryTestPython())(
+    "server launcher forwards thread callbacks when create_agency supports them",
+    async () => {
+      await using dir = await tmpdir()
+      await writeServerLauncherFixture(
+        dir.path,
+        [
+          "from agency_swarm import Agency",
+          "",
+          "def create_agency(load_threads_callback=None):",
+          "    return Agency('threaded', load_threads_callback)",
+        ].join("\n"),
+        [
+          "def run_fastapi(*, agencies, host, port, server_url, app_token_env):",
+          "    def load_threads_callback():",
+          "        return 'threads'",
+          "    agency = agencies['local-agency'](load_threads_callback=load_threads_callback)",
+          "    assert agency.name == 'threaded'",
+          "    assert agency.callback is load_threads_callback",
+          "    assert agency.callback() == 'threads'",
+          "    print('ok:threaded')",
+        ].join("\n"),
+      )
+
+      const result = runServerLauncherScript(dir.path)
+
+      expect(readSpawnText(result.stderr)).toBe("")
+      expect(result.exitCode).toBe(0)
+      expect(readSpawnText(result.stdout)).toContain("ok:threaded")
+    },
+  )
+
   test("prepareProjectLaunch refreshes an existing venv when the import canary hangs", async () => {
     await using dir = await tmpdir()
     await writeAgency(dir.path)
@@ -4921,6 +4974,39 @@ async function writeVenvPython(dir: string) {
   const venvPython = getTestVenvPython(dir)
   await mkdir(path.dirname(venvPython), { recursive: true })
   await Bun.write(venvPython, "")
+}
+
+async function writeServerLauncherFixture(dir: string, agency: string, fastapi: string) {
+  await Bun.write(path.join(dir, "launch_agency.py"), SERVER_LAUNCHER_SCRIPT)
+  await Bun.write(path.join(dir, "agency.py"), agency)
+  await mkdir(path.join(dir, "agency_swarm", "integrations"), { recursive: true })
+  await Bun.write(
+    path.join(dir, "agency_swarm", "__init__.py"),
+    [
+      "class Agency:",
+      "    def __init__(self, name=None, callback=None):",
+      "        self.name = name",
+      "        self.callback = callback",
+    ].join("\n"),
+  )
+  await Bun.write(path.join(dir, "agency_swarm", "integrations", "__init__.py"), "")
+  await Bun.write(path.join(dir, "agency_swarm", "integrations", "fastapi.py"), fastapi)
+}
+
+function runServerLauncherScript(dir: string) {
+  const python = findCanaryTestPython()
+  if (!python) throw new Error("Python is required to verify the generated Agency Swarm server launcher script")
+  return Bun.spawnSync({
+    cmd: [...python, path.join(dir, "launch_agency.py"), "8765", "local-agency", "agency"],
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+}
+
+function readSpawnText(value: Uint8Array | string | undefined) {
+  if (typeof value === "string") return value
+  return new TextDecoder().decode(value)
 }
 
 function mockPrepareProjectLaunchCanaryFailure(canaryStderr: string) {


### PR DESCRIPTION
### Issue for this PR

N/A - feature-scoped PR.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps successful Agent Swarm setup quieter.

The launcher already logged dependency setup details to the setup log. This patch adds coverage for the local `uv` bootstrap path so successful pip output stays out of the terminal, while failure paths still keep their existing concise summaries and log access.

It also changes the final startup line from `Starting your agency project.` to `Starting your Agent Swarm project.`.

### How did you verify your code works?

- `git diff --check`
- `bun test test/agency-swarm/npx.test.ts`
- `bun typecheck`
- `bun run build --single --skip-embed-web-ui`
- Built binary smoke test with `--version`
- Fresh `.venv` rebuild QA confirmed compact setup output and no raw successful pip/uv output in the terminal.
- Push hook: `bun turbo typecheck`

### Screenshots / recordings

N/A - terminal output behavior covered by automated tests and local binary QA.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

