### PR TITLE
fix(ci): timeout Windows unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,15 @@ jobs:
             turbo-${{ runner.os }}-
 
       - name: Run unit tests
+        if: runner.os != 'Windows'
         run: bun turbo test:ci
+        env:
+          OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
+
+      - name: Run unit tests
+        if: runner.os == 'Windows'
+        run: bun turbo test:ci
+        timeout-minutes: 35
         env:
           OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
 


### PR DESCRIPTION
### Issue for this PR

Fixes #298

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a timeout to the Windows unit-test step so a hung `bun turbo test:ci` run fails instead of blocking PR and release readiness indefinitely.

The Linux unit step keeps the existing command. The Windows step runs the same command with the same environment and a 35-minute timeout.

### How did you verify your code works?

- Parsed `.github/workflows/test.yml` as YAML and checked that the unit job now has separate Linux and Windows unit-test steps.
- Ran `git diff --check`.
- Ran local Codex review on commit `d3c68a3bca0fe8523dbf79a1235b953e955e68e7`; it found no actionable regression in the workflow split.

### Screenshots / recordings

Not applicable. This changes a GitHub Actions workflow only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
