### PR TITLE
docs: refresh Agent Swarm flow and changelog coverage

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -106,6 +106,12 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Implementation: `resolveClientConfig` and `buildAuthClientConfig` in `packages/opencode/src/session/agency-swarm.ts`.
   - Added by: `79b55ab8`
 
+- **Direct OpenRouter client config isolation**
+  - Intent: keep direct OpenRouter Agency Swarm runs from accidentally inheriting stored OpenAI OAuth routing state.
+  - Behavior: direct OpenRouter client config uses the OpenRouter API key and model without forwarding stored OpenAI OAuth base URLs or default headers.
+  - Implementation: `resolveClientConfig` in `packages/opencode/src/session/agency-swarm-client-config.ts`.
+  - Added by: PR #288
+
 - **Respect explicit Agency Swarm base URL**
   - Intent: let users target a chosen Agency Swarm server instead of always using the default loopback address.
   - Behavior: when a base URL is configured, agency session and run traffic use that URL.
@@ -141,6 +147,12 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Behavior: when the bridge emits an error frame, the session fails with visible error state the UI can surface.
   - Implementation: the `kind === "error"` branches inside `fullStream` in `packages/opencode/src/session/agency-swarm.ts`.
   - Added by: `ad0cc2c1`
+
+- **Compact HTML backend error pages**
+  - Intent: keep gateway or proxy failures readable when an upstream provider returns an HTML page through the Agency Swarm bridge.
+  - Behavior: HTTP failures, SSE error frames, raw response error events, and bridge error payloads that contain HTML are shown as concise Unauthorized, Forbidden, or backend HTML error messages instead of raw HTML documents.
+  - Implementation: `AgencySwarmAdapter.normalizeErrorMessage` in `packages/opencode/src/agency-swarm/adapter.ts`, plus stream-event and session error handling in `packages/opencode/src/session/agency-swarm-stream-events.ts` and `packages/opencode/src/session/agency-swarm.ts`.
+  - Added by: PR #288
 
 - **Filter Codex OAuth to OpenAI-based LiteLLM runs**
   - Intent: avoid sending Codex OAuth credentials to non-OpenAI agency backends that cannot use them.
@@ -241,8 +253,9 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Behavior: the Plan approval question owns keyboard input while visible, so base session shortcuts do not fire during the question.
   - Behavior: mixed-mode histories keep completed turn labels tied to the mode that handled each turn, including older Run turns without stored mode metadata.
   - Behavior: message actions use the selected turn's stored or legacy-inferred Run/native routing metadata, so mode switching does not hide or expose Revert for the wrong turn.
-  - Implementation: product mode state in `packages/opencode/src/cli/cmd/tui/context/local.tsx`, `DialogMode` in `packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx`, framework-mode gates in `packages/opencode/src/cli/cmd/tui/session-error.ts`, native routing metadata in `packages/opencode/src/session/prompt.ts` and `packages/opencode/src/session/compaction.ts`, selected-turn message actions in `packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx`, and upstream-aligned question keymap isolation in `packages/opencode/src/cli/cmd/tui/keymap.tsx` and `packages/opencode/src/cli/cmd/tui/routes/session/question.tsx`.
-  - Added by: `d6b9ed38`
+  - Behavior: Redo restore affordances are hidden when the reverted turn or next redo target belongs to Run, while native Build redo stays available for native Build history.
+  - Implementation: product mode state in `packages/opencode/src/cli/cmd/tui/context/local.tsx`, `DialogMode` in `packages/opencode/src/cli/cmd/tui/component/dialog-mode.tsx`, framework-mode gates in `packages/opencode/src/cli/cmd/tui/session-error.ts`, native routing metadata in `packages/opencode/src/session/prompt.ts` and `packages/opencode/src/session/compaction.ts`, selected-turn message actions in `packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx`, redo gating in `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`, and upstream-aligned question keymap isolation in `packages/opencode/src/cli/cmd/tui/keymap.tsx` and `packages/opencode/src/cli/cmd/tui/routes/session/question.tsx`.
+  - Added by: `d6b9ed38`, PR #300
 
 - **Tab switches native agents outside Run and swarm agents in Run**
   - Intent: preserve upstream native agent cycling while keeping fast target switching during run sessions.
@@ -311,6 +324,26 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Behavior: non-Agency explicit models do not trigger fork auto-project setup.
   - Implementation: `shouldRunNpxOnboarding` and `resolveNpxAutoProject` in `packages/opencode/src/agency-swarm/npx.ts`.
   - Added by: `772db106`
