### PR TITLE
feat(opencode): show Agent Swarm sidebar counts

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -266,9 +266,9 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 - **Run-target labels use live agency names**
   - Intent: show the names users know from Agency Swarm instead of stale or generic labels.
   - Behavior: agent pickers, run-target labels, and the sidebar reflect current live agency names.
-  - Behavior: Run mode shows the selected swarm and metadata-derived main and subagent counts in the sidebar, and `/agents` shows those counts in swarm sections.
+  - Behavior: Run mode shows the selected swarm and metadata-derived main and subagent counts in the sidebar.
   - Behavior: Run mode usage surfaces Agency Swarm FastAPI token and cost totals, and hides context percentages when the visible model has only a placeholder context limit.
-  - Implementation: `resolveAgencyTargetSelection` in `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`, `formatAgencyCategory` in `packages/opencode/src/cli/cmd/tui/util/agency-counts.ts`, `formatUsageDisplay` in `packages/opencode/src/cli/cmd/tui/util/usage-display.ts`, `getUsage` in `packages/opencode/src/session/session.ts`, `DialogAgent` in `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `SidebarAgency` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx`, and `ContextSidebar` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx`.
+  - Implementation: `resolveAgencyTargetSelection` in `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`, `formatAgencyCounts` in `packages/opencode/src/cli/cmd/tui/util/agency-counts.ts`, `formatUsageDisplay` in `packages/opencode/src/cli/cmd/tui/util/usage-display.ts`, `getUsage` in `packages/opencode/src/session/session.ts`, `DialogAgent` in `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `SidebarAgency` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx`, and `ContextSidebar` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx`.
   - Added by: `a798a402`
 
 - **Agent Swarm theme stays on the dark palette**

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -267,7 +267,8 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Intent: show the names users know from Agency Swarm instead of stale or generic labels.
   - Behavior: agent pickers, run-target labels, and the sidebar reflect current live agency names.
   - Behavior: Run mode shows the selected swarm and metadata-derived main-agent and subagent counts in the sidebar, and `/agents` shows those counts in swarm sections.
-  - Implementation: `resolveAgencyTargetSelection` in `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`, `formatAgencyCategory` in `packages/opencode/src/cli/cmd/tui/util/agency-counts.ts`, `DialogAgent` in `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, and `SidebarAgency` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx`.
+  - Behavior: Run mode usage surfaces Agency Swarm FastAPI token and cost totals, and hides context percentages when the visible model has only a placeholder context limit.
+  - Implementation: `resolveAgencyTargetSelection` in `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`, `formatAgencyCategory` in `packages/opencode/src/cli/cmd/tui/util/agency-counts.ts`, `formatUsageDisplay` in `packages/opencode/src/cli/cmd/tui/util/usage-display.ts`, `getUsage` in `packages/opencode/src/session/session.ts`, `DialogAgent` in `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `SidebarAgency` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx`, and `ContextSidebar` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx`.
   - Added by: `a798a402`
 
 - **Agent Swarm theme stays on the dark palette**

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -265,8 +265,9 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 
 - **Run-target labels use live agency names**
   - Intent: show the names users know from Agency Swarm instead of stale or generic labels.
-  - Behavior: agent pickers and run-target labels reflect current live agency names.
-  - Implementation: `resolveAgencyTargetSelection` in `packages/opencode/src/cli/cmd/tui/util/agency-target.ts` and `DialogAgent` in `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`.
+  - Behavior: agent pickers, run-target labels, and the sidebar reflect current live agency names.
+  - Behavior: Run mode shows the selected swarm and metadata-derived main-agent and subagent counts in the sidebar, and `/agents` shows those counts in swarm sections.
+  - Implementation: `resolveAgencyTargetSelection` in `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`, `formatAgencyCategory` in `packages/opencode/src/cli/cmd/tui/util/agency-counts.ts`, `DialogAgent` in `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, and `SidebarAgency` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx`.
   - Added by: `a798a402`
 
 - **Agent Swarm theme stays on the dark palette**

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -266,7 +266,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 - **Run-target labels use live agency names**
   - Intent: show the names users know from Agency Swarm instead of stale or generic labels.
   - Behavior: agent pickers, run-target labels, and the sidebar reflect current live agency names.
-  - Behavior: Run mode shows the selected swarm and metadata-derived main and other counts in the sidebar, and `/agents` shows those counts in swarm sections.
+  - Behavior: Run mode shows the selected swarm and metadata-derived main and subagent counts in the sidebar, and `/agents` shows those counts in swarm sections.
   - Behavior: Run mode usage surfaces Agency Swarm FastAPI token and cost totals, and hides context percentages when the visible model has only a placeholder context limit.
   - Implementation: `resolveAgencyTargetSelection` in `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`, `formatAgencyCategory` in `packages/opencode/src/cli/cmd/tui/util/agency-counts.ts`, `formatUsageDisplay` in `packages/opencode/src/cli/cmd/tui/util/usage-display.ts`, `getUsage` in `packages/opencode/src/session/session.ts`, `DialogAgent` in `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `SidebarAgency` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx`, and `ContextSidebar` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx`.
   - Added by: `a798a402`

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -266,7 +266,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 - **Run-target labels use live agency names**
   - Intent: show the names users know from Agency Swarm instead of stale or generic labels.
   - Behavior: agent pickers, run-target labels, and the sidebar reflect current live agency names.
-  - Behavior: Run mode shows the selected swarm and metadata-derived main-agent and subagent counts in the sidebar, and `/agents` shows those counts in swarm sections.
+  - Behavior: Run mode shows the selected swarm and metadata-derived main and other counts in the sidebar, and `/agents` shows those counts in swarm sections.
   - Behavior: Run mode usage surfaces Agency Swarm FastAPI token and cost totals, and hides context percentages when the visible model has only a placeholder context limit.
   - Implementation: `resolveAgencyTargetSelection` in `packages/opencode/src/cli/cmd/tui/util/agency-target.ts`, `formatAgencyCategory` in `packages/opencode/src/cli/cmd/tui/util/agency-counts.ts`, `formatUsageDisplay` in `packages/opencode/src/cli/cmd/tui/util/usage-display.ts`, `getUsage` in `packages/opencode/src/session/session.ts`, `DialogAgent` in `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx`, `SidebarAgency` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx`, and `ContextSidebar` in `packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx`.
   - Added by: `a798a402`

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -187,7 +187,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** Upstream provider/model state used for auth or LLM choice does not pull the user out of Run mode by accident.
 - **Happy-path proof:** `agency-swarm/default` stays active over stale stored model state until the user explicitly chooses another model.
 - **Happy-path proof:** Footer/status labels and completed run rows show actual Agent Swarm model labels when agency metadata exposes them, without changing the internal `agency-swarm/default` route.
-- **Happy-path proof:** Live agency names, the selected sidebar swarm, and metadata-derived main-agent and subagent counts appear in Run mode.
+- **Happy-path proof:** Live agency names, the selected sidebar swarm, and metadata-derived main and other counts appear in Run mode.
 - **Happy-path proof:** Tab cycles run targets.
 - **Failure scenarios to test:** Agent discovery failure offers `/connect`.
 - **Failure scenarios to test:** Server reachability or authorization failure opens `/connect`.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -187,7 +187,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** Upstream provider/model state used for auth or LLM choice does not pull the user out of Run mode by accident.
 - **Happy-path proof:** `agency-swarm/default` stays active over stale stored model state until the user explicitly chooses another model.
 - **Happy-path proof:** Footer/status labels and completed run rows show actual Agent Swarm model labels when agency metadata exposes them, without changing the internal `agency-swarm/default` route.
-- **Happy-path proof:** Live agency names, the selected sidebar swarm, and metadata-derived main and other counts appear in Run mode.
+- **Happy-path proof:** Live agency names, the selected sidebar swarm, and metadata-derived main and subagent counts appear in Run mode.
 - **Happy-path proof:** Tab cycles run targets.
 - **Failure scenarios to test:** Agent discovery failure offers `/connect`.
 - **Failure scenarios to test:** Server reachability or authorization failure opens `/connect`.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -187,7 +187,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** Upstream provider/model state used for auth or LLM choice does not pull the user out of Run mode by accident.
 - **Happy-path proof:** `agency-swarm/default` stays active over stale stored model state until the user explicitly chooses another model.
 - **Happy-path proof:** Footer/status labels and completed run rows show actual Agent Swarm model labels when agency metadata exposes them, without changing the internal `agency-swarm/default` route.
-- **Happy-path proof:** Live agency names appear in run-target labels.
+- **Happy-path proof:** Live agency names, the selected sidebar swarm, and metadata-derived main-agent and subagent counts appear in Run mode.
 - **Happy-path proof:** Tab cycles run targets.
 - **Failure scenarios to test:** Agent discovery failure offers `/connect`.
 - **Failure scenarios to test:** Server reachability or authorization failure opens `/connect`.

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -7,7 +7,7 @@
 - `USER_FLOWS.md` Detected Local Project: launcher mode shows startup project-file checking, the detected-project choice before `.venv` work begins, unreadable `agency.py` recovery choices, and Agent Swarm connect copy.
 - `USER_FLOWS.md` Startup `/auth` and In-TUI `/connect`: `/auth` and `/connect` stay separate in the real terminal UI.
 - `USER_FLOWS.md` Run Mode: native `/editor`, `/variants`, `/init`, and `/review` slash commands stay hidden.
-- `USER_FLOWS.md` Run Mode: `/agents` uses Swarm and agent wording, live agency labels, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
+- `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/subagent counts; `/agents` uses Swarm and agent wording, live agency labels, main/subagent counts, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
 - `USER_FLOWS.md` Run Mode: prompt submit reaches a local Agency Swarm protocol server with the configured agent.
 - `USER_FLOWS.md` Run Mode: simulated visible OpenAI model state does not pull prompts, slash-command `/new`, run-session local-project marking, `/connect`, or runtime auth recovery out of Agency Swarm routing.
 - `USER_FLOWS.md` Run Mode: bracketed-paste image paths reach the local Agency Swarm protocol server as structured Responses `message` content.

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -12,7 +12,7 @@
 - `USER_FLOWS.md` Run Mode: simulated visible OpenAI model state does not pull prompts, slash-command `/new`, run-session local-project marking, `/connect`, or runtime auth recovery out of Agency Swarm routing.
 - `USER_FLOWS.md` Run Mode: bracketed-paste image paths reach the local Agency Swarm protocol server as structured Responses `message` content.
 - `USER_FLOWS.md` Run Mode: ordinary and nested `SendMessage` delegation does not switch the user's active recipient.
-- `USER_FLOWS.md` Run Mode: `transfer_to_*`, top-level handoff, and `agent_updated_stream_event` handoffs switch control to the target agent for the next turn.
+- `USER_FLOWS.md` Run Mode: `transfer_to_*`, top-level handoff, and `agent_updated_stream_event` handoffs switch control to the target agent for the next turn, and a default single-swarm handoff shows the target agent as active in the sidebar.
 - Harness setup: a copied real `agency.py` project path plus deterministic protocol server proves the same Run Mode delegation and handoff semantics without claiming launcher or Python bridge startup coverage.
 
 ## Manual Gap

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -7,7 +7,7 @@
 - `USER_FLOWS.md` Detected Local Project: launcher mode shows startup project-file checking, the detected-project choice before `.venv` work begins, unreadable `agency.py` recovery choices, and Agent Swarm connect copy.
 - `USER_FLOWS.md` Startup `/auth` and In-TUI `/connect`: `/auth` and `/connect` stay separate in the real terminal UI.
 - `USER_FLOWS.md` Run Mode: native `/editor`, `/variants`, `/init`, and `/review` slash commands stay hidden.
-- `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/other counts; `/agents` uses Swarm and agent wording, live agency labels, main/other counts, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
+- `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/subagent counts; `/agents` uses Swarm and agent wording, live agency labels, main/subagent counts, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
 - `USER_FLOWS.md` Run Mode: prompt submit reaches a local Agency Swarm protocol server with the configured agent.
 - `USER_FLOWS.md` Run Mode: simulated visible OpenAI model state does not pull prompts, slash-command `/new`, run-session local-project marking, `/connect`, or runtime auth recovery out of Agency Swarm routing.
 - `USER_FLOWS.md` Run Mode: bracketed-paste image paths reach the local Agency Swarm protocol server as structured Responses `message` content.

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -7,7 +7,7 @@
 - `USER_FLOWS.md` Detected Local Project: launcher mode shows startup project-file checking, the detected-project choice before `.venv` work begins, unreadable `agency.py` recovery choices, and Agent Swarm connect copy.
 - `USER_FLOWS.md` Startup `/auth` and In-TUI `/connect`: `/auth` and `/connect` stay separate in the real terminal UI.
 - `USER_FLOWS.md` Run Mode: native `/editor`, `/variants`, `/init`, and `/review` slash commands stay hidden.
