### PR TITLE
fix(opencode): isolate OpenRouter agency credentials

### DIFF
--- a/packages/opencode/src/agency-swarm/adapter.ts
+++ b/packages/opencode/src/agency-swarm/adapter.ts
@@ -114,6 +114,22 @@ export namespace AgencySwarmAdapter {
     return new URL(cleanRelativePath, cleanBase).toString()
   }
 
+  export function normalizeErrorMessage(message: string, status?: number): string {
+    const text = message.trim()
+    if (!text) return "No response body"
+    if (!containsHTMLBody(text)) return text
+
+    const code = status ?? readStatusCode(text)
+    const detail =
+      code === 401
+        ? "Unauthorized: request was blocked by a gateway or proxy and returned an HTML error page. Check authentication and routing."
+        : code === 403
+          ? "Forbidden: request was blocked by a gateway or proxy and returned an HTML error page. Check authentication and routing."
+          : "Agency Swarm backend returned an HTML error page instead of JSON/SSE."
+    const prefix = status === undefined && code === undefined ? readErrorPrefix(text) : undefined
+    return prefix ? `${prefix}: ${detail}` : detail
+  }
+
   export function parseAgencyIDsFromOpenAPI(openapi: Record<string, unknown>): string[] {
     const paths = openapi["paths"]
     if (!paths || typeof paths !== "object") return []
@@ -255,14 +271,15 @@ export namespace AgencySwarmAdapter {
 
     if (!response.ok) {
       const body = await response.text().catch(() => "")
+      const error = normalizeErrorMessage(body || "No response body", response.status)
       log.error("agency-swarm stream request failed", {
         url,
         status: response.status,
-        body: body || "No response body",
+        body: error,
       })
       yield {
         type: "error",
-        error: `Streaming request failed (${response.status}): ${body || "No response body"}`,
+        error: `Streaming request failed (${response.status}): ${error}`,
       }
       yield { type: "end" }
       return
@@ -319,7 +336,7 @@ export namespace AgencySwarmAdapter {
         if (typeof payload["error"] === "string") {
           yield {
             type: "error",
-            error: payload["error"],
+            error: normalizeErrorMessage(payload["error"]),
           }
           continue
         }
@@ -557,6 +574,23 @@ export namespace AgencySwarmAdapter {
     } catch {
       return undefined
     }
+  }
+
+  function containsHTMLBody(value: string) {
+    return /(^|:\s*|\s+-\s+)(?:<!doctype\s+html\b|<html(?:\s|>))/i.test(value)
+  }
+
+  function readStatusCode(value: string): number | undefined {
+    const match =
+      value.match(/\((\d{3})\)/) ?? value.match(/\b(?:error code|status(?: code)?|http)\s*[:=]?\s*(\d{3})\b/i)
+    if (!match?.[1]) return undefined
+    const status = Number(match[1])
+    return Number.isFinite(status) ? status : undefined
+  }
+
+  function readErrorPrefix(value: string): string | undefined {
+    const match = value.match(/^(.+?)\s*(?::|-)\s*(?:<!doctype\s+html\b|<html(?:\s|>))/i)
+    return match?.[1]?.trim() || undefined
   }
 
   async function* parseSSE(response: Response): AsyncGenerator<{ event: string; data: string }> {

--- a/packages/opencode/src/session/agency-swarm-client-config.ts
+++ b/packages/opencode/src/session/agency-swarm-client-config.ts
@@ -139,8 +139,9 @@ export async function resolveClientConfig(
   const rawGenerated = forwardGenerated
     ? await buildAuthClientConfig(await Auth.all(), await listProvidersForEnvCheck(), await getEnvForClientConfig(), {
         skipOpenAIApiKeyInjection: skipOpenAIApiKey,
-        skipOpenAIOAuthFromStored: hasExplicitOpenAIClientConfig(config),
-        allowStoredOpenAIOAuth: !explicitUpstreamBaseURL || isCodexAPIBaseURL(explicitUpstreamBaseURL),
+        skipOpenAIOAuthFromStored: hasExplicitOpenAIClientConfig(config) || targetOpenRouter,
+        allowStoredOpenAIOAuth:
+          !targetOpenRouter && (!explicitUpstreamBaseURL || isCodexAPIBaseURL(explicitUpstreamBaseURL)),
         targetOpenRouter,
       })
     : undefined

--- a/packages/opencode/src/session/agency-swarm-stream-events.ts
+++ b/packages/opencode/src/session/agency-swarm-stream-events.ts
@@ -1,3 +1,4 @@
+import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import { MessageV2 } from "@/session/message-v2"
 import {
   asRawString,
@@ -1525,7 +1526,7 @@ export function createAgencySwarmStreamEvents(input: StreamEventsInput) {
 
     if (responseType === "error") {
       const message = asString(nested["message"]) || asString(nested["error"]) || "Unknown stream error"
-      return { parts: [], error: new Error(message) }
+      return { parts: [], error: new Error(AgencySwarmAdapter.normalizeErrorMessage(message)) }
     }
 
     return { parts: [] }

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -549,7 +549,7 @@ export namespace SessionAgencySwarm {
           }
 
           if (frame.type === "error") {
-            streamError = new Error(frame.error)
+            streamError = new Error(AgencySwarmAdapter.normalizeErrorMessage(frame.error))
             break
           }
 
@@ -567,7 +567,11 @@ export namespace SessionAgencySwarm {
           const kind = asString(frame.payload["type"])
           if (kind === "error") {
             const content = asString(frame.payload["content"]) ?? ""
-            streamError = new Error(content || "Agency Swarm backend returned an error without a message")
+            streamError = new Error(
+              content
+                ? AgencySwarmAdapter.normalizeErrorMessage(content)
+                : "Agency Swarm backend returned an error without a message",
+            )
             break
           }
           if (kind === "agent_updated_stream_event") {

--- a/packages/opencode/test/agency-swarm/adapter.test.ts
+++ b/packages/opencode/test/agency-swarm/adapter.test.ts
@@ -28,6 +28,26 @@ describe("agency-swarm.adapter", () => {
     expect(result).toEqual(["builder", "research"])
   })
 
+  test("normalizeErrorMessage compacts wrapped HTML provider errors", () => {
+    expect(
+      AgencySwarmAdapter.normalizeErrorMessage(
+        "Error code: 403 - <!DOCTYPE html><html><body>Enable JavaScript and cookies</body></html>",
+      ),
+    ).toBe(
+      "Forbidden: request was blocked by a gateway or proxy and returned an HTML error page. Check authentication and routing.",
+    )
+    expect(
+      AgencySwarmAdapter.normalizeErrorMessage(
+        "OpenAIException - Error code: 401 - <!DOCTYPE html><html><body>Enable JavaScript and cookies</body></html>",
+      ),
+    ).toBe(
+      "Unauthorized: request was blocked by a gateway or proxy and returned an HTML error page. Check authentication and routing.",
+    )
+    expect(AgencySwarmAdapter.normalizeErrorMessage("Error code: 403 - Invalid API key")).toBe(
+      "Error code: 403 - Invalid API key",
+    )
+  })
+
   test("discover reads openapi and validates metadata endpoints", async () => {
     const calls: string[] = []
 
@@ -265,6 +285,72 @@ describe("agency-swarm.adapter", () => {
 
     expect(frames.map((frame) => frame.type)).toEqual(["error", "end"])
     expect(frames[0]).toEqual({ type: "error", error: "boom" })
+  })
+
+  test("streamRun compacts HTML error-only stream payloads", async () => {
+    globalThis.fetch = asFetch(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const encoder = new TextEncoder()
+          controller.enqueue(
+            encoder.encode('data: {"error":"<html><body>Enable JavaScript and cookies</body></html>"}\n\n'),
+          )
+          controller.enqueue(encoder.encode("event: end\ndata: [DONE]\n\n"))
+          controller.close()
+        },
+      })
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+        },
+      })
+    })
+
+    const frames: AgencySwarmAdapter.StreamFrame[] = []
+    for await (const frame of AgencySwarmAdapter.streamRun({
+      baseURL: "http://127.0.0.1:8000",
+      agency: "builder",
+      message: "hello",
+      chatHistory: [],
+    })) {
+      frames.push(frame)
+    }
+
+    expect(frames.map((frame) => frame.type)).toEqual(["error", "end"])
+    const first = frames[0]
+    expect(first?.type).toBe("error")
+    if (first?.type === "error") {
+      expect(first.error).toContain("HTML error page")
+      expect(first.error).not.toContain("<html")
+    }
+  })
+
+  test("streamRun compacts HTML HTTP error bodies", async () => {
+    globalThis.fetch = asFetch(async () => {
+      return new Response("<html><body>Enable JavaScript and cookies to continue</body></html>", {
+        status: 403,
+      })
+    })
+
+    const frames: AgencySwarmAdapter.StreamFrame[] = []
+    for await (const frame of AgencySwarmAdapter.streamRun({
+      baseURL: "http://127.0.0.1:8000",
+      agency: "builder",
+      message: "hello",
+      chatHistory: [],
+    })) {
+      frames.push(frame)
+    }
+
+    expect(frames.map((frame) => frame.type)).toEqual(["error", "end"])
+    const first = frames[0]
+    expect(first?.type).toBe("error")
+    if (first?.type === "error") {
+      expect(first.error).toContain("Streaming request failed (403): Forbidden")
+      expect(first.error).toContain("gateway or proxy")
+      expect(first.error).not.toContain("<html")
+    }
   })
 
   test("streamRun surfaces connection failures as stream error frames", async () => {

--- a/packages/opencode/test/agency-swarm/session-runtime.test.ts
+++ b/packages/opencode/test/agency-swarm/session-runtime.test.ts
@@ -516,6 +516,31 @@ describe("session.agency-swarm runtime history", () => {
     expect(appended).toEqual([])
   }, 6000)
 
+  test("stream compacts backend HTML error events", async () => {
+    const { input } = makeInput("current", "html error")
+
+    stubSessionMessages([userMessage("current", "html error", 1)] as any)
+    mockHistory([])
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "error",
+          content: "<html><body>Enable JavaScript and cookies to continue</body></html>",
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const events = await consumeStream(input)
+    const event = events.find((event) => event.type === "error")
+    expect(event?.type).toBe("error")
+    if (event?.type === "error") {
+      expect(event.error.message).toContain("HTML error page")
+      expect(event.error.message).not.toContain("<html")
+    }
+  })
+
   function makeInput(currentID: string, text: string) {
     const abort = new AbortController()
     const input = {

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -1380,10 +1380,16 @@ describe("session.agency-swarm", () => {
     })
   })
 
-  test("stream prefers stored OpenRouter key over stale env for direct client config", async () => {
+  test("stream isolates direct OpenRouter client config from stored OpenAI OAuth", async () => {
     mockHistory()
     spyOn(Auth, "all").mockImplementation(async () => ({
-      openai: { type: "api", key: "stored-openai" } as any,
+      openai: {
+        type: "oauth",
+        access: "oauth-access",
+        refresh: "oauth-refresh",
+        expires: Date.now() + 60_000,
+        accountId: "acct_123",
+      } as any,
       openrouter: { type: "api", key: "stored-openrouter" } as any,
     })) as typeof Auth.all
     spyOn(Env, "all").mockImplementation(() => ({
@@ -1432,6 +1438,8 @@ describe("session.agency-swarm", () => {
       api_key: "stored-openrouter",
       model: "openrouter/anthropic/claude-sonnet-4.5",
     })
+    expect(captured?.["base_url"]).toBeUndefined()
+    expect(captured?.["default_headers"]).toBeUndefined()
   })
 
   test("stream caps OpenRouter Claude max tokens for free tier keys", async () => {
@@ -11248,6 +11256,41 @@ describe("session.agency-swarm", () => {
       "text-end",
       "error",
     ])
+    expect(events.some((event) => event.type === "finish-step")).toBeFalse()
+    expect(events.some((event) => event.type === "finish")).toBeFalse()
+  })
+
+  test("stream compacts raw_response_event HTML errors", async () => {
+    mockHistory()
+    AgencySwarmAdapter.streamRun = async function* () {
+      yield {
+        type: "data",
+        payload: {
+          type: "raw_response_event",
+          data: {
+            type: "error",
+            message:
+              "Error code: 403 - <!DOCTYPE html><html><body>Enable JavaScript and cookies to continue</body></html>",
+          },
+        },
+      }
+      yield { type: "end" }
+    } as typeof AgencySwarmAdapter.streamRun
+
+    const { input } = helper()
+    const stream = await SessionAgencySwarm.stream(input)
+    const events: any[] = []
+    for await (const event of stream.fullStream) {
+      events.push(event)
+    }
+
+    const errorEvent = events.find((event) => event.type === "error")
+    expect(errorEvent).toBeDefined()
+    const message = String(errorEvent.error?.message ?? errorEvent.error ?? "")
+    expect(message).toContain("Forbidden")
+    expect(message).toContain("HTML error page")
+    expect(message).not.toContain("<html")
+    expect(message).not.toContain("<!DOCTYPE")
     expect(events.some((event) => event.type === "finish-step")).toBeFalse()
     expect(events.some((event) => event.type === "finish")).toBeFalse()
   })


### PR DESCRIPTION
### Issue for this PR

Fixes #289

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes direct Agent Swarm runs with OpenRouter-selected models when stored OpenAI OAuth auth is also present.

Direct OpenRouter client config now uses the OpenRouter API key without inheriting OpenAI/Codex `base_url` or default headers. The Agency Swarm bridge also compacts HTML gateway/proxy error pages before they reach the terminal UI, so users see a short actionable error instead of a raw HTML document.

### How did you verify your code works?

- Ran the focused Agency Swarm adapter/session tests.
- Ran package typecheck.
- Ran a built Agent Swarm binary in the normal project environment, selected an OpenRouter Claude model from `/models`, sent a prompt, and confirmed the response completed without the raw HTML error page.

### Screenshots / recordings

Not included; this fixes provider routing and error text rather than layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
