### PR TITLE
fix(release): refresh SDK types and stabilize Windows test

### DIFF
--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1854,7 +1854,8 @@ describe("agency-swarm npx onboarding", () => {
     await writeAgency(dir.path)
 
     const realSetTimeout = globalThis.setTimeout
-    const timers: Array<{ fn: TimerHandler; cleared: boolean }> = []
+    const timers: Array<{ fn: TimerHandler; cleared: boolean; install: boolean }> = []
+    let installTimerPending = false
 
     spyOn(prompts, "confirm").mockResolvedValue(true as never)
     spyOn(prompts, "spinner").mockReturnValue({
@@ -1863,7 +1864,8 @@ describe("agency-swarm npx onboarding", () => {
     } as never)
     spyOn(prompts.log, "info").mockImplementation(() => undefined as never)
     const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((fn: TimerHandler) => {
-      const timer = { fn, cleared: false }
+      const timer = { fn, cleared: false, install: installTimerPending }
+      installTimerPending = false
       timers.push(timer)
       return timer as never
     }) as unknown as typeof setTimeout)
@@ -1907,6 +1909,7 @@ describe("agency-swarm npx onboarding", () => {
         } as never
       }
       if (isUvPipInstallCommand(cmd)) {
+        installTimerPending = true
         return {
           exited: Promise.resolve(0),
           stdout: "",
@@ -1949,15 +1952,18 @@ describe("agency-swarm npx onboarding", () => {
     let launch: Awaited<ReturnType<typeof prepareProjectLaunch>>
     try {
       const deadline = Date.now() + 1000
-      while (timers.length === 0 && !launchSettled && Date.now() < deadline) {
+      const installTimeout = () => timers.find((timer) => timer.install)
+      while (installTimeout()?.cleared !== true && !launchSettled && Date.now() < deadline) {
         await new Promise((resolve) => realSetTimeout(resolve, 5))
       }
 
       expect(timers).not.toHaveLength(0)
-      expect(timers[0]?.cleared).toBe(true)
-      const installTimeout = timers[0]
-      if (typeof installTimeout?.fn !== "function") throw new Error("Expected install timeout callback")
-      await installTimeout.fn()
+      const timeout = installTimeout()
+      expect(timeout).toBeDefined()
+      if (!timeout) throw new Error("Expected install timeout")
+      expect(timeout.cleared).toBe(true)
+      if (typeof timeout.fn !== "function") throw new Error("Expected install timeout callback")
+      await timeout.fn()
       restoreTimers()
       installStderr.close()
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5,11 +5,13 @@ export type ClientOptions = {
 }
 
 export type Event =
-  | EventServerInstanceDisposed
   | EventTuiPromptAppend
   | EventTuiCommandExecute
   | EventTuiToastShow1
   | EventTuiSessionSelect
+  | EventServerConnected
+  | EventGlobalDisposed
+  | EventServerInstanceDisposed
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventPermissionAsked
@@ -42,8 +44,6 @@ export type Event =
   | EventPtyDeleted
   | EventInstallationUpdated
   | EventInstallationUpdateAvailable
-  | EventServerConnected
-  | EventGlobalDisposed
   | EventMessageUpdated
   | EventMessageRemoved
   | EventMessagePartUpdated
@@ -799,11 +799,13 @@ export type GlobalEvent = {
   project?: string
   workspace?: string
   payload:
-    | EventServerInstanceDisposed
     | EventTuiPromptAppend
     | EventTuiCommandExecute
     | EventTuiToastShow
     | EventTuiSessionSelect
+    | EventServerConnected
+    | EventGlobalDisposed
+    | EventServerInstanceDisposed
     | EventMcpToolsChanged
     | EventMcpBrowserOpenFailed
     | EventPermissionAsked
@@ -836,8 +838,6 @@ export type GlobalEvent = {
     | EventPtyDeleted
     | EventInstallationUpdated
     | EventInstallationUpdateAvailable
-    | EventServerConnected
-    | EventGlobalDisposed
     | EventMessageUpdated
     | EventMessageRemoved
     | EventMessagePartUpdated
@@ -2433,6 +2433,22 @@ export type SyncEventSessionNextCompactionEnded = {
   }
 }
 
+export type EventServerConnected = {
+  id: string
+  type: "server.connected"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
+export type EventGlobalDisposed = {
+  id: string
+  type: "global.disposed"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
 export type EventServerInstanceDisposed = {
   id: string
   type: "server.instance.disposed"
@@ -2710,22 +2726,6 @@ export type EventInstallationUpdateAvailable = {
   type: "installation.update-available"
   properties: {
     version: string
-  }
-}
-
-export type EventServerConnected = {
-  id: string
-  type: "server.connected"
-  properties: {
-    [key: string]: unknown
-  }
-}
-
-export type EventGlobalDisposed = {
-  id: string
-  type: "global.disposed"
-  properties: {
-    [key: string]: unknown
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Fixes #293
Fixes #301

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Regenerates `packages/sdk/js/src/v2/gen/types.gen.ts` from the current OpenAPI schema so the SDK generator leaves the tree clean. It also stabilizes the launcher install-timeout cleanup test that failed the hosted Windows unit gate while this release-blocking PR was being refreshed.

### How did you verify your code works?

- `bun install --frozen-lockfile`
- `bun ./packages/sdk/js/script/build.ts`
- `git diff --check`
- `bun typecheck`
- push hook: `bun turbo typecheck`
- `bun test test/agency-swarm/npx.test.ts -t "prepareProjectLaunch clears the install timeout as soon as the child exits"`
- `bun test test/agency-swarm/npx.test.ts -t "timeout"`
- `bun test test/agency-swarm/npx.test.ts -t "times out"`

### Screenshots / recordings

Not applicable. This is a generated TypeScript SDK file update and test-only CI stabilization.

### Checklist

- [x] Tests or checks were run
- [x] No unrelated changes