-- `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/subagent counts; `/agents` uses Swarm and agent wording, live agency labels, main/subagent counts, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
+- `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/subagent counts; `/agents` uses Swarm and agent wording, live agency labels, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
 - `USER_FLOWS.md` Run Mode: prompt submit reaches a local Agency Swarm protocol server with the configured agent.
 - `USER_FLOWS.md` Run Mode: simulated visible OpenAI model state does not pull prompts, slash-command `/new`, run-session local-project marking, `/connect`, or runtime auth recovery out of Agency Swarm routing.
 - `USER_FLOWS.md` Run Mode: bracketed-paste image paths reach the local Agency Swarm protocol server as structured Responses `message` content.

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -7,7 +7,7 @@
 - `USER_FLOWS.md` Detected Local Project: launcher mode shows startup project-file checking, the detected-project choice before `.venv` work begins, unreadable `agency.py` recovery choices, and Agent Swarm connect copy.
 - `USER_FLOWS.md` Startup `/auth` and In-TUI `/connect`: `/auth` and `/connect` stay separate in the real terminal UI.
 - `USER_FLOWS.md` Run Mode: native `/editor`, `/variants`, `/init`, and `/review` slash commands stay hidden.
-- `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/subagent counts; `/agents` uses Swarm and agent wording, live agency labels, main/subagent counts, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
+- `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/other counts; `/agents` uses Swarm and agent wording, live agency labels, main/other counts, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
 - `USER_FLOWS.md` Run Mode: prompt submit reaches a local Agency Swarm protocol server with the configured agent.
 - `USER_FLOWS.md` Run Mode: simulated visible OpenAI model state does not pull prompts, slash-command `/new`, run-session local-project marking, `/connect`, or runtime auth recovery out of Agency Swarm routing.
 - `USER_FLOWS.md` Run Mode: bracketed-paste image paths reach the local Agency Swarm protocol server as structured Responses `message` content.

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -478,8 +478,32 @@ const tuiDemoAgencyFixture: AgencyFixture = {
       },
     ],
   },
