### PR TITLE
fix(opencode): keep scanning agency entry fallbacks

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -522,10 +522,16 @@ export async function detectAgencyProject(
   profile: Pick<ProductProfile, "agencyEntryFiles"> = AgencyProduct,
 ) {
   const dir = path.resolve(directory)
+  let readError: ProjectEntryReadError | undefined
   for (const entryFile of profile.agencyEntryFiles) {
     const agencyFile = path.join(dir, entryFile)
     if (!(await Filesystem.exists(agencyFile))) continue
-    const source = await readProjectEntryFile(agencyFile)
+    const source = await readProjectEntryFile(agencyFile).catch((error) => {
+      if (!(error instanceof ProjectEntryReadError)) throw error
+      readError ??= error
+      return
+    })
+    if (!source) continue
     if (!source.includes("def create_agency")) continue
     if (!source.includes("agency_swarm")) continue
     return {
@@ -534,6 +540,7 @@ export async function detectAgencyProject(
       moduleName: agencyEntryModuleName(entryFile),
     } satisfies AgencyProject
   }
+  if (readError) throw readError
 }
 
 async function readProjectEntryFile(file: string) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -3498,6 +3498,21 @@ describe("agency-swarm npx onboarding", () => {
     expect(project?.moduleName).toBe("src.main")
   })
 
+  test("detectAgencyProject keeps checking configured entry files after read errors", async () => {
+    await using dir = await tmpdir()
+    await mkdir(path.join(dir.path, "main.py"))
+    await writeAgency(dir.path)
+
+    const project = await detectAgencyProject(dir.path, {
+      ...downstreamProfile,
+      agencyEntryFiles: ["main.py", "agency.py"],
+    })
+
+    expect(project?.directory).toBe(dir.path)
+    expect(project?.agencyFile).toBe(path.join(dir.path, "agency.py"))
+    expect(project?.moduleName).toBe("agency")
+  })
+
   test("detectAgencyProject does not detect swarm.py in the default Agent Swarm profile", async () => {
     await using dir = await tmpdir()
     await Bun.write(


### PR DESCRIPTION
### Issue for this PR

Closes #289

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps Agency Swarm project detection scanning configured fallback entry files after an entry-file read error.

A downstream profile can list more than one entry file, such as `main.py` before `agency.py`. If the first existing entry cannot be read, the launcher should still detect a later valid entry. If no valid fallback exists, it still surfaces the original read error.

### How did you verify your code works?

- `bun test test/agency-swarm/npx.test.ts -t "detectAgencyProject keeps checking configured entry files after read errors"`
- `bun test test/agency-swarm/npx.test.ts -t "prepareNpxLaunch offers recovery when agency.py cannot be read"`
- `bun typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
