### PR TITLE
fix(opencode): hide redo for reverted Run turns

### DIFF
--- a/e2e/agent-swarm-tui/QA_COVERAGE.md
+++ b/e2e/agent-swarm-tui/QA_COVERAGE.md
@@ -9,6 +9,7 @@
 - `USER_FLOWS.md` Run Mode: native `/editor`, `/variants`, `/init`, and `/review` slash commands stay hidden.
 - `USER_FLOWS.md` `/modes`, Build, and Plan: `/modes` appears as the product switch, `/build` and `/plan` do not exist, Build and Plan restore native `/review` and `/init`, native `/review` execution stays server-free, and switching back to Run hides native commands again.
 - `USER_FLOWS.md` `/modes`, Build, and Plan: Tab cycles native local agents outside Run and Agency Swarm targets in Run.
+- `USER_FLOWS.md` `/modes`, Build, and Plan: mixed-mode message actions keep Run undo/redo surfaces hidden while preserving native Build redo.
 - `USER_FLOWS.md` Run Mode: the sidebar shows the selected swarm and main/subagent counts; `/agents` uses Swarm and agent wording, live agency labels, swarm-row routing, and specific-agent routing against an Agency Swarm TUI-demo-shaped swarm.
 - `USER_FLOWS.md` Run Mode: prompt submit reaches a local Agency Swarm protocol server with the configured agent.
 - `USER_FLOWS.md` Run Mode: simulated visible OpenAI model state does not pull prompts, slash-command `/new`, run-session local-project marking, `/connect`, or runtime auth recovery out of Agency Swarm routing.

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -43,6 +43,14 @@ function hasCommand(screen: string, command: string) {
   return screen.split("\n").some((line) => new RegExp(`┃\\s+${command}\\b`).test(line))
 }
 
