### PR TITLE
feat(opencode): simplify Agent Swarm startup output

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -958,7 +958,7 @@ async function createProductStateRootProject(input: {
 
 // Run a long, silent step under a clack spinner so the terminal animates instead of looking hung.
 // Compact product-state lines (`prompts.log.info`) stay as phase headers; the spinner covers the wait.
-async function withSpinner<T>(start: string, done: string, task: () => Promise<T>): Promise<T> {
+async function withSpinner<T>(start: string, done: string, fail: string, task: () => Promise<T>): Promise<T> {
   const spin = prompts.spinner()
   spin.start(start)
   try {
@@ -966,7 +966,7 @@ async function withSpinner<T>(start: string, done: string, task: () => Promise<T
     spin.stop(done)
     return result
   } catch (error) {
-    spin.stop(start, 1)
+    spin.stop(fail, 1)
     throw error
   }
 }
@@ -980,8 +980,11 @@ export async function prepareProjectLaunch(
   const python = await ensureProjectPython(project.directory, profile)
   if (!python) return
 
-  const server = await withSpinner(`Starting ${profile.name}`, `${profile.name} ready`, () =>
-    startProjectServer(project.directory, python, project.moduleName, project.agencyFile),
+  const server = await withSpinner(
+    `Starting ${profile.name}`,
+    `${profile.name} ready`,
+    `${profile.name} start failed`,
+    () => startProjectServer(project.directory, python, project.moduleName, project.agencyFile),
   )
   return {
     directory: project.directory,
@@ -1042,24 +1045,29 @@ async function ensureProjectPython(
         "launcher refresh",
         profile,
       )
-      let localUv: string | undefined
-      try {
-        localUv = await ensureLocalUv(directory, venvPython, {
-          logFile: refreshLogFile,
-          timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
-        })
-      } catch {
+      const refresh = await withSpinner(
+        `Refreshing ${profile.name}`,
+        `${profile.name} refresh checked`,
+        `${profile.name} refresh failed`,
+        async () => {
+          const localUv = await ensureLocalUv(directory, venvPython, {
+            logFile: refreshLogFile,
+            timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+          }).catch(() => undefined)
+          if (!localUv) return { installerFailed: false, skippedUv: true }
+          const result = await refreshProjectDependencies(directory, venvPython, localUv, {
+            logFile: refreshLogFile,
+            timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+          })
+          return { ...result, skippedUv: false }
+        },
+      )
+      if (refresh.skippedUv) {
         prompts.log.warn(
           "Local uv could not be installed, so dependency refresh was skipped. The current venv package set will be used as-is.",
         )
       }
-      if (localUv) {
-        const refresh = await refreshProjectDependencies(directory, venvPython, localUv, {
-          logFile: refreshLogFile,
-          timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
-        })
-        if (refresh.installerFailed) corruptedVenv = true
-      }
+      if (refresh.installerFailed) corruptedVenv = true
       if (!corruptedVenv) {
         let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
         try {
@@ -1139,37 +1147,42 @@ async function ensureProjectPython(
     "launcher rebuild",
     profile,
   )
-  return withSpinner(`Setting up ${profile.name}`, `${profile.name} setup ready`, async () => {
-    const localUv = await ensureLocalUv(directory, venvPython, {
-      forceInstall: true,
-      logFile: installLogFile,
-      timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
-    })
-    const install = await installProjectDependencies(directory, venvPython, localUv, {
-      logFile: installLogFile,
-      timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
-    })
-    if (install.timedOut) {
-      throw new Error(formatCommandTimeout(install, "Dependency install", REBUILD_INSTALL_TIMEOUT_MS))
-    }
-    if (install.code !== 0) {
-      throw new Error(formatCommandFailure(install, "Dependency install failed"))
-    }
-    const canary = await venvCanaryPasses([venvPython], {
-      cwd: directory,
-      includeStderr: true,
-      minimumAgencySwarmVersion: install.hadManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
-    })
-    if (canary.timedOut) {
-      throw new Error(await formatCanaryTimeoutFailure(directory, canary.stderr))
-    }
-    if (!canary.healthy) {
-      throw new Error(
-        await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr, install.logFile),
-      )
-    }
-    return [venvPython]
-  })
+  return withSpinner(
+    `Setting up ${profile.name}`,
+    `${profile.name} setup ready`,
+    `${profile.name} setup failed`,
+    async () => {
+      const localUv = await ensureLocalUv(directory, venvPython, {
+        forceInstall: true,
+        logFile: installLogFile,
+        timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+      })
+      const install = await installProjectDependencies(directory, venvPython, localUv, {
+        logFile: installLogFile,
+        timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+      })
+      if (install.timedOut) {
+        throw new Error(formatCommandTimeout(install, "Dependency install", REBUILD_INSTALL_TIMEOUT_MS))
+      }
+      if (install.code !== 0) {
+        throw new Error(formatCommandFailure(install, "Dependency install failed"))
+      }
+      const canary = await venvCanaryPasses([venvPython], {
+        cwd: directory,
+        includeStderr: true,
+        minimumAgencySwarmVersion: install.hadManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+      })
+      if (canary.timedOut) {
+        throw new Error(await formatCanaryTimeoutFailure(directory, canary.stderr))
+      }
+      if (!canary.healthy) {
+        throw new Error(
+          await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr, install.logFile),
+        )
+      }
+      return [venvPython]
+    },
+  )
 }
 
 async function installProjectDependencies(

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -120,6 +120,20 @@ class ProjectEntryReadError extends Error {
   }
 }
 
+class StartupCancelledError extends Error {
+  constructor() {
+    super("Startup cancelled.")
+  }
+}
+
+function isStartupCancelledError(error: unknown) {
+  return error instanceof StartupCancelledError
+}
+
+function throwIfStartupCancelled(signal?: AbortSignal) {
+  if (signal?.aborted) throw new StartupCancelledError()
+}
+
 interface DependencyInstallResult extends CommandResult {
   hadManifests: boolean
 }
@@ -128,6 +142,7 @@ interface RunCommandOptions {
   cwd?: string
   env?: NodeJS.ProcessEnv
   logFile?: string
+  signal?: AbortSignal
   streamOutputToStderr?: boolean
   suppressPythonTracebackStderr?: boolean
   timeoutMs?: number
@@ -958,14 +973,38 @@ async function createProductStateRootProject(input: {
 
 // Run a long, silent step under a clack spinner so the terminal animates instead of looking hung.
 // Compact product-state lines (`prompts.log.info`) stay as phase headers; the spinner covers the wait.
-async function withSpinner<T>(start: string, done: string, fail: string, task: () => Promise<T>): Promise<T> {
-  const spin = prompts.spinner()
+async function withSpinner<T>(
+  start: string,
+  done: string,
+  fail: string,
+  task: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const abort = new AbortController()
+  let settled = false
+  let cancel!: () => void
+  const cancelled = new Promise<never>((_, reject) => {
+    cancel = () => {
+      if (settled) return
+      abort.abort()
+      reject(new StartupCancelledError())
+    }
+  })
+  const spin = prompts.spinner({ onCancel: cancel })
   spin.start(start)
   try {
-    const result = await task()
+    throwIfStartupCancelled(abort.signal)
+    const result = await Promise.race([task(abort.signal), cancelled])
+    throwIfStartupCancelled(abort.signal)
+    if (spin.isCancelled) throw new StartupCancelledError()
+    settled = true
     spin.stop(done)
     return result
   } catch (error) {
+    settled = true
+    if (isStartupCancelledError(error) || abort.signal.aborted || spin.isCancelled) {
+      abort.abort()
+      throw isStartupCancelledError(error) ? error : new StartupCancelledError()
+    }
     spin.stop(fail, 1)
     throw error
   }
@@ -975,25 +1014,30 @@ export async function prepareProjectLaunch(
   project: AgencyProject,
   profile: LaunchProfile = AgencyProduct,
 ): Promise<PreparedNpxLaunch | undefined> {
-  prompts.log.info(`Preparing ${profile.name}...`)
+  try {
+    prompts.log.info(`Preparing ${profile.name}...`)
 
-  const python = await ensureProjectPython(project.directory, profile)
-  if (!python) return
+    const python = await ensureProjectPython(project.directory, profile)
+    if (!python) return
 
-  const server = await withSpinner(
-    `Starting ${profile.name}`,
-    `${profile.name} ready`,
-    `${profile.name} start failed`,
-    () => startProjectServer(project.directory, python, project.moduleName, project.agencyFile),
-  )
-  return {
-    directory: project.directory,
-    runProjectDirectory: project.directory,
-    configContent: buildAgencyConfig({
-      baseURL: server.baseURL,
-      agency: LOCAL_AGENCY_ID,
-    }),
-    cleanup: server.cleanup,
+    const server = await withSpinner(
+      `Starting ${profile.name}`,
+      `${profile.name} ready`,
+      `${profile.name} start failed`,
+      (signal) => startProjectServer(project.directory, python, project.moduleName, project.agencyFile, signal),
+    )
+    return {
+      directory: project.directory,
+      runProjectDirectory: project.directory,
+      configContent: buildAgencyConfig({
+        baseURL: server.baseURL,
+        agency: LOCAL_AGENCY_ID,
+      }),
+      cleanup: server.cleanup,
+    }
+  } catch (error) {
+    if (isStartupCancelledError(error)) return
+    throw error
   }
 }
 
@@ -1030,10 +1074,11 @@ async function ensureProjectPython(
         `Checking ${profile.name} environment`,
         `${profile.name} environment checked`,
         `${profile.name} environment check failed`,
-        () =>
+        (signal) =>
           checkVenvCanary([venvPython], {
             includeStderr: true,
             minimumAgencySwarmVersion: hasManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+            signal,
             timeoutMs: EXISTING_VENV_CANARY_TIMEOUT_MS,
           }),
       )
@@ -1050,16 +1095,21 @@ async function ensureProjectPython(
         `Refreshing ${profile.name}`,
         `${profile.name} refresh checked`,
         `${profile.name} refresh failed`,
-        async () => {
+        async (signal) => {
           const localUv = await ensureLocalUv(directory, venvPython, {
             logFile: refreshLogFile,
+            signal,
             timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
-          }).catch(() => undefined)
+          }).catch((error) => {
+            if (isStartupCancelledError(error)) throw error
+            return undefined
+          })
           if (!localUv) {
             return {
               canary: await checkVenvCanary([venvPython], {
                 includeStderr: true,
                 minimumAgencySwarmVersion: hasManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+                signal,
               }),
               installerFailed: false,
               skippedUv: true,
@@ -1067,6 +1117,7 @@ async function ensureProjectPython(
           }
           const result = await refreshProjectDependencies(directory, venvPython, localUv, {
             logFile: refreshLogFile,
+            signal,
             timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
           })
           return {
@@ -1076,6 +1127,7 @@ async function ensureProjectPython(
               : await checkVenvCanary([venvPython], {
                   includeStderr: true,
                   minimumAgencySwarmVersion: hasManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+                  signal,
                 }),
             skippedUv: false,
           }
@@ -1161,14 +1213,16 @@ async function ensureProjectPython(
     `Setting up ${profile.name}`,
     `${profile.name} setup ready`,
     `${profile.name} setup failed`,
-    async () => {
+    async (signal) => {
       const localUv = await ensureLocalUv(directory, venvPython, {
         forceInstall: true,
         logFile: installLogFile,
+        signal,
         timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
       })
       const install = await installProjectDependencies(directory, venvPython, localUv, {
         logFile: installLogFile,
+        signal,
         timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
       })
       if (install.timedOut) {
@@ -1181,6 +1235,7 @@ async function ensureProjectPython(
         cwd: directory,
         includeStderr: true,
         minimumAgencySwarmVersion: install.hadManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+        signal,
       })
       if (canary.timedOut) {
         throw new Error(await formatCanaryTimeoutFailure(directory, canary.stderr))
@@ -1197,16 +1252,24 @@ async function ensureProjectPython(
 
 async function checkVenvCanary(
   python: string[],
-  options: { cwd?: string; includeStderr: true; minimumAgencySwarmVersion?: string; timeoutMs?: number },
+  options: {
+    cwd?: string
+    includeStderr: true
+    minimumAgencySwarmVersion?: string
+    signal?: AbortSignal
+    timeoutMs?: number
+  },
 ): Promise<VenvCanaryResult> {
   try {
     return await venvCanaryPasses(python, {
       cwd: options.cwd,
       includeStderr: true,
       minimumAgencySwarmVersion: options.minimumAgencySwarmVersion,
+      signal: options.signal,
       timeoutMs: options.timeoutMs,
     })
-  } catch {
+  } catch (error) {
+    if (isStartupCancelledError(error)) throw error
     return { healthy: false, stderr: "", timedOut: false }
   }
 }
@@ -1217,6 +1280,7 @@ async function installProjectDependencies(
   localUv: string,
   options: {
     logFile?: string
+    signal?: AbortSignal
     timeoutMs: number
   },
 ): Promise<DependencyInstallResult> {
@@ -1227,6 +1291,7 @@ async function installProjectDependencies(
       {
         cwd: directory,
         logFile: options.logFile,
+        signal: options.signal,
         timeoutMs: options.timeoutMs,
       },
     )
@@ -1238,6 +1303,7 @@ async function installProjectDependencies(
     const result = await runCommand([localUv, "pip", "install", "--python", venvPython, "--upgrade", "-e", "."], {
       cwd: directory,
       logFile: options.logFile,
+      signal: options.signal,
       timeoutMs: options.timeoutMs,
     })
     return { ...result, hadManifests: true }
@@ -1247,6 +1313,7 @@ async function installProjectDependencies(
     [localUv, "pip", "install", "--python", venvPython, FALLBACK_AGENCY_SWARM_REQUIREMENT],
     {
       logFile: options.logFile,
+      signal: options.signal,
       timeoutMs: options.timeoutMs,
     },
   )
@@ -1259,6 +1326,7 @@ async function refreshProjectDependencies(
   localUv: string,
   options: {
     logFile?: string
+    signal?: AbortSignal
     timeoutMs: number
   },
 ): Promise<{ installerFailed: boolean }> {
@@ -1333,15 +1401,27 @@ async function findProjectShadowingFiles(directory: string) {
 
 async function venvCanaryPasses(
   python: string[],
-  options?: { cwd?: string; minimumAgencySwarmVersion?: string; timeoutMs?: number },
+  options?: { cwd?: string; minimumAgencySwarmVersion?: string; signal?: AbortSignal; timeoutMs?: number },
 ): Promise<boolean>
 async function venvCanaryPasses(
   python: string[],
-  options: { cwd?: string; includeStderr: true; minimumAgencySwarmVersion?: string; timeoutMs?: number },
+  options: {
+    cwd?: string
+    includeStderr: true
+    minimumAgencySwarmVersion?: string
+    signal?: AbortSignal
+    timeoutMs?: number
+  },
 ): Promise<VenvCanaryResult>
 async function venvCanaryPasses(
   python: string[],
-  options?: { cwd?: string; includeStderr?: boolean; minimumAgencySwarmVersion?: string; timeoutMs?: number },
+  options?: {
+    cwd?: string
+    includeStderr?: boolean
+    minimumAgencySwarmVersion?: string
+    signal?: AbortSignal
+    timeoutMs?: number
+  },
 ) {
   // No cwd by default: the canary must not pick up project-local modules (e.g. `fastapi.py`
   // sitting next to `agency.py`) that shadow installed packages and falsely flag a healthy
@@ -1349,6 +1429,7 @@ async function venvCanaryPasses(
   // pass it explicitly.
   const result = await runCommand([...python, "-c", buildVenvCanaryScript(options?.minimumAgencySwarmVersion)], {
     cwd: options?.cwd,
+    signal: options?.signal,
     timeoutMs: options?.timeoutMs ?? VENV_CANARY_TIMEOUT_MS,
   })
   if (options?.includeStderr) {
@@ -1367,6 +1448,7 @@ async function ensureLatestAgencySwarm(
   localUv: string,
   options?: {
     logFile?: string
+    signal?: AbortSignal
     timeoutMs?: number
   },
 ): Promise<{ installerFailed: boolean }> {
@@ -1384,6 +1466,7 @@ async function ensureLatestAgencySwarm(
       {
         cwd: directory,
         logFile: options?.logFile,
+        signal: options?.signal,
         suppressPythonTracebackStderr: true,
         timeoutMs: options?.timeoutMs,
       },
@@ -1409,7 +1492,8 @@ async function ensureLatestAgencySwarm(
       )
       return { installerFailed: isUvLaunchFailure(`${result.stderr}\n${result.stdout}`) }
     }
-  } catch {
+  } catch (error) {
+    if (isStartupCancelledError(error)) throw error
     prompts.log.warn("Could not refresh launcher-managed agency-swarm. The current venv package will be used as-is.")
   }
   return { installerFailed: false }
@@ -1421,15 +1505,17 @@ async function ensureLocalUv(
   options: {
     forceInstall?: boolean
     logFile?: string
+    signal?: AbortSignal
     timeoutMs: number
   },
 ) {
   const localUv = getVenvUvPath(directory)
-  if (!options.forceInstall && (await localUvWorks(localUv))) return localUv
+  if (!options.forceInstall && (await localUvWorks(localUv, options.signal))) return localUv
 
   const result = await runCommand([venvPython, "-m", "pip", "install", "--upgrade", "uv"], {
     cwd: directory,
     logFile: options.logFile,
+    signal: options.signal,
     timeoutMs: options.timeoutMs,
   })
   if (result.timedOut) {
@@ -1441,18 +1527,21 @@ async function ensureLocalUv(
     throw new Error(formatCommandFailure(result, "Project Python environment setup failed while installing uv"))
   }
   try {
-    const verified = await runCommand([localUv, "--version"])
+    const verified = await runCommand([localUv, "--version"], { signal: options.signal })
     if (verified.code === 0) return localUv
-  } catch {}
+  } catch (error) {
+    if (isStartupCancelledError(error)) throw error
+  }
 
   throw new Error("Project Python environment setup installed uv, but the local `.venv` uv command is not runnable.")
 }
 
-async function localUvWorks(localUv: string) {
+async function localUvWorks(localUv: string, signal?: AbortSignal) {
   try {
-    const result = await runCommand([localUv, "--version"])
+    const result = await runCommand([localUv, "--version"], { signal })
     return result.code === 0
-  } catch {
+  } catch (error) {
+    if (isStartupCancelledError(error)) throw error
     return false
   }
 }
@@ -1522,8 +1611,16 @@ function formatInstallDuration(ms: number) {
   return `${ms}ms`
 }
 
-async function startProjectServer(directory: string, python: string[], moduleName: string, entryFile: string) {
+async function startProjectServer(
+  directory: string,
+  python: string[],
+  moduleName: string,
+  entryFile: string,
+  signal?: AbortSignal,
+) {
+  throwIfStartupCancelled(signal)
   const port = await getFreePort()
+  throwIfStartupCancelled(signal)
   const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "agentswarm-npx-"))
   const scriptPath = path.join(tempDirectory, "launch_agency.py")
   const remove = () =>
@@ -1541,6 +1638,7 @@ async function startProjectServer(directory: string, python: string[], moduleNam
 
   let child
   try {
+    throwIfStartupCancelled(signal)
     child = Bun.spawn({
       cmd: [...python, scriptPath, String(port), LOCAL_AGENCY_ID, moduleName],
       cwd: directory,
@@ -1560,19 +1658,27 @@ async function startProjectServer(directory: string, python: string[], moduleNam
     await Promise.race([child.exited, sleep(5000)])
     await remove()
   }
+  const abort = () => {
+    void cleanup()
+  }
+  signal?.addEventListener("abort", abort, { once: true })
 
   try {
     await waitForServer({
       baseURL: `http://127.0.0.1:${port}`,
       child,
       entryFile,
+      signal,
       stderr,
     })
   } catch (error) {
     await cleanup()
     throw error
+  } finally {
+    signal?.removeEventListener("abort", abort)
   }
 
+  throwIfStartupCancelled(signal)
   return {
     baseURL: `http://127.0.0.1:${port}`,
     cleanup,
@@ -1583,21 +1689,25 @@ async function waitForServer(input: {
   baseURL: string
   child: ReturnType<typeof Bun.spawn>
   entryFile: string
+  signal?: AbortSignal
   stderr: ServerStderrCollector
 }) {
   const deadline = Date.now() + SERVER_START_TIMEOUT_MS
   const metadataURL = `${input.baseURL}/${LOCAL_AGENCY_ID}/get_metadata`
   while (Date.now() < deadline) {
+    throwIfStartupCancelled(input.signal)
     const exited = await Promise.race([input.child.exited.then((code: number) => code), sleep(200).then(() => null)])
+    throwIfStartupCancelled(input.signal)
     if (typeof exited === "number") {
       const stderr = await input.stderr.read(SERVER_STDERR_COLLECT_TIMEOUT_MS)
       throw new Error(formatAgencyServerExitFailure(exited, stderr, input.entryFile))
     }
 
     try {
-      const response = await fetch(metadataURL)
+      const response = await fetch(metadataURL, { signal: input.signal })
       if (response.ok) return
     } catch {
+      throwIfStartupCancelled(input.signal)
       // server still starting
     }
   }
@@ -1822,6 +1932,7 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
     suppressPythonTracebacks: options?.suppressPythonTracebackStderr === true,
   })
   try {
+    throwIfStartupCancelled(options?.signal)
     const proc = Bun.spawn({
       cmd: resolveLauncherCommand(cmd),
       cwd: options?.cwd,
@@ -1831,8 +1942,31 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
     })
     const outputAbort = new AbortController()
     let timeout: ReturnType<typeof setTimeout> | undefined
+    let forceKill: ReturnType<typeof setTimeout> | undefined
+    let cancelRun: (() => void) | undefined
+    const cancelResult =
+      options?.signal === undefined
+        ? undefined
+        : new Promise<{ code: -1; timedOut: false; cancelled: true }>((resolve) => {
+            cancelRun = () => {
+              try {
+                proc.kill()
+              } catch {}
+              outputAbort.abort()
+              forceKill = globalThis.setTimeout(() => {
+                try {
+                  proc.kill("SIGKILL")
+                } catch {}
+              }, PROCESS_KILL_GRACE_MS)
+              resolve({ code: -1, timedOut: false, cancelled: true })
+            }
+          })
+    if (options?.signal?.aborted) cancelRun?.()
+    else if (cancelRun) options?.signal?.addEventListener("abort", cancelRun, { once: true })
     const exitPromise = proc.exited.finally(() => {
       if (timeout) globalThis.clearTimeout(timeout)
+      if (forceKill) globalThis.clearTimeout(forceKill)
+      if (options?.signal && cancelRun) options.signal.removeEventListener("abort", cancelRun)
     })
     const exitResult = exitPromise.then((code) => ({ code, timedOut: false as const }))
     const timeoutResult =
@@ -1845,19 +1979,26 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
                 try {
                   proc.kill()
                 } catch {}
-                const forceKill = globalThis.setTimeout(() => {
+                const timeoutKill = globalThis.setTimeout(() => {
                   try {
                     proc.kill("SIGKILL")
                   } catch {}
                 }, PROCESS_KILL_GRACE_MS)
                 await exitPromise.catch(() => undefined)
-                globalThis.clearTimeout(forceKill)
+                globalThis.clearTimeout(timeoutKill)
                 outputAbort.abort()
               })()
             }, options.timeoutMs)
           })
+    const resultPromise = cancelResult
+      ? timeoutResult
+        ? Promise.race([exitResult, timeoutResult, cancelResult])
+        : Promise.race([exitResult, cancelResult])
+      : timeoutResult
+        ? Promise.race([exitResult, timeoutResult])
+        : exitResult
     const [result, stdout, stderr] = await Promise.all([
-      timeoutResult ? Promise.race([exitResult, timeoutResult]) : exitResult,
+      resultPromise,
       readCommandOutput(
         proc.stdout,
         (chunk) => writeChunk(chunk, options?.streamOutputToStderr === true),
@@ -1865,10 +2006,12 @@ async function runCommand(cmd: string[], options?: RunCommandOptions): Promise<C
       ),
       readCommandOutput(proc.stderr, stderrWriter, outputAbort.signal),
     ])
+    if ("cancelled" in result) throw new StartupCancelledError()
     const logFile = await closeCommandLog(commandLog)
     return { code: result.code, stdout, stderr, timedOut: result.timedOut, logFile }
   } catch (error) {
     const logFile = await closeCommandLog(commandLog)
+    if (isStartupCancelledError(error)) throw error
     return {
       code: -1,
       stdout: "",
@@ -2024,6 +2167,7 @@ async function readCommandOutput(
     void reader.cancel().catch(() => undefined)
   }
   signal?.addEventListener("abort", abortRead, { once: true })
+  if (signal?.aborted) abortRead()
 
   try {
     while (true) {

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -15,7 +15,6 @@ import { AgencyProduct } from "./product"
 import {
   collectUnixPythonCandidates,
   findPythonExecutable,
-  formatPython,
   inspectPython,
   isCondaPython,
   type PythonInfo,
@@ -709,11 +708,6 @@ async function chooseLaunchChoice(
   project: AgencyProject | undefined,
   profile: Pick<ProductProfile, "custom" | "name" | "stateRoot"> = AgencyProduct,
 ) {
-  prompts.log.info("1. Choose how to start the terminal UI.")
-  prompts.log.info(
-    "   The launcher can use a detected project, create a starter project, or connect to an existing server.",
-  )
-
   const result = await prompts.select<LaunchChoice>({
     message: "How do you want to start?",
     options: [
@@ -834,8 +828,7 @@ async function createStarterProject(input: {
   baseDirectory: string
   profile: ProductProfile
 }): Promise<AgencyProject | undefined> {
-  prompts.log.info("2. Create the starter project.")
-  prompts.log.info(`   This gives the terminal UI a ready-to-run ${input.profile.name} project to launch.`)
+  prompts.log.info(`Creating ${input.profile.name} project...`)
 
   const starterProfile = input.profile.customStarter ? input.profile : AgencyProduct
 
@@ -845,7 +838,6 @@ async function createStarterProject(input: {
     if (await Filesystem.exists(targetDirectory)) {
       throw new Error(`Target directory already exists: ${targetDirectory}`)
     }
-    prompts.log.step(`Creating starter project in \`${name}/\``)
     const clone = await runCommand(["git", "clone", "--depth=1", starterTemplateUrl(input.profile), targetDirectory])
     if (clone.code !== 0) {
       throw new Error(clone.stderr.trim() || clone.stdout.trim() || "Starter template clone failed")
@@ -859,8 +851,8 @@ async function createStarterProject(input: {
   }
 
   const repoName = await prompts.text({
-    message: "Project or repository name",
-    placeholder: input.profile.starterProjectName,
+    message: "Project name",
+    initialValue: input.profile.starterProjectName,
     validate(value) {
       return validateStarterName(input.baseDirectory, value)
     },
@@ -871,17 +863,17 @@ async function createStarterProject(input: {
   let mode: StarterMode = "local"
   if (ghReady) {
     const selected = await prompts.select<StarterMode>({
-      message: "How should the starter be created?",
+      message: "Where should this project be created?",
       options: [
         {
           value: "github",
-          label: "Create a GitHub repository from the template",
+          label: "On GitHub",
           hint: "recommended",
         },
         {
           value: "local",
-          label: "Create a local folder from the template",
-          hint: "skip GitHub for now",
+          label: "On this computer",
+          hint: "skip GitHub",
         },
       ],
     })
@@ -895,7 +887,6 @@ async function createStarterProject(input: {
     throw new Error(`Target directory already exists: ${targetDirectory}`)
   }
 
-  prompts.log.step(mode === "github" ? "Creating repository from the starter template" : "Cloning the starter template")
   try {
     if (mode === "github") {
       const visibility = await prompts.select<"private" | "public">({
@@ -936,7 +927,6 @@ async function createStarterProject(input: {
       }).catch(() => undefined)
       await runCommand(["git", "init", "-b", "main"], { cwd: targetDirectory })
     }
-    prompts.log.step("Starter project ready")
   } catch (error) {
     prompts.log.error("Starter project setup failed")
     throw error
@@ -949,13 +939,11 @@ async function createProductStateRootProject(input: {
   directory: string
   profile: ProductProfile
 }): Promise<AgencyProject | undefined> {
-  prompts.log.info("2. Create the product state project.")
-  prompts.log.info(`   This keeps ${input.profile.name} launcher state in one user folder.`)
+  prompts.log.info(`Creating ${input.profile.name} project...`)
 
   const starterProfile = input.profile.customStarter ? input.profile : AgencyProduct
 
   await mkdir(path.dirname(input.directory), { recursive: true })
-  prompts.log.step(`Creating starter project in \`${input.directory}\``)
   const clone = await runCommand(["git", "clone", "--depth=1", starterTemplateUrl(input.profile), input.directory])
   if (clone.code !== 0) {
     throw new Error(clone.stderr.trim() || clone.stdout.trim() || "Starter template clone failed")
@@ -972,15 +960,11 @@ export async function prepareProjectLaunch(
   project: AgencyProject,
   profile: LaunchProfile = AgencyProduct,
 ): Promise<PreparedNpxLaunch | undefined> {
-  prompts.log.info(`Starting the ${profile.name} project.`)
-  prompts.log.info(
-    "The launcher will reuse a project `.venv`, start a local FastAPI server, and connect the terminal UI to it.",
-  )
+  prompts.log.info(`Preparing ${profile.name}...`)
 
   const python = await ensureProjectPython(project.directory, profile)
   if (!python) return
 
-  prompts.log.info("Starting your agency project.")
   const server = await startProjectServer(project.directory, python, project.moduleName, project.agencyFile)
   return {
     directory: project.directory,
@@ -1022,8 +1006,6 @@ async function ensureProjectPython(
       prompts.log.warn("Project `.venv` uses a Conda-family Python. Rebuilding with a standalone Python...")
       corruptedVenv = true
     } else {
-      prompts.log.info(`Using project Python: ${formatPython(info, [venvPython])}`)
-      prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
       let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
       try {
         canary = await venvCanaryPasses([venvPython], {
@@ -1035,7 +1017,6 @@ async function ensureProjectPython(
         canary = { healthy: false, stderr: "", timedOut: false }
       }
       if (canary.healthy) {
-        prompts.log.success("Agency Swarm packages ready")
         return [venvPython]
       }
       const refreshLogFile = await tryCreateProjectCommandLogFile(
@@ -1044,7 +1025,6 @@ async function ensureProjectPython(
         "launcher refresh",
         profile,
       )
-      prompts.log.info("Refreshing project dependencies...")
       let localUv: string | undefined
       try {
         localUv = await ensureLocalUv(directory, venvPython, {
@@ -1064,7 +1044,6 @@ async function ensureProjectPython(
         if (refresh.installerFailed) corruptedVenv = true
       }
       if (!corruptedVenv) {
-        prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
         let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
         try {
           canary = await venvCanaryPasses([venvPython], {
@@ -1075,7 +1054,6 @@ async function ensureProjectPython(
           canary = { healthy: false, stderr: "", timedOut: false }
         }
         if (canary.healthy) {
-          prompts.log.success("Agency Swarm packages ready")
           return [venvPython]
         }
         corruptedVenv = true
@@ -1104,7 +1082,6 @@ async function ensureProjectPython(
   // (python3 etc.) resolves via PATH and, in an activated broken venv, still points at
   // the .venv binary we are about to delete.
   const rebuildCmd = corruptedVenv ? [detected.executable] : detected.cmd
-  prompts.log.info(`Detected Python: ${formatPython(detected, rebuildCmd)}`)
 
   if (corruptedVenv) {
     prompts.log.warn("Project `.venv` is incomplete or corrupted. Rebuilding...")
@@ -1114,7 +1091,7 @@ async function ensureProjectPython(
 
   if (!selfHealing) {
     const createVenv = await prompts.confirm({
-      message: "Create a local `.venv` in this project?",
+      message: "Set up this project now?",
       initialValue: true,
     })
     if (prompts.isCancel(createVenv)) {
@@ -1131,7 +1108,6 @@ async function ensureProjectPython(
     }
   }
 
-  prompts.log.step("Creating `.venv`")
   const created = await runCommand([...rebuildCmd, "-m", "venv", ".venv"], {
     cwd: directory,
   })
@@ -1140,14 +1116,12 @@ async function ensureProjectPython(
     throw new Error(created.stderr.trim() || created.stdout.trim() || "Virtual environment creation failed")
   }
 
-  prompts.log.step("`.venv` created")
   const installLogFile = await tryCreateProjectCommandLogFile(
     directory,
     "launcher-rebuild",
     "launcher rebuild",
     profile,
   )
-  prompts.log.info("Installing project dependencies...")
   const localUv = await ensureLocalUv(directory, venvPython, {
     forceInstall: true,
     logFile: installLogFile,
@@ -1163,7 +1137,6 @@ async function ensureProjectPython(
   if (install.code !== 0) {
     throw new Error(formatCommandFailure(install, "Dependency install failed"))
   }
-  prompts.log.info("Verifying Agency Swarm imports. First launch can take a minute.")
   const canary = await venvCanaryPasses([venvPython], {
     cwd: directory,
     includeStderr: true,
@@ -1177,7 +1150,6 @@ async function ensureProjectPython(
       await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr, install.logFile),
     )
   }
-  prompts.log.success("Agency Swarm packages ready")
   return [venvPython]
 }
 

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -956,6 +956,21 @@ async function createProductStateRootProject(input: {
   return requireDetectedStarterProject(input.directory, starterProfile)
 }
 
+// Run a long, silent step under a clack spinner so the terminal animates instead of looking hung.
+// Compact product-state lines (`prompts.log.info`) stay as phase headers; the spinner covers the wait.
+async function withSpinner<T>(start: string, done: string, task: () => Promise<T>): Promise<T> {
+  const spin = prompts.spinner()
+  spin.start(start)
+  try {
+    const result = await task()
+    spin.stop(done)
+    return result
+  } catch (error) {
+    spin.stop(start, 1)
+    throw error
+  }
+}
+
 export async function prepareProjectLaunch(
   project: AgencyProject,
   profile: LaunchProfile = AgencyProduct,
@@ -965,7 +980,9 @@ export async function prepareProjectLaunch(
   const python = await ensureProjectPython(project.directory, profile)
   if (!python) return
 
-  const server = await startProjectServer(project.directory, python, project.moduleName, project.agencyFile)
+  const server = await withSpinner(`Starting ${profile.name}`, `${profile.name} ready`, () =>
+    startProjectServer(project.directory, python, project.moduleName, project.agencyFile),
+  )
   return {
     directory: project.directory,
     runProjectDirectory: project.directory,
@@ -979,7 +996,7 @@ export async function prepareProjectLaunch(
 
 async function ensureProjectPython(
   directory: string,
-  profile: Pick<LaunchProfile, "launcherPackageName" | "pythonEnvironment" | "stateRoot">,
+  profile: Pick<LaunchProfile, "launcherPackageName" | "name" | "pythonEnvironment" | "stateRoot">,
 ) {
   const venvPython = getVenvPythonPath(directory)
   const venvDir = path.resolve(path.join(directory, ".venv"))
@@ -1122,35 +1139,37 @@ async function ensureProjectPython(
     "launcher rebuild",
     profile,
   )
-  const localUv = await ensureLocalUv(directory, venvPython, {
-    forceInstall: true,
-    logFile: installLogFile,
-    timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+  return withSpinner(`Setting up ${profile.name}`, `${profile.name} setup ready`, async () => {
+    const localUv = await ensureLocalUv(directory, venvPython, {
+      forceInstall: true,
+      logFile: installLogFile,
+      timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+    })
+    const install = await installProjectDependencies(directory, venvPython, localUv, {
+      logFile: installLogFile,
+      timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
+    })
+    if (install.timedOut) {
+      throw new Error(formatCommandTimeout(install, "Dependency install", REBUILD_INSTALL_TIMEOUT_MS))
+    }
+    if (install.code !== 0) {
+      throw new Error(formatCommandFailure(install, "Dependency install failed"))
+    }
+    const canary = await venvCanaryPasses([venvPython], {
+      cwd: directory,
+      includeStderr: true,
+      minimumAgencySwarmVersion: install.hadManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+    })
+    if (canary.timedOut) {
+      throw new Error(await formatCanaryTimeoutFailure(directory, canary.stderr))
+    }
+    if (!canary.healthy) {
+      throw new Error(
+        await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr, install.logFile),
+      )
+    }
+    return [venvPython]
   })
-  const install = await installProjectDependencies(directory, venvPython, localUv, {
-    logFile: installLogFile,
-    timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
-  })
-  if (install.timedOut) {
-    throw new Error(formatCommandTimeout(install, "Dependency install", REBUILD_INSTALL_TIMEOUT_MS))
-  }
-  if (install.code !== 0) {
-    throw new Error(formatCommandFailure(install, "Dependency install failed"))
-  }
-  const canary = await venvCanaryPasses([venvPython], {
-    cwd: directory,
-    includeStderr: true,
-    minimumAgencySwarmVersion: install.hadManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
-  })
-  if (canary.timedOut) {
-    throw new Error(await formatCanaryTimeoutFailure(directory, canary.stderr))
-  }
-  if (!canary.healthy) {
-    throw new Error(
-      await formatPostInstallCanaryFailure(directory, install.hadManifests, canary.stderr, install.logFile),
-    )
-  }
-  return [venvPython]
 }
 
 async function installProjectDependencies(

--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1026,16 +1026,17 @@ async function ensureProjectPython(
       prompts.log.warn("Project `.venv` uses a Conda-family Python. Rebuilding with a standalone Python...")
       corruptedVenv = true
     } else {
-      let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
-      try {
-        canary = await venvCanaryPasses([venvPython], {
-          includeStderr: true,
-          minimumAgencySwarmVersion: hasManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
-          timeoutMs: EXISTING_VENV_CANARY_TIMEOUT_MS,
-        })
-      } catch {
-        canary = { healthy: false, stderr: "", timedOut: false }
-      }
+      const canary = await withSpinner(
+        `Checking ${profile.name} environment`,
+        `${profile.name} environment checked`,
+        `${profile.name} environment check failed`,
+        () =>
+          checkVenvCanary([venvPython], {
+            includeStderr: true,
+            minimumAgencySwarmVersion: hasManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+            timeoutMs: EXISTING_VENV_CANARY_TIMEOUT_MS,
+          }),
+      )
       if (canary.healthy) {
         return [venvPython]
       }
@@ -1054,12 +1055,30 @@ async function ensureProjectPython(
             logFile: refreshLogFile,
             timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
           }).catch(() => undefined)
-          if (!localUv) return { installerFailed: false, skippedUv: true }
+          if (!localUv) {
+            return {
+              canary: await checkVenvCanary([venvPython], {
+                includeStderr: true,
+                minimumAgencySwarmVersion: hasManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+              }),
+              installerFailed: false,
+              skippedUv: true,
+            }
+          }
           const result = await refreshProjectDependencies(directory, venvPython, localUv, {
             logFile: refreshLogFile,
             timeoutMs: REBUILD_INSTALL_TIMEOUT_MS,
           })
-          return { ...result, skippedUv: false }
+          return {
+            ...result,
+            canary: result.installerFailed
+              ? undefined
+              : await checkVenvCanary([venvPython], {
+                  includeStderr: true,
+                  minimumAgencySwarmVersion: hasManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
+                }),
+            skippedUv: false,
+          }
         },
       )
       if (refresh.skippedUv) {
@@ -1069,16 +1088,7 @@ async function ensureProjectPython(
       }
       if (refresh.installerFailed) corruptedVenv = true
       if (!corruptedVenv) {
-        let canary: VenvCanaryResult = { healthy: false, stderr: "", timedOut: false }
-        try {
-          canary = await venvCanaryPasses([venvPython], {
-            includeStderr: true,
-            minimumAgencySwarmVersion: hasManifests ? undefined : MIN_AGENCY_SWARM_VERSION,
-          })
-        } catch {
-          canary = { healthy: false, stderr: "", timedOut: false }
-        }
-        if (canary.healthy) {
+        if (refresh.canary?.healthy) {
           return [venvPython]
         }
         corruptedVenv = true
@@ -1183,6 +1193,22 @@ async function ensureProjectPython(
       return [venvPython]
     },
   )
+}
+
+async function checkVenvCanary(
+  python: string[],
+  options: { cwd?: string; includeStderr: true; minimumAgencySwarmVersion?: string; timeoutMs?: number },
+): Promise<VenvCanaryResult> {
+  try {
+    return await venvCanaryPasses(python, {
+      cwd: options.cwd,
+      includeStderr: true,
+      minimumAgencySwarmVersion: options.minimumAgencySwarmVersion,
+      timeoutMs: options.timeoutMs,
+    })
+  } catch {
+    return { healthy: false, stderr: "", timedOut: false }
+  }
 }
 
 async function installProjectDependencies(

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -130,7 +130,7 @@ const cli = yargs(args)
     const marker = path.join(Global.Path.data, "opencode.db")
     if (!(await Filesystem.exists(marker))) {
       const tty = process.stderr.isTTY
-      process.stderr.write("Performing one time database migration, may take a few minutes..." + EOL)
+      process.stderr.write(`Getting ${AgencyProduct.name} ready for first use. This can take a few minutes...` + EOL)
       const width = 36
       const orange = "\x1b[38;5;214m"
       const muted = "\x1b[0;2m"
@@ -161,7 +161,7 @@ const cli = yargs(args)
           process.stderr.write(`sqlite-migration:done${EOL}`)
         }
       }
-      process.stderr.write("Database migration complete." + EOL)
+      process.stderr.write(`${AgencyProduct.name} is ready.` + EOL)
     }
   })
   .usage("")

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -44,18 +44,21 @@ describe("agency-swarm npx onboarding", () => {
   }
   let spinnerStarts: string[] = []
   let spinnerStops: string[] = []
+  let spinnerStopCodes: Array<number | undefined> = []
 
   // The launcher wraps long setup/startup waits in a clack spinner. Stub it for every test so
   // assertions on product-state logs and commands run without spinner frames leaking into output.
   beforeEach(() => {
     spinnerStarts = []
     spinnerStops = []
+    spinnerStopCodes = []
     spyOn(prompts, "spinner").mockReturnValue({
       start(message: string) {
         spinnerStarts.push(message)
       },
-      stop(message: string) {
+      stop(message: string, code?: number) {
         spinnerStops.push(message)
+        spinnerStopCodes.push(code)
       },
     } as never)
   })
@@ -629,6 +632,9 @@ describe("agency-swarm npx onboarding", () => {
     expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
     expect(commands.filter(isCanaryCommand).every((cmd) => !(cmd.at(-1) ?? "").includes("meets_floor"))).toBe(true)
     expect(canaryRuns).toBe(2)
+    expect(spinnerStarts).toEqual(["Refreshing Agent Swarm", "Starting Agent Swarm"])
+    expect(spinnerStops).toEqual(["Agent Swarm refresh checked", "Agent Swarm ready"])
+    expect(spinnerStopCodes).toEqual([undefined, undefined])
 
     await launch?.cleanup?.()
   })
@@ -1584,10 +1590,6 @@ describe("agency-swarm npx onboarding", () => {
     await writeAgency(dir.path)
 
     spyOn(prompts, "confirm").mockResolvedValue(true as never)
-    spyOn(prompts, "spinner").mockReturnValue({
-      start() {},
-      stop() {},
-    } as never)
     spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     let timeoutCurrentInstall = false
     spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
@@ -1663,6 +1665,9 @@ describe("agency-swarm npx onboarding", () => {
       /Dependency install timed out after 10 minutes\. Last output: still working\.\.\..*launcher-rebuild\.log/,
     )
     expect(error.message).not.toContain(dir.path)
+    expect(spinnerStarts).toEqual(["Setting up Agent Swarm"])
+    expect(spinnerStops).toEqual(["Agent Swarm setup failed"])
+    expect(spinnerStopCodes).toEqual([1])
   })
 
   test("prepareProjectLaunch times out even when the install process ignores kill", async () => {
@@ -2053,6 +2058,9 @@ describe("agency-swarm npx onboarding", () => {
       expect.stringContaining("Installer output: ERROR: No matching distribution found"),
     )
     expect(canaryRuns).toBe(2)
+    expect(spinnerStarts).toEqual(["Refreshing Agent Swarm", "Starting Agent Swarm"])
+    expect(spinnerStops).toEqual(["Agent Swarm refresh checked", "Agent Swarm ready"])
+    expect(spinnerStopCodes).toEqual([undefined, undefined])
     const logContent = await Bun.file(launcherLogFilePath(dir.path, "launcher-refresh", iso)).text()
     expect(logContent).toContain("Collecting agency-swarm...")
     expect(logContent).toContain("ERROR: No matching distribution found for agency-swarm[fastapi,litellm]")

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { mkdir, symlink } from "node:fs/promises"
 import os from "node:os"
@@ -42,6 +42,23 @@ describe("agency-swarm npx onboarding", () => {
     starterProjectName: "example-project",
     agencyEntryFiles: ["main.py"],
   }
+  let spinnerStarts: string[] = []
+  let spinnerStops: string[] = []
+
+  // The launcher wraps long setup/startup waits in a clack spinner. Stub it for every test so
+  // assertions on product-state logs and commands run without spinner frames leaking into output.
+  beforeEach(() => {
+    spinnerStarts = []
+    spinnerStops = []
+    spyOn(prompts, "spinner").mockReturnValue({
+      start(message: string) {
+        spinnerStarts.push(message)
+      },
+      stop(message: string) {
+        spinnerStops.push(message)
+      },
+    } as never)
+  })
 
   afterEach(() => {
     mock.restore()
@@ -765,6 +782,8 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(warn).not.toHaveBeenCalled()
+    expect(spinnerStarts).toEqual(["Starting Agent Swarm"])
+    expect(spinnerStops).toEqual(["Agent Swarm ready"])
     expect(commands.some(isPythonPipInstallUvCommand)).toBe(false)
     expect(commands.some(isUvPipInstallCommand)).toBe(false)
     expect(commands.some(isPythonVenvCommand)).toBe(false)
@@ -1464,10 +1483,6 @@ describe("agency-swarm npx onboarding", () => {
       confirms.push(String(input.message))
       return Promise.resolve(true as never)
     })
-    spyOn(prompts, "spinner").mockReturnValue({
-      start() {},
-      stop() {},
-    } as never)
     const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
     spyOn(Date.prototype, "toISOString").mockReturnValue(iso)
@@ -1538,6 +1553,8 @@ describe("agency-swarm npx onboarding", () => {
     expect(confirms).toContain("Set up this project now?")
     expect(confirms.join("\n")).not.toContain(".venv")
     expect(info).toHaveBeenCalledWith("Preparing Agent Swarm...")
+    expect(spinnerStarts).toEqual(["Setting up Agent Swarm", "Starting Agent Swarm"])
+    expect(spinnerStops).toEqual(["Agent Swarm setup ready", "Agent Swarm ready"])
     expect(visible).not.toContain("Installing project dependencies...")
     expect(visible).not.toContain("Detected Python:")
     expect(visible).not.toContain("Verifying Agency Swarm imports")

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1506,11 +1506,18 @@ describe("agency-swarm npx onboarding", () => {
           stderr: "",
         } as never
       }
-      if (isPythonVenvCommand(cmd) || isPythonPipInstallUvCommand(cmd)) {
+      if (isPythonVenvCommand(cmd)) {
         return {
           exited: Promise.resolve(0),
           stdout: "",
           stderr: "",
+        } as never
+      }
+      if (isPythonPipInstallUvCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "Collecting uv...\n",
+          stderr: "Installing uv...\n",
         } as never
       }
       if (isUvPipInstallCommand(cmd)) {
@@ -1559,8 +1566,13 @@ describe("agency-swarm npx onboarding", () => {
     expect(visible).not.toContain("Detected Python:")
     expect(visible).not.toContain("Verifying Agency Swarm imports")
     expect(visible).not.toContain("Full log")
-    expect(stderrWrite.mock.calls.map((call) => call[0]).join("")).not.toContain("Resolving packages")
+    const mirrored = stderrWrite.mock.calls.map((call) => call[0]).join("")
+    expect(mirrored).not.toContain("Collecting uv")
+    expect(mirrored).not.toContain("Installing uv")
+    expect(mirrored).not.toContain("Resolving packages")
     const logContent = await Bun.file(launcherLogFilePath(dir.path, "launcher-rebuild", iso)).text()
+    expect(logContent).toContain("Collecting uv...")
+    expect(logContent).toContain("Installing uv...")
     expect(logContent).toContain("Resolving packages...")
     expect(logContent).toContain("Downloading wheels...")
 

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -2580,6 +2580,105 @@ describe("agency-swarm npx onboarding", () => {
     expect(info).toHaveBeenCalledWith("Preparing Agent Swarm...")
   })
 
+  test("prepareProjectLaunch cancels spinner-wrapped server startup without printing success", async () => {
+    await using dir = await tmpdir()
+    await writeAgency(dir.path)
+    await mkdir(path.join(dir.path, ".venv", process.platform === "win32" ? "Scripts" : "bin"), {
+      recursive: true,
+    })
+    await Bun.write(
+      path.join(
+        dir.path,
+        ".venv",
+        process.platform === "win32" ? "Scripts" : "bin",
+        process.platform === "win32" ? "python.exe" : "python",
+      ),
+      "",
+    )
+
+    const killSignals: Array<string | undefined> = []
+    let cancelStartup: (() => void) | undefined
+    let resolveServerExit!: (code: number) => void
+
+    spyOn(prompts, "spinner").mockImplementation((options?: Parameters<typeof prompts.spinner>[0]) => {
+      let cancelled = false
+      return {
+        start(message: string) {
+          spinnerStarts.push(message)
+          if (message === "Starting Agent Swarm") {
+            cancelStartup = () => {
+              cancelled = true
+              options?.onCancel?.()
+            }
+          }
+        },
+        stop(message: string, code?: number) {
+          spinnerStops.push(message)
+          spinnerStopCodes.push(code)
+        },
+        message() {},
+        get isCancelled() {
+          return cancelled
+        },
+      } as ReturnType<typeof prompts.spinner>
+    })
+    spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
+
+    spyOn(Bun, "spawn").mockImplementation((options: unknown) => {
+      const cmd = (options as { cmd?: string[] }).cmd
+      if (!cmd) throw new Error("Missing command")
+      if (isUvVersionCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "uv 0.8.0\n",
+          stderr: "",
+        } as never
+      }
+      if (cmd.includes("import sys; print(sys.executable); print(sys.version.split()[0])")) {
+        const target = cmd[0] ?? ""
+        return {
+          exited: Promise.resolve(0),
+          stdout: `${target}\n3.12.7\n`,
+          stderr: "",
+        } as never
+      }
+      if (isCanaryCommand(cmd)) {
+        return {
+          exited: Promise.resolve(0),
+          stdout: "",
+          stderr: "",
+        } as never
+      }
+      if (cmd[1]?.endsWith("launch_agency.py")) {
+        queueMicrotask(() => cancelStartup?.())
+        return {
+          exited: new Promise<number>((resolve) => {
+            resolveServerExit = resolve
+          }),
+          stderr: "",
+          kill(signal?: string) {
+            killSignals.push(signal)
+            resolveServerExit(0)
+          },
+        } as never
+      }
+      throw new Error(`Unexpected command: ${cmd.join(" ")}`)
+    })
+
+    const launch = await prepareProjectLaunch({
+      directory: dir.path,
+      agencyFile: path.join(dir.path, "agency.py"),
+      moduleName: "agency",
+    })
+
+    expect(launch).toBeUndefined()
+    expect(killSignals).toContain(undefined)
+    expect(spinnerStarts).toEqual(["Checking Agent Swarm environment", "Starting Agent Swarm"])
+    expect(spinnerStops).toEqual(["Agent Swarm environment checked"])
+    expect(spinnerStops).not.toContain("Agent Swarm ready")
+    expect(spinnerStopCodes).toEqual([undefined])
+  })
+
   test("prepareProjectLaunch points startup import failures at the active entry file", async () => {
     await using dir = await tmpdir()
     await Bun.write(

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -632,9 +632,17 @@ describe("agency-swarm npx onboarding", () => {
     expect(uvInstallCommands.some((cmd) => cmd.includes("agency-swarm[fastapi,litellm]"))).toBe(false)
     expect(commands.filter(isCanaryCommand).every((cmd) => !(cmd.at(-1) ?? "").includes("meets_floor"))).toBe(true)
     expect(canaryRuns).toBe(2)
-    expect(spinnerStarts).toEqual(["Refreshing Agent Swarm", "Starting Agent Swarm"])
-    expect(spinnerStops).toEqual(["Agent Swarm refresh checked", "Agent Swarm ready"])
-    expect(spinnerStopCodes).toEqual([undefined, undefined])
+    expect(spinnerStarts).toEqual([
+      "Checking Agent Swarm environment",
+      "Refreshing Agent Swarm",
+      "Starting Agent Swarm",
+    ])
+    expect(spinnerStops).toEqual([
+      "Agent Swarm environment checked",
+      "Agent Swarm refresh checked",
+      "Agent Swarm ready",
+    ])
+    expect(spinnerStopCodes).toEqual([undefined, undefined, undefined])
 
     await launch?.cleanup?.()
   })
@@ -788,8 +796,8 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     expect(warn).not.toHaveBeenCalled()
-    expect(spinnerStarts).toEqual(["Starting Agent Swarm"])
-    expect(spinnerStops).toEqual(["Agent Swarm ready"])
+    expect(spinnerStarts).toEqual(["Checking Agent Swarm environment", "Starting Agent Swarm"])
+    expect(spinnerStops).toEqual(["Agent Swarm environment checked", "Agent Swarm ready"])
     expect(commands.some(isPythonPipInstallUvCommand)).toBe(false)
     expect(commands.some(isUvPipInstallCommand)).toBe(false)
     expect(commands.some(isPythonVenvCommand)).toBe(false)
@@ -2058,9 +2066,17 @@ describe("agency-swarm npx onboarding", () => {
       expect.stringContaining("Installer output: ERROR: No matching distribution found"),
     )
     expect(canaryRuns).toBe(2)
-    expect(spinnerStarts).toEqual(["Refreshing Agent Swarm", "Starting Agent Swarm"])
-    expect(spinnerStops).toEqual(["Agent Swarm refresh checked", "Agent Swarm ready"])
-    expect(spinnerStopCodes).toEqual([undefined, undefined])
+    expect(spinnerStarts).toEqual([
+      "Checking Agent Swarm environment",
+      "Refreshing Agent Swarm",
+      "Starting Agent Swarm",
+    ])
+    expect(spinnerStops).toEqual([
+      "Agent Swarm environment checked",
+      "Agent Swarm refresh checked",
+      "Agent Swarm ready",
+    ])
+    expect(spinnerStopCodes).toEqual([undefined, undefined, undefined])
     const logContent = await Bun.file(launcherLogFilePath(dir.path, "launcher-refresh", iso)).text()
     expect(logContent).toContain("Collecting agency-swarm...")
     expect(logContent).toContain("ERROR: No matching distribution found for agency-swarm[fastapi,litellm]")
@@ -2759,6 +2775,7 @@ describe("agency-swarm npx onboarding", () => {
       ),
     ])
     if (canaryStartedResult !== true) throw canaryStartedResult
+    expect(spinnerStarts).toEqual(["Checking Agent Swarm environment"])
 
     const outcome = await Promise.race([
       launch.catch((error) => error),
@@ -2776,6 +2793,9 @@ describe("agency-swarm npx onboarding", () => {
     expect(outcome.message).toContain("Project `.venv` appears corrupted")
     expect(killSignals).toEqual([undefined, "SIGKILL"])
     expect(canaryRuns).toBe(2)
+    expect(spinnerStarts).toEqual(["Checking Agent Swarm environment", "Refreshing Agent Swarm"])
+    expect(spinnerStops).toEqual(["Agent Swarm environment checked", "Agent Swarm refresh checked"])
+    expect(spinnerStopCodes).toEqual([undefined, undefined])
     expect(commands.filter(isUvPipInstallCommand)).toEqual([
       [
         getTestVenvUv(dir.path),

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1459,7 +1459,11 @@ describe("agency-swarm npx onboarding", () => {
     await writeAgency(dir.path)
     const iso = "2026-04-23T02:15:00.000Z"
 
-    spyOn(prompts, "confirm").mockResolvedValue(true as never)
+    const confirms: string[] = []
+    spyOn(prompts, "confirm").mockImplementation((input) => {
+      confirms.push(String(input.message))
+      return Promise.resolve(true as never)
+    })
     spyOn(prompts, "spinner").mockReturnValue({
       start() {},
       stop() {},
@@ -1530,8 +1534,14 @@ describe("agency-swarm npx onboarding", () => {
       moduleName: "agency",
     })
 
-    expect(info).toHaveBeenCalledWith("Installing project dependencies...")
-    expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain("Full log")
+    const visible = info.mock.calls.map((call) => String(call[0])).join("\n")
+    expect(confirms).toContain("Set up this project now?")
+    expect(confirms.join("\n")).not.toContain(".venv")
+    expect(info).toHaveBeenCalledWith("Preparing Agent Swarm...")
+    expect(visible).not.toContain("Installing project dependencies...")
+    expect(visible).not.toContain("Detected Python:")
+    expect(visible).not.toContain("Verifying Agency Swarm imports")
+    expect(visible).not.toContain("Full log")
     expect(stderrWrite.mock.calls.map((call) => call[0]).join("")).not.toContain("Resolving packages")
     const logContent = await Bun.file(launcherLogFilePath(dir.path, "launcher-rebuild", iso)).text()
     expect(logContent).toContain("Resolving packages...")
@@ -2004,8 +2014,11 @@ describe("agency-swarm npx onboarding", () => {
       moduleName: "agency",
     })
 
-    expect(info).toHaveBeenCalledWith("Refreshing project dependencies...")
-    expect(info.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain("Full log")
+    const visible = info.mock.calls.map((call) => String(call[0])).join("\n")
+    expect(info).toHaveBeenCalledWith("Preparing Agent Swarm...")
+    expect(visible).not.toContain("Refreshing project dependencies...")
+    expect(visible).not.toContain("Verifying Agency Swarm imports")
+    expect(visible).not.toContain("Full log")
     expect(stderrWrite.mock.calls.map((call) => call[0]).join("")).not.toContain("Collecting agency-swarm")
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("Installer output: ERROR: No matching distribution found"),
@@ -2510,8 +2523,8 @@ describe("agency-swarm npx onboarding", () => {
       "Fix the missing import or dependency in this project, then run agentswarm again.",
     )
     expect(outcome.message).not.toContain("Agency Swarm server exited with code 1")
-    expect(success).toHaveBeenCalledWith("Agency Swarm packages ready")
-    expect(info).toHaveBeenCalledWith("Starting your agency project.")
+    expect(success).not.toHaveBeenCalled()
+    expect(info).toHaveBeenCalledWith("Preparing Agent Swarm...")
   })
 
   test("prepareProjectLaunch points startup import failures at the active entry file", async () => {
@@ -3767,9 +3780,9 @@ describe("agency-swarm npx onboarding", () => {
     const target = path.join(dir.path, downstreamProfile.starterProjectName)
     const commands: string[][] = []
 
-    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
-    spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
-    spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const step = spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
+    const success = spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
     spyOn(prompts, "outro").mockImplementation(() => undefined as never)
     spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as never)
     spyOn(Bun, "spawn").mockImplementation((options: any) => {
@@ -3827,6 +3840,18 @@ describe("agency-swarm npx onboarding", () => {
     expect(launch?.runProjectDirectory).toBe(target)
     expect(commands.find((cmd) => cmd[1]?.endsWith("launch_agency.py"))?.at(-1)).toBe("main")
     expect(launch?.configContent).toContain("agency-swarm/default")
+    const visible = info.mock.calls.map((call) => String(call[0])).join("\n")
+    expect(visible).toContain("Checking Example Product project files...")
+    expect(visible).toContain("Creating Example Product project...")
+    expect(visible).toContain("Preparing Example Product...")
+    expect(visible).not.toContain("Choose how to start the terminal UI")
+    expect(visible).not.toContain("ready-to-run")
+    expect(visible).not.toContain("Detected Python:")
+    expect(visible).not.toContain("Verifying Agency Swarm imports")
+    expect(visible).not.toContain("Agency Swarm packages ready")
+    expect(visible).not.toContain("FastAPI server")
+    expect(step).not.toHaveBeenCalled()
+    expect(success).not.toHaveBeenCalled()
 
     await launch?.cleanup?.()
   })
@@ -3841,16 +3866,24 @@ describe("agency-swarm npx onboarding", () => {
       starterProjectName: "my-agency",
       agencyEntryFiles: ["main.py"],
     }
-    const name = "entry-only-starter"
-    const target = path.join(dir.path, name)
+    const target = path.join(dir.path, profile.starterProjectName)
     const commands: string[][] = []
+    const choices: Parameters<typeof prompts.select>[0][] = []
 
-    spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
+    const info = spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "step").mockImplementation(() => undefined as never)
     spyOn(prompts.log, "success").mockImplementation(() => undefined as never)
     spyOn(prompts, "outro").mockImplementation(() => undefined as never)
-    spyOn(prompts, "select").mockResolvedValue("starter" as never)
-    spyOn(prompts, "text").mockResolvedValue(name as never)
+    spyOn(prompts, "select").mockImplementation((input) => {
+      choices.push(input)
+      return Promise.resolve((input.message === "How do you want to start?" ? "starter" : "local") as never)
+    })
+    const text = spyOn(prompts, "text").mockImplementation((input) => {
+      const value = input.initialValue
+      const result = input.validate?.(value)
+      if (result) throw result instanceof Error ? result : new Error(String(result))
+      return Promise.resolve(value as never)
+    })
     spyOn(prompts, "spinner").mockReturnValue({
       start() {},
       stop() {},
@@ -3861,8 +3894,8 @@ describe("agency-swarm npx onboarding", () => {
       if (!cmd) throw new Error("Missing command")
       commands.push(cmd)
 
-      if (cmd[0] === "gh") {
-        return { exited: Promise.resolve(1), stdout: "", stderr: "gh unavailable" } as never
+      if (cmd[0] === "gh" && (cmd[1] === "--version" || (cmd[1] === "auth" && cmd[2] === "status"))) {
+        return { exited: Promise.resolve(0), stdout: "gh ready", stderr: "" } as never
       }
 
       if (cmd[0] === "git" && cmd[1] === "clone") {
@@ -3913,6 +3946,18 @@ describe("agency-swarm npx onboarding", () => {
     expect(commands).toContainEqual(["git", "clone", "--depth=1", starterTemplateUrl(), target])
     expect(launch?.runProjectDirectory).toBe(target)
     expect(commands.find((cmd) => cmd[1]?.endsWith("launch_agency.py"))?.at(-1)).toBe("agency")
+    expect(text.mock.calls[0]?.[0].message).toBe("Project name")
+    expect(text.mock.calls[0]?.[0].initialValue).toBe(profile.starterProjectName)
+    expect(text.mock.calls[0]?.[0].placeholder).toBeUndefined()
+    expect(text.mock.calls[0]?.[0].defaultValue).toBeUndefined()
+    expect(choices[1]?.message).toBe("Where should this project be created?")
+    expect(choices[1]?.options.map((option) => option.label)).toEqual(["On GitHub", "On this computer"])
+    expect(choices[1]?.options.map((option) => option.hint)).toEqual(["recommended", "skip GitHub"])
+    const visible = info.mock.calls.map((call) => String(call[0])).join("\n")
+    expect(visible).not.toContain("Choose how to start the terminal UI")
+    expect(visible).not.toContain("launcher can use a detected project")
+    expect(visible).not.toContain("Create the starter project")
+    expect(visible).not.toContain("ready-to-run")
 
     await launch?.cleanup?.()
   })


### PR DESCRIPTION
### Issue for this PR

No public issue: Agent Swarm launcher UX polish.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reduces the Agent Swarm first-run launcher output to user choices and two product-level progress states. The detailed Python, venv, dependency, import, and server details stay out of the happy path.

It also makes the starter project name a real initial value, so pressing Enter accepts `my-agency`.

### How did you verify your code works?

Focused npx onboarding tests, package typecheck, pre-push typecheck, built macOS binary, and a fresh local create flow from `/tmp` into the TUI.

### Screenshots / recordings

Fresh local build shows the compact flow:

```text
Agent Swarm
Checking Agent Swarm project files...
How do you want to start?
Create a new Agent Swarm project
Connect to a running Agent Swarm

Creating Agent Swarm project...
Project name
Where should this project be created?
Preparing Agent Swarm...
Set up this project now?
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
