### PR TITLE
fix(shell): wait for output drain before final result

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Fiber, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -481,7 +481,7 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
-          yield* Effect.forkScoped(
+          const output = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
@@ -553,6 +553,7 @@ export const ShellTool = Tool.define(
             expired = true
             yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
           }
+          yield* Fiber.join(output)
 
           return exit.kind === "exit" ? exit.code : null
         }),

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Cause, Effect, Exit, Layer } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import type * as Scope from "effect/Scope"
 import os from "os"
 import path from "path"
@@ -210,6 +210,62 @@ describe("tool.shell", () => {
       )
     }),
   )
+
+  if (process.platform !== "win32") {
+    it.live("waits for output stream drain before final result", () =>
+      Effect.gen(function* () {
+        const tmp = yield* tmpdirScoped()
+        const done = path.join(tmp, "done")
+        const seen = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        yield* Effect.gen(function* () {
+          let gated = false
+          const code = [
+            'process.stdout.write("first\\n")',
+            'setTimeout(async () => { process.stdout.write("second\\n"); await Bun.write(Bun.argv[1], "done") }, 25)',
+          ].join(";")
+
+          const fiber = yield* runIn(
+            tmp,
+            run(
+              {
+                command: `${bin} -e ${evalarg(code)} ${quote(done)}`,
+                description: "Drain output stream",
+              },
+              {
+                ...ctx,
+                metadata: (input) =>
+                  Effect.gen(function* () {
+                    const output = (input.metadata as { output?: string })?.output
+                    if (!output?.includes("first") || gated) return
+                    gated = true
+                    yield* Deferred.succeed(seen, undefined)
+                    yield* Deferred.await(release)
+                  }),
+              },
+            ),
+          ).pipe(Effect.forkScoped)
+
+          yield* Deferred.await(seen).pipe(Effect.timeout("2 seconds"))
+          yield* Effect.promise(async () => {
+            for (let i = 0; i < 200; i++) {
+              if (await Bun.file(done).exists()) return
+              await Bun.sleep(10)
+            }
+            throw new Error("command did not finish writing output")
+          })
+
+          const early = yield* Fiber.await(fiber).pipe(Effect.timeoutOption("100 millis"))
+          expect(early._tag).toBe("None")
+
+          yield* Deferred.succeed(release, undefined)
+          const result = yield* Fiber.join(fiber).pipe(Effect.timeout("2 seconds"))
+          expect(result.output).toContain("first")
+          expect(result.output).toContain("second")
+        }).pipe(Effect.ensuring(Deferred.succeed(release, undefined).pipe(Effect.ignore)))
+      }),
+    )
+  }
 })
 
 describe("tool.shell permissions", () => {


### PR DESCRIPTION
### Issue for this PR

Fixes #307

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shell commands can exit before the combined stdout/stderr stream has delivered its final chunks. In that race, the shell tool can return a final result before all output is present.

This PR waits for the output reader fiber to drain before building the final shell result. The regression test gates metadata after the first output chunk and proves the shell tool does not finish until delayed output has been read.

### How did you verify your code works?

Local verification covered the focused output-drain regression, the shell tool test file, package typecheck, root typecheck, formatting, diff whitespace, stress reruns, and the monorepo test suite. GitHub Actions on the previous PR head for the same commit also passed before the non-compliant PR artifact was auto-closed.

### Screenshots / recordings

Not applicable. This is shell tool runtime behavior covered by automated tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