+
+- **Unreadable project entry recovery**
+  - Intent: keep users out of the wrong starter-project path when a directory already looks like an Agent Swarm project but its entry file cannot be read.
+  - Behavior: an unreadable default `agency.py` shows a clear read-recovery message and offers only Try again, Connect to a running Agent Swarm, or Cancel.
+  - Implementation: `detectLaunchProject`, `chooseProjectReadRecovery`, and `readProjectEntryFile` in `packages/opencode/src/agency-swarm/npx.ts`.
+  - Added by: PR #281
+
+- **Configured entry-file fallback after read errors**
+  - Intent: let downstream profiles with multiple entry-file names still detect a later valid project entry when an earlier candidate cannot be read.
+  - Behavior: project detection keeps checking configured entry files after a read error and throws the original read error only when no later valid entry file is found.
+  - Implementation: `detectAgencyProject` in `packages/opencode/src/agency-swarm/npx.ts`.
+  - Added by: PR #290
+
+- **Compact launcher setup and starter prompts**
+  - Intent: keep the first-run launcher path focused on user choices and product-level progress instead of low-level Python, dependency, and server details.
+  - Behavior: launcher setup shows compact phases such as project-file checking, project creation, preparing, environment check or refresh, setup, start, and ready while raw Python, uv, pip, dependency, and FastAPI output stays in launcher logs.
+  - Behavior: starter creation asks for `Project name` with the configured starter name as the initial value and, when GitHub creation is available, asks `Where should this project be created?` with `On GitHub` and `On this computer` choices.
+  - Behavior: first-use database setup uses Agent Swarm readiness copy instead of generic database migration copy.
+  - Implementation: launcher output and spinner handling in `packages/opencode/src/agency-swarm/npx.ts`, plus first-use readiness copy in `packages/opencode/src/index.ts`.
+  - Added by: PR #283
 
 - **Launcher bootstraps or repairs the project Python env**
   - Intent: make the launcher fix missing or broken project Python setup instead of failing early.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -29,6 +29,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Trigger:** Start from `npx @vrsen/agentswarm`, an installed `agentswarm`, or the direct fork binary.
 - **Happy-path proof:** Launcher mode can be inferred from the `agentswarm` command shape or `AGENTSWARM_LAUNCHER=1`.
 - **Happy-path proof:** The wrapper finds the fork package or platform binary, sets or preserves `AGENTSWARM_LAUNCHER=1`, and opens the default TUI command with Agent Swarm branding.
+- **Happy-path proof:** First-use database setup says `Getting Agent Swarm ready for first use. This can take a few minutes...` and finishes with `Agent Swarm is ready.`
 - **Failure scenarios to test:** Missing fork package or platform binary fails before the TUI opens.
 - **Failure scenarios to test:** The end-user path does not rely on the unapproved local `dist/` fallback.
 
@@ -37,6 +38,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Trigger:** Start from a downstream wrapper or release binary that sets `AGENTSWARM_PRODUCT_*` values.
 - **Happy-path proof:** Help, upgrade, mDNS, release repository, docs, issue links, and package copy use the configured downstream values.
 - **Happy-path proof:** The launcher detects configured entry files; the default Agent Swarm profile still detects only `agency.py`.
+- **Happy-path proof:** If a configured entry file exists but cannot be read, detection keeps checking later configured entry files and uses a later valid entry before showing read-recovery choices.
 - **Happy-path proof:** A missing local project creates the configured starter repository in the configured starter folder.
 - **Happy-path proof:** A release-built binary reports `AGENTSWARM_PRODUCT_VERSION` when it is set.
 - **Happy-path proof:** A downstream profile can provide `AGENTSWARM_PRODUCT_ADDONS` to expose `/addons`, while the default Agent Swarm profile keeps `/addons` hidden.
@@ -50,6 +52,7 @@ For each failure scenario, capture the visible user result and cite the matching
 
 - **Trigger:** Launch from a directory containing `agency.py` with `def create_agency` and an `agency_swarm` import.
 - **Happy-path proof:** Onboarding shows `Checking Agent Swarm project files...`, then offers `Use detected Agent Swarm project` first.
+- **Happy-path proof:** Setup output stays compact: environment checking, refresh, setup, start, and ready states are shown while raw Python, uv, pip, dependency, and FastAPI details stay in launcher logs.
 - **Happy-path proof:** A healthy `.venv` is reused.
 - **Happy-path proof:** A broken `.venv` is rebuilt when Python 3.12+ is available.
 - **Happy-path proof:** Launcher-managed uv is installed or repaired inside `.venv`.
