### PR TITLE
test: cover Build and Run repair loops

### DIFF
--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -220,6 +220,10 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** The Plan approval question owns keyboard input while it is open, so session shortcuts do not fire at the same time.
 - **Happy-path proof:** Switching back to Run in the same project reconnects to or keeps using the Agency Swarm server and returns `/agents` to the swarm/agent picker.
 - **Happy-path proof:** Message actions use the selected turn's saved or legacy-inferred Run/native routing metadata, so Revert is shown or hidden for the selected turn even after switching modes.
+- **User story:** After changing or repairing a swarm in Build, the user can return to Run in the same project and confirm the fixed swarm works.
+- **Success looks like:** Run uses the repaired swarm and gives a good response instead of staying on the earlier broken behavior.
+- **User story:** When a Run attempt shows the swarm needs work, the user can switch to Build, make the fix, return to Run, and try again.
+- **Success looks like:** The failed Run attempt does not trap the user; the next Run uses the fixed swarm and succeeds.
 - **Failure scenarios to test:** Server failure in Run still lets the user switch to Build or Plan in the same project, make a plan or build a fix, then return to Run.
 - **Failure scenarios to test:** Run mode stays server-backed even when visible provider/model state is native.
 

--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -8,6 +8,7 @@
 - `USER_FLOWS.md` Startup `/auth` and In-TUI `/connect`: `/auth` and `/connect` stay separate in the real terminal UI.
 - `USER_FLOWS.md` Run Mode: native `/editor`, `/variants`, `/init`, and `/review` slash commands stay hidden.
 - `USER_FLOWS.md` `/modes`, Build, and Plan: `/modes` appears as the product switch, `/build` and `/plan` do not exist, Build and Plan restore native `/review` and `/init`, native `/review` execution stays server-free, and switching back to Run hides native commands again.