+function hasCompletedRunTurn(screen: string) {
+  return /▣\s+Run · .+ · \d+(?:\.\d+)?(?:ms|s)\b/.test(screen)
+}
+
+function hasTimelineRow(screen: string, prompt: string) {
+  return screen.split("\n").some((line) => line.includes(prompt) && /\d{1,2}:\d{2}/.test(line))
+}
+
 async function waitForCommand(tui: TuiProcess, command: string) {
   await tui.waitFor(() => hasCommand(tui.screen(), command), `${command} command`, tuiInteractionTimeoutMs)
   return tui.screen()
@@ -129,6 +137,30 @@ function stripAgencySwarmBridgeMetadata(dbPath: string) {
       count++
     }
     return count
+  } finally {
+    db.close()
+  }
+}
+
+function seedSessionRevertForPrompt(dbPath: string, prompt: string) {
+  const db = new Database(dbPath)
+  try {
+    const rows = db
+      .query<
+        { session_id: string; message_id: string; data: string },
+        []
+      >("select session_id, message_id, data from part order by id")
+      .all()
+    const row = rows.find((item) => {
+      const data = JSON.parse(item.data) as { type?: string; text?: string; synthetic?: boolean; ignored?: boolean }
+      return data.type === "text" && data.text === prompt && !data.synthetic && !data.ignored
+    })
+    if (!row) throw new Error(`No user text part found for ${prompt}`)
+    db.query("update session set revert = ? where id = ?").run(
+      JSON.stringify({ messageID: row.message_id }),
+      row.session_id,
+    )
+    return row.message_id
   } finally {
     db.close()
   }
@@ -997,11 +1029,233 @@ describe("Agent Swarm terminal TUI e2e", () => {
 
     currentTui.write("/undo\r")
     await currentTui.waitForText("message reverted", tuiInteractionTimeoutMs)
+    await currentTui.waitForText("/redo to restore", tuiInteractionTimeoutMs)
 
     await selectProductMode(currentTui, "Run")
+    await currentTui.waitForText("/redo to restore", tuiInteractionTimeoutMs)
     currentTui.write("/red")
     const screen = await waitForCommand(currentTui, "/redo")
     expect(hasCommand(screen, "/redo")).toBe(true)
+  })
+
+  test("/modes Run hides redo when the next reverted turn is Run", async () => {
+    const buildPrompt = "build before hidden redo target"
+    const runPrompt = "run after hidden redo target"
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    await selectProductMode(currentTui, "Build")
+    currentTui.write(`${buildPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
+
+    await selectProductMode(currentTui, "Run")
+    currentTui.write(`${runPrompt}\r`)
+    await currentTui.waitForText("TUI demo response complete.", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => hasCompletedRunTurn(currentTui?.screen() ?? ""),
+      "completed Run turn",
+      tuiInteractionTimeoutMs,
+    )
+
+    currentTui.write("/timeline\r")
+    await currentTui.waitForText("Timeline", tuiInteractionTimeoutMs)
+    currentTui.write(buildPrompt)
+    await currentTui.waitFor(
+      () => hasTimelineRow(currentTui?.screen() ?? "", buildPrompt),
+      "filtered Build timeline row",
+      tuiInteractionTimeoutMs,
+    )
+    currentTui.write("\r")
+    await currentTui.waitForText("Message Actions", tuiInteractionTimeoutMs)
+    currentTui.write("\r")
+    await currentTui.waitForText("message reverted", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => {
+        const screen = currentTui?.screen() ?? ""
+        return screen.includes("message reverted") && !screen.includes("/redo to restore")
+      },
+      "hidden Run redo banner",
+      tuiInteractionTimeoutMs,
+    )
+
+    clearPrompt(currentTui)
+    currentTui.write("/red")
+    await currentTui.waitForText("/red", tuiInteractionTimeoutMs)
+    await Bun.sleep(100)
+    expect(hasCommand(currentTui.screen(), "/redo")).toBe(false)
+  })
+
+  test("/modes Run hides redo for a reverted final Run turn", async () => {
+    const runPrompt = "final run hidden redo target"
+    const dataHome = await mkdtemp(path.join(os.tmpdir(), "agentswarm-final-run-redo-data-"))
+    tempDirs.push(dataHome)
+    currentServer = await startTuiDemoAgencyServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      env: {
+        XDG_DATA_HOME: dataHome,
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    currentTui.write(`${runPrompt}\r`)
+    await currentTui.waitForText("TUI demo response complete.", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => hasCompletedRunTurn(currentTui?.screen() ?? ""),
+      "completed Run turn",
+      tuiInteractionTimeoutMs,
+    )
+    await currentTui.close()
+    currentTui = undefined
+
+    const messageID = seedSessionRevertForPrompt(await findOpenCodeDatabase(dataHome), runPrompt)
+    expect(messageID.length).toBeGreaterThan(0)
+
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      env: {
+        XDG_DATA_HOME: dataHome,
+      },
+    })
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    if (!currentTui.screen().includes("message reverted")) {
+      currentTui.write("/sessions\r")
+      await currentTui.waitForText("Sessions", tuiInteractionTimeoutMs)
+      currentTui.write("\r")
+    }
+    await currentTui.waitForText("message reverted", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => {
+        const screen = currentTui?.screen() ?? ""
+        return screen.includes("message reverted") && !screen.includes("/redo to restore")
+      },
+      "hidden final Run redo banner",
+      tuiInteractionTimeoutMs,
+    )
+
+    clearPrompt(currentTui)
+    currentTui.write("/red")
+    await currentTui.waitForText("/red", tuiInteractionTimeoutMs)
+    await Bun.sleep(100)
+    expect(hasCommand(currentTui.screen(), "/redo")).toBe(false)
+  })
+
+  test("/modes Run hides redo when the reverted turn is Run before later Build history", async () => {
+    const runPrompt = "run before later build hidden redo"
+    const buildPrompt = "build after reverted run hidden redo"
+    const dataHome = await mkdtemp(path.join(os.tmpdir(), "agentswarm-run-before-build-redo-data-"))
+    tempDirs.push(dataHome)
+    currentServer = await startTuiDemoAgencyServer()
+    currentNativeServer = await startNativeLLMServer()
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      env: {
+        XDG_DATA_HOME: dataHome,
+      },
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    currentTui.write(`${runPrompt}\r`)
+    await currentTui.waitForText("TUI demo response complete.", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => hasCompletedRunTurn(currentTui?.screen() ?? ""),
+      "completed Run turn",
+      tuiInteractionTimeoutMs,
+    )
+
+    await selectProductMode(currentTui, "Build")
+    currentTui.write(`${buildPrompt}\r`)
+    await currentTui.waitForText("native-mode-ok", tuiInteractionTimeoutMs)
+    await waitForNativeLLMRequest(currentTui, currentNativeServer, buildPrompt)
+    await currentTui.close()
+    currentTui = undefined
+
+    const messageID = seedSessionRevertForPrompt(await findOpenCodeDatabase(dataHome), runPrompt)
+    expect(messageID.length).toBeGreaterThan(0)
+
+    currentTui = await startTui({
+      baseURL: currentServer.baseURL,
+      agency: "tui-demo-agency",
+      recipientAgent: "UserSupportAgent",
+      configSource: "file",
+      env: {
+        XDG_DATA_HOME: dataHome,
+      },
+      config: {
+        model: latestOpenAITestModel,
+        enabled_providers: openAIProviderTestConfig.enabled_providers,
+        provider: {
+          openai: {
+            options: {
+              apiKey: "test-openai-key",
+              baseURL: currentNativeServer.baseURL,
+            },
+          },
+        },
+      },
+    })
+    await currentTui.waitForText("Swarm Default", tuiReadyTimeoutMs)
+    if (!currentTui.screen().includes("message reverted")) {
+      currentTui.write("/sessions\r")
+      await currentTui.waitForText("Sessions", tuiInteractionTimeoutMs)
+      currentTui.write("\r")
+    }
+    await currentTui.waitForText("message reverted", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => {
+        const screen = currentTui?.screen() ?? ""
+        return screen.includes("message reverted") && !screen.includes("/redo to restore")
+      },
+      "hidden reverted Run redo banner before later Build history",
+      tuiInteractionTimeoutMs,
+    )
+
+    clearPrompt(currentTui)
+    currentTui.write("/red")
+    await currentTui.waitForText("/red", tuiInteractionTimeoutMs)
+    await Bun.sleep(100)
+    expect(hasCommand(currentTui.screen(), "/redo")).toBe(false)
   })
 
   test("legacy Run sessions without bridge metadata keep Run labels after mode switch", async () => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -564,7 +564,13 @@ export function Session() {
   const redoTarget = createMemo(() => {
     const messageID = session()?.revert?.messageID
     if (!messageID) return undefined
-    return messages().find((message): message is UserMessage => message.role === "user" && message.id >= messageID)
+    return messages().find((message): message is UserMessage => message.role === "user" && message.id > messageID)
+  })
+
+  const revertedTarget = createMemo(() => {
+    const messageID = session()?.revert?.messageID
+    if (!messageID) return undefined
+    return messages().find((message): message is UserMessage => message.role === "user" && message.id === messageID)
   })
 
   const targetAgencySwarmBridge = (message: UserMessage | undefined) => {
@@ -578,7 +584,12 @@ export function Session() {
   }
 
   const undoAgencySwarmBridge = createMemo(() => targetAgencySwarmBridge(undoTarget()))
-  const redoAgencySwarmBridge = createMemo(() => targetAgencySwarmBridge(redoTarget()))
+  const redoAgencySwarmBridge = createMemo(() => {
+    const reverted = revertedTarget()
+    const target = redoTarget()
+    return (reverted ? targetAgencySwarmBridge(reverted) : false) || (target ? targetAgencySwarmBridge(target) : false)
+  })
+  const redoable = createMemo(() => !!session()?.revert?.messageID && !redoAgencySwarmBridge())
 
   const sessionCommandList = createMemo(() => [
     {
@@ -767,7 +778,7 @@ export function Session() {
       title: "Redo",
       value: "session.redo",
       category: "Session",
-      enabled: !!session()?.revert?.messageID && !redoAgencySwarmBridge(),
+      enabled: redoable(),
       hidden: redoAgencySwarmBridge(),
       slash: {
         name: "redo",
@@ -1284,6 +1295,7 @@ export function Session() {
                           const dialog = useDialog()
 
                           const handleUnrevert = async () => {
+                            if (!redoable()) return
                             const confirmed = await DialogConfirm.show(
                               dialog,
                               "Confirm Redo",
@@ -1296,7 +1308,9 @@ export function Session() {
 
                           return (
                             <box
-                              onMouseOver={() => setHover(true)}
+                              onMouseOver={() => {
+                                if (redoable()) setHover(true)
+                              }}
                               onMouseOut={() => setHover(false)}
                               onMouseUp={handleUnrevert}
                               marginTop={1}
@@ -1309,12 +1323,16 @@ export function Session() {
                                 paddingTop={1}
                                 paddingBottom={1}
                                 paddingLeft={2}
-                                backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
+                                backgroundColor={
+                                  redoable() && hover() ? theme.backgroundElement : theme.backgroundPanel
+                                }
                               >
                                 <text fg={theme.textMuted}>{revert()!.reverted.length} message reverted</text>
-                                <text fg={theme.textMuted}>
-                                  <span style={{ fg: theme.text }}>{redoShortcut()}</span> or /redo to restore
-                                </text>
+                                <Show when={redoable()}>
+                                  <text fg={theme.textMuted}>
+                                    <span style={{ fg: theme.text }}>{redoShortcut()}</span> or /redo to restore
+                                  </text>
+                                </Show>
                                 <Show when={revert()!.diffFiles?.length}>
                                   <box marginTop={1}>
                                     <For each={revert()!.diffFiles}>


### PR DESCRIPTION
### Issue for this PR

Fixes #297

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Hides native redo UI for Agent Swarm Run turns when a mixed Build/Run history has been reverted.

The change keeps native Build redo available, but hides the `/redo` slash command, shortcut text, and banner restore affordance when the reverted turn or the next redo target belongs to the Agent Swarm Run bridge.

### How did you verify your code works?

- Ran focused terminal TUI redo coverage from `packages/opencode`: `bun test --timeout 180000 --max-concurrency=1 ../../e2e/agent-swarm-tui/terminal-tui.test.ts -t "/modes Run .*redo"`; 4 passed, 0 failed.
- Ran `bun --cwd packages/opencode typecheck`.
- Ran `git diff --check origin/dev`.
- Ran `bun turbo test:ci`; 6/6 tasks successful, 3412 passed, 13 skipped, 1 todo, 0 failed.
- Ran Codex review on commit `1f3cdce9d`; no actionable issues found.

### Screenshots / recordings

Not attached. This is covered by terminal TUI E2E tests for the changed visible states.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
