### PR TITLE
fix(tui): separate connect from provider auth

### DIFF
--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -1904,7 +1904,21 @@ describe("Agent Swarm terminal TUI e2e", () => {
     currentTui.write("/connect")
     await currentTui.waitForText("/connect", tuiInteractionTimeoutMs)
     currentTui.write("\r")
-    const screen = await currentTui.waitForText("Connect to local agency-swarm server", tuiInteractionTimeoutMs)
+    await currentTui.waitFor(
+      () => {
+        const screen = currentTui!.screen()
+        return (
+          screen.includes("http://127.0.0.1:8000") &&
+          screen.includes("http://127.0.0.1:8080") &&
+          screen.includes("Add local port") &&
+          screen.includes("Authentication") &&
+          !screen.includes("Connect a provider")
+        )
+      },
+      "Agency Swarm connect dialog without configured server",
+      tuiInteractionTimeoutMs,
+    )
+    const screen = currentTui.screen()
 
     expect(screen).toContain("http://127.0.0.1:8000")
     expect(screen).toContain("http://127.0.0.1:8080")

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -43,6 +43,10 @@ function hasCommand(screen: string, command: string) {
   return screen.split("\n").some((line) => new RegExp(`┃\\s+${command}\\b`).test(line))
 }
 
+function commandLine(screen: string, command: string) {
+  return screen.split("\n").find((line) => new RegExp(`┃\\s+${command}\\b`).test(line)) ?? ""
+}
+
 function hasCompletedRunTurn(screen: string) {
   return /▣\s+Run · .+ · \d+(?:\.\d+)?(?:ms|s)\b/.test(screen)
 }
@@ -262,6 +266,10 @@ describe("Agent Swarm terminal TUI e2e", () => {
 
     expect(hasCommand(screen, "/auth")).toBe(true)
     expect(hasCommand(screen, "/connect")).toBe(true)
+    expect(commandLine(screen, "/auth")).toContain("Manage provider auth")
+    expect(commandLine(screen, "/connect")).toContain("Connect to local agency-swarm server")
+    expect(commandLine(screen, "/connect")).not.toContain("Manage provider auth")
+    expect(commandLine(screen, "/connect")).not.toContain("Authenticate providers")
     expect(hasCommand(screen, "/models")).toBe(true)
     expect(hasCommand(screen, "/agents")).toBe(true)
     expect(hasCommand(screen, "/addons")).toBe(false)
@@ -1823,7 +1831,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(screen).not.toContain("1.5K (0%)")
   })
 
-  test("/connect opens the Agency Swarm server dialog with visible OpenAI model state", async () => {
+  test("/connect opens the Agency Swarm server dialog with visible OpenAI model state outside Run mode", async () => {
     currentServer = await startAgencyProtocolServer()
     currentTui = await startTui({
       baseURL: currentServer.baseURL,
@@ -1832,10 +1840,12 @@ describe("Agent Swarm terminal TUI e2e", () => {
     })
 
     await currentTui.waitForText(latestOpenAITestModelLabel, tuiReadyTimeoutMs)
-    currentTui.write("/con")
+    await selectProductMode(currentTui, "Build")
+    await currentTui.waitForText("Build ·", tuiInteractionTimeoutMs)
+    currentTui.write("/connect")
     await currentTui.waitFor(
-      () => currentTui!.screen().includes("/connect") && currentTui!.screen().includes("/con"),
-      "filtered /connect slash command",
+      () => currentTui!.screen().includes("/connect"),
+      "/connect slash command",
       tuiInteractionTimeoutMs,
     )
     currentTui.write("\r")
@@ -1869,6 +1879,38 @@ describe("Agent Swarm terminal TUI e2e", () => {
     expect(tokenScreen).toContain("Update token")
     expect(tokenScreen).toContain("Clear token")
     expect(tokenScreen).not.toContain("Connect a provider")
+  })
+
+  test("/connect opens local server controls when Agency Swarm is not configured", async () => {
+    currentTui = await startTui({
+      args: ["--model", latestOpenAITestModel],
+      env: {
+        OPENCODE_CONFIG_CONTENT: JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          enabled_providers: ["openai"],
+          model: latestOpenAITestModel,
+          provider: {
+            openai: {
+              options: {
+                apiKey: "test-openai-key",
+              },
+            },
+          },
+        }),
+      },
+    })
+
+    await currentTui.waitForText(latestOpenAITestModelLabel, tuiReadyTimeoutMs)
+    currentTui.write("/connect")
+    await currentTui.waitForText("/connect", tuiInteractionTimeoutMs)
+    currentTui.write("\r")
+    const screen = await currentTui.waitForText("Connect to local agency-swarm server", tuiInteractionTimeoutMs)
+
+    expect(screen).toContain("http://127.0.0.1:8000")
+    expect(screen).toContain("http://127.0.0.1:8080")
+    expect(screen).toContain("Add local port")
+    expect(screen).toContain("Authentication")
+    expect(screen).not.toContain("Connect a provider")
   })
 
   test("Run-mode auth failures open /auth with visible OpenAI model state", async () => {

--- a/packages/opencode/src/agency-swarm/product.ts
+++ b/packages/opencode/src/agency-swarm/product.ts
@@ -308,7 +308,8 @@ export namespace AgencyProduct {
   export const wordmarkLines = current.wordmarkLines
   export const pythonEnvironment = current.pythonEnvironment
   export const stateRoot = current.stateRoot
-  export const connect = "Authenticate providers"
+  export const auth = "Manage provider auth"
+  export const connect = "Connect to local agency-swarm server"
   export const start = [
     "Authenticate providers and connect to a local agency-swarm server before sending prompts.",
     "Use /auth for provider credentials, then /connect to choose the server and store a token.",

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -796,7 +796,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
       {
         name: "provider.auth",
-        title: "Manage provider auth",
+        title: AgencyProduct.auth,
         suggested: !connected(),
         slashName: "auth",
         slashAliases: ["logout"],
@@ -828,7 +828,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         suggested: !connected(),
         slashName: "connect",
         run: () => {
-          dialog.replace(() => (frameworkMode() ? <DialogAgencySwarmConnect /> : <DialogProviderConnect />))
+          dialog.replace(() => <DialogAgencySwarmConnect />)
         },
         category: "Provider",
       },

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -70,6 +70,7 @@ export function inferProductMode(input: {
   if (input.storedBridge === true) return agencySwarmEnabled ? "run" : "build"
   if (input.agentName === "plan") return "plan"
   if (input.storedBridge === false) return "build"
+  if (input.hasAgencySwarmProvider && agencySwarmEnabled) return "run"
   if (
     input.agentName === "build" &&
     !input.argModel &&
@@ -79,7 +80,6 @@ export function inferProductMode(input: {
   ) {
     return "build"
   }
-  if (input.hasAgencySwarmProvider && agencySwarmEnabled) return "run"
   if (
     agencySwarmEnabled &&
     isAgencySwarmRunMode({

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -68,7 +68,7 @@ function parse(tip: string): TipPart[] {
   return parts
 }
 
-const NO_MODELS_TIP = "Run {highlight}/connect{/highlight} to add an AI provider and start coding"
+const NO_MODELS_TIP = "Use {highlight}/auth{/highlight} for provider credentials, then {highlight}/connect{/highlight} for a local server"
 
 function shortcutText(value: string) {
   return `{highlight}${value}{/highlight}`

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/footer.tsx
@@ -53,8 +53,12 @@ function View(props: { api: TuiPluginApi }) {
             <text fg={theme().textMuted}>{AgencyProduct.start[0]}</text>
             <text fg={theme().textMuted}>{AgencyProduct.start[1]}</text>
             <box flexDirection="row" gap={1} justifyContent="space-between">
-              <text fg={theme().text}>{AgencyProduct.connect}</text>
+              <text fg={theme().text}>{AgencyProduct.auth}</text>
               <text fg={theme().textMuted}>/auth</text>
+            </box>
+            <box flexDirection="row" gap={1} justifyContent="space-between">
+              <text fg={theme().text}>{AgencyProduct.connect}</text>
+              <text fg={theme().textMuted}>/connect</text>
             </box>
           </box>
         </box>

--- a/packages/opencode/test/cli/tui/local-context.test.tsx
+++ b/packages/opencode/test/cli/tui/local-context.test.tsx
@@ -4,7 +4,7 @@ import { testRender } from "@opentui/solid"
 import { createStore } from "solid-js/store"
 import * as ArgsContext from "../../../src/cli/cmd/tui/context/args"
 import * as EventContext from "../../../src/cli/cmd/tui/context/event"
-import { LocalProvider, useLocal } from "../../../src/cli/cmd/tui/context/local"
+import { inferProductMode, LocalProvider, useLocal } from "../../../src/cli/cmd/tui/context/local"
 import * as RouteContext from "../../../src/cli/cmd/tui/context/route"
 import * as SDKContext from "../../../src/cli/cmd/tui/context/sdk"
 import * as SyncContext from "../../../src/cli/cmd/tui/context/sync"
@@ -15,6 +15,73 @@ import { Filesystem } from "../../../src/util/filesystem"
 function flushEffects() {
   return Promise.resolve().then(() => Promise.resolve())
 }
+
+describe("tui local context product mode inference", () => {
+  test("keeps Run mode when Agency Swarm is configured over stale explicit provider state", () => {
+    expect(
+      inferProductMode({
+        agentName: "build",
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+          explicit: true,
+        },
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        hasAgencySwarmProvider: true,
+      }),
+    ).toBe("run")
+  })
+
+  test("preserves explicit Build and Plan mode selections", () => {
+    expect(
+      inferProductMode({
+        storedMode: "build",
+        agentName: "build",
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+          explicit: true,
+        },
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        hasAgencySwarmProvider: true,
+      }),
+    ).toBe("build")
+
+    expect(
+      inferProductMode({
+        storedMode: "plan",
+        agentName: "plan",
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+          explicit: true,
+        },
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        hasAgencySwarmProvider: true,
+      }),
+    ).toBe("plan")
+  })
+
+  test("keeps stored native bridge sessions out of Run mode", () => {
+    expect(
+      inferProductMode({
+        agentName: "build",
+        storedBridge: false,
+        storedModel: {
+          providerID: "openai",
+          modelID: "gpt-5",
+          explicit: true,
+        },
+        currentProviderID: "openai",
+        configuredModel: "agency-swarm/default",
+        hasAgencySwarmProvider: true,
+      }),
+    ).toBe("build")
+  })
+})
 
 describe("tui local context model sync", () => {
   afterEach(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #311

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Restores `/auth` and `/connect` as separate Agent Swarm TUI actions.

`/auth` now owns provider credential copy. `/connect` uses local agency-swarm server wording and always opens the local server connection controls. The getting-started footer and no-models tip now use the same split so users are not sent to `/connect` for provider credentials.

The mode inference fix keeps configured Agency Swarm sessions in Run mode when stale native model state is present, while preserving explicit Build/Plan choices and stored native sessions.

### How did you verify your code works?

Focused local coverage exercised the affected slash-command rows, `/connect` server-dialog routing in Run, Build, and unconfigured states, product-mode inference, and type safety. A fresh independent Codex review of the final diff found no blocking issues.

### Screenshots / recordings

Not attached. The changed terminal flows are covered by the Agent Swarm TUI regression tests added in this PR.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