+- `USER_FLOWS.md` `/modes`, Build, and Plan: users can repair or change a swarm in Build, return to Run, and verify the fixed swarm; users can also recover from a failed Run attempt by switching to Build, then back to Run for a successful response.
 - `USER_FLOWS.md` `/modes`, Build, and Plan: Tab cycles native local agents outside Run and Agency Swarm targets in Run.
 - `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/subagent counts; `/agents` uses Swarm and agent wording, live agency labels, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
 - `USER_FLOWS.md` Run Mode: prompt submit reaches a local Agency Swarm protocol server with the configured agent.

--- a/e2e/agent-swarm-tui/harness.ts
+++ b/e2e/agent-swarm-tui/harness.ts
@@ -474,7 +474,7 @@ export async function startNativeLLMServer(): Promise<NativeLLMServer> {
 }
 
 export async function startAgencyProtocolServer(
-  input: { scenario?: AgencyServerScenario } = {},
+  input: { scenario?: AgencyServerScenario; repair?: { done: boolean } } = {},
 ): Promise<AgencyProtocolServer> {
   const scenario = input.scenario ?? "qa"
   const fixtures = fixturesForScenario(scenario)
@@ -522,7 +522,7 @@ export async function startAgencyProtocolServer(
           resolveStreamClosed()
         }
         requests.push({ path: url.pathname, body, releaseStream, streamClosed })
-        const responseBody = await fixture.stream(body, requests.length, streamReleased, closeStream)
+        const responseBody = await fixture.stream(body, requests.length, streamReleased, closeStream, input.repair)
         if (!(responseBody instanceof ReadableStream)) closeStream()
         return new Response(responseBody, {
           headers: {
@@ -549,8 +549,10 @@ export async function startAgencyProtocolServer(
   }
 }
 
-export async function startTuiDemoAgencyServer(): Promise<AgencyProtocolServer> {
-  return startAgencyProtocolServer({ scenario: "tui-demo" })
+export async function startTuiDemoAgencyServer(
+  input: { repair?: { done: boolean } } = {},
+): Promise<AgencyProtocolServer> {
+  return startAgencyProtocolServer({ scenario: "tui-demo", repair: input.repair })
 }
 
 export async function startMultiAgencyServer(): Promise<AgencyProtocolServer> {
@@ -800,6 +802,7 @@ type AgencyFixture = {
     requestCount: number,
     streamReleased: Promise<void>,
     closeStream: () => void,
+    repair?: { done: boolean },
   ): BodyInit | Promise<BodyInit>
 }
 
@@ -900,8 +903,15 @@ const tuiDemoAgencyFixture: AgencyFixture = {
       },
     ],
   },
-  stream(body, requestCount, streamReleased, closeStream) {
+  stream(body, requestCount, streamReleased, closeStream, repair) {
     const message = typeof body.message === "string" ? body.message.toLowerCase() : ""
+    if (message.includes("build repair") && repair?.done === false) {
+      return sse([
+        ["meta", { run_id: `run_tui_demo_${requestCount}` }],
+        ["data", { error: "Swarm code crashed before repair" }],
+        ["end", {}],
+      ])
+    }
     if (message.includes("fresh sidebar hold")) {
       return controlledSse(
         [

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -854,9 +854,9 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(currentServer.requests).toHaveLength(0)
   })
 
-  test("/modes can return to server-backed Run after Build", async () => {
-    const buildPrompt = "native build before run return"
-    const runPrompt = "run after native build return"
+  test("Build repair can be verified by returning to Run", async () => {
+    const buildPrompt = "repair changed swarm before run verification"
+    const runPrompt = "verify repaired swarm after build"
     currentServer = await startTuiDemoAgencyServer()
     currentNativeServer = await startNativeLLMServer()
     currentTui = await startTui({
@@ -882,7 +882,9 @@ describe("Agent Swarm terminal TUI e2e", () => {
     await selectProductMode(currentTui, "Build")
     currentTui.write(`${buildPrompt}\r`)
     await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
-    await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
+
+    const request = await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
+    expect(JSON.stringify(request.body)).toContain("Agent Swarm Build Instructions")
     expect(currentServer.requests).toHaveLength(0)
 
     await selectProductMode(currentTui, "Run")
@@ -894,11 +896,68 @@ describe("Agent Swarm terminal TUI e2e", () => {
       "Run request after native Build prompt",
       tuiInteractionTimeoutMs,
     )
+    expect(currentServer.requests[0]?.body).toMatchObject({
+      message: runPrompt,
+      recipient_agent: "UserSupportAgent",
+    })
 
     currentTui.write("/")
     const screen = await waitForCommand(currentTui, "/agents")
     expect(hasCommand(screen, "/agents")).toBe(true)
     expect(hasCommand(screen, "/review")).toBe(false)
+  })
+
+  test("Run failure can be fixed in Build and verified back in Run", async () => {
+    const failedPrompt = "run broken swarm before build repair"
+    const buildPrompt = "fix run failure in build mode"
+    const runPrompt = "run fixed swarm after build repair"
+    const repair = { done: false }
+    currentServer = await startTuiDemoAgencyServer({ repair })
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    currentTui.write(`${failedPrompt}\r`)
+    await currentTui.waitForText("Swarm code crashed before repair", tuiInteractionTimeoutMs)
+    expect(currentServer.requests[0]?.body).toMatchObject({
+      message: failedPrompt,
+      recipient_agent: "UserSupportAgent",
+    })
+
+    await selectProductMode(currentTui, "Build")
+    currentTui.write(`${buildPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    const request = await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
+    expect(JSON.stringify(request.body)).toContain("Agent Swarm Build Instructions")
+    expect(currentServer.requests).toHaveLength(1)
+    repair.done = true
+
+    await selectProductMode(currentTui, "Run")
+    currentTui.write(`${runPrompt}\r`)
+    await currentTui.waitForText("TUI demo response complete.", tuiInteractionTimeoutMs)
+
+    expect(currentServer.requests).toHaveLength(2)
+    expect(currentServer.requests[1]?.body).toMatchObject({
+      message: runPrompt,
+      recipient_agent: "UserSupportAgent",
+    })
   })
 
   test("mixed Run and Build sessions keep per-turn labels stable", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #295

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds user-story coverage for the Build and Run repair loop, then maps it to terminal TUI E2E coverage.

It also extends the existing mode-switch TUI tests so the repair loop is proven through `/modes`: Build stays native, Run stays server-backed, and a failed Run attempt can recover only after the Build repair step is observed.

### How did you verify your code works?

- `bun test --timeout 180000 --max-concurrency=1 ../../e2e/agent-swarm-tui -t "Build repair can be verified by returning to Run|Run failure can be fixed in Build and verified back in Run"`
- `bun typecheck` from `packages/opencode`
- `bun x prettier --check USER_FLOWS.md e2e/agent-swarm-tui/QA_COVERAGE.md e2e/agent-swarm-tui/harness.ts e2e/agent-swarm-tui/terminal-tui.test.ts`
- `git diff --check`
- Local Codex review against `origin/dev`: no actionable regressions on commit `7157f91b4aaac235fd670326ce540127afa30cab`

### Screenshots / recordings

Not applicable. This PR adds docs and terminal E2E coverage without changing visible product behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