-  stream(body, requestCount) {
+  stream(body, requestCount, streamReleased, closeStream) {
     const message = typeof body.message === "string" ? body.message.toLowerCase() : ""
+    if (message.includes("fresh sidebar hold")) {
+      return controlledSse(
+        [
+          ["meta", { run_id: `run_tui_demo_${requestCount}` }],
+          [
+            "messages",
+            {
+              new_messages: [
+                {
+                  id: `msg_fresh_sidebar_${requestCount}`,
+                  type: "message",
+                  role: "assistant",
+                  agent: body.recipient_agent || "UserSupportAgent",
+                  content: [{ type: "output_text", text: "TUI demo response complete." }],
+                },
+              ],
+            },
+          ],
+          ["end", {}],
+        ],
+        streamReleased,
+        closeStream,
+      )
+    }
     if (message.includes("nested delegate")) {
       return sse([
         ["meta", { run_id: `run_tui_demo_${requestCount}` }],

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -212,6 +212,8 @@ export async function startTui(input: {
   args?: string[]
   cwd?: string
   env?: Record<string, string | undefined>
+  cols?: number
+  rows?: number
   baseURL?: string
   agency?: string
   recipientAgent?: string
@@ -225,7 +227,9 @@ export async function startTui(input: {
   await mkdir(path.join(root, "data"), { recursive: true })
   await mkdir(path.join(root, "managed"), { recursive: true })
 
-  const screen = new TerminalScreen(100, 30)
+  const cols = input.cols ?? 100
+  const rows = input.rows ?? 30
+  const screen = new TerminalScreen(cols, rows)
   let raw = ""
   let exitCode: number | undefined
   const configContent = input.baseURL ? JSON.stringify(buildTuiConfig(input)) : undefined
@@ -256,7 +260,7 @@ export async function startTui(input: {
     ...(configContent && input.configSource !== "file" ? { OPENCODE_CONFIG_CONTENT: configContent } : {}),
     ...(input.env ?? {}),
   })
-  let proc = spawnTuiProcess({ args, cwd: input.cwd, env })
+  let proc = spawnTuiProcess({ args, cwd: input.cwd, env, cols, rows })
 
   let dataReceived = false
   let activeProc = proc
@@ -286,7 +290,7 @@ export async function startTui(input: {
       onRetry: async () => {
         await closeProcess(proc)
         await Bun.sleep(initialOutputRetryDelayMs)
-        proc = spawnTuiProcess({ args, cwd: input.cwd, env })
+        proc = spawnTuiProcess({ args, cwd: input.cwd, env, cols, rows })
         dataReceived = false
         exitCode = undefined
         attachProcess(proc)
@@ -343,11 +347,17 @@ export async function startTui(input: {
   }
 }
 
-function spawnTuiProcess(input: { args: string[]; cwd?: string; env: Record<string, string | undefined> }) {
+function spawnTuiProcess(input: {
+  args: string[]
+  cwd?: string
+  env: Record<string, string | undefined>
+  cols: number
+  rows: number
+}) {
   return spawn(process.execPath, ["--conditions=browser", "./src/index.ts", ...input.args], {
     cwd: input.cwd ?? packageRoot,
-    cols: 100,
-    rows: 30,
+    cols: input.cols,
+    rows: input.rows,
     name: "xterm-256color",
     env: cleanEnv(input.env),
   })

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -781,6 +781,33 @@ const tuiDemoAgencyFixture: AgencyFixture = {
       ])
     }
 
+    if (message.includes("usage footer proof")) {
+      return sse([
+        ["meta", { run_id: `run_tui_demo_${requestCount}` }],
+        [
+          "messages",
+          {
+            new_messages: [
+              {
+                id: `msg_usage_${requestCount}`,
+                type: "message",
+                role: "assistant",
+                agent: body.recipient_agent || "UserSupportAgent",
+                content: [{ type: "output_text", text: "Usage footer response complete." }],
+              },
+            ],
+            usage: {
+              input_tokens: 1_000,
+              output_tokens: 500,
+              total_tokens: 1_500,
+              total_cost: 0.42,
+            },
+          },
+        ],
+        ["end", {}],
+      ])
+    }
+
     return sse([
       ["meta", { run_id: `run_tui_demo_${requestCount}` }],
       [

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -367,6 +367,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     currentTui.write("/agents\r")
     const screen = await currentTui.waitForText("Live QA Agency")
 
+    expect(screen).toContain("Swarm: Live QA Agency (1 main / 1 sub)")
     expect(screen).toContain("Entry Agent")
     expect(screen).toContain("Review Agent")
     expect(screen).not.toContain("local-agency")
@@ -424,7 +425,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     const screen = await currentTui.waitForText("TuiDemoAgency")
 
     expect(screen).toContain("Select swarm")
-    expect(screen).toContain("Swarm: TuiDemoAgency")
+    expect(screen).toContain("Swarm: TuiDemoAgency (1 main / 1 sub)")
     expect(screen).toContain("UserSupportAgent")
     expect(screen).toContain("MathAgent")
     expect(screen.toLowerCase()).not.toContain("recipient")
@@ -552,6 +553,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
       agency: "tui-demo-agency",
       recipientAgent: "UserSupportAgent",
       args: ["--model", alternateOpenAITestModel],
+      cols: 150,
       env: {
         AGENTSWARM_RUN_PROJECT: runProject,
         XDG_STATE_HOME: stateHome,
@@ -563,6 +565,10 @@ describe("Agent Swarm terminal TUI e2e", () => {
     currentTui.write("run through agency despite visible openai model state\r")
     await currentTui.waitForText("TUI demo response complete.", tuiInteractionTimeoutMs)
     const screen = await currentTui.waitForText("Run · GPT-5.2", tuiInteractionTimeoutMs)
+    expect(screen).toContain("Swarm")
+    expect(screen).toContain("TuiDemoAgency")
+    expect(screen).toContain("1 main / 1 sub")
+    expect(screen).toContain("Active: UserSupportAgent")
     await currentTui.waitFor(
       () => currentServer!.requests.length === 1,
       "agency request with visible openai model state",

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -608,6 +608,11 @@ describe("Agent Swarm terminal TUI e2e", () => {
     const screen = await currentTui.waitForText("1.5K · $0.42", tuiInteractionTimeoutMs)
 
     expect(screen).toContain("1.5K · $0.42")
+    expect(screen).toContain("Context")
+    expect(screen).toContain("1,500 tokens")
+    expect(screen).toContain("$0.42 spent")
+    expect(screen).not.toContain("Usage percent unavailable")
+    expect(screen).not.toContain("% used")
     expect(screen).not.toContain("1.5K (0%)")
   })
 

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -367,7 +367,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     currentTui.write("/agents\r")
     const screen = await currentTui.waitForText("Live QA Agency")
 
-    expect(screen).toContain("Swarm: Live QA Agency (1 main / 1 sub)")
+    expect(screen).toContain("Swarm: Live QA Agency (1 main / 1 other)")
     expect(screen).toContain("Entry Agent")
     expect(screen).toContain("Review Agent")
     expect(screen).not.toContain("local-agency")
@@ -425,7 +425,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     const screen = await currentTui.waitForText("TuiDemoAgency")
 
     expect(screen).toContain("Select swarm")
-    expect(screen).toContain("Swarm: TuiDemoAgency (1 main / 1 sub)")
+    expect(screen).toContain("Swarm: TuiDemoAgency (1 main / 1 other)")
     expect(screen).toContain("UserSupportAgent")
     expect(screen).toContain("MathAgent")
     expect(screen.toLowerCase()).not.toContain("recipient")
@@ -580,7 +580,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     const screen = await currentTui.waitForText("Run · GPT-5.2", tuiInteractionTimeoutMs)
     expect(screen).toContain("Swarm")
     expect(screen).toContain("TuiDemoAgency")
-    expect(screen).toContain("1 main / 1 sub")
+    expect(screen).toContain("1 main / 1 other")
     expect(screen).toContain("Active: UserSupportAgent")
     const body = currentServer.requests[0]?.body
     expect(body?.message).toContain("fresh sidebar hold despite visible openai model state")

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -591,6 +591,26 @@ describe("Agent Swarm terminal TUI e2e", () => {
     })
   })
 
+  test("run-mode prompt footer does not show false zero percent for placeholder context", async () => {
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      cols: 150,
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    await waitForConfiguredDemoRecipient(currentTui)
+    currentTui.write("usage footer proof\r")
+    await currentTui.waitForText("Usage footer response complete.", tuiInteractionTimeoutMs)
+    const screen = await currentTui.waitForText("1.5K · $0.42", tuiInteractionTimeoutMs)
+
+    expect(screen).toContain("1.5K · $0.42")
+    expect(screen).not.toContain("1.5K (0%)")
+  })
+
   test("/connect opens the Agency Swarm server dialog with visible OpenAI model state", async () => {
     currentServer = await startAgencyProtocolServer()
     currentTui = await startTui({

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -864,6 +864,36 @@ describe("Agent Swarm terminal TUI e2e", () => {
     ).toBeFalse()
   })
 
+  test("default single-swarm transfer_to handoff shows target agent as active in sidebar", async () => {
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      cols: 150,
+      config: {
+        provider: {
+          "agency-swarm": {
+            options: {
+              agency: undefined,
+              recipientAgent: undefined,
+              recipientAgentSelectedAt: undefined,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    currentTui.write("please handoff this calculation\r")
+    await currentTui.waitForText("Math agent now has control.", tuiInteractionTimeoutMs)
+    const screen = await currentTui.waitForText("Active: MathAgent", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(() => currentServer!.requests.length === 1, "default swarm handoff request")
+
+    const body = currentServer.requests[0]?.body
+    expect(body?.message).toContain("please handoff this calculation")
+    expect(body).not.toHaveProperty("recipient_agent")
+    expect(screen).toContain("TuiDemoAgency")
+  })
+
   test("top-level handoff wins over later nested handoff-like metadata", async () => {
     currentServer = await startTuiDemoAgencyServer()
     currentTui = await startTui({

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -367,7 +367,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     currentTui.write("/agents\r")
     const screen = await currentTui.waitForText("Live QA Agency")
 
-    expect(screen).toContain("Swarm: Live QA Agency (1 main / 1 subagent)")
+    expect(screen).toContain("Swarm: Live QA Agency")
     expect(screen).toContain("Entry Agent")
     expect(screen).toContain("Review Agent")
     expect(screen).not.toContain("local-agency")
@@ -425,7 +425,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     const screen = await currentTui.waitForText("TuiDemoAgency")
 
     expect(screen).toContain("Select swarm")
-    expect(screen).toContain("Swarm: TuiDemoAgency (1 main / 1 subagent)")
+    expect(screen).toContain("Swarm: TuiDemoAgency")
     expect(screen).toContain("UserSupportAgent")
     expect(screen).toContain("MathAgent")
     expect(screen.toLowerCase()).not.toContain("recipient")

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -367,7 +367,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     currentTui.write("/agents\r")
     const screen = await currentTui.waitForText("Live QA Agency")
 
-    expect(screen).toContain("Swarm: Live QA Agency (1 main / 1 other)")
+    expect(screen).toContain("Swarm: Live QA Agency (1 main / 1 subagent)")
     expect(screen).toContain("Entry Agent")
     expect(screen).toContain("Review Agent")
     expect(screen).not.toContain("local-agency")
@@ -425,7 +425,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     const screen = await currentTui.waitForText("TuiDemoAgency")
 
     expect(screen).toContain("Select swarm")
-    expect(screen).toContain("Swarm: TuiDemoAgency (1 main / 1 other)")
+    expect(screen).toContain("Swarm: TuiDemoAgency (1 main / 1 subagent)")
     expect(screen).toContain("UserSupportAgent")
     expect(screen).toContain("MathAgent")
     expect(screen.toLowerCase()).not.toContain("recipient")
@@ -580,7 +580,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     const screen = await currentTui.waitForText("Run · GPT-5.2", tuiInteractionTimeoutMs)
     expect(screen).toContain("Swarm")
     expect(screen).toContain("TuiDemoAgency")
-    expect(screen).toContain("1 main / 1 other")
+    expect(screen).toContain("1 main / 1 subagent")
     expect(screen).toContain("Active: UserSupportAgent")
     const body = currentServer.requests[0]?.body
     expect(body?.message).toContain("fresh sidebar hold despite visible openai model state")

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -562,21 +562,28 @@ describe("Agent Swarm terminal TUI e2e", () => {
     })
 
     await currentTui.waitForText(alternateOpenAITestModelLabel, tuiReadyTimeoutMs)
-    currentTui.write("run through agency despite visible openai model state\r")
+    currentTui.write("fresh sidebar hold despite visible openai model state\r")
+    await currentTui.waitFor(
+      () => currentServer!.requests.length === 1,
+      "held agency request with visible openai model state",
+      tuiInteractionTimeoutMs,
+    )
+    const activeRequest = currentServer.requests[0]
+    expect(activeRequest?.releaseStream).toBeDefined()
+    expect(activeRequest?.streamClosed).toBeDefined()
+    const fresh = await currentTui.waitForText("0 tokens", tuiInteractionTimeoutMs)
+    expect(fresh).toContain("Context")
+    expect(fresh).not.toContain("% used")
+    activeRequest!.releaseStream!()
+    await activeRequest!.streamClosed
     await currentTui.waitForText("TUI demo response complete.", tuiInteractionTimeoutMs)
     const screen = await currentTui.waitForText("Run · GPT-5.2", tuiInteractionTimeoutMs)
     expect(screen).toContain("Swarm")
     expect(screen).toContain("TuiDemoAgency")
     expect(screen).toContain("1 main / 1 sub")
     expect(screen).toContain("Active: UserSupportAgent")
-    await currentTui.waitFor(
-      () => currentServer!.requests.length === 1,
-      "agency request with visible openai model state",
-      tuiInteractionTimeoutMs,
-    )
-
     const body = currentServer.requests[0]?.body
-    expect(body?.message).toContain("run through agency despite visible openai model state")
+    expect(body?.message).toContain("fresh sidebar hold despite visible openai model state")
     expect(body).toMatchObject({
       recipient_agent: "UserSupportAgent",
     })

--- a/packages/opencode/specs/tui-plugins.md
+++ b/packages/opencode/specs/tui-plugins.md
@@ -446,6 +446,7 @@ Metadata is persisted by plugin id.
 
 - `internal:home-tips`
 - `internal:sidebar-context`
+- `internal:sidebar-agency`
 - `internal:sidebar-mcp`
 - `internal:sidebar-lsp`
 - `internal:sidebar-todo`
@@ -453,7 +454,7 @@ Metadata is persisted by plugin id.
 - `internal:sidebar-footer`
 - `internal:plugin-manager`
 
-Sidebar content order is currently: context `100`, mcp `200`, lsp `300`, todo `400`, files `500`.
+Sidebar content order is currently: context `100`, agency `150`, mcp `200`, lsp `300`, todo `400`, files `500`.
 
 The plugin manager is exposed as a command with title `Plugins` and value `plugins.list`.
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -9,7 +9,6 @@ import { useToast } from "@tui/ui/toast"
 import { createMemo, createResource } from "solid-js"
 import { DialogAgencySwarmConnect } from "./dialog-provider"
 import { isAgencySwarmFrameworkMode } from "../session-error"
-import { formatAgencyCategory } from "../util/agency-counts"
 import {
   buildAgencyTargetOptions,
   readAgencyProviderOptions,
@@ -145,7 +144,7 @@ export function DialogAgent() {
 
     const agencies = discovered?.agencies ?? []
     for (const agency of agencies) {
-      const category = formatAgencyCategory(agency)
+      const category = `Swarm: ${agency.name}`
       const entry = agency.agents.find((agent) => agent.isEntryPoint) ?? agency.agents[0]
       const description =
         agency.description && agency.description !== entry?.description ? agency.description : undefined

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@tui/ui/toast"
 import { createMemo, createResource } from "solid-js"
 import { DialogAgencySwarmConnect } from "./dialog-provider"
 import { isAgencySwarmFrameworkMode } from "../session-error"
+import { formatAgencyCategory } from "../util/agency-counts"
 import {
   buildAgencyTargetOptions,
   readAgencyProviderOptions,
@@ -144,7 +145,7 @@ export function DialogAgent() {
 
     const agencies = discovered?.agencies ?? []
     for (const agency of agencies) {
-      const category = `Swarm: ${agency.name}`
+      const category = formatAgencyCategory(agency)
       const entry = agency.agents.find((agent) => agent.isEntryPoint) ?? agency.agents[0]
       const description =
         agency.description && agency.description !== entry?.description ? agency.description : undefined

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -86,6 +86,7 @@ import {
   updateAgencyRecipientSelectionState,
 } from "../../util/agency-target"
 import { resolveModelLabel } from "../../util/model-label"
+import { formatUsageDisplay, tokenTotal } from "../../util/usage-display"
 import { hasAgencyHandoffEvidence } from "@/session/agency-swarm-utils"
 import {
   confirmWorkspaceFileChanges,
@@ -129,11 +130,6 @@ export type PromptRef = {
   focus(): void
   submit(): void
 }
-
-const money = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-})
 
 type TaskTelemetryProperties = {
   framework_mode: boolean
@@ -722,20 +718,12 @@ export function Prompt(props: PromptProps) {
     if (!props.sessionID) return
     const session = sync.session.get(props.sessionID)
     const msg = sync.data.message[props.sessionID] ?? []
-    const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
+    const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && tokenTotal(item) > 0)
     if (!last) return
 
-    const tokens =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
-    if (tokens <= 0) return
-
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
-    const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
     const cost = session?.cost ?? 0
-    return {
-      context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
-      cost: cost > 0 ? money.format(cost) : undefined,
-    }
+    return formatUsageDisplay({ message: last, model, cost })
   })
 
   const [store, setStore] = createStore<{

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx
@@ -79,9 +79,10 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const handoff = createMemo(() => {
     const opts = options()
     if (!opts) return undefined
+    const selected = selection()
     return resolveAgencyHandoffRecipientFromMessages({
       frameworkMode: true,
-      agency: opts.agency,
+      agency: selected?.agency ?? opts.agency,
       currentRecipient: opts.recipientAgent,
       currentRecipientSelectedAt: opts.recipientAgentSelectedAt,
       sessionID: props.session_id,

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx
@@ -5,7 +5,11 @@ import { useLocal } from "../../context/local"
 import type { InternalTuiPlugin } from "../../plugin/internal"
 import { isAgencySwarmFrameworkMode } from "../../session-error"
 import { countAgencyAgents, formatAgencyCounts } from "../../util/agency-counts"
-import { readAgencyProviderOptions, resolveAgencyTargetSelection } from "../../util/agency-target"
+import {
+  readAgencyProviderOptions,
+  resolveAgencyHandoffRecipientFromMessages,
+  resolveAgencyTargetSelection,
+} from "../../util/agency-target"
 
 const id = "internal:sidebar-agency"
 
@@ -14,7 +18,7 @@ type Discovery = {
   error?: string
 }
 
-function View(props: { api: TuiPluginApi }) {
+function View(props: { api: TuiPluginApi; session_id: string }) {
   const local = useLocal()
   const theme = () => props.api.theme.current
   const options = createMemo(() => {
@@ -68,11 +72,29 @@ function View(props: { api: TuiPluginApi }) {
     if (!selected) return undefined
     return discovery().agencies.find((item) => item.id === selected.agency)
   })
+  const messages = createMemo(() => [...props.api.state.session.messages(props.session_id)])
+  const parts = createMemo(() =>
+    Object.fromEntries(messages().map((item) => [item.id, [...props.api.state.part(item.id)]])),
+  )
+  const handoff = createMemo(() => {
+    const opts = options()
+    if (!opts) return undefined
+    return resolveAgencyHandoffRecipientFromMessages({
+      frameworkMode: true,
+      agency: opts.agency,
+      currentRecipient: opts.recipientAgent,
+      currentRecipientSelectedAt: opts.recipientAgentSelectedAt,
+      sessionID: props.session_id,
+      messages: messages(),
+      partsByMessage: parts(),
+    })
+  })
   const active = createMemo(() => {
     const item = agency()
     const selected = selection()
-    if (!item || !selected?.recipientAgent) return undefined
-    return item.agents.find((agent) => agent.id === selected.recipientAgent)?.name ?? selected.recipientAgent
+    const agentID = handoff()?.agent ?? selected?.recipientAgent
+    if (!item || !agentID) return undefined
+    return item.agents.find((agent) => agent.id === agentID)?.name ?? agentID
   })
   const empty = createMemo(() => {
     if (!discovery().agencies.length) return "No swarms"
@@ -114,8 +136,8 @@ const tui: TuiPlugin = async (api) => {
   api.slots.register({
     order: 150,
     slots: {
-      sidebar_content() {
-        return <View api={api} />
+      sidebar_content(_ctx, props) {
+        return <View api={api} session_id={props.session_id} />
       },
     },
   })

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/agency.tsx
@@ -1,0 +1,129 @@
+import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
+import { createMemo, createResource, Match, Show, Switch } from "solid-js"
+import { useLocal } from "../../context/local"
+import type { InternalTuiPlugin } from "../../plugin/internal"
+import { isAgencySwarmFrameworkMode } from "../../session-error"
+import { countAgencyAgents, formatAgencyCounts } from "../../util/agency-counts"
+import { readAgencyProviderOptions, resolveAgencyTargetSelection } from "../../util/agency-target"
+
+const id = "internal:sidebar-agency"
+
+type Discovery = {
+  agencies: AgencySwarmAdapter.AgencyDescriptor[]
+  error?: string
+}
+
+function View(props: { api: TuiPluginApi }) {
+  const local = useLocal()
+  const theme = () => props.api.theme.current
+  const options = createMemo(() => {
+    const framework = isAgencySwarmFrameworkMode({
+      currentProviderID: local.model.current()?.providerID,
+      configuredModel: props.api.state.config.model,
+      agentModel: local.agent.current()?.model,
+    })
+    if (!framework) return undefined
+    const configuredProvider = props.api.state.config.provider?.[AgencySwarmAdapter.PROVIDER_ID]
+    const connectedProvider = props.api.state.provider.find((item) => item.id === AgencySwarmAdapter.PROVIDER_ID)
+    if (!configuredProvider && !connectedProvider) return undefined
+    return readAgencyProviderOptions({
+      configuredProvider,
+      connectedProvider,
+    })
+  })
+  const [discovery] = createResource(
+    options,
+    async (opts): Promise<Discovery> => {
+      try {
+        const result = await AgencySwarmAdapter.discover({
+          baseURL: opts.baseURL,
+          token: opts.token,
+          timeoutMs: opts.discoveryTimeoutMs,
+        })
+        return { agencies: result.agencies }
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") throw error
+        return {
+          agencies: [],
+          error: error instanceof Error ? error.message : String(error),
+        }
+      }
+    },
+    {
+      initialValue: { agencies: [] },
+    },
+  )
+  const selection = createMemo(() => {
+    const opts = options()
+    if (!opts) return undefined
+    return resolveAgencyTargetSelection({
+      agencies: discovery().agencies,
+      configuredAgency: opts.agency,
+      configuredRecipient: opts.recipientAgent,
+    })
+  })
+  const agency = createMemo(() => {
+    const selected = selection()
+    if (!selected) return undefined
+    return discovery().agencies.find((item) => item.id === selected.agency)
+  })
+  const active = createMemo(() => {
+    const item = agency()
+    const selected = selection()
+    if (!item || !selected?.recipientAgent) return undefined
+    return item.agents.find((agent) => agent.id === selected.recipientAgent)?.name ?? selected.recipientAgent
+  })
+  const empty = createMemo(() => {
+    if (!discovery().agencies.length) return "No swarms"
+    return "Pick with /agents"
+  })
+
+  return (
+    <Show when={options()}>
+      <box>
+        <text fg={theme().text}>
+          <b>Swarm</b>
+        </text>
+        <Switch>
+          <Match when={discovery.loading}>
+            <text fg={theme().textMuted}>Loading agents...</text>
+          </Match>
+          <Match when={discovery().error}>
+            <text fg={theme().textMuted}>Agents unavailable</text>
+          </Match>
+          <Match when={agency()}>
+            {(item) => (
+              <>
+                <text fg={theme().text}>{item().name}</text>
+                <text fg={theme().textMuted}>{formatAgencyCounts(countAgencyAgents(item().agents))}</text>
+                <Show when={active()}>{(value) => <text fg={theme().textMuted}>Active: {value()}</text>}</Show>
+              </>
+            )}
+          </Match>
+          <Match when={!agency()}>
+            <text fg={theme().textMuted}>{empty()}</text>
+          </Match>
+        </Switch>
+      </box>
+    </Show>
+  )
+}
+
+const tui: TuiPlugin = async (api) => {
+  api.slots.register({
+    order: 150,
+    slots: {
+      sidebar_content() {
+        return <View api={api} />
+      },
+    },
+  })
+}
+
+const plugin: InternalTuiPlugin = {
+  id,
+  tui,
+}
+
+export default plugin

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -22,7 +22,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
     if (!last) {
       return {
         tokens: 0,
-        percent: null,
+        percent: 0,
       }
     }
 

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -41,9 +41,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
         <b>Context</b>
       </text>
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
-      <text fg={theme().textMuted}>
-        {state().percent === null ? "Usage percent unavailable" : `${state().percent}% used`}
-      </text>
+      {state().percent === null ? null : <text fg={theme().textMuted}>{state().percent}% used</text>}
       <text fg={theme().textMuted}>{money.format(cost())} spent</text>
     </box>
   )

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -3,21 +3,16 @@ import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { InternalTuiPlugin } from "../../plugin/internal"
 import { createMemo } from "solid-js"
 import { useLocal } from "../../context/local"
-import { contextLimit, tokenTotal } from "../../util/usage-display"
+import { contextLimit, formatCostDisplay, tokenTotal } from "../../util/usage-display"
 
 const id = "internal:sidebar-context"
-
-const money = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-})
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
   const local = useLocal()
   const theme = () => props.api.theme.current
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
-  const cost = createMemo(() => session()?.cost ?? 0)
+  const cost = createMemo(() => formatCostDisplay(session()?.cost ?? 0, { zero: true }))
   const model = createMemo(() => {
     const current = local.model.current()
     if (!current) return undefined
@@ -50,7 +45,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       </text>
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
       {state().percent === null ? null : <text fg={theme().textMuted}>{state().percent}% used</text>}
-      <text fg={theme().textMuted}>{money.format(cost())} spent</text>
+      {cost() ? <text fg={theme().textMuted}>{cost()} spent</text> : null}
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -3,6 +3,7 @@ import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { InternalTuiPlugin } from "../../plugin/internal"
 import { createMemo } from "solid-js"
 import { useLocal } from "../../context/local"
+import { isAgencySwarmFrameworkMode } from "../../session-error"
 import { contextLimit, formatCostDisplay, tokenTotal } from "../../util/usage-display"
 
 const id = "internal:sidebar-context"
@@ -13,6 +14,13 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
   const cost = createMemo(() => formatCostDisplay(session()?.cost ?? 0, { zero: true }))
+  const framework = createMemo(() =>
+    isAgencySwarmFrameworkMode({
+      currentProviderID: local.model.current()?.providerID,
+      configuredModel: props.api.state.config.model,
+      agentModel: local.agent.current()?.model,
+    }),
+  )
   const model = createMemo(() => {
     const current = local.model.current()
     if (!current) return undefined
@@ -22,7 +30,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const state = createMemo(() => {
     const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && tokenTotal(item) > 0)
     if (!last) {
-      const limit = contextLimit(model())
+      const limit = framework() ? undefined : contextLimit(model())
       return {
         tokens: 0,
         percent: limit ? 0 : null,

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -10,6 +10,25 @@ const money = new Intl.NumberFormat("en-US", {
   currency: "USD",
 })
 
+function tokenTotal(message: AssistantMessage) {
+  const total = message.tokens.total
+  if (typeof total === "number" && total > 0) return total
+  return (
+    message.tokens.input +
+    message.tokens.output +
+    message.tokens.reasoning +
+    message.tokens.cache.read +
+    message.tokens.cache.write
+  )
+}
+
+function contextLimit(model: { limit?: { context?: number } } | undefined) {
+  const context = model?.limit?.context
+  if (typeof context !== "number" || context <= 0) return undefined
+  if (context >= Number.MAX_SAFE_INTEGER) return undefined
+  return context
+}
+
 function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
@@ -17,7 +36,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const cost = createMemo(() => session()?.cost ?? 0)
 
   const state = createMemo(() => {
-    const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
+    const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && tokenTotal(item) > 0)
     if (!last) {
       return {
         tokens: 0,
@@ -25,12 +44,12 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       }
     }
 
-    const tokens =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
+    const tokens = tokenTotal(last)
     const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
+    const limit = contextLimit(model)
     return {
       tokens,
-      percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,
+      percent: limit ? Math.round((tokens / limit) * 100) : null,
     }
   })
 
@@ -40,7 +59,9 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
         <b>Context</b>
       </text>
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
-      <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
+      <text fg={theme().textMuted}>
+        {state().percent === null ? "Usage percent unavailable" : `${state().percent}% used`}
+      </text>
       <text fg={theme().textMuted}>{money.format(cost())} spent</text>
     </box>
   )

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { InternalTuiPlugin } from "../../plugin/internal"
 import { createMemo } from "solid-js"
+import { useLocal } from "../../context/local"
 import { contextLimit, tokenTotal } from "../../util/usage-display"
 
 const id = "internal:sidebar-context"
@@ -12,23 +13,30 @@ const money = new Intl.NumberFormat("en-US", {
 })
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
+  const local = useLocal()
   const theme = () => props.api.theme.current
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
   const cost = createMemo(() => session()?.cost ?? 0)
+  const model = createMemo(() => {
+    const current = local.model.current()
+    if (!current) return undefined
+    return props.api.state.provider.find((item) => item.id === current.providerID)?.models[current.modelID]
+  })
 
   const state = createMemo(() => {
     const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && tokenTotal(item) > 0)
     if (!last) {
+      const limit = contextLimit(model())
       return {
         tokens: 0,
-        percent: 0,
+        percent: limit ? 0 : null,
       }
     }
 
     const tokens = tokenTotal(last)
-    const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
-    const limit = contextLimit(model)
+    const lastModel = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
+    const limit = contextLimit(lastModel)
     return {
       tokens,
       percent: limit ? Math.round((tokens / limit) * 100) : null,

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { InternalTuiPlugin } from "../../plugin/internal"
 import { createMemo } from "solid-js"
+import { contextLimit, tokenTotal } from "../../util/usage-display"
 
 const id = "internal:sidebar-context"
 
@@ -9,25 +10,6 @@ const money = new Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "USD",
 })
-
-function tokenTotal(message: AssistantMessage) {
-  const total = message.tokens.total
-  if (typeof total === "number" && total > 0) return total
-  return (
-    message.tokens.input +
-    message.tokens.output +
-    message.tokens.reasoning +
-    message.tokens.cache.read +
-    message.tokens.cache.write
-  )
-}
-
-function contextLimit(model: { limit?: { context?: number } } | undefined) {
-  const context = model?.limit?.context
-  if (typeof context !== "number" || context <= 0) return undefined
-  if (context >= Number.MAX_SAFE_INTEGER) return undefined
-  return context
-}
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current

--- a/packages/opencode/src/cli/cmd/tui/plugin/internal.ts
+++ b/packages/opencode/src/cli/cmd/tui/plugin/internal.ts
@@ -1,5 +1,6 @@
 import HomeFooter from "../feature-plugins/home/footer"
 import HomeTips from "../feature-plugins/home/tips"
+import SidebarAgency from "../feature-plugins/sidebar/agency"
 import SidebarContext from "../feature-plugins/sidebar/context"
 import SidebarMcp from "../feature-plugins/sidebar/mcp"
 import SidebarLsp from "../feature-plugins/sidebar/lsp"
@@ -24,6 +25,7 @@ export function internalTuiPlugins(flags: Pick<RuntimeFlags.Info, "experimentalE
     HomeFooter,
     HomeTips,
     SidebarContext,
+    SidebarAgency,
     SidebarMcp,
     SidebarLsp,
     SidebarTodo,

--- a/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
@@ -8,6 +8,7 @@ import { Locale } from "@/util/locale"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useCommandPalette } from "../../context/command-palette"
 import { useCommandShortcut } from "../../keymap"
+import { formatUsageDisplay, tokenTotal } from "../../util/usage-display"
 
 export function SubagentFooter() {
   const route = useRouteData("session")
@@ -33,26 +34,13 @@ export function SubagentFooter() {
 
   const usage = createMemo(() => {
     const msg = messages()
-    const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
+    const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && tokenTotal(item) > 0)
     if (!last) return
 
-    const tokens =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
-    if (tokens <= 0) return
-
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
-    const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
     const cost = session()?.cost ?? 0
 
-    const money = new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-    })
-
-    return {
-      context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
-      cost: cost > 0 ? money.format(cost) : undefined,
-    }
+    return formatUsageDisplay({ message: last, model, cost })
   })
 
   const { theme } = useTheme()

--- a/packages/opencode/src/cli/cmd/tui/util/agency-counts.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-counts.ts
@@ -14,7 +14,8 @@ export function countAgencyAgents(agents: readonly AgencySwarmAdapter.AgencyAgen
 }
 
 export function formatAgencyCounts(counts: AgencyCounts) {
-  return `${counts.main} main / ${counts.sub} other`
+  const sub = counts.sub === 1 ? "subagent" : "subagents"
+  return `${counts.main} main / ${counts.sub} ${sub}`
 }
 
 export function formatAgencyCategory(agency: AgencySwarmAdapter.AgencyDescriptor) {

--- a/packages/opencode/src/cli/cmd/tui/util/agency-counts.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-counts.ts
@@ -17,7 +17,3 @@ export function formatAgencyCounts(counts: AgencyCounts) {
   const sub = counts.sub === 1 ? "subagent" : "subagents"
   return `${counts.main} main / ${counts.sub} ${sub}`
 }
-
-export function formatAgencyCategory(agency: AgencySwarmAdapter.AgencyDescriptor) {
-  return `Swarm: ${agency.name} (${formatAgencyCounts(countAgencyAgents(agency.agents))})`
-}

--- a/packages/opencode/src/cli/cmd/tui/util/agency-counts.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-counts.ts
@@ -14,7 +14,7 @@ export function countAgencyAgents(agents: readonly AgencySwarmAdapter.AgencyAgen
 }
 
 export function formatAgencyCounts(counts: AgencyCounts) {
-  return `${counts.main} main / ${counts.sub} sub`
+  return `${counts.main} main / ${counts.sub} other`
 }
 
 export function formatAgencyCategory(agency: AgencySwarmAdapter.AgencyDescriptor) {

--- a/packages/opencode/src/cli/cmd/tui/util/agency-counts.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-counts.ts
@@ -1,0 +1,22 @@
+import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
+
+export type AgencyCounts = {
+  main: number
+  sub: number
+}
+
+export function countAgencyAgents(agents: readonly AgencySwarmAdapter.AgencyAgentDescriptor[]): AgencyCounts {
+  const main = agents.filter((agent) => agent.isEntryPoint).length
+  return {
+    main,
+    sub: agents.length - main,
+  }
+}
+
+export function formatAgencyCounts(counts: AgencyCounts) {
+  return `${counts.main} main / ${counts.sub} sub`
+}
+
+export function formatAgencyCategory(agency: AgencySwarmAdapter.AgencyDescriptor) {
+  return `Swarm: ${agency.name} (${formatAgencyCounts(countAgencyAgents(agency.agents))})`
+}

--- a/packages/opencode/src/cli/cmd/tui/util/usage-display.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/usage-display.ts
@@ -1,0 +1,50 @@
+import type { AssistantMessage } from "@opencode-ai/sdk/v2"
+import { Locale } from "@/util/locale"
+
+const money = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+})
+
+type ContextModel = { limit?: { context?: number } } | undefined
+
+export function tokenTotal(message: Pick<AssistantMessage, "tokens">) {
+  const total = message.tokens.total
+  if (typeof total === "number" && total > 0) return total
+  return (
+    message.tokens.input +
+    message.tokens.output +
+    message.tokens.reasoning +
+    message.tokens.cache.read +
+    message.tokens.cache.write
+  )
+}
+
+export function contextLimit(model: ContextModel) {
+  const context = model?.limit?.context
+  if (typeof context !== "number" || !Number.isFinite(context) || context <= 0) return undefined
+  if (context >= Number.MAX_SAFE_INTEGER) return undefined
+  return context
+}
+
+export function usagePercent(tokens: number, model: ContextModel) {
+  const limit = contextLimit(model)
+  if (!limit) return undefined
+  return Math.round((tokens / limit) * 100)
+}
+
+export function formatUsageDisplay(input: {
+  message: Pick<AssistantMessage, "tokens">
+  model: ContextModel
+  cost?: number
+}) {
+  const tokens = tokenTotal(input.message)
+  if (tokens <= 0) return undefined
+
+  const pct = usagePercent(tokens, input.model)
+  const cost = input.cost ?? 0
+  return {
+    context: pct === undefined ? Locale.number(tokens) : `${Locale.number(tokens)} (${pct}%)`,
+    cost: cost > 0 ? money.format(cost) : undefined,
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/util/usage-display.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/usage-display.ts
@@ -38,9 +38,9 @@ export function formatCostDisplay(cost: number | undefined, opts: { zero?: boole
   if (typeof cost !== "number" || !Number.isFinite(cost)) return undefined
   if (cost < 0) return undefined
   if (cost === 0) return opts.zero ? zero : undefined
+  if (cost < 0.01) return "<$0.01"
 
-  const formatted = money.format(cost)
-  return formatted === zero ? "<$0.01" : formatted
+  return money.format(cost)
 }
 
 export function formatUsageDisplay(input: {

--- a/packages/opencode/src/cli/cmd/tui/util/usage-display.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/usage-display.ts
@@ -5,6 +5,7 @@ const money = new Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "USD",
 })
+const zero = money.format(0)
 
 type ContextModel = { limit?: { context?: number } } | undefined
 
@@ -33,6 +34,15 @@ export function usagePercent(tokens: number, model: ContextModel) {
   return Math.round((tokens / limit) * 100)
 }
 
+export function formatCostDisplay(cost: number | undefined, opts: { zero?: boolean } = {}) {
+  if (typeof cost !== "number" || !Number.isFinite(cost)) return undefined
+  if (cost < 0) return undefined
+  if (cost === 0) return opts.zero ? zero : undefined
+
+  const formatted = money.format(cost)
+  return formatted === zero ? "<$0.01" : formatted
+}
+
 export function formatUsageDisplay(input: {
   message: Pick<AssistantMessage, "tokens">
   model: ContextModel
@@ -42,9 +52,8 @@ export function formatUsageDisplay(input: {
   if (tokens <= 0) return undefined
 
   const pct = usagePercent(tokens, input.model)
-  const cost = input.cost ?? 0
   return {
     context: pct === undefined ? Locale.number(tokens) : `${Locale.number(tokens)} (${pct}%)`,
-    cost: cost > 0 ? money.format(cost) : undefined,
+    cost: formatCostDisplay(input.cost),
   }
 }

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -652,7 +652,7 @@ export namespace SessionAgencySwarm {
         cachedInputTokens: 0,
         cacheWriteInputTokens: 0,
       }
-      const cost = finalUsage.cost ?? 0
+      const cost = finalUsage.cost
 
       yield {
         type: "finish-step",
@@ -667,7 +667,7 @@ export namespace SessionAgencySwarm {
         providerMetadata: {
           agency_swarm: {
             cacheWriteInputTokens: finalUsage.cacheWriteInputTokens,
-            totalCost: cost,
+            ...(cost === undefined ? {} : { totalCost: cost }),
           },
         },
       }

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -381,9 +381,19 @@ export const getUsage = (input: { model: Provider.Model; usage: LanguageModelUsa
     if (!Number.isFinite(value)) return 0
     return Math.max(0, value)
   }
+  const finite = (value: unknown) => {
+    if (typeof value !== "number") return undefined
+    if (!Number.isFinite(value)) return undefined
+    return Math.max(0, value)
+  }
+  const record = (value: unknown) => {
+    if (!value || typeof value !== "object") return undefined
+    return value as Record<string, unknown>
+  }
   const inputTokens = safe(input.usage.inputTokens ?? 0)
   const outputTokens = safe(input.usage.outputTokens ?? 0)
   const reasoningTokens = safe(input.usage.outputTokenDetails?.reasoningTokens ?? input.usage.reasoningTokens ?? 0)
+  const agencySwarmCost = finite(record(input.metadata?.["agency_swarm"])?.["totalCost"])
 
   const cacheReadInputTokens = safe(
     input.usage.inputTokenDetails?.cacheReadTokens ?? input.usage.cachedInputTokens ?? 0,
@@ -429,18 +439,19 @@ export const getUsage = (input: { model: Provider.Model; usage: LanguageModelUsa
     (input.model.cost?.experimentalOver200K && contextTokens > 200_000
       ? input.model.cost.experimentalOver200K
       : input.model.cost)
+  const calculatedCost = safe(
+    new Decimal(0)
+      .add(new Decimal(tokens.input).mul(costInfo?.input ?? 0).div(1_000_000))
+      .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))
+      .add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
+      .add(new Decimal(tokens.cache.write).mul(costInfo?.cache?.write ?? 0).div(1_000_000))
+      // TODO: update models.dev to have better pricing model, for now:
+      // charge reasoning tokens at the same rate as output tokens
+      .add(new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000))
+      .toNumber(),
+  )
   return {
-    cost: safe(
-      new Decimal(0)
-        .add(new Decimal(tokens.input).mul(costInfo?.input ?? 0).div(1_000_000))
-        .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))
-        .add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
-        .add(new Decimal(tokens.cache.write).mul(costInfo?.cache?.write ?? 0).div(1_000_000))
-        // TODO: update models.dev to have better pricing model, for now:
-        // charge reasoning tokens at the same rate as output tokens
-        .add(new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000))
-        .toNumber(),
-    ),
+    cost: agencySwarmCost ?? calculatedCost,
     tokens,
   }
 }

--- a/packages/opencode/test/cli/tui/dialog-agent.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-agent.test.tsx
@@ -134,7 +134,7 @@ describe("DialogAgent agency selection", () => {
 
     const agencyOption = selectProps?.options.find((option) => option.title === "Live Agency")
     expect(agencyOption).toBeDefined()
-    expect(agencyOption?.category).toBe("Swarm: Live Agency")
+    expect(agencyOption?.category).toBe("Swarm: Live Agency (1 main / 1 sub)")
     expect(agencyOption?.description).toBeUndefined()
 
     selectProps!.onSelect!(agencyOption!)

--- a/packages/opencode/test/cli/tui/dialog-agent.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-agent.test.tsx
@@ -134,7 +134,7 @@ describe("DialogAgent agency selection", () => {
 
     const agencyOption = selectProps?.options.find((option) => option.title === "Live Agency")
     expect(agencyOption).toBeDefined()
-    expect(agencyOption?.category).toBe("Swarm: Live Agency (1 main / 1 sub)")
+    expect(agencyOption?.category).toBe("Swarm: Live Agency (1 main / 1 other)")
     expect(agencyOption?.description).toBeUndefined()
 
     selectProps!.onSelect!(agencyOption!)

--- a/packages/opencode/test/cli/tui/dialog-agent.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-agent.test.tsx
@@ -134,7 +134,7 @@ describe("DialogAgent agency selection", () => {
 
     const agencyOption = selectProps?.options.find((option) => option.title === "Live Agency")
     expect(agencyOption).toBeDefined()
-    expect(agencyOption?.category).toBe("Swarm: Live Agency (1 main / 1 other)")
+    expect(agencyOption?.category).toBe("Swarm: Live Agency (1 main / 1 subagent)")
     expect(agencyOption?.description).toBeUndefined()
 
     selectProps!.onSelect!(agencyOption!)

--- a/packages/opencode/test/cli/tui/dialog-agent.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-agent.test.tsx
@@ -134,7 +134,7 @@ describe("DialogAgent agency selection", () => {
 
     const agencyOption = selectProps?.options.find((option) => option.title === "Live Agency")
     expect(agencyOption).toBeDefined()
-    expect(agencyOption?.category).toBe("Swarm: Live Agency (1 main / 1 subagent)")
+    expect(agencyOption?.category).toBe("Swarm: Live Agency")
     expect(agencyOption?.description).toBeUndefined()
 
     selectProps!.onSelect!(agencyOption!)

--- a/packages/opencode/test/cli/tui/internal-plugins.test.ts
+++ b/packages/opencode/test/cli/tui/internal-plugins.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test"
+import { internalTuiPlugins } from "../../../src/cli/cmd/tui/plugin/internal"
+
+test("internal plugins register the agency sidebar between context and MCP", () => {
+  const ids = internalTuiPlugins({ experimentalEventSystem: false }).map((plugin) => plugin.id)
+
+  expect(ids).toContain("internal:sidebar-agency")
+  expect(ids.indexOf("internal:sidebar-context")).toBeLessThan(ids.indexOf("internal:sidebar-agency"))
+  expect(ids.indexOf("internal:sidebar-agency")).toBeLessThan(ids.indexOf("internal:sidebar-mcp"))
+})

--- a/packages/opencode/test/cli/tui/sidebar-agency.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-agency.test.tsx
@@ -270,6 +270,24 @@ describe("sidebar agency plugin", () => {
     expect(frame).not.toContain("Active: Lead")
   })
 
+  test("shows handed off recipient as active for default single swarm", async () => {
+    const sessionID = "session_1"
+    const messageID = "message_assistant_1"
+    const frame = await renderSidebar({
+      sessionID,
+      messages: [assistant({ id: messageID, sessionID, agent: "Lead", completed: 2 })],
+      parts: {
+        [messageID]: [transfer({ id: "part_transfer", sessionID, messageID, agent: "Review" })],
+      },
+      agencies: [agency({ id: "live", name: "Live Agency", agents: [main("Lead"), sub("Review")] })],
+    })
+
+    expect(frame).toContain("Swarm")
+    expect(frame).toContain("Live Agency")
+    expect(frame).toContain("Active: Review")
+    expect(frame).not.toContain("Active: Lead")
+  })
+
   test("shows concise fallback states", async () => {
     const empty = await renderSidebar({
       agencies: [],

--- a/packages/opencode/test/cli/tui/sidebar-agency.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-agency.test.tsx
@@ -222,9 +222,12 @@ describe("sidebar agency plugin", () => {
   })
 
   test("formats main and subagent counts", () => {
-    expect(formatAgencyCounts(countAgencyAgents([]))).toBe("0 main / 0 other")
-    expect(formatAgencyCounts(countAgencyAgents([main("Lead")]))).toBe("1 main / 0 other")
-    expect(formatAgencyCounts(countAgencyAgents([main("Lead"), sub("Review"), sub("Write")]))).toBe("1 main / 2 other")
+    expect(formatAgencyCounts(countAgencyAgents([]))).toBe("0 main / 0 subagents")
+    expect(formatAgencyCounts(countAgencyAgents([main("Lead")]))).toBe("1 main / 0 subagents")
+    expect(formatAgencyCounts(countAgencyAgents([main("Lead"), sub("Review")]))).toBe("1 main / 1 subagent")
+    expect(formatAgencyCounts(countAgencyAgents([main("Lead"), sub("Review"), sub("Write")]))).toBe(
+      "1 main / 2 subagents",
+    )
   })
 
   test("does not discover or render outside framework mode", async () => {
@@ -245,7 +248,7 @@ describe("sidebar agency plugin", () => {
 
     expect(frame).toContain("Swarm")
     expect(frame).toContain("Live Agency")
-    expect(frame).toContain("1 main / 2 other")
+    expect(frame).toContain("1 main / 2 subagents")
     expect(frame).toContain("Active: Review")
   })
 

--- a/packages/opencode/test/cli/tui/sidebar-agency.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-agency.test.tsx
@@ -222,9 +222,9 @@ describe("sidebar agency plugin", () => {
   })
 
   test("formats main and subagent counts", () => {
-    expect(formatAgencyCounts(countAgencyAgents([]))).toBe("0 main / 0 sub")
-    expect(formatAgencyCounts(countAgencyAgents([main("Lead")]))).toBe("1 main / 0 sub")
-    expect(formatAgencyCounts(countAgencyAgents([main("Lead"), sub("Review"), sub("Write")]))).toBe("1 main / 2 sub")
+    expect(formatAgencyCounts(countAgencyAgents([]))).toBe("0 main / 0 other")
+    expect(formatAgencyCounts(countAgencyAgents([main("Lead")]))).toBe("1 main / 0 other")
+    expect(formatAgencyCounts(countAgencyAgents([main("Lead"), sub("Review"), sub("Write")]))).toBe("1 main / 2 other")
   })
 
   test("does not discover or render outside framework mode", async () => {
@@ -245,7 +245,7 @@ describe("sidebar agency plugin", () => {
 
     expect(frame).toContain("Swarm")
     expect(frame).toContain("Live Agency")
-    expect(frame).toContain("1 main / 2 sub")
+    expect(frame).toContain("1 main / 2 other")
     expect(frame).toContain("Active: Review")
   })
 

--- a/packages/opencode/test/cli/tui/sidebar-agency.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-agency.test.tsx
@@ -1,0 +1,196 @@
+/** @jsxImportSource @opentui/solid */
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { RGBA } from "@opentui/core"
+import { AgencySwarmAdapter } from "../../../src/agency-swarm/adapter"
+import * as LocalContext from "../../../src/cli/cmd/tui/context/local"
+import { countAgencyAgents, formatAgencyCounts } from "../../../src/cli/cmd/tui/util/agency-counts"
+import { createTuiPluginApi } from "../../fixture/tui-plugin"
+
+function flushEffects() {
+  return Promise.resolve().then(() => Promise.resolve())
+}
+
+function agency(input: {
+  id: string
+  name: string
+  agents: AgencySwarmAdapter.AgencyAgentDescriptor[]
+}): AgencySwarmAdapter.AgencyDescriptor {
+  return {
+    id: input.id,
+    name: input.name,
+    agents: input.agents,
+    metadata: {},
+  }
+}
+
+function main(id: string): AgencySwarmAdapter.AgencyAgentDescriptor {
+  return {
+    id,
+    name: id,
+    isEntryPoint: true,
+  }
+}
+
+function sub(id: string): AgencySwarmAdapter.AgencyAgentDescriptor {
+  return {
+    id,
+    name: id,
+    isEntryPoint: false,
+  }
+}
+
+function stubLocal(providerID = AgencySwarmAdapter.PROVIDER_ID) {
+  spyOn(LocalContext, "useLocal").mockReturnValue({
+    agent: {
+      current: () => ({
+        name: "build",
+        model: {
+          providerID,
+          modelID: AgencySwarmAdapter.DEFAULT_MODEL_ID,
+        },
+      }),
+      list: () => [{ name: "build" }],
+      set: mock(() => undefined),
+      color: () => RGBA.fromHex("#38bdf8"),
+    },
+    model: {
+      current: () => ({
+        providerID,
+        modelID: providerID === AgencySwarmAdapter.PROVIDER_ID ? AgencySwarmAdapter.DEFAULT_MODEL_ID : "gpt-5.5",
+      }),
+      variant: {
+        current: () => undefined,
+        list: () => [],
+        set: mock(() => undefined),
+      },
+    },
+  } as unknown as ReturnType<typeof LocalContext.useLocal>)
+}
+
+async function renderSidebar(input: {
+  agencies?: AgencySwarmAdapter.AgencyDescriptor[]
+  error?: Error
+  agency?: string
+  recipientAgent?: string
+  providerID?: string
+}) {
+  const providerID = input.providerID ?? AgencySwarmAdapter.PROVIDER_ID
+  stubLocal(providerID)
+  if (input.error) {
+    spyOn(AgencySwarmAdapter, "discover").mockRejectedValue(input.error)
+  } else {
+    spyOn(AgencySwarmAdapter, "discover").mockResolvedValue({
+      agencies: input.agencies ?? [],
+      rawOpenAPI: {},
+    })
+  }
+
+  let render: (() => unknown) | undefined
+  const base = createTuiPluginApi({
+    state: {
+      config: {
+        model:
+          providerID === AgencySwarmAdapter.PROVIDER_ID
+            ? `${AgencySwarmAdapter.PROVIDER_ID}/${AgencySwarmAdapter.DEFAULT_MODEL_ID}`
+            : "openai/gpt-5.5",
+        provider: {
+          [AgencySwarmAdapter.PROVIDER_ID]: {
+            options: {
+              baseURL: "http://127.0.0.1:8000",
+              agency: input.agency,
+              recipientAgent: input.recipientAgent,
+            },
+          },
+        },
+      },
+      provider: [
+        {
+          id: AgencySwarmAdapter.PROVIDER_ID,
+          name: "Agency Swarm",
+          source: "config",
+          env: [],
+          options: {},
+          models: {},
+          key: "token",
+        },
+      ],
+    },
+  })
+  const api = {
+    ...base,
+    slots: {
+      register(plugin: { slots: { sidebar_content?: () => unknown } }) {
+        render = plugin.slots.sidebar_content
+        return "fixture-slot"
+      },
+    },
+  } as typeof base
+
+  const plugin = (await import("../../../src/cli/cmd/tui/feature-plugins/sidebar/agency")).default
+  await plugin.tui(api, undefined, {
+    state: "same",
+    id: "internal:sidebar-agency",
+    source: "internal",
+    spec: "internal:sidebar-agency",
+    target: "internal:sidebar-agency",
+    first_time: 0,
+    last_time: 0,
+    time_changed: 0,
+    load_count: 1,
+    fingerprint: "internal:sidebar-agency",
+  })
+  const rendered = await testRender(() => render?.() ?? null, { width: 80, height: 16 })
+  await flushEffects()
+  await Bun.sleep(0)
+  await flushEffects()
+  await rendered.renderOnce()
+
+  return rendered.captureCharFrame()
+}
+
+describe("sidebar agency plugin", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test("formats main and subagent counts", () => {
+    expect(formatAgencyCounts(countAgencyAgents([]))).toBe("0 main / 0 sub")
+    expect(formatAgencyCounts(countAgencyAgents([main("Lead")]))).toBe("1 main / 0 sub")
+    expect(formatAgencyCounts(countAgencyAgents([main("Lead"), sub("Review"), sub("Write")]))).toBe("1 main / 2 sub")
+  })
+
+  test("does not discover or render outside framework mode", async () => {
+    const frame = await renderSidebar({
+      providerID: "openai",
+    })
+
+    expect(AgencySwarmAdapter.discover).not.toHaveBeenCalled()
+    expect(frame).not.toContain("Swarm")
+  })
+
+  test("shows selected swarm counts and active agent", async () => {
+    const frame = await renderSidebar({
+      agency: "live",
+      recipientAgent: "Review",
+      agencies: [agency({ id: "live", name: "Live Agency", agents: [main("Lead"), sub("Review"), sub("Write")] })],
+    })
+
+    expect(frame).toContain("Swarm")
+    expect(frame).toContain("Live Agency")
+    expect(frame).toContain("1 main / 2 sub")
+    expect(frame).toContain("Active: Review")
+  })
+
+  test("shows concise fallback states", async () => {
+    const empty = await renderSidebar({
+      agencies: [],
+    })
+    expect(empty).toContain("No swarms")
+
+    const failed = await renderSidebar({
+      error: new Error("offline"),
+    })
+    expect(failed).toContain("Agents unavailable")
+  })
+})

--- a/packages/opencode/test/cli/tui/sidebar-agency.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-agency.test.tsx
@@ -2,10 +2,14 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { testRender } from "@opentui/solid"
 import { RGBA } from "@opentui/core"
+import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
 import { AgencySwarmAdapter } from "../../../src/agency-swarm/adapter"
 import * as LocalContext from "../../../src/cli/cmd/tui/context/local"
 import { countAgencyAgents, formatAgencyCounts } from "../../../src/cli/cmd/tui/util/agency-counts"
 import { createTuiPluginApi } from "../../fixture/tui-plugin"
+
+type StateMessage = ReturnType<TuiPluginApi["state"]["session"]["messages"]>[number]
+type StatePart = ReturnType<TuiPluginApi["state"]["part"]>[number]
 
 function flushEffects() {
   return Promise.resolve().then(() => Promise.resolve())
@@ -37,6 +41,59 @@ function sub(id: string): AgencySwarmAdapter.AgencyAgentDescriptor {
     id,
     name: id,
     isEntryPoint: false,
+  }
+}
+
+function assistant(input: { id: string; sessionID: string; agent: string; completed: number }): StateMessage {
+  return {
+    id: input.id,
+    sessionID: input.sessionID,
+    role: "assistant",
+    time: {
+      created: input.completed - 1,
+      completed: input.completed,
+    },
+    parentID: "message_user_1",
+    modelID: AgencySwarmAdapter.DEFAULT_MODEL_ID,
+    providerID: AgencySwarmAdapter.PROVIDER_ID,
+    mode: "build",
+    agent: input.agent,
+    path: {
+      cwd: "",
+      root: "",
+    },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: {
+        read: 0,
+        write: 0,
+      },
+    },
+  }
+}
+
+function transfer(input: { id: string; sessionID: string; messageID: string; agent: string }): StatePart {
+  return {
+    id: input.id,
+    sessionID: input.sessionID,
+    messageID: input.messageID,
+    type: "tool",
+    callID: "call_transfer",
+    tool: `transfer_to_${input.agent}`,
+    state: {
+      status: "completed",
+      input: {},
+      output: "",
+      title: "Transfer",
+      metadata: {},
+      time: {
+        start: 1,
+        end: 2,
+      },
+    },
   }
 }
 
@@ -73,9 +130,14 @@ async function renderSidebar(input: {
   error?: Error
   agency?: string
   recipientAgent?: string
+  recipientAgentSelectedAt?: number
+  sessionID?: string
+  messages?: StateMessage[]
+  parts?: Record<string, StatePart[]>
   providerID?: string
 }) {
   const providerID = input.providerID ?? AgencySwarmAdapter.PROVIDER_ID
+  const sessionID = input.sessionID ?? "session_1"
   stubLocal(providerID)
   if (input.error) {
     spyOn(AgencySwarmAdapter, "discover").mockRejectedValue(input.error)
@@ -86,7 +148,7 @@ async function renderSidebar(input: {
     })
   }
 
-  let render: (() => unknown) | undefined
+  let render: ((ctx: unknown, props: { session_id: string }) => unknown) | undefined
   const base = createTuiPluginApi({
     state: {
       config: {
@@ -100,6 +162,7 @@ async function renderSidebar(input: {
               baseURL: "http://127.0.0.1:8000",
               agency: input.agency,
               recipientAgent: input.recipientAgent,
+              recipientAgentSelectedAt: input.recipientAgentSelectedAt,
             },
           },
         },
@@ -115,12 +178,16 @@ async function renderSidebar(input: {
           key: "token",
         },
       ],
+      session: {
+        messages: (id) => (id === sessionID ? (input.messages ?? []) : []),
+      },
+      part: (id) => input.parts?.[id] ?? [],
     },
   })
   const api = {
     ...base,
     slots: {
-      register(plugin: { slots: { sidebar_content?: () => unknown } }) {
+      register(plugin: { slots: { sidebar_content?: (ctx: unknown, props: { session_id: string }) => unknown } }) {
         render = plugin.slots.sidebar_content
         return "fixture-slot"
       },
@@ -140,7 +207,7 @@ async function renderSidebar(input: {
     load_count: 1,
     fingerprint: "internal:sidebar-agency",
   })
-  const rendered = await testRender(() => render?.() ?? null, { width: 80, height: 16 })
+  const rendered = await testRender(() => render?.({}, { session_id: sessionID }) ?? null, { width: 80, height: 16 })
   await flushEffects()
   await Bun.sleep(0)
   await flushEffects()
@@ -180,6 +247,27 @@ describe("sidebar agency plugin", () => {
     expect(frame).toContain("Live Agency")
     expect(frame).toContain("1 main / 2 sub")
     expect(frame).toContain("Active: Review")
+  })
+
+  test("shows handed off recipient from session history as active", async () => {
+    const sessionID = "session_1"
+    const messageID = "message_assistant_1"
+    const frame = await renderSidebar({
+      agency: "live",
+      recipientAgent: "Lead",
+      recipientAgentSelectedAt: 1,
+      sessionID,
+      messages: [assistant({ id: messageID, sessionID, agent: "Lead", completed: 2 })],
+      parts: {
+        [messageID]: [transfer({ id: "part_transfer", sessionID, messageID, agent: "Review" })],
+      },
+      agencies: [agency({ id: "live", name: "Live Agency", agents: [main("Lead"), sub("Review")] })],
+    })
+
+    expect(frame).toContain("Swarm")
+    expect(frame).toContain("Live Agency")
+    expect(frame).toContain("Active: Review")
+    expect(frame).not.toContain("Active: Lead")
   })
 
   test("shows concise fallback states", async () => {

--- a/packages/opencode/test/cli/tui/sidebar-context.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-context.test.tsx
@@ -178,9 +178,9 @@ describe("sidebar context plugin", () => {
     expect(frame).not.toContain("$0.00 spent")
   })
 
-  test("shows positive rounded-zero spend as less than one cent", async () => {
+  test("shows positive sub-cent spend as less than one cent", async () => {
     mockLocal()
-    const frame = await renderContext({ context: 3_000, cost: 0.001 })
+    const frame = await renderContext({ context: 3_000, cost: 0.006 })
 
     expect(frame).toContain("1,500 tokens")
     expect(frame).toContain("50% used")

--- a/packages/opencode/test/cli/tui/sidebar-context.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-context.test.tsx
@@ -1,0 +1,154 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import type { AssistantMessage, Provider } from "@opencode-ai/sdk/v2"
+import { createTuiPluginApi } from "../../fixture/tui-plugin"
+
+type SidebarContent = (ctx: unknown, props: { session_id: string }) => unknown
+
+function assistant(tokens: AssistantMessage["tokens"]): AssistantMessage {
+  return {
+    id: "message_assistant_1",
+    role: "assistant",
+    sessionID: "session_1",
+    parentID: "message_user_1",
+    time: {
+      created: 1,
+      completed: 2,
+    },
+    modelID: "default",
+    providerID: "agency-swarm",
+    mode: "build",
+    agent: "build",
+    path: {
+      cwd: "/tmp/project",
+      root: "/tmp/project",
+    },
+    cost: 0.42,
+    tokens,
+    finish: "stop",
+  } as unknown as AssistantMessage
+}
+
+function provider(context: number): Provider {
+  return {
+    id: "agency-swarm",
+    name: "Agency Swarm",
+    source: "config",
+    env: [],
+    options: {},
+    key: "token",
+    models: {
+      default: {
+        id: "default",
+        providerID: "agency-swarm",
+        name: "Swarm Default",
+        api: {
+          id: "default",
+          npm: "@ai-sdk/openai-compatible",
+          url: "http://127.0.0.1:8000",
+        },
+        status: "active",
+        headers: {},
+        options: {},
+        release_date: "2026-01-01",
+        cost: {
+          input: 0,
+          output: 0,
+          cache: {
+            read: 0,
+            write: 0,
+          },
+        },
+        limit: {
+          context,
+          output: 8_192,
+        },
+        capabilities: {
+          toolcall: true,
+          attachment: true,
+          reasoning: false,
+          temperature: false,
+          input: { text: true, image: true, audio: false, video: false, pdf: false },
+          output: { text: true, image: false, audio: false, video: false, pdf: false },
+          interleaved: false,
+        },
+      },
+    },
+  }
+}
+
+async function renderContext(input: { context: number }) {
+  let render: SidebarContent | undefined
+  const api = createTuiPluginApi({
+    state: {
+      provider: [provider(input.context)],
+      session: {
+        get: () => ({ cost: 0.42 }) as never,
+        messages: () => [
+          assistant({
+            total: 1_500,
+            input: 1_200,
+            output: 0,
+            reasoning: 0,
+            cache: {
+              read: 0,
+              write: 0,
+            },
+          }),
+        ],
+      },
+    },
+  })
+  const withSlot = {
+    ...api,
+    slots: {
+      register(plugin: { slots: { sidebar_content?: SidebarContent } }) {
+        render = plugin.slots.sidebar_content
+        return "fixture-slot"
+      },
+    },
+  } as typeof api
+
+  const plugin = (await import("../../../src/cli/cmd/tui/feature-plugins/sidebar/context")).default
+  await plugin.tui(withSlot, undefined, {
+    state: "same",
+    id: "internal:sidebar-context",
+    source: "internal",
+    spec: "internal:sidebar-context",
+    target: "internal:sidebar-context",
+    first_time: 0,
+    last_time: 0,
+    time_changed: 0,
+    load_count: 1,
+    fingerprint: "internal:sidebar-context",
+  })
+  const rendered = await testRender(() => render?.({}, { session_id: "session_1" }) ?? null, {
+    width: 80,
+    height: 8,
+  })
+  await rendered.renderOnce()
+  return rendered.captureCharFrame()
+}
+
+describe("sidebar context plugin", () => {
+  test("shows real usage totals and spend when output tokens are zero", async () => {
+    const frame = await renderContext({ context: 3_000 })
+    const lines = frame.split("\n").map((line) => line.trim())
+
+    expect(frame).toContain("1,500 tokens")
+    expect(frame).toContain("50% used")
+    expect(frame).toContain("$0.42 spent")
+    expect(lines).not.toContain("0% used")
+    expect(frame).not.toContain("$0.00 spent")
+  })
+
+  test("does not show a false zero percent for placeholder Agency Swarm context limits", async () => {
+    const frame = await renderContext({ context: Number.MAX_SAFE_INTEGER })
+    const lines = frame.split("\n").map((line) => line.trim())
+
+    expect(frame).toContain("1,500 tokens")
+    expect(frame).toContain("Usage percent unavailable")
+    expect(lines).not.toContain("0% used")
+  })
+})

--- a/packages/opencode/test/cli/tui/sidebar-context.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-context.test.tsx
@@ -153,12 +153,13 @@ describe("sidebar context plugin", () => {
     expect(frame).not.toContain("$0.00 spent")
   })
 
-  test("does not show a false zero percent for placeholder Agency Swarm context limits", async () => {
+  test("hides percent for placeholder Agency Swarm context limits", async () => {
     const frame = await renderContext({ context: Number.MAX_SAFE_INTEGER })
     const lines = frame.split("\n").map((line) => line.trim())
 
     expect(frame).toContain("1,500 tokens")
-    expect(frame).toContain("Usage percent unavailable")
+    expect(frame).not.toContain("Usage percent unavailable")
     expect(lines).not.toContain("0% used")
+    expect(frame).not.toContain("% used")
   })
 })

--- a/packages/opencode/test/cli/tui/sidebar-context.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-context.test.tsx
@@ -78,25 +78,26 @@ function provider(context: number): Provider {
   }
 }
 
-async function renderContext(input: { context: number }) {
+async function renderContext(input: { context: number; messages?: AssistantMessage[]; cost?: number }) {
   let render: SidebarContent | undefined
   const api = createTuiPluginApi({
     state: {
       provider: [provider(input.context)],
       session: {
-        get: () => ({ cost: 0.42 }) as never,
-        messages: () => [
-          assistant({
-            total: 1_500,
-            input: 1_200,
-            output: 0,
-            reasoning: 0,
-            cache: {
-              read: 0,
-              write: 0,
-            },
-          }),
-        ],
+        get: () => ({ cost: input.cost ?? 0.42 }) as never,
+        messages: () =>
+          input.messages ?? [
+            assistant({
+              total: 1_500,
+              input: 1_200,
+              output: 0,
+              reasoning: 0,
+              cache: {
+                read: 0,
+                write: 0,
+              },
+            }),
+          ],
       },
     },
   })
@@ -132,6 +133,15 @@ async function renderContext(input: { context: number }) {
 }
 
 describe("sidebar context plugin", () => {
+  test("shows zero percent for fresh sessions without assistant usage", async () => {
+    const frame = await renderContext({ context: 3_000, messages: [], cost: 0 })
+
+    expect(frame).toContain("0 tokens")
+    expect(frame).toContain("0% used")
+    expect(frame).toContain("$0.00 spent")
+    expect(frame).not.toContain("Usage percent unavailable")
+  })
+
   test("shows real usage totals and spend when output tokens are zero", async () => {
     const frame = await renderContext({ context: 3_000 })
     const lines = frame.split("\n").map((line) => line.trim())

--- a/packages/opencode/test/cli/tui/sidebar-context.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-context.test.tsx
@@ -1,10 +1,19 @@
 /** @jsxImportSource @opentui/solid */
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { testRender } from "@opentui/solid"
 import type { AssistantMessage, Provider } from "@opencode-ai/sdk/v2"
+import * as LocalContext from "../../../src/cli/cmd/tui/context/local"
 import { createTuiPluginApi } from "../../fixture/tui-plugin"
 
 type SidebarContent = (ctx: unknown, props: { session_id: string }) => unknown
+
+function mockLocal() {
+  spyOn(LocalContext, "useLocal").mockReturnValue({
+    model: {
+      current: () => ({ providerID: "agency-swarm", modelID: "default" }),
+    },
+  } as unknown as ReturnType<typeof LocalContext.useLocal>)
+}
 
 function assistant(tokens: AssistantMessage["tokens"]): AssistantMessage {
   return {
@@ -133,7 +142,12 @@ async function renderContext(input: { context: number; messages?: AssistantMessa
 }
 
 describe("sidebar context plugin", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
   test("shows zero percent for fresh sessions without assistant usage", async () => {
+    mockLocal()
     const frame = await renderContext({ context: 3_000, messages: [], cost: 0 })
 
     expect(frame).toContain("0 tokens")
@@ -142,7 +156,18 @@ describe("sidebar context plugin", () => {
     expect(frame).not.toContain("Usage percent unavailable")
   })
 
+  test("hides percent for fresh sessions with placeholder Agency Swarm context limits", async () => {
+    mockLocal()
+    const frame = await renderContext({ context: Number.MAX_SAFE_INTEGER, messages: [], cost: 0 })
+
+    expect(frame).toContain("0 tokens")
+    expect(frame).toContain("$0.00 spent")
+    expect(frame).not.toContain("Usage percent unavailable")
+    expect(frame).not.toContain("% used")
+  })
+
   test("shows real usage totals and spend when output tokens are zero", async () => {
+    mockLocal()
     const frame = await renderContext({ context: 3_000 })
     const lines = frame.split("\n").map((line) => line.trim())
 
@@ -154,6 +179,7 @@ describe("sidebar context plugin", () => {
   })
 
   test("hides percent for placeholder Agency Swarm context limits", async () => {
+    mockLocal()
     const frame = await renderContext({ context: Number.MAX_SAFE_INTEGER })
     const lines = frame.split("\n").map((line) => line.trim())
 

--- a/packages/opencode/test/cli/tui/sidebar-context.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-context.test.tsx
@@ -7,10 +7,22 @@ import { createTuiPluginApi } from "../../fixture/tui-plugin"
 
 type SidebarContent = (ctx: unknown, props: { session_id: string }) => unknown
 
-function mockLocal() {
+type ModelSelection = {
+  providerID: string
+  modelID: string
+}
+
+const agencyModel = { providerID: "agency-swarm", modelID: "default" }
+const openaiModel = { providerID: "openai", modelID: "gpt-5.1" }
+
+function mockLocal(input: { current?: ModelSelection; agentModel?: ModelSelection } = {}) {
+  const current = input.current ?? agencyModel
   spyOn(LocalContext, "useLocal").mockReturnValue({
     model: {
-      current: () => ({ providerID: "agency-swarm", modelID: "default" }),
+      current: () => current,
+    },
+    agent: {
+      current: () => ({ model: input.agentModel }),
     },
   } as unknown as ReturnType<typeof LocalContext.useLocal>)
 }
@@ -39,21 +51,22 @@ function assistant(tokens: AssistantMessage["tokens"]): AssistantMessage {
   } as unknown as AssistantMessage
 }
 
-function provider(context: number): Provider {
+function provider(input: { context: number; model?: ModelSelection; name?: string; modelName?: string }): Provider {
+  const model = input.model ?? agencyModel
   return {
-    id: "agency-swarm",
-    name: "Agency Swarm",
+    id: model.providerID,
+    name: input.name ?? "Agency Swarm",
     source: "config",
     env: [],
     options: {},
     key: "token",
     models: {
-      default: {
-        id: "default",
-        providerID: "agency-swarm",
-        name: "Swarm Default",
+      [model.modelID]: {
+        id: model.modelID,
+        providerID: model.providerID,
+        name: input.modelName ?? "Swarm Default",
         api: {
-          id: "default",
+          id: model.modelID,
           npm: "@ai-sdk/openai-compatible",
           url: "http://127.0.0.1:8000",
         },
@@ -70,7 +83,7 @@ function provider(context: number): Provider {
           },
         },
         limit: {
-          context,
+          context: input.context,
           output: 8_192,
         },
         capabilities: {
@@ -87,11 +100,18 @@ function provider(context: number): Provider {
   }
 }
 
-async function renderContext(input: { context: number; messages?: AssistantMessage[]; cost?: number }) {
+async function renderContext(input: {
+  context?: number
+  providers?: Provider[]
+  messages?: AssistantMessage[]
+  cost?: number
+  configModel?: string
+}) {
   let render: SidebarContent | undefined
   const api = createTuiPluginApi({
     state: {
-      provider: [provider(input.context)],
+      config: input.configModel ? ({ model: input.configModel } as never) : undefined,
+      provider: input.providers ?? [provider({ context: input.context ?? 3_000 })],
       session: {
         get: () => ({ cost: input.cost ?? 0.42 }) as never,
         messages: () =>
@@ -146,14 +166,36 @@ describe("sidebar context plugin", () => {
     mock.restore()
   })
 
-  test("shows zero percent for fresh sessions without assistant usage", async () => {
-    mockLocal()
-    const frame = await renderContext({ context: 3_000, messages: [], cost: 0 })
+  test("shows zero percent for fresh non-Run-mode sessions without assistant usage", async () => {
+    mockLocal({ current: openaiModel })
+    const frame = await renderContext({
+      providers: [provider({ context: 3_000, model: openaiModel, name: "OpenAI", modelName: "GPT-5.1" })],
+      messages: [],
+      cost: 0,
+    })
 
     expect(frame).toContain("0 tokens")
     expect(frame).toContain("0% used")
     expect(frame).toContain("$0.00 spent")
     expect(frame).not.toContain("Usage percent unavailable")
+  })
+
+  test("hides percent for fresh Run-mode sessions with visible OpenAI model state", async () => {
+    mockLocal({ current: openaiModel, agentModel: agencyModel })
+    const frame = await renderContext({
+      configModel: "agency-swarm/default",
+      providers: [
+        provider({ context: 128_000, model: openaiModel, name: "OpenAI", modelName: "GPT-5.1" }),
+        provider({ context: Number.MAX_SAFE_INTEGER, model: agencyModel }),
+      ],
+      messages: [],
+      cost: 0,
+    })
+
+    expect(frame).toContain("0 tokens")
+    expect(frame).toContain("$0.00 spent")
+    expect(frame).not.toContain("Usage percent unavailable")
+    expect(frame).not.toContain("% used")
   })
 
   test("hides percent for fresh sessions with placeholder Agency Swarm context limits", async () => {

--- a/packages/opencode/test/cli/tui/sidebar-context.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-context.test.tsx
@@ -178,6 +178,16 @@ describe("sidebar context plugin", () => {
     expect(frame).not.toContain("$0.00 spent")
   })
 
+  test("shows positive rounded-zero spend as less than one cent", async () => {
+    mockLocal()
+    const frame = await renderContext({ context: 3_000, cost: 0.001 })
+
+    expect(frame).toContain("1,500 tokens")
+    expect(frame).toContain("50% used")
+    expect(frame).not.toContain("$0.00 spent")
+    expect(frame).toContain("<$0.01 spent")
+  })
+
   test("hides percent for placeholder Agency Swarm context limits", async () => {
     mockLocal()
     const frame = await renderContext({ context: Number.MAX_SAFE_INTEGER })

--- a/packages/opencode/test/cli/tui/usage-display.test.ts
+++ b/packages/opencode/test/cli/tui/usage-display.test.ts
@@ -43,4 +43,32 @@ describe("usage display", () => {
       cost: "$0.42",
     })
   })
+
+  test("shows positive rounded-zero cost as less than one cent", () => {
+    const display = formatUsageDisplay({
+      message: message(tokens),
+      model: { limit: { context: 3_000 } },
+      cost: 0.001,
+    })
+
+    expect(display?.context).toBe("1.5K (50%)")
+    expect(display?.cost).toBe("<$0.01")
+  })
+
+  test("hides absent and zero cost", () => {
+    const absent = formatUsageDisplay({
+      message: message(tokens),
+      model: { limit: { context: 3_000 } },
+    })
+    const zero = formatUsageDisplay({
+      message: message(tokens),
+      model: { limit: { context: 3_000 } },
+      cost: 0,
+    })
+
+    expect(absent?.context).toBe("1.5K (50%)")
+    expect(absent?.cost).toBeUndefined()
+    expect(zero?.context).toBe("1.5K (50%)")
+    expect(zero?.cost).toBeUndefined()
+  })
 })

--- a/packages/opencode/test/cli/tui/usage-display.test.ts
+++ b/packages/opencode/test/cli/tui/usage-display.test.ts
@@ -44,15 +44,26 @@ describe("usage display", () => {
     })
   })
 
-  test("shows positive rounded-zero cost as less than one cent", () => {
+  test("shows positive sub-cent cost as less than one cent", () => {
     const display = formatUsageDisplay({
       message: message(tokens),
       model: { limit: { context: 3_000 } },
-      cost: 0.001,
+      cost: 0.006,
     })
 
     expect(display?.context).toBe("1.5K (50%)")
     expect(display?.cost).toBe("<$0.01")
+  })
+
+  test("shows one-cent cost as normal currency", () => {
+    const display = formatUsageDisplay({
+      message: message(tokens),
+      model: { limit: { context: 3_000 } },
+      cost: 0.01,
+    })
+
+    expect(display?.context).toBe("1.5K (50%)")
+    expect(display?.cost).toBe("$0.01")
   })
 
   test("hides absent and zero cost", () => {

--- a/packages/opencode/test/cli/tui/usage-display.test.ts
+++ b/packages/opencode/test/cli/tui/usage-display.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import type { AssistantMessage } from "@opencode-ai/sdk/v2"
+import { formatUsageDisplay } from "../../../src/cli/cmd/tui/util/usage-display"
+
+function message(tokens: AssistantMessage["tokens"]): Pick<AssistantMessage, "tokens"> {
+  return { tokens }
+}
+
+const tokens: AssistantMessage["tokens"] = {
+  total: 1_500,
+  input: 1_200,
+  output: 0,
+  reasoning: 0,
+  cache: {
+    read: 0,
+    write: 0,
+  },
+}
+
+describe("usage display", () => {
+  test("does not show a false zero percent for placeholder Agency Swarm context limits", () => {
+    const display = formatUsageDisplay({
+      message: message(tokens),
+      model: { limit: { context: Number.MAX_SAFE_INTEGER } },
+      cost: 0.42,
+    })
+
+    expect(display).toEqual({
+      context: "1.5K",
+      cost: "$0.42",
+    })
+  })
+
+  test("shows percent when the model has a real context limit", () => {
+    const display = formatUsageDisplay({
+      message: message(tokens),
+      model: { limit: { context: 3_000 } },
+      cost: 0.42,
+    })
+
+    expect(display).toEqual({
+      context: "1.5K (50%)",
+      cost: "$0.42",
+    })
+  })
+})

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3619,6 +3619,74 @@ describe("session.agency-swarm", () => {
     expect(appended[0]).toEqual([{ type: "function_call_output", call_id: "call_1", output: "done" }])
   })
 
+  test("stream omits Agency Swarm total cost metadata when usage has no cost", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield { type: "meta", runID: "run_1" }
+      yield {
+        type: "messages",
+        payload: {
+          run_id: "run_1",
+          usage: {
+            input_tokens: 2,
+            output_tokens: 3,
+          },
+          new_messages: [],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: any[] = []
+
+    for await (const event of stream.fullStream) {
+      events.push(event)
+    }
+
+    const metadata = events.find((event) => event.type === "finish-step")?.providerMetadata?.agency_swarm
+    expect(metadata).toMatchObject({
+      cacheWriteInputTokens: 0,
+    })
+    expect(Object.prototype.hasOwnProperty.call(metadata, "totalCost")).toBe(false)
+  })
+
+  test("stream preserves explicit zero Agency Swarm total cost metadata", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield { type: "meta", runID: "run_1" }
+      yield {
+        type: "messages",
+        payload: {
+          run_id: "run_1",
+          usage: {
+            input_tokens: 2,
+            output_tokens: 3,
+            total_cost: 0,
+          },
+          new_messages: [],
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: any[] = []
+
+    for await (const event of stream.fullStream) {
+      events.push(event)
+    }
+
+    expect(events.find((event) => event.type === "finish-step")?.providerMetadata).toMatchObject({
+      agency_swarm: {
+        cacheWriteInputTokens: 0,
+        totalCost: 0,
+      },
+    })
+  })
+
   test("stream maps non-function responses tool calls from response.*_call.* events", async () => {
     mockHistory()
     AgencySwarmAdapter.streamRun = async function* () {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -3569,6 +3569,7 @@ describe("session.agency-swarm", () => {
           usage: {
             input_tokens: 2,
             output_tokens: 3,
+            total_cost: 0.42,
             output_tokens_details: { reasoning_tokens: 1 },
             input_tokens_details: { cached_tokens: 1 },
           },
@@ -3608,6 +3609,11 @@ describe("session.agency-swarm", () => {
       outputTokens: 3,
       reasoningTokens: 1,
       cachedInputTokens: 1,
+    })
+    expect(events.find((event) => event.type === "finish-step")?.providerMetadata).toMatchObject({
+      agency_swarm: {
+        totalCost: 0.42,
+      },
     })
     expect(runs).toEqual(["run_1", "run_1"])
     expect(appended[0]).toEqual([{ type: "function_call_output", call_id: "call_1", output: "done" }])

--- a/packages/opencode/test/session/usage.test.ts
+++ b/packages/opencode/test/session/usage.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import { Session } from "@/session/session"
+import type { Provider } from "@/provider/provider"
+
+function createModel(): Provider.Model {
+  return {
+    id: "default",
+    providerID: "agency-swarm",
+    name: "Swarm Default",
+    limit: {
+      context: Number.MAX_SAFE_INTEGER,
+      input: Number.MAX_SAFE_INTEGER,
+      output: Number.MAX_SAFE_INTEGER,
+    },
+    cost: {
+      input: 12,
+      output: 24,
+      cache: {
+        read: 3,
+        write: 6,
+      },
+    },
+    capabilities: {
+      toolcall: true,
+      attachment: true,
+      reasoning: false,
+      temperature: false,
+      input: { text: true, image: true, audio: false, video: false },
+      output: { text: true, image: false, audio: false, video: false },
+      interleaved: false,
+    },
+    api: {
+      id: "default",
+      npm: "@ai-sdk/openai-compatible",
+      url: "http://127.0.0.1:8000",
+    },
+    options: {},
+  } as Provider.Model
+}
+
+describe("Session.getUsage", () => {
+  test("uses Agency Swarm payload cost from provider metadata", () => {
+    const result = Session.getUsage({
+      model: createModel(),
+      usage: {
+        inputTokens: 1_000,
+        outputTokens: 500,
+        totalTokens: 1_500,
+        inputTokenDetails: {
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+          noCacheTokens: undefined,
+        },
+        outputTokenDetails: {
+          reasoningTokens: undefined,
+          textTokens: undefined,
+        },
+      },
+      metadata: {
+        agency_swarm: {
+          totalCost: 0.42,
+        },
+      },
+    })
+
+    expect(result.tokens.total).toBe(1_500)
+    expect(result.tokens.input).toBe(1_000)
+    expect(result.tokens.output).toBe(500)
+    expect(result.cost).toBe(0.42)
+  })
+})

--- a/packages/opencode/test/session/usage.test.ts
+++ b/packages/opencode/test/session/usage.test.ts
@@ -68,4 +68,56 @@ describe("Session.getUsage", () => {
     expect(result.tokens.output).toBe(500)
     expect(result.cost).toBe(0.42)
   })
+
+  test("falls back to model pricing when Agency Swarm metadata omits cost", () => {
+    const result = Session.getUsage({
+      model: createModel(),
+      usage: {
+        inputTokens: 1_000,
+        outputTokens: 500,
+        totalTokens: 1_500,
+        inputTokenDetails: {
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+          noCacheTokens: undefined,
+        },
+        outputTokenDetails: {
+          reasoningTokens: undefined,
+          textTokens: undefined,
+        },
+      },
+      metadata: {
+        agency_swarm: {},
+      },
+    })
+
+    expect(result.cost).toBe(0.024)
+  })
+
+  test("preserves explicit zero-cost Agency Swarm metadata", () => {
+    const result = Session.getUsage({
+      model: createModel(),
+      usage: {
+        inputTokens: 1_000,
+        outputTokens: 500,
+        totalTokens: 1_500,
+        inputTokenDetails: {
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+          noCacheTokens: undefined,
+        },
+        outputTokenDetails: {
+          reasoningTokens: undefined,
+          textTokens: undefined,
+        },
+      },
+      metadata: {
+        agency_swarm: {
+          totalCost: 0,
+        },
+      },
+    })
+
+    expect(result.cost).toBe(0)
+  })
 })


### PR DESCRIPTION
### Issue for this PR

No issue - Agent Swarm TUI polish.

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shows an Agent Swarm sidebar section with the agency name, main and subagent counts, and the active agent. The `/agents` dialog uses the same count label for swarm sections.

The context sidebar and prompt footers also use Agency Swarm usage payloads for token and cost totals. Fresh sessions still show `0% used`, sessions with trusted model limits show the real percent, and placeholder Agent Swarm limits hide the percent row instead of inventing fallback text or fake percentages. Positive spend below one cent is shown as `<$0.01`.

### How did you verify your code works?

Focused TUI coverage and Agent Swarm terminal E2E cover sidebar count labels, usage payload handling, fresh-session usage, placeholder context-limit handling, sub-cent spend, and footer percent hiding. The PR page carries hosted checks for the latest head.

### Screenshots / recordings

Local terminal capture shows the Swarm sidebar section:

```text
Swarm
TuiDemoAgency
1 main / 1 subagent
Active: UserSupportAgent
```

Usage proof covers these visible states:

```text
0 tokens
0% used
$0.00 spent

1.5K
$0.42 spent

1.5K · $0.42
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

