### PR TITLE
fix(sdk): document agency swarm bridge field

### DIFF
--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -5302,6 +5302,9 @@
                   "agencyLabelRecipientAgent": {
                     "type": "string"
                   },
+                  "agencySwarmBridge": {
+                    "type": "boolean"
+                  },
                   "parts": {
                     "type": "array",
                     "items": {
@@ -5987,6 +5990,9 @@
                   },
                   "auto": {
                     "type": "boolean"
+                  },
+                  "agencySwarmBridge": {
+                    "type": "boolean"
                   }
                 },
                 "required": ["providerID", "modelID"],
@@ -6113,6 +6119,9 @@
                   },
                   "agencyLabelRecipientAgent": {
                     "type": "string"
+                  },
+                  "agencySwarmBridge": {
+                    "type": "boolean"
                   },
                   "parts": {
                     "type": "array",
@@ -6249,6 +6258,9 @@
                   },
                   "variant": {
                     "type": "string"
+                  },
+                  "agencySwarmBridge": {
+                    "type": "boolean"
                   },
                   "parts": {
                     "type": "array",
@@ -6402,6 +6414,9 @@
                   },
                   "command": {
                     "type": "string"
+                  },
+                  "agencySwarmBridge": {
+                    "type": "boolean"
                   }
                 },
                 "required": ["agent", "command"],


### PR DESCRIPTION
### Issue for this PR

Fixes #303

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the missing optional `agencySwarmBridge` field to the tracked OpenAPI request bodies for session prompt, summarize, async prompt, command, and shell calls.

The server schemas and generated JS SDK already include this field. This keeps `packages/sdk/openapi.json` aligned with that release surface without taking unrelated generator drift.

### How did you verify your code works?

- `rg -n 'agencySwarmBridge' packages/sdk/openapi.json`
- Focused JSON check for the five affected operations: each has optional boolean `agencySwarmBridge`; none mark it required.
- `git diff --check`
- `bun x prettier --check packages/sdk/openapi.json`
- `bun --cwd packages/sdk/js typecheck`
- `bun typecheck`
- `bun turbo test:ci`
- Local Codex review found no regression in the diff.

### Screenshots / recordings

Not applicable; this updates an API artifact only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
