### PR TITLE
fix(opencode): filter Codex OAuth models

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -15,7 +15,7 @@ export const CODEX_API_BASE_URL = "https://chatgpt.com/backend-api/codex"
 const CODEX_API_ENDPOINT = `${CODEX_API_BASE_URL}/responses`
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
-const CODEX_OAUTH_MODELS = new Set(["gpt-5.4-mini", "gpt-5.5"])
+const CODEX_OAUTH_MODELS = new Set(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"])
 
 interface PkceCodes {
   verifier: string

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -15,7 +15,7 @@ export const CODEX_API_BASE_URL = "https://chatgpt.com/backend-api/codex"
 const CODEX_API_ENDPOINT = `${CODEX_API_BASE_URL}/responses`
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
-const CODEX_OAUTH_MODELS = new Set(["gpt-5.5", "gpt-5.4-mini"])
+const CODEX_OAUTH_MODELS = new Set(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"])
 
 interface PkceCodes {
   verifier: string

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -15,14 +15,7 @@ export const CODEX_API_BASE_URL = "https://chatgpt.com/backend-api/codex"
 const CODEX_API_ENDPOINT = `${CODEX_API_BASE_URL}/responses`
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
-const ALLOWED_MODELS = new Set([
-  "gpt-5.5",
-  "gpt-5.2",
-  "gpt-5.3-codex",
-  "gpt-5.3-codex-spark",
-  "gpt-5.4",
-  "gpt-5.4-mini",
-])
+const CODEX_OAUTH_MODELS = new Set(["gpt-5.4-mini", "gpt-5.5"])
 
 interface PkceCodes {
   verifier: string
@@ -374,11 +367,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
 
         return Object.fromEntries(
           Object.entries(provider.models)
-            .filter(([, model]) => {
-              if (ALLOWED_MODELS.has(model.api.id)) return true
-              const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
-              return match ? parseFloat(match[1]) > 5.4 : false
-            })
+            .filter(([modelID]) => CODEX_OAUTH_MODELS.has(modelID))
             .map(([modelID, model]) => [
               modelID,
               {
@@ -388,13 +377,14 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                   output: 0,
                   cache: { read: 0, write: 0 },
                 },
-                limit: model.id.includes("gpt-5.5")
-                  ? {
-                      context: 400_000,
-                      input: 272_000,
-                      output: 128_000,
-                    }
-                  : model.limit,
+                limit:
+                  modelID === "gpt-5.5"
+                    ? {
+                        context: 400_000,
+                        input: 272_000,
+                        output: 128_000,
+                      }
+                    : model.limit,
               },
             ]),
         )

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -15,7 +15,7 @@ export const CODEX_API_BASE_URL = "https://chatgpt.com/backend-api/codex"
 const CODEX_API_ENDPOINT = `${CODEX_API_BASE_URL}/responses`
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
-const CODEX_OAUTH_MODELS = new Set(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"])
+const CODEX_OAUTH_MODELS = new Set(["gpt-5.5", "gpt-5.4-mini"])
 
 interface PkceCodes {
   verifier: string

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -367,7 +367,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
 
         return Object.fromEntries(
           Object.entries(provider.models)
-            .filter(([modelID]) => CODEX_OAUTH_MODELS.has(modelID))
+            .filter(([modelID, model]) => CODEX_OAUTH_MODELS.has(modelID) && CODEX_OAUTH_MODELS.has(model.api.id))
             .map(([modelID, model]) => [
               modelID,
               {

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -84,7 +84,7 @@ async function loadModels(provider: Provider, auth: Auth | undefined) {
 
 describe("plugin.codex", () => {
   describe("models", () => {
-    test("keeps only supported Codex OAuth visible model keys", async () => {
+    test("keeps recommended Codex OAuth visible model keys", async () => {
       const result = await loadModels(
         createProvider({
           "gpt-5.5": createModel("gpt-5.5"),
@@ -112,7 +112,9 @@ describe("plugin.codex", () => {
         },
       )
 
-      expect(Object.keys(result)).toEqual(["gpt-5.5", "gpt-5.4-mini"])
+      expect(Object.keys(result)).toEqual(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"])
+      expect(result["gpt-5.2"]).toBeUndefined()
+      expect(result["gpt-5.3-codex"]).toBeUndefined()
       expect(result["gpt-5.4-mini"]?.cost).toEqual({
         input: 0,
         output: 0,

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -87,16 +87,21 @@ describe("plugin.codex", () => {
     test("filters Codex OAuth models by visible model key", async () => {
       const result = await loadModels(
         createProvider({
-          "gpt-5.2": createModel("gpt-5.2"),
-          "gpt-5.3-codex": createModel("gpt-5.3-codex"),
-          "gpt-5.3-codex-spark": createModel("gpt-5.3-codex-spark"),
-          "gpt-5.4": createModel("gpt-5.4"),
-          "gpt-5.4-fast": createModel("gpt-5.4-fast", "gpt-5.4"),
-          "gpt-5.4-mini": createModel("gpt-5.4-mini"),
-          "gpt-5.4-mini-fast": createModel("gpt-5.4-mini-fast", "gpt-5.4-mini"),
           "gpt-5.5": createModel("gpt-5.5"),
+          "gpt-5.5-2026-06-18": createModel("gpt-5.5-2026-06-18", "gpt-5.5"),
           "gpt-5.5-fast": createModel("gpt-5.5-fast", "gpt-5.5"),
           "gpt-5.5-pro": createModel("gpt-5.5-pro", "gpt-5.5"),
+          "gpt-5.4": createModel("gpt-5.4"),
+          "gpt-5.4-2026-06-18": createModel("gpt-5.4-2026-06-18", "gpt-5.4"),
+          "gpt-5.4-fast": createModel("gpt-5.4-fast", "gpt-5.4"),
+          "gpt-5.4-nano": createModel("gpt-5.4-nano"),
+          "gpt-5.4-pro": createModel("gpt-5.4-pro", "gpt-5.4"),
+          "gpt-5.4-mini": createModel("gpt-5.4-mini"),
+          "gpt-5.4-mini-2026-06-18": createModel("gpt-5.4-mini-2026-06-18", "gpt-5.4-mini"),
+          "gpt-5.4-mini-fast": createModel("gpt-5.4-mini-fast", "gpt-5.4-mini"),
+          "gpt-5.3-codex-spark": createModel("gpt-5.3-codex-spark"),
+          "gpt-5.2": createModel("gpt-5.2"),
+          "gpt-5.3-codex": createModel("gpt-5.3-codex"),
         }),
         {
           type: "oauth",
@@ -106,13 +111,27 @@ describe("plugin.codex", () => {
         },
       )
 
-      expect(Object.keys(result)).toEqual(["gpt-5.4-mini", "gpt-5.5"])
+      expect(Object.keys(result)).toEqual(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"])
+      expect(result["gpt-5.4"]?.cost).toEqual({
+        input: 0,
+        output: 0,
+        cache: { read: 0, write: 0 },
+      })
       expect(result["gpt-5.4-mini"]?.cost).toEqual({
         input: 0,
         output: 0,
         cache: { read: 0, write: 0 },
       })
+      expect(result["gpt-5.3-codex-spark"]?.cost).toEqual({
+        input: 0,
+        output: 0,
+        cache: { read: 0, write: 0 },
+      })
       expect(result["gpt-5.4-mini"]?.limit).toEqual({
+        context: 128_000,
+        output: 16_384,
+      })
+      expect(result["gpt-5.3-codex-spark"]?.limit).toEqual({
         context: 128_000,
         output: 16_384,
       })
@@ -125,8 +144,14 @@ describe("plugin.codex", () => {
 
     test("keeps API key models unfiltered", async () => {
       const provider = createProvider({
+        "gpt-5.2": createModel("gpt-5.2"),
+        "gpt-5.3-codex": createModel("gpt-5.3-codex"),
+        "gpt-5.3-codex-spark": createModel("gpt-5.3-codex-spark"),
         "gpt-5.4": createModel("gpt-5.4"),
+        "gpt-5.4-nano": createModel("gpt-5.4-nano"),
         "gpt-5.4-mini": createModel("gpt-5.4-mini"),
+        "gpt-5.4-mini-2026-06-18": createModel("gpt-5.4-mini-2026-06-18", "gpt-5.4-mini"),
+        "gpt-5.5": createModel("gpt-5.5"),
         "gpt-5.5-fast": createModel("gpt-5.5-fast", "gpt-5.5"),
         "gpt-5.5-pro": createModel("gpt-5.5-pro", "gpt-5.5"),
       })

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import {
+  CodexAuthPlugin,
   parseJwtClaims,
   extractAccountIdFromClaims,
   extractAccountId,
   type IdTokenClaims,
 } from "../../src/plugin/codex"
+import type { Auth, Model, Provider } from "@opencode-ai/sdk/v2"
 
 function createTestJwt(payload: object): string {
   const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")
@@ -12,7 +14,132 @@ function createTestJwt(payload: object): string {
   return `${header}.${body}.sig`
 }
 
+function createModel(id: string, apiID = id): Model {
+  return {
+    id,
+    providerID: "openai",
+    api: {
+      id: apiID,
+      url: "https://api.openai.com/v1",
+      npm: "@ai-sdk/openai",
+    },
+    name: id,
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: false,
+      toolcall: true,
+      input: {
+        text: true,
+        audio: false,
+        image: true,
+        video: false,
+        pdf: true,
+      },
+      output: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        pdf: false,
+      },
+      interleaved: false,
+    },
+    cost: {
+      input: 1,
+      output: 2,
+      cache: {
+        read: 3,
+        write: 4,
+      },
+    },
+    limit: {
+      context: 128_000,
+      output: 16_384,
+    },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-01-01",
+  }
+}
+
+function createProvider(models: Record<string, Model>): Provider {
+  return {
+    id: "openai",
+    name: "OpenAI",
+    source: "api",
+    env: [],
+    options: {},
+    models,
+  }
+}
+
+async function loadModels(provider: Provider, auth: Auth | undefined) {
+  const hooks = await CodexAuthPlugin({} as never)
+  const models = hooks.provider?.models
+  if (!models) throw new Error("Codex provider hook missing")
+  return models(provider, { auth })
+}
+
 describe("plugin.codex", () => {
+  describe("models", () => {
+    test("filters Codex OAuth models by visible model key", async () => {
+      const result = await loadModels(
+        createProvider({
+          "gpt-5.2": createModel("gpt-5.2"),
+          "gpt-5.3-codex": createModel("gpt-5.3-codex"),
+          "gpt-5.3-codex-spark": createModel("gpt-5.3-codex-spark"),
+          "gpt-5.4": createModel("gpt-5.4"),
+          "gpt-5.4-fast": createModel("gpt-5.4-fast", "gpt-5.4"),
+          "gpt-5.4-mini": createModel("gpt-5.4-mini"),
+          "gpt-5.4-mini-fast": createModel("gpt-5.4-mini-fast", "gpt-5.4-mini"),
+          "gpt-5.5": createModel("gpt-5.5"),
+          "gpt-5.5-fast": createModel("gpt-5.5-fast", "gpt-5.5"),
+          "gpt-5.5-pro": createModel("gpt-5.5-pro", "gpt-5.5"),
+        }),
+        {
+          type: "oauth",
+          refresh: "refresh",
+          access: "access",
+          expires: Date.now() + 60_000,
+        },
+      )
+
+      expect(Object.keys(result)).toEqual(["gpt-5.4-mini", "gpt-5.5"])
+      expect(result["gpt-5.4-mini"]?.cost).toEqual({
+        input: 0,
+        output: 0,
+        cache: { read: 0, write: 0 },
+      })
+      expect(result["gpt-5.4-mini"]?.limit).toEqual({
+        context: 128_000,
+        output: 16_384,
+      })
+      expect(result["gpt-5.5"]?.limit).toEqual({
+        context: 400_000,
+        input: 272_000,
+        output: 128_000,
+      })
+    })
+
+    test("keeps API key models unfiltered", async () => {
+      const provider = createProvider({
+        "gpt-5.4": createModel("gpt-5.4"),
+        "gpt-5.4-mini": createModel("gpt-5.4-mini"),
+        "gpt-5.5-fast": createModel("gpt-5.5-fast", "gpt-5.5"),
+        "gpt-5.5-pro": createModel("gpt-5.5-pro", "gpt-5.5"),
+      })
+
+      const result = await loadModels(provider, {
+        type: "api",
+        key: "sk-test",
+      })
+
+      expect(result).toBe(provider.models)
+    })
+  })
+
   describe("parseJwtClaims", () => {
     test("parses valid JWT with claims", () => {
       const payload = { email: "test@example.com", chatgpt_account_id: "acc-123" }

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -84,7 +84,7 @@ async function loadModels(provider: Provider, auth: Auth | undefined) {
 
 describe("plugin.codex", () => {
   describe("models", () => {
-    test("filters Codex OAuth models by visible model key", async () => {
+    test("keeps only supported Codex OAuth visible model keys", async () => {
       const result = await loadModels(
         createProvider({
           "gpt-5.5": createModel("gpt-5.5"),
@@ -99,6 +99,7 @@ describe("plugin.codex", () => {
           "gpt-5.4-mini": createModel("gpt-5.4-mini"),
           "gpt-5.4-mini-2026-06-18": createModel("gpt-5.4-mini-2026-06-18", "gpt-5.4-mini"),
           "gpt-5.4-mini-fast": createModel("gpt-5.4-mini-fast", "gpt-5.4-mini"),
+          "gpt-5.4-mini-pro": createModel("gpt-5.4-mini-pro", "gpt-5.4-mini"),
           "gpt-5.3-codex-spark": createModel("gpt-5.3-codex-spark"),
           "gpt-5.2": createModel("gpt-5.2"),
           "gpt-5.3-codex": createModel("gpt-5.3-codex"),
@@ -111,27 +112,13 @@ describe("plugin.codex", () => {
         },
       )
 
-      expect(Object.keys(result)).toEqual(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"])
-      expect(result["gpt-5.4"]?.cost).toEqual({
-        input: 0,
-        output: 0,
-        cache: { read: 0, write: 0 },
-      })
+      expect(Object.keys(result)).toEqual(["gpt-5.5", "gpt-5.4-mini"])
       expect(result["gpt-5.4-mini"]?.cost).toEqual({
         input: 0,
         output: 0,
         cache: { read: 0, write: 0 },
       })
-      expect(result["gpt-5.3-codex-spark"]?.cost).toEqual({
-        input: 0,
-        output: 0,
-        cache: { read: 0, write: 0 },
-      })
       expect(result["gpt-5.4-mini"]?.limit).toEqual({
-        context: 128_000,
-        output: 16_384,
-      })
-      expect(result["gpt-5.3-codex-spark"]?.limit).toEqual({
         context: 128_000,
         output: 16_384,
       })

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -131,12 +131,30 @@ describe("plugin.codex", () => {
       })
     })
 
+    test("hides Codex OAuth models with unsupported API ids", async () => {
+      const result = await loadModels(
+        createProvider({
+          "gpt-5.4": createModel("gpt-5.4", "gpt-5.4-nano"),
+          "gpt-5.4-mini": createModel("gpt-5.4-mini"),
+        }),
+        {
+          type: "oauth",
+          refresh: "refresh",
+          access: "access",
+          expires: Date.now() + 60_000,
+        },
+      )
+
+      expect(Object.keys(result)).toEqual(["gpt-5.4-mini"])
+      expect(result["gpt-5.4"]).toBeUndefined()
+    })
+
     test("keeps API key models unfiltered", async () => {
       const provider = createProvider({
         "gpt-5.2": createModel("gpt-5.2"),
         "gpt-5.3-codex": createModel("gpt-5.3-codex"),
         "gpt-5.3-codex-spark": createModel("gpt-5.3-codex-spark"),
-        "gpt-5.4": createModel("gpt-5.4"),
+        "gpt-5.4": createModel("gpt-5.4", "gpt-5.4-nano"),
         "gpt-5.4-nano": createModel("gpt-5.4-nano"),
         "gpt-5.4-mini": createModel("gpt-5.4-mini"),
         "gpt-5.4-mini-2026-06-18": createModel("gpt-5.4-mini-2026-06-18", "gpt-5.4-mini"),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1408,7 +1408,7 @@ it.instance(
       expect(JSON.stringify(inputs.at(-1)?.messages)).toContain("second")
     }),
   { git: true },
-  5_000,
+  3_000,
 )
 
 it.instance(

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1408,7 +1408,7 @@ it.instance(
       expect(JSON.stringify(inputs.at(-1)?.messages)).toContain("second")
     }),
   { git: true },
-  3_000,
+  5_000,
 )
 
 it.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #287

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Filters OpenAI model choices when the Codex OAuth route is active. Codex OAuth now offers the current ChatGPT sign-in models that passed the live route check: `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex-spark`.

Normal OpenAI API-key users still see the full provider list. Unsupported Codex OAuth models such as `gpt-5.2` and `gpt-5.3-codex` stay hidden from the OAuth picker.

### How did you verify your code works?

Focused Codex plugin coverage confirms that OAuth keeps the supported visible models, filters unsupported OAuth models, and leaves API-key OpenAI discovery unfiltered. A live Codex OAuth probe accepted the four included models and rejected `gpt-5.2`.

### Screenshots / recordings

No visual layout change. This changes the model list data returned to the picker.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