@@ -80,6 +83,8 @@ For each failure scenario, capture the visible user result and cite the matching
 
 - **Trigger:** Launch without a detected project and choose `Create a new Agent Swarm project`.
 - **Happy-path proof:** Empty, unsafe, or already-used project names are rejected.
+- **Happy-path proof:** The project-name prompt shows `Project name` with the configured starter name already filled in, so Enter accepts it.
+- **Happy-path proof:** When GitHub creation is available, the creation-location prompt asks `Where should this project be created?` with `On GitHub` and `On this computer`.
 - **Happy-path proof:** The starter uses `agency-ai-solutions/agency-starter-template`.
 - **Happy-path proof:** GitHub template creation is used only when `gh` is present and authenticated.
 - **Happy-path proof:** Local clone mode is used when GitHub template creation is unavailable.
@@ -175,6 +180,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** Selecting a swarm routes through the default agency path without a stale explicit recipient.
 - **Happy-path proof:** Selecting an agent routes the next prompt to that agent.
 - **Happy-path proof:** Compatible configured provider credentials pass through the credential bridge.
+- **Happy-path proof:** Direct OpenRouter runs use the OpenRouter API key without inheriting stored OpenAI OAuth base URLs or default headers.
 - **Happy-path proof:** Provider auth stays a credential flow and does not act as a Run-mode switch.
 - **Happy-path proof:** `/models` selects the LLM config passed to Agency Swarm and does not act as a product mode switch.
 - **Happy-path proof:** Selecting an Ollama local model in `/models` routes the run through Agency Swarm as a LiteLLM `ollama_chat` model.
@@ -195,6 +201,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Failure scenarios to test:** Server reachability or authorization failure opens `/connect`.
 - **Failure scenarios to test:** Provider credential failure opens `/auth`.
 - **Failure scenarios to test:** Non-OpenAI LiteLLM agency runs do not receive Codex OAuth credentials while OpenAI-based LiteLLM runs still keep them.
+- **Failure scenarios to test:** HTML gateway or proxy error pages from streaming, HTTP, or raw-response failures are compacted into short actionable auth/routing errors instead of raw HTML.
 - **Failure scenarios to test:** Missing or unreachable Ollama fails visibly without switching out of Run mode.
 
 #### `/modes`, Build, and Plan
@@ -220,6 +227,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** The Plan approval question owns keyboard input while it is open, so session shortcuts do not fire at the same time.
 - **Happy-path proof:** Switching back to Run in the same project reconnects to or keeps using the Agency Swarm server and returns `/agents` to the swarm/agent picker.
 - **Happy-path proof:** Message actions use the selected turn's saved or legacy-inferred Run/native routing metadata, so Revert is shown or hidden for the selected turn even after switching modes.
+- **Happy-path proof:** Redo restore affordances stay hidden when the reverted turn or next redo target belongs to Run, while native Build redo stays available for native Build turns.
 - **User story:** After changing or repairing a swarm in Build, the user can return to Run in the same project and confirm the fixed swarm works.
 - **Success looks like:** Run uses the repaired swarm and gives a good response instead of staying on the earlier broken behavior.
 - **User story:** When a Run attempt shows the swarm needs work, the user can switch to Build, make the fix, return to Run, and try again.


### PR DESCRIPTION
### Issue for this PR

Follow-up to recent Agent Swarm UX/runtime PRs where the fork source-of-truth docs were not fully updated.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates `USER_FLOWS.md` and `FORK_CHANGELOG.md` for recent fork-specific behavior that was missing from one or both docs:

- Run redo restore affordances stay hidden for reverted Run turns while native Build redo remains available.
- Direct OpenRouter Agent Swarm runs do not inherit stored OpenAI OAuth base URL/default-header state.
- HTML gateway/proxy error pages are compacted into short actionable auth/routing errors.
- Downstream entry-file detection keeps scanning configured fallbacks after read errors.
- Unreadable `agency.py` recovery, compact launcher setup output, starter prompt copy, and first-use Agent Swarm readiness copy are recorded as intentional fork behavior.

### How did you verify your code works?

- Re-read the updated `USER_FLOWS.md` and `FORK_CHANGELOG.md` from branch `codex/docs-flow-changelog-misses` through the GitHub contents API.
- Compared `dev...codex/docs-flow-changelog-misses`: only `USER_FLOWS.md` and `FORK_CHANGELOG.md` changed.

### Screenshots / recordings

Not applicable. Documentation-only change.

### Checklist

- [x] Source-of-truth docs updated
- [x] No runtime code changed
