### PR TITLE
fix(tui): restore prompt drafts after send failures

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -223,6 +223,12 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Implementation: `createAgencySwarmConnectionMonitor` in `packages/opencode/src/cli/cmd/tui/context/agency-swarm-connection.tsx`.
   - Added by: `92ef7ee2`
 
+- **Prompt submit failures keep retryable drafts**
+  - Intent: prevent users from losing a prompt when a submit request fails after the TUI has already cleared or navigated away from the prompt input.
+  - Behavior: failed prompt submissions restore the submitted draft only when the user turn was not already persisted, preserve newer edits, and keep retry routing for Agent Swarm Run targets.
+  - Implementation: prompt draft recovery in `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`, route prompt handoff in `packages/opencode/src/cli/cmd/tui/context/route.tsx` and `packages/opencode/src/cli/cmd/tui/routes/home.tsx`, and prompt refs in `packages/opencode/src/cli/cmd/tui/context/prompt.tsx`.
+  - Added by: issue #305
+
 - **Agency backend management commands are debugging and development tools**
   - Intent: keep backend lifecycle commands available for debugging and development without treating them as the main end-user path.
   - Behavior: the fork exposes backend install and maintenance commands, but they are debugging and development tools rather than core product surface.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -78,6 +78,8 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** One-shot `--prompt` submits after sync and model state are ready.
 - **Failure scenarios to test:** Non-Agency explicit models do not trigger fork auto-project setup.
 - **Failure scenarios to test:** Missing or broken detected projects fail through the local project setup failure path before prompt launch.
+- **Failure scenarios to test:** If the first prompt fails after the TUI has cleared or left the prompt input, the submitted draft reappears for retry when the user turn was not persisted.
+- **Failure scenarios to test:** Failed first prompts do not overwrite newer user edits or restore/delete sessions when the user turn was already persisted.
 
 #### Starter project
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1980,6 +1980,9 @@ export function Prompt(props: PromptProps) {
                 route.navigate({
                   type: "session",
                   sessionID: routeSessionID,
+                  ...(usedExplicitRecipient && explicitSelectedAt !== undefined
+                    ? { promptRecipientSelectedAt: explicitSelectedAt }
+                    : {}),
                   prompt: restoredPrompt,
                 })
                 restored = true
@@ -2014,6 +2017,9 @@ export function Prompt(props: PromptProps) {
               } else {
                 route.navigate({
                   type: "home",
+                  ...(usedExplicitRecipient && explicitSelectedAt !== undefined
+                    ? { promptRecipientSelectedAt: explicitSelectedAt }
+                    : {}),
                   prompt: restoredPrompt,
                 })
               }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -103,6 +103,7 @@ import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut, useLeaderActive, u
 import { useTuiConfig } from "../../context/tui-config"
 import { Telemetry } from "@/telemetry/telemetry"
 import { captureCommand } from "@/telemetry/command"
+import { useOptionalPromptRef } from "../../context/prompt"
 
 export type PromptProps = {
   sessionID?: string
@@ -124,6 +125,9 @@ export type PromptProps = {
 export type PromptRef = {
   focused: boolean
   current: PromptInfo
+  empty?(): boolean
+  version?(): number
+  restoreRecipientSelection?(selectedAt: number | undefined): void
   set(prompt: PromptInfo): void
   reset(): void
   blur(): void
@@ -191,7 +195,6 @@ function formatEditorContext(selection: EditorSelection) {
 }
 
 let stashed: { prompt: PromptInfo; cursor: number } | undefined
-
 type AgencyAssistantMessageInfo = {
   id: string
   sessionID: string
@@ -218,6 +221,7 @@ export function Prompt(props: PromptProps) {
   const tuiConfig = useTuiConfig()
   const dialog = useDialog()
   const toast = useToast()
+  const activePrompt = useOptionalPromptRef()
   const status = createMemo(() => sync.data.session_status?.[props.sessionID ?? ""] ?? { type: "idle" })
   const history = usePromptHistory()
   const stash = usePromptStash()
@@ -246,6 +250,12 @@ export function Prompt(props: PromptProps) {
   const taskTelemetryByMessageID = new Map<string, TaskTelemetryState>()
   const activeOrgName = createMemo(() => sync.data.console_state.activeOrgName)
   const canSwitchOrgs = createMemo(() => sync.data.console_state.switchableOrgCount > 1)
+  let promptVersion = 0
+  let ignoreSubmittedClearChange = false
+  const markPromptChanged = () => {
+    promptVersion += 1
+    return promptVersion
+  }
   const frameworkMode = createMemo(() =>
     isAgencySwarmFrameworkMode({
       productMode: local.product?.current(),
@@ -1022,6 +1032,7 @@ export function Prompt(props: PromptProps) {
           })
           restoreExtmarksFromParts(updatedNonTextParts)
           input.cursorOffset = Bun.stringWidth(content)
+          markPromptChanged()
         },
       },
       {
@@ -1039,6 +1050,7 @@ export function Prompt(props: PromptProps) {
                   parts: [],
                 })
                 input.gotoBufferEnd()
+                markPromptChanged()
               }}
             />
           ))
@@ -1097,6 +1109,18 @@ export function Prompt(props: PromptProps) {
     get current() {
       return store.prompt
     },
+    empty() {
+      if (store.prompt.input !== "" || store.prompt.parts.length > 0) return false
+      if (input.isDestroyed) return true
+      if (input.plainText !== "") return false
+      return input.extmarks.getAllForTypeId(promptPartTypeId).length === 0
+    },
+    version() {
+      return promptVersion
+    },
+    restoreRecipientSelection(selectedAt) {
+      setExplicitRecipientSelectedAt(selectedAt)
+    },
     focus() {
       input.focus()
     },
@@ -1109,6 +1133,7 @@ export function Prompt(props: PromptProps) {
       if (prompt.mode) setStore("mode", prompt.mode)
       restoreExtmarksFromParts(prompt.parts)
       input.gotoBufferEnd()
+      markPromptChanged()
     },
     reset() {
       input.clear()
@@ -1118,6 +1143,7 @@ export function Prompt(props: PromptProps) {
         parts: [],
       })
       setStore("extmarkToPartIndex", new Map())
+      markPromptChanged()
     },
     submit() {
       void submit()
@@ -1133,6 +1159,7 @@ export function Prompt(props: PromptProps) {
       setStore("prompt", saved.prompt)
       restoreExtmarksFromParts(saved.prompt.parts)
       input.cursorOffset = saved.cursor
+      markPromptChanged()
     }
   })
 
@@ -1270,6 +1297,7 @@ export function Prompt(props: PromptProps) {
           input.clear()
           setStore("prompt", { input: "", parts: [] })
           setStore("extmarkToPartIndex", new Map())
+          markPromptChanged()
           dialog.clear()
         },
       },
@@ -1285,6 +1313,7 @@ export function Prompt(props: PromptProps) {
             setStore("prompt", { input: entry.input, parts: entry.parts })
             restoreExtmarksFromParts(entry.parts)
             input.gotoBufferEnd()
+            markPromptChanged()
           }
           dialog.clear()
         },
@@ -1302,6 +1331,7 @@ export function Prompt(props: PromptProps) {
                 setStore("prompt", { input: entry.input, parts: entry.parts })
                 restoreExtmarksFromParts(entry.parts)
                 input.gotoBufferEnd()
+                markPromptChanged()
               }}
             />
           ))
@@ -1411,6 +1441,7 @@ export function Prompt(props: PromptProps) {
             setStore("mode", item.mode ?? "normal")
             restoreExtmarksFromParts(item.parts)
             input.cursorOffset = 0
+            markPromptChanged()
           },
         },
       ],
@@ -1448,6 +1479,7 @@ export function Prompt(props: PromptProps) {
             setStore("mode", item.mode ?? "normal")
             restoreExtmarksFromParts(item.parts)
             input.cursorOffset = input.plainText.length
+            markPromptChanged()
           },
         },
       ],
@@ -1481,6 +1513,7 @@ export function Prompt(props: PromptProps) {
     if (input && !input.isDestroyed && input.plainText !== store.prompt.input) {
       setStore("prompt", "input", input.plainText)
       syncExtmarksWithPromptParts()
+      markPromptChanged()
     }
     if (props.disabled) return false
     if (isDialogBlockingPrompt()) return false
@@ -1527,6 +1560,7 @@ export function Prompt(props: PromptProps) {
       ? command.slashes().find((item) => [item.display, ...(item.aliases ?? [])].includes(firstWord))
       : undefined
 
+    let clearedPromptVersion: number | undefined
     const clearSubmittedPrompt = (submittedMode: typeof store.mode) => {
       history.append({
         ...store.prompt,
@@ -1539,7 +1573,24 @@ export function Prompt(props: PromptProps) {
       })
       setStore("extmarkToPartIndex", new Map())
       props.onSubmit?.()
+      ignoreSubmittedClearChange = true
       input.clear()
+      clearedPromptVersion = markPromptChanged()
+    }
+    const promptStillCleared = () => {
+      if (clearedPromptVersion !== promptVersion) return false
+      if (store.prompt.input !== "" || store.prompt.parts.length > 0) return false
+      if (!input.isDestroyed) {
+        if (input.plainText !== "") return false
+        if (input.extmarks.getAllForTypeId(promptPartTypeId).length > 0) return false
+      }
+      return true
+    }
+    const emptyPrompt = (prompt: PromptInfo) => prompt.input === "" && prompt.parts.length === 0
+    const emptyRef = (prompt: PromptRef) => prompt.empty?.() ?? emptyPrompt(prompt.current)
+    const untouchedEmptyRef = (prompt: PromptRef) => {
+      if (prompt.version !== undefined && prompt.version() !== 0) return false
+      return emptyRef(prompt)
     }
 
     if (localSlash) {
@@ -1686,7 +1737,10 @@ export function Prompt(props: PromptProps) {
       return false
     }
 
+    const savedPrompt = structuredClone(unwrap(store.prompt))
     let sessionID = props.sessionID
+    let createdSessionID: string | undefined
+    let navigateTimer: ReturnType<typeof setTimeout> | undefined
     if (sessionID == null) {
       const workspace = workspaceSelection()
       const workspaceID = iife(() => {
@@ -1716,17 +1770,41 @@ export function Prompt(props: PromptProps) {
       }
 
       sessionID = res.data.id
+      createdSessionID = sessionID
     }
 
     const messageID = MessageID.ascending()
-    const productMode = local.product?.current()
-    if (productMode === "run") {
-      void AgencySwarmRunSession.sync({
-        sessionID,
-        providerID: productProviderID,
-        directory: process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV],
-      })
+    const submittedMessageStored = () =>
+      (sync.data.message[sessionID] ?? []).some((message) => message.id === messageID && message.role === "user")
+    const sessionHasOtherMessages = (id: string) =>
+      (sync.data.message[id] ?? []).some((message) => message.id !== messageID)
+    const submittedMessagePersistence = async () => {
+      if (submittedMessageStored()) return "stored"
+      const read = () => {
+        try {
+          return sdk.client.session.message({
+            sessionID,
+            messageID,
+          })
+        } catch {
+          return undefined
+        }
+      }
+      const result = await Promise.resolve(read()).catch(() => undefined)
+      if (!result) return "unknown"
+      if (result.data) return "stored"
+      if (result.error?.name === "NotFoundError") return "missing"
+      return "unknown"
     }
+    const productMode = local.product?.current()
+    const runSessionSync =
+      productMode === "run"
+        ? AgencySwarmRunSession.sync({
+            sessionID,
+            providerID: productProviderID,
+            directory: process.env[AgencySwarmRunSession.LOCAL_PROJECT_ENV],
+          })
+        : undefined
 
     const editorSelection = editorContext()
     const editorParts =
@@ -1868,8 +1946,89 @@ export function Prompt(props: PromptProps) {
         .then((result) => {
           captureTaskCompleted(messageID, result)
         })
-        .catch((error) => {
+        .catch(async (error) => {
           captureTaskFailed(messageID, error)
+          const persistence = promptStillCleared() ? await submittedMessagePersistence() : "unknown"
+          if (promptStillCleared() && persistence !== "stored") {
+            const restoredPrompt = {
+              ...savedPrompt,
+              mode: currentMode,
+            }
+            const active = activePrompt?.current
+            const currentRoute = route.data
+            const routeSessionID =
+              currentRoute.type === "session" && currentRoute.sessionID === sessionID ? sessionID : undefined
+            const routeSession = routeSessionID !== undefined
+            const restoreHome = createdSessionID !== undefined && currentRoute.type === "home"
+            const activeSessionPrompt = routeSession && active && active !== ref
+            const activeHomePrompt = restoreHome && active && active !== ref
+            const samePrompt = !active || active === ref
+            const sessionStillCleared = routeSession && (samePrompt || untouchedEmptyRef(active))
+            const homeStillCleared = restoreHome && (samePrompt || untouchedEmptyRef(active))
+            let restored = false
+            let restoredRef: PromptRef | undefined
+            if (samePrompt || restoreHome || sessionStillCleared) {
+              if (activeSessionPrompt && sessionStillCleared) {
+                active.set(restoredPrompt)
+                restoredRef = active
+                restored = true
+              } else if (activeHomePrompt && homeStillCleared) {
+                active.set(restoredPrompt)
+                restoredRef = active
+                restored = true
+              } else if (!active && routeSessionID) {
+                route.navigate({
+                  type: "session",
+                  sessionID: routeSessionID,
+                  prompt: restoredPrompt,
+                })
+                restored = true
+              } else if (samePrompt) {
+                setStore("prompt", savedPrompt)
+                setStore("mode", currentMode)
+                if (!input.isDestroyed) {
+                  input.setText(savedPrompt.input)
+                  restoreExtmarksFromParts(savedPrompt.parts)
+                  input.gotoBufferEnd()
+                }
+                restored = true
+                restoredRef = ref
+              }
+              if (restored) {
+                if (editorSelection && editorParts.length > 0) editor.restoreSelectionPending(editorSelection)
+                if (usedExplicitRecipient) {
+                  if (restoredRef?.restoreRecipientSelection) restoredRef.restoreRecipientSelection(explicitSelectedAt)
+                  else setExplicitRecipientSelectedAt(explicitSelectedAt)
+                }
+              }
+            }
+            if (restoreHome && createdSessionID) {
+              if (navigateTimer) {
+                clearTimeout(navigateTimer)
+                navigateTimer = undefined
+              }
+              if (activeHomePrompt || active === ref) {
+                route.navigate({
+                  type: "home",
+                })
+              } else {
+                route.navigate({
+                  type: "home",
+                  prompt: restoredPrompt,
+                })
+              }
+              if (persistence === "missing") {
+                if (sessionHasOtherMessages(createdSessionID)) {
+                  void runSessionSync?.catch(() => undefined)
+                } else {
+                  await runSessionSync?.catch(() => undefined)
+                  void sdk.client.session.delete({
+                    sessionID: createdSessionID,
+                  })
+                }
+              }
+            }
+          }
           const message = toErrorMessage(error)
           const shouldReopenAuth = shouldOpenAgencyAuthDialog({
             providerID: productProviderID,
@@ -1898,7 +2057,8 @@ export function Prompt(props: PromptProps) {
     // temporary hack to make sure the message is sent
     if (!props.sessionID) {
       if (editorParts.length > 0) editor.preserveSelectionFromNewSession()
-      setTimeout(() => {
+      navigateTimer = setTimeout(() => {
+        navigateTimer = undefined
         route.navigate({
           type: "session",
           sessionID,
@@ -1941,6 +2101,7 @@ export function Prompt(props: PromptProps) {
         draft.extmarkToPartIndex.set(extmarkId, partIndex)
       }),
     )
+    markPromptChanged()
   }
 
   async function pasteInputText(text: string) {
@@ -1996,6 +2157,7 @@ export function Prompt(props: PromptProps) {
     }
 
     input.insertText(normalizedText)
+    markPromptChanged()
 
     setTimeout(() => {
       if (!input || input.isDestroyed) return
@@ -2049,6 +2211,7 @@ export function Prompt(props: PromptProps) {
         draft.extmarkToPartIndex.set(extmarkId, partIndex)
       }),
     )
+    markPromptChanged()
     return
   }
 
@@ -2066,6 +2229,7 @@ export function Prompt(props: PromptProps) {
       parts: [],
     })
     setStore("extmarkToPartIndex", new Map())
+    markPromptChanged()
   }
 
   const highlight = createMemo(() => {
@@ -2185,6 +2349,8 @@ export function Prompt(props: PromptProps) {
               onContentChange={() => {
                 const value = input.plainText
                 setStore("prompt", "input", value)
+                if (ignoreSubmittedClearChange && value === "") ignoreSubmittedClearChange = false
+                else markPromptChanged()
                 auto()?.onInput(value)
                 syncExtmarksWithPromptParts()
                 setCursorVersion((value) => value + 1)
@@ -2495,6 +2661,7 @@ export function Prompt(props: PromptProps) {
         input={() => input}
         setPrompt={(cb) => {
           setStore("prompt", produce(cb))
+          markPromptChanged()
         }}
         setExtmark={(partIndex, extmarkId) => {
           setStore("extmarkToPartIndex", (map: Map<number, number>) => {

--- a/packages/opencode/src/cli/cmd/tui/context/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor.ts
@@ -331,6 +331,10 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
         if (!store.selection) return
         setStore("selectionSent", true)
       },
+      restoreSelectionPending(selection: EditorSelection) {
+        if (editorSelectionKey(selection) !== editorSelectionKey(store.selection)) return
+        setStore("selectionSent", false)
+      },
       labelState(): EditorLabelState {
         if (!store.selection) return "none"
         return store.selectionSent ? "sent" : "pending"

--- a/packages/opencode/src/cli/cmd/tui/context/prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/prompt.tsx
@@ -1,18 +1,33 @@
-import { createSimpleContext } from "./helper"
+import { createContext, useContext, type ParentProps } from "solid-js"
 import type { PromptRef } from "../component/prompt"
 
-export const { use: usePromptRef, provider: PromptRefProvider } = createSimpleContext({
-  name: "PromptRef",
-  init: () => {
-    let current: PromptRef | undefined
+type PromptRefContext = {
+  readonly current: PromptRef | undefined
+  set(ref: PromptRef | undefined): void
+}
 
-    return {
-      get current() {
-        return current
-      },
-      set(ref: PromptRef | undefined) {
-        current = ref
-      },
-    }
-  },
-})
+const ctx = createContext<PromptRefContext>()
+
+export function PromptRefProvider(props: ParentProps) {
+  let current: PromptRef | undefined
+  const state: PromptRefContext = {
+    get current() {
+      return current
+    },
+    set(ref) {
+      current = ref
+    },
+  }
+
+  return <ctx.Provider value={state}>{props.children}</ctx.Provider>
+}
+
+export function usePromptRef() {
+  const value = useContext(ctx)
+  if (!value) throw new Error("PromptRef context must be used within a context provider")
+  return value
+}
+
+export function useOptionalPromptRef() {
+  return useContext(ctx)
+}

--- a/packages/opencode/src/cli/cmd/tui/context/route.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/route.tsx
@@ -5,12 +5,14 @@ import type { PromptInfo } from "../component/prompt/history"
 export type HomeRoute = {
   type: "home"
   prompt?: PromptInfo
+  promptRecipientSelectedAt?: number
 }
 
 export type SessionRoute = {
   type: "session"
   sessionID: string
   prompt?: PromptInfo
+  promptRecipientSelectedAt?: number
 }
 
 export type PluginRoute = {

--- a/packages/opencode/src/cli/cmd/tui/context/route.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/route.tsx
@@ -40,6 +40,20 @@ export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
       navigate(route: Route) {
         setStore(reconcile(route))
       },
+      clearPrompt() {
+        if (store.type === "home") {
+          setStore(reconcile({ type: "home" }))
+          return
+        }
+        if (store.type === "session") {
+          setStore(
+            reconcile({
+              type: "session",
+              sessionID: store.sessionID,
+            }),
+          )
+        }
+      },
     }
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -4,7 +4,7 @@ import { Logo } from "../component/logo"
 import { useProject } from "../context/project"
 import { useSync } from "../context/sync"
 import { useArgs } from "../context/args"
-import { useRouteData } from "@tui/context/route"
+import { useRoute, useRouteData } from "@tui/context/route"
 import { usePromptRef } from "../context/prompt"
 import { useLocal } from "../context/local"
 import { TuiPluginRuntime } from "@/cli/cmd/tui/plugin/runtime"
@@ -19,6 +19,7 @@ const placeholder = {
 export function Home() {
   const sync = useSync()
   const project = useProject()
+  const routeContext = useRoute()
   const route = useRouteData("home")
   const promptRef = usePromptRef()
   const [ref, setRef] = createSignal<PromptRef | undefined>()
@@ -26,20 +27,26 @@ export function Home() {
   const local = useLocal()
   const editor = useEditorContext()
   let sent = false
+  let routePromptApplied = false
 
   onMount(() => {
+    if (route.prompt || routePromptApplied) return
     editor.clearSelection()
   })
 
   const bind = (r: PromptRef | undefined) => {
     setRef(r)
     promptRef.set(r)
-    if (once || !r) return
+    if (!r) return
     if (route.prompt) {
-      r.set(route.prompt)
+      const prompt = route.prompt
+      r.set(prompt)
+      routeContext.clearPrompt()
+      routePromptApplied = true
       once = true
       return
     }
+    if (once) return
     if (!args.prompt) return
     r.set({ input: args.prompt, parts: [] })
     once = true
@@ -50,6 +57,7 @@ export function Home() {
     const r = ref()
     if (sent) return
     if (!r) return
+    if (routePromptApplied) return
     if (!sync.ready || !local.model.ready) return
     if (!args.prompt) return
     if (r.current.input !== args.prompt) return

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -41,6 +41,7 @@ export function Home() {
     if (route.prompt) {
       const prompt = route.prompt
       r.set(prompt)
+      if (route.promptRecipientSelectedAt !== undefined) r.restoreRecipientSelection?.(route.promptRecipientSelectedAt)
       routeContext.clearPrompt()
       routePromptApplied = true
       once = true

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -217,7 +217,8 @@ function use() {
 
 export function Session() {
   const route = useRouteData("session")
-  const { navigate } = useRoute()
+  const routeContext = useRoute()
+  const { navigate } = routeContext
   const sync = useSync()
   const event = useEvent()
   const project = useProject()
@@ -421,6 +422,7 @@ export function Session() {
     if (seeded || !route.prompt || !r) return
     seeded = true
     r.set(route.prompt)
+    routeContext.clearPrompt()
   }
   const command = useCommandPalette()
   const dialog = useDialog()

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -422,6 +422,7 @@ export function Session() {
     if (seeded || !route.prompt || !r) return
     seeded = true
     r.set(route.prompt)
+    if (route.promptRecipientSelectedAt !== undefined) r.restoreRecipientSelection?.(route.promptRecipientSelectedAt)
     routeContext.clearPrompt()
   }
   const command = useCommandPalette()

--- a/packages/opencode/test/cli/tui/prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt.test.tsx
@@ -467,7 +467,8 @@ describe("prompt auth rejection handling", () => {
     expect(syncRunSession).not.toHaveBeenCalled()
     expect(clearRunSession).not.toHaveBeenCalled()
     const payload = promptSession.mock.calls[0]?.[0] as
-      { $body_agencySwarmBridge?: boolean; agent?: string } | undefined
+      | { $body_agencySwarmBridge?: boolean; agent?: string }
+      | undefined
     expect(payload?.$body_agencySwarmBridge).toBe(false)
     expect(payload?.agent).toBe("plan")
   })
@@ -850,7 +851,8 @@ describe("prompt auth rejection handling", () => {
 
     expect(promptSession).toHaveBeenCalledTimes(1)
     const payload = promptSession.mock.calls[0]?.[0] as
-      { parts: Array<{ synthetic?: boolean; text?: string }> } | undefined
+      | { parts: Array<{ synthetic?: boolean; text?: string }> }
+      | undefined
     const editorText = payload?.parts[0]?.text
     if (editorText === undefined) throw new Error("missing editor context payload")
     expect(payload?.parts[0]?.synthetic).toBe(true)
@@ -1825,6 +1827,7 @@ describe("prompt auth rejection handling", () => {
     newerDraft?: string
     newerLiveDraft?: string
     newerSubmit?: string
+    routeRecipientState?: boolean
     runMode?: boolean
     serverPersistenceError?: boolean
     serverPersisted?: boolean
@@ -1832,6 +1835,7 @@ describe("prompt auth rejection handling", () => {
   }) {
     process.env.OPENAI_API_KEY = "sk-test"
 
+    const routeRecipientState = input.routeRecipientState
     const routeStates: string[] = []
     const dialogDepth: number[] = []
     const toasts: Array<{ duration?: number; variant?: string; message?: string }> = []
@@ -2245,7 +2249,7 @@ describe("prompt auth rejection handling", () => {
 
     expect(promptRef!.focused).toBe(true)
 
-    if (input.explicitRecipientRetry) {
+    if (input.explicitRecipientRetry || routeRecipientState) {
       setSyncData((data) => ({
         ...data,
         config: {
@@ -2274,6 +2278,12 @@ describe("prompt auth rejection handling", () => {
       await Bun.sleep(60)
       await flushEffects()
       expect(routeStates.at(-1)).toBe(`session:${targetSessionID}`)
+    }
+    if (routeRecipientState) {
+      activeContext!.set(undefined)
+      promptRef = undefined
+      await flushEffects()
+      expect(activeContext!.current).toBeUndefined()
     }
 
     if (input.newerDraft) {
@@ -2366,6 +2376,22 @@ describe("prompt auth rejection handling", () => {
     rejects[0]?.(promptError)
     await failures[0]?.catch(() => undefined)
     await flushEffects()
+    if (routeRecipientState) {
+      expect(routeContext!.data).toEqual({
+        type: "session",
+        sessionID: targetSessionID,
+        promptRecipientSelectedAt: 123,
+        prompt: {
+          input: "recover this draft",
+          mode: "normal",
+          parts: [],
+        },
+      })
+      expect(promptSession).toHaveBeenCalledTimes(1)
+      expect(markSelectionSent).toHaveBeenCalledTimes(1)
+      expect(restoreSelectionPending).toHaveBeenCalledWith(selection)
+      return
+    }
     if (input.deferRunSessionSync) {
       expect(syncRunSession).toHaveBeenCalledWith({
         sessionID: targetSessionID,
@@ -2567,6 +2593,12 @@ describe("prompt auth rejection handling", () => {
     })
   })
 
+  test("preserves explicit recipient on restored session route prompts", async () => {
+    await runFirstPromptNavigationFailure({
+      routeRecipientState: true,
+    })
+  })
+
   test("keeps newer session draft when first-prompt failure arrives after navigation", async () => {
     await runFirstPromptNavigationFailure({
       newerDraft: "newer session draft",
@@ -2634,7 +2666,7 @@ describe("prompt auth rejection handling", () => {
     })
   })
 
-  async function renderRecoveredSessionRoutePrompt() {
+  async function renderRecoveredSessionRoutePrompt(input: { promptRecipientSelectedAt?: number } = {}) {
     const sessionID = "session_recovered_route_prompt"
     const recovered = {
       input: "recover this draft",
@@ -2642,6 +2674,7 @@ describe("prompt auth rejection handling", () => {
     }
     const routes: Array<{ prompt?: unknown; type: string }> = []
     const promptSets: Array<ReturnType<typeof mock>> = []
+    const restoreRecipients: Array<ReturnType<typeof mock>> = []
     const [showSession, setShowSession] = createSignal(true)
 
     spyOn(EventContext, "useEvent").mockReturnValue({
@@ -2832,7 +2865,9 @@ describe("prompt auth rejection handling", () => {
           const set = mock((prompt: PromptRef["current"]) => {
             current = prompt
           })
+          const restoreRecipientSelection = mock((_selectedAt: number | undefined) => undefined)
           promptSets.push(set)
+          restoreRecipients.push(restoreRecipientSelection)
           props.ref?.({
             focused: false,
             get current() {
@@ -2842,6 +2877,7 @@ describe("prompt auth rejection handling", () => {
             focus() {},
             reset() {},
             set,
+            restoreRecipientSelection,
             submit() {},
           })
           return null
@@ -2870,6 +2906,7 @@ describe("prompt auth rejection handling", () => {
           initialRoute={{
             type: "session",
             sessionID,
+            promptRecipientSelectedAt: input.promptRecipientSelectedAt,
             prompt: recovered,
           }}
         >
@@ -2890,6 +2927,7 @@ describe("prompt auth rejection handling", () => {
     return {
       promptSets,
       recovered,
+      restoreRecipients,
       routes,
       async remount() {
         setShowSession(false)
@@ -2913,6 +2951,19 @@ describe("prompt auth rejection handling", () => {
 
     expect(rendered.promptSets).toHaveLength(2)
     expect(rendered.promptSets.reduce((count, set) => count + set.mock.calls.length, 0)).toBe(1)
+    expect(rendered.routes.at(-1)).toEqual({
+      type: "session",
+      prompt: undefined,
+    })
+  })
+
+  test("restores recovered session route prompt recipient state", async () => {
+    const rendered = await renderRecoveredSessionRoutePrompt({
+      promptRecipientSelectedAt: 123,
+    })
+
+    expect(rendered.promptSets[0]).toHaveBeenCalledWith(rendered.recovered)
+    expect(rendered.restoreRecipients[0]).toHaveBeenCalledWith(123)
     expect(rendered.routes.at(-1)).toEqual({
       type: "session",
       prompt: undefined,
@@ -3092,5 +3143,103 @@ describe("prompt auth rejection handling", () => {
     })
     expect(promptSession).not.toHaveBeenCalled()
     expect(clearSelection).not.toHaveBeenCalled()
+  })
+
+  test("restores recovered home route prompt recipient state", async () => {
+    const recovered = {
+      input: "recovered draft",
+      parts: [],
+    }
+    const setPrompt = mock((_prompt: PromptRef["current"]) => undefined)
+    const restoreRecipientSelection = mock((_selectedAt: number | undefined) => undefined)
+    const routeStates: Array<{ prompt?: unknown; promptRecipientSelectedAt?: number; type: string }> = []
+
+    spyOn(ArgsContext, "useArgs").mockReturnValue({} as any)
+    spyOn(ProjectContext, "useProject").mockReturnValue({
+      workspace: { current: () => "workspace_home_recipient" },
+      instance: { directory: () => "/tmp" },
+    } as any)
+    spyOn(EditorContext, "useEditorContext").mockReturnValue({
+      clearSelection: () => undefined,
+    } as any)
+    spyOn(PromptRefContext, "usePromptRef").mockReturnValue({
+      set: () => undefined,
+    } as any)
+    spyOn(SyncContext, "useSync").mockReturnValue({
+      ready: false,
+    } as any)
+    spyOn(LocalContext, "useLocal").mockReturnValue({
+      model: {
+        ready: false,
+      },
+    } as any)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: () => undefined,
+      error: () => undefined,
+      currentToast: null,
+    } as any)
+    spyOn(TuiPluginRuntime, "Slot").mockImplementation(
+      (props: { children?: unknown; name?: string; ref?: (ref: PromptRef | undefined) => void }) => {
+        if (props.name === "home_prompt") {
+          props.ref?.({
+            focused: false,
+            current: {
+              input: "typed draft",
+              parts: [],
+            },
+            blur() {},
+            focus() {},
+            reset() {},
+            restoreRecipientSelection,
+            set: setPrompt,
+            submit() {},
+          })
+        }
+        return null
+      },
+    )
+
+    const { Home } = await import("../../../src/cli/cmd/tui/routes/home")
+    const CaptureRoute = () => {
+      const route = useRoute()
+
+      createEffect(() => {
+        routeStates.push({
+          type: route.data.type,
+          prompt: route.data.type === "plugin" ? undefined : route.data.prompt,
+          promptRecipientSelectedAt: route.data.type === "plugin" ? undefined : route.data.promptRecipientSelectedAt,
+        })
+      })
+
+      return <box />
+    }
+
+    await testRender(() => (
+      <TestKeymapProvider>
+        <RouteProvider
+          initialRoute={{
+            type: "home",
+            promptRecipientSelectedAt: 123,
+            prompt: recovered,
+          }}
+        >
+          <DialogProvider>
+            <CommandPaletteProvider>
+              <CaptureRoute />
+              <Home />
+            </CommandPaletteProvider>
+          </DialogProvider>
+        </RouteProvider>
+      </TestKeymapProvider>
+    ))
+    await flushEffects()
+
+    expect(setPrompt).toHaveBeenCalledWith(recovered)
+    expect(restoreRecipientSelection).toHaveBeenCalledWith(123)
+    expect(routeStates.at(-1)).toEqual({
+      type: "home",
+      prompt: undefined,
+      promptRecipientSelectedAt: undefined,
+    })
   })
 })

--- a/packages/opencode/test/cli/tui/prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt.test.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource @opentui/solid */
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
-import { RGBA } from "@opentui/core"
+import { RGBA, TextareaRenderable, type Renderable } from "@opentui/core"
 import { testRender, useRenderer } from "@opentui/solid"
 import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
-import { createEffect, type ParentProps } from "solid-js"
+import { createEffect, createSignal, Match, Switch, type ParentProps } from "solid-js"
 import * as AutocompleteModule from "../../../src/cli/cmd/tui/component/prompt/autocomplete"
 import * as CommandDialogModule from "../../../src/cli/cmd/tui/component/dialog-command"
 import { CommandPaletteProvider } from "../../../src/cli/cmd/tui/context/command-palette"
@@ -17,6 +17,7 @@ import * as KeybindContext from "@tui/context/keybind"
 import * as KVContext from "../../../src/cli/cmd/tui/context/kv"
 import * as LocalContext from "../../../src/cli/cmd/tui/context/local"
 import * as ProjectContext from "../../../src/cli/cmd/tui/context/project"
+import * as PromptRefContext from "../../../src/cli/cmd/tui/context/prompt"
 import { RouteProvider, useRoute } from "../../../src/cli/cmd/tui/context/route"
 import * as SDKContext from "../../../src/cli/cmd/tui/context/sdk"
 import * as SyncContext from "../../../src/cli/cmd/tui/context/sync"
@@ -31,10 +32,15 @@ import { AgencySwarmOllama } from "../../../src/agency-swarm/ollama"
 import { AgencySwarmRunSession } from "../../../src/agency-swarm/run-session"
 import { Telemetry } from "../../../src/telemetry/telemetry"
 import { OpencodeKeymapProvider } from "../../../src/cli/cmd/tui/keymap"
+import { TuiPluginRuntime } from "../../../src/cli/cmd/tui/plugin/runtime"
+
+let lastKeymap: ReturnType<typeof createDefaultOpenTuiKeymap> | undefined
 
 function TestKeymapProvider(props: ParentProps) {
   const renderer = useRenderer()
-  return <OpencodeKeymapProvider keymap={createDefaultOpenTuiKeymap(renderer)}>{props.children}</OpencodeKeymapProvider>
+  const keymap = createDefaultOpenTuiKeymap(renderer)
+  lastKeymap = keymap
+  return <OpencodeKeymapProvider keymap={keymap}>{props.children}</OpencodeKeymapProvider>
 }
 
 const testTuiConfig = {
@@ -91,9 +97,18 @@ function createEditorSelection(input: { filePath?: string; text?: string } = {})
   }
 }
 
+function findTextarea(node: Renderable): TextareaRenderable | undefined {
+  if (node instanceof TextareaRenderable) return node
+  for (const child of node.getChildren()) {
+    const found = findTextarea(child)
+    if (found) return found
+  }
+}
+
 describe("prompt auth rejection handling", () => {
   afterEach(() => {
     mock.restore()
+    lastKeymap = undefined
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENROUTER_API_KEY
     delete process.env.OPENROUTER_TOKEN
@@ -106,7 +121,10 @@ describe("prompt auth rejection handling", () => {
     openrouterEnv?: string[]
     productMode?: "build" | "plan" | "run"
     selectedModel?: { providerID: string; modelID: string }
+    localModelReady?: boolean | (() => boolean)
+    syncReady?: boolean | (() => boolean)
     prompt: (input: { messageID: string; sessionID: string }) => Promise<unknown>
+    message?: (input: { messageID: string; sessionID: string }) => Promise<unknown> | unknown
     sessionID: string
     workspaceID: string
   }) {
@@ -118,6 +136,10 @@ describe("prompt auth rejection handling", () => {
     const modelID = agency ? "default" : "gpt-4.1"
     const selectedModel = input.selectedModel ?? { providerID, modelID }
     const openrouterEnv = input.openrouterEnv ?? ["OPENROUTER_API_KEY"]
+    const localModelReady = () =>
+      typeof input.localModelReady === "function" ? input.localModelReady() : (input.localModelReady ?? false)
+    const syncReady = () => (typeof input.syncReady === "function" ? input.syncReady() : (input.syncReady ?? false))
+    const messages: Record<string, unknown[]> = {}
     const parts: Record<string, unknown[]> = {}
 
     const promptSession = spyOn(
@@ -126,11 +148,36 @@ describe("prompt auth rejection handling", () => {
       },
       "prompt",
     )
+    const messageSession = spyOn(
+      {
+        message:
+          input.message ??
+          (async () => ({
+            error: {
+              name: "NotFoundError",
+              data: {
+                message: "Message not found",
+              },
+            },
+          })),
+      },
+      "message",
+    )
     const shellSession = spyOn(
       {
         shell: async () => ({}),
       },
       "shell",
+    )
+    const createSession = spyOn(
+      {
+        create: async () => ({
+          data: {
+            id: input.sessionID,
+          },
+        }),
+      },
+      "create",
     )
 
     const syncRunSession = spyOn(AgencySwarmRunSession, "sync").mockResolvedValue(undefined)
@@ -205,6 +252,9 @@ describe("prompt auth rejection handling", () => {
         color: () => RGBA.fromHex("#38bdf8"),
       },
       model: {
+        get ready() {
+          return localModelReady()
+        },
         current: () => ({
           providerID: selectedModel.providerID,
           modelID: selectedModel.modelID,
@@ -231,6 +281,8 @@ describe("prompt auth rejection handling", () => {
     spyOn(SDKContext, "useSDK").mockReturnValue({
       client: {
         session: {
+          create: createSession,
+          message: messageSession,
           prompt: promptSession,
           shell: shellSession,
         },
@@ -238,6 +290,9 @@ describe("prompt auth rejection handling", () => {
       event: input.events,
     } as any)
     spyOn(SyncContext, "useSync").mockReturnValue({
+      get ready() {
+        return syncReady()
+      },
       data: {
         command: [],
         config: {
@@ -249,7 +304,7 @@ describe("prompt auth rejection handling", () => {
           consoleManagedProviders: [],
           switchableOrgCount: 0,
         },
-        message: {},
+        message: messages,
         part: parts,
         provider: [
           {
@@ -337,25 +392,40 @@ describe("prompt auth rejection handling", () => {
 
     let promptRef: PromptRef | undefined
 
-    await testRender(() => (
+    const rendered = await testRender(() => (
       <TestKeymapProvider>
         <RouteProvider>
-          <DialogProvider>
-            <CommandPaletteProvider>
-              <Prompt
-                ref={(value) => (promptRef = value)}
-                sessionID={input.sessionID}
-                workspaceID={input.workspaceID}
-                placeholders={{ normal: [] }}
-              />
-            </CommandPaletteProvider>
-          </DialogProvider>
+          <PromptRefContext.PromptRefProvider>
+            <DialogProvider>
+              <CommandPaletteProvider>
+                <Prompt
+                  ref={(value) => (promptRef = value)}
+                  sessionID={input.sessionID}
+                  workspaceID={input.workspaceID}
+                  placeholders={{ normal: [] }}
+                />
+              </CommandPaletteProvider>
+            </DialogProvider>
+          </PromptRefContext.PromptRefProvider>
         </RouteProvider>
       </TestKeymapProvider>
     ))
 
     expect(promptRef).toBeDefined()
-    return { clearRunSession, parts, promptRef: promptRef!, promptSession, shellSession, syncRunSession }
+    const textarea = findTextarea(rendered.renderer.root)
+    expect(textarea).toBeDefined()
+    return {
+      clearRunSession,
+      createSession,
+      parts,
+      messages,
+      messageSession,
+      promptRef: promptRef!,
+      promptSession,
+      shellSession,
+      syncRunSession,
+      textarea: textarea!,
+    }
   }
 
   test("keeps saved Run session state when submitting a Build prompt", async () => {
@@ -397,8 +467,7 @@ describe("prompt auth rejection handling", () => {
     expect(syncRunSession).not.toHaveBeenCalled()
     expect(clearRunSession).not.toHaveBeenCalled()
     const payload = promptSession.mock.calls[0]?.[0] as
-      | { $body_agencySwarmBridge?: boolean; agent?: string }
-      | undefined
+      { $body_agencySwarmBridge?: boolean; agent?: string } | undefined
     expect(payload?.$body_agencySwarmBridge).toBe(false)
     expect(payload?.agent).toBe("plan")
   })
@@ -752,16 +821,18 @@ describe("prompt auth rejection handling", () => {
     await testRender(() => (
       <TestKeymapProvider>
         <RouteProvider>
-          <DialogProvider>
-            <CommandPaletteProvider>
-              <Prompt
-                ref={(value) => (promptRef = value)}
-                sessionID="session_immediate_clear"
-                workspaceID="workspace_immediate_clear"
-                placeholders={{ normal: [] }}
-              />
-            </CommandPaletteProvider>
-          </DialogProvider>
+          <PromptRefContext.PromptRefProvider>
+            <DialogProvider>
+              <CommandPaletteProvider>
+                <Prompt
+                  ref={(value) => (promptRef = value)}
+                  sessionID="session_immediate_clear"
+                  workspaceID="workspace_immediate_clear"
+                  placeholders={{ normal: [] }}
+                />
+              </CommandPaletteProvider>
+            </DialogProvider>
+          </PromptRefContext.PromptRefProvider>
         </RouteProvider>
       </TestKeymapProvider>
     ))
@@ -779,8 +850,7 @@ describe("prompt auth rejection handling", () => {
 
     expect(promptSession).toHaveBeenCalledTimes(1)
     const payload = promptSession.mock.calls[0]?.[0] as
-      | { parts: Array<{ synthetic?: boolean; text?: string }> }
-      | undefined
+      { parts: Array<{ synthetic?: boolean; text?: string }> } | undefined
     const editorText = payload?.parts[0]?.text
     if (editorText === undefined) throw new Error("missing editor context payload")
     expect(payload?.parts[0]?.synthetic).toBe(true)
@@ -862,6 +932,364 @@ describe("prompt auth rejection handling", () => {
     expect(JSON.stringify(telemetryCapture.mock.calls)).not.toContain("clear right away")
     expect(JSON.stringify(telemetryCapture.mock.calls)).not.toContain("session_immediate_clear")
     expect(markSelectionSent).toHaveBeenCalledTimes(1)
+  })
+
+  test("restores the draft when the prompt request fails after clearing", async () => {
+    const events = createEventBus()
+    const telemetryCapture = spyOn(Telemetry, "capture").mockResolvedValue(false)
+    let rejectPrompt!: (error: Error) => void
+    const failedPrompt = new Promise<never>((_, reject) => {
+      rejectPrompt = reject
+    })
+    const { promptRef, promptSession, shellSession, textarea } = await renderTelemetryPrompt({
+      events,
+      sessionID: "session_restore_failed_prompt",
+      workspaceID: "workspace_restore_failed_prompt",
+      prompt: async () => failedPrompt,
+    })
+
+    promptRef.set({
+      input: "do not lose this prompt",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef.submit()
+    await flushEffects()
+
+    expect(promptSession).toHaveBeenCalledTimes(1)
+    expect(promptRef.current).toEqual({
+      input: "",
+      parts: [],
+    })
+    const shellMode = lastKeymap?.getActiveKeys({ includeBindings: true }).find((key) => key.display === "!")
+    const switchMode = shellMode?.command
+    expect(typeof switchMode).toBe("function")
+    if (typeof switchMode !== "function") throw new Error("Shell mode key binding was not active")
+    switchMode({
+      keymap: lastKeymap!,
+      event: undefined as never,
+      focused: null,
+      target: null,
+      data: {},
+      input: "!",
+      payload: undefined,
+    })
+    await flushEffects()
+
+    rejectPrompt(new Error("connection dropped"))
+    await failedPrompt.catch(() => undefined)
+    await flushEffects()
+
+    expect(promptRef.current).toEqual({
+      input: "do not lose this prompt",
+      parts: [],
+    })
+    expect(textarea.cursorOffset).toBe(Bun.stringWidth("do not lose this prompt"))
+    const failed = telemetryCapture.mock.calls.find(([event]) => event === "task_failed")
+    expect(failed?.[1]).toMatchObject({
+      error_bucket: "unknown",
+      framework_mode: true,
+      has_agent_parts: false,
+      has_file_parts: false,
+      mode: "normal",
+      provider_id: "agency-swarm",
+    })
+
+    promptRef.submit()
+    await flushEffects()
+
+    expect(promptSession).toHaveBeenCalledTimes(2)
+    expect(shellSession).not.toHaveBeenCalled()
+  })
+
+  test("does not restore the draft when the submitted user turn is already in session state", async () => {
+    const events = createEventBus()
+    let rejectPrompt!: (error: Error) => void
+    const failedPrompt = new Promise<never>((_, reject) => {
+      rejectPrompt = reject
+    })
+    const { messages, promptRef, promptSession } = await renderTelemetryPrompt({
+      events,
+      sessionID: "session_accepted_rejected_prompt",
+      workspaceID: "workspace_accepted_rejected_prompt",
+      prompt: async () => failedPrompt,
+    })
+
+    promptRef.set({
+      input: "already accepted prompt",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef.submit()
+    await flushEffects()
+
+    const payload = promptSession.mock.calls[0]?.[0] as
+      | {
+          messageID: string
+          sessionID: string
+        }
+      | undefined
+    expect(payload).toBeDefined()
+    messages[payload!.sessionID] = [
+      {
+        agent: "builder",
+        id: payload!.messageID,
+        model: {
+          providerID: "agency-swarm",
+          modelID: "default",
+        },
+        role: "user",
+        sessionID: payload!.sessionID,
+        time: { created: 1 },
+      },
+    ]
+
+    rejectPrompt(new Error("model removed after persistence"))
+    await failedPrompt.catch(() => undefined)
+    await flushEffects()
+
+    expect(promptRef.current).toEqual({
+      input: "",
+      parts: [],
+    })
+  })
+
+  test("does not restore the draft when the submitted user turn is only stored on the server", async () => {
+    const events = createEventBus()
+    let rejectPrompt!: (error: Error) => void
+    const failedPrompt = new Promise<never>((_, reject) => {
+      rejectPrompt = reject
+    })
+    const { messageSession, promptRef, promptSession } = await renderTelemetryPrompt({
+      events,
+      sessionID: "session_server_stored_prompt",
+      workspaceID: "workspace_server_stored_prompt",
+      prompt: async () => failedPrompt,
+      message: async (input) => ({
+        data: {
+          info: {
+            agent: "builder",
+            id: input.messageID,
+            model: {
+              providerID: "agency-swarm",
+              modelID: "default",
+            },
+            role: "user",
+            sessionID: input.sessionID,
+            time: { created: 1 },
+          },
+          parts: [],
+        },
+      }),
+    })
+
+    promptRef.set({
+      input: "already persisted on server",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef.submit()
+    await flushEffects()
+
+    const payload = promptSession.mock.calls[0]?.[0] as
+      | {
+          messageID: string
+          sessionID: string
+        }
+      | undefined
+    expect(payload).toBeDefined()
+
+    rejectPrompt(new Error("provider failed after user message"))
+    await failedPrompt.catch(() => undefined)
+    await flushEffects()
+
+    expect(messageSession).toHaveBeenCalledWith({
+      sessionID: payload!.sessionID,
+      messageID: payload!.messageID,
+    })
+    expect(promptRef.current).toEqual({
+      input: "",
+      parts: [],
+    })
+  })
+
+  test("restores the draft when submitted user turn persistence cannot be checked", async () => {
+    const events = createEventBus()
+    let rejectPrompt!: (error: Error) => void
+    const failedPrompt = new Promise<never>((_, reject) => {
+      rejectPrompt = reject
+    })
+    const { messageSession, promptRef, promptSession } = await renderTelemetryPrompt({
+      events,
+      sessionID: "session_unknown_persistence_prompt",
+      workspaceID: "workspace_unknown_persistence_prompt",
+      prompt: async () => failedPrompt,
+      message: () => {
+        throw new Error("message lookup failed")
+      },
+    })
+
+    promptRef.set({
+      input: "unknown persistence draft",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef.submit()
+    await flushEffects()
+
+    expect(promptSession).toHaveBeenCalledTimes(1)
+
+    rejectPrompt(new Error("provider failed before lookup finished"))
+    await failedPrompt.catch(() => undefined)
+    await flushEffects()
+
+    expect(messageSession).toHaveBeenCalledTimes(1)
+    expect(promptRef.current).toEqual({
+      input: "unknown persistence draft",
+      parts: [],
+    })
+  })
+
+  test("keeps a newer draft when the cleared prompt request fails", async () => {
+    const events = createEventBus()
+    let rejectPrompt!: (error: Error) => void
+    const failedPrompt = new Promise<never>((_, reject) => {
+      rejectPrompt = reject
+    })
+    const { promptRef, promptSession } = await renderTelemetryPrompt({
+      events,
+      sessionID: "session_keep_newer_prompt",
+      workspaceID: "workspace_keep_newer_prompt",
+      prompt: async () => failedPrompt,
+    })
+
+    promptRef.set({
+      input: "old request",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef.submit()
+    await flushEffects()
+
+    expect(promptSession).toHaveBeenCalledTimes(1)
+    expect(promptRef.current).toEqual({
+      input: "",
+      parts: [],
+    })
+
+    promptRef.set({
+      input: "new draft",
+      parts: [],
+    })
+    await flushEffects()
+
+    rejectPrompt(new Error("connection dropped"))
+    await failedPrompt.catch(() => undefined)
+    await flushEffects()
+
+    expect(promptRef.current).toEqual({
+      input: "new draft",
+      parts: [],
+    })
+  })
+
+  test("keeps live textarea text when failure lands before content change flushes", async () => {
+    const events = createEventBus()
+    let rejectPrompt!: (error: Error) => void
+    const failedPrompt = new Promise<never>((_, reject) => {
+      rejectPrompt = reject
+    })
+    const { promptRef, promptSession, textarea } = await renderTelemetryPrompt({
+      events,
+      sessionID: "session_keep_live_textarea_prompt",
+      workspaceID: "workspace_keep_live_textarea_prompt",
+      prompt: async () => failedPrompt,
+    })
+
+    promptRef.set({
+      input: "old request",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef.submit()
+    await flushEffects()
+
+    expect(promptSession).toHaveBeenCalledTimes(1)
+    expect(promptRef.current).toEqual({
+      input: "",
+      parts: [],
+    })
+
+    const onContentChange = textarea.onContentChange
+    textarea.onContentChange = undefined
+    textarea.insertText("new draft")
+    textarea.onContentChange = onContentChange
+
+    expect(textarea.plainText).toBe("new draft")
+    expect(promptRef.current).toEqual({
+      input: "",
+      parts: [],
+    })
+
+    rejectPrompt(new Error("connection dropped"))
+    await failedPrompt.catch(() => undefined)
+    await flushEffects()
+
+    expect(textarea.plainText).toBe("new draft")
+    textarea.onContentChange?.({})
+    await flushEffects()
+
+    expect(promptRef.current).toEqual({
+      input: "new draft",
+      parts: [],
+    })
+  })
+
+  test("does not restore a stale draft after a later edit clears the prompt", async () => {
+    const events = createEventBus()
+    let rejectPrompt!: (error: Error) => void
+    const failedPrompt = new Promise<never>((_, reject) => {
+      rejectPrompt = reject
+    })
+    const { promptRef, promptSession } = await renderTelemetryPrompt({
+      events,
+      sessionID: "session_keep_later_empty_prompt",
+      workspaceID: "workspace_keep_later_empty_prompt",
+      prompt: async () => failedPrompt,
+    })
+
+    promptRef.set({
+      input: "old request",
+      parts: [],
+    })
+    await flushEffects()
+
+    promptRef.submit()
+    await flushEffects()
+
+    expect(promptSession).toHaveBeenCalledTimes(1)
+
+    promptRef.set({
+      input: "new draft",
+      parts: [],
+    })
+    promptRef.reset()
+    await flushEffects()
+
+    rejectPrompt(new Error("connection dropped"))
+    await failedPrompt.catch(() => undefined)
+    await flushEffects()
+
+    expect(promptRef.current).toEqual({
+      input: "",
+      parts: [],
+    })
   })
 
   test("drops task telemetry when the assistant run is cancelled", async () => {
@@ -1330,16 +1758,18 @@ describe("prompt auth rejection handling", () => {
     await testRender(() => (
       <TestKeymapProvider>
         <RouteProvider>
-          <DialogProvider>
-            <CommandPaletteProvider>
-              <Prompt
-                ref={(value) => (promptRef = value)}
-                sessionID="session_server_command"
-                workspaceID="workspace_server_command"
-                placeholders={{ normal: [] }}
-              />
-            </CommandPaletteProvider>
-          </DialogProvider>
+          <PromptRefContext.PromptRefProvider>
+            <DialogProvider>
+              <CommandPaletteProvider>
+                <Prompt
+                  ref={(value) => (promptRef = value)}
+                  sessionID="session_server_command"
+                  workspaceID="workspace_server_command"
+                  placeholders={{ normal: [] }}
+                />
+              </CommandPaletteProvider>
+            </DialogProvider>
+          </PromptRefContext.PromptRefProvider>
         </RouteProvider>
       </TestKeymapProvider>
     ))
@@ -1384,7 +1814,22 @@ describe("prompt auth rejection handling", () => {
     })
   })
 
-  test("routes first-prompt SDK auth error through auth after upstream-style prompt clearing", async () => {
+  async function runFirstPromptNavigationFailure(input: {
+    deferRunSessionSync?: boolean
+    existingSessionID?: string
+    explicitRecipientRetry?: boolean
+    failBeforeNavigation?: boolean
+    homeSlotRebindDraft?: string
+    legacyActivePromptRef?: boolean
+    laterSessionUserMessage?: boolean
+    newerDraft?: string
+    newerLiveDraft?: string
+    newerSubmit?: string
+    runMode?: boolean
+    serverPersistenceError?: boolean
+    serverPersisted?: boolean
+    returnHome?: boolean
+  }) {
     process.env.OPENAI_API_KEY = "sk-test"
 
     const routeStates: string[] = []
@@ -1396,12 +1841,20 @@ describe("prompt auth rejection handling", () => {
         message: "Streaming request failed (403): Invalid API key for OpenAI",
       },
     }
+    const targetSessionID = input.existingSessionID ?? "session_auth_race"
+    const cleanupOrder: string[] = []
+    let resolveRunSessionSync: (() => void) | undefined
+    const runSessionSync = input.deferRunSessionSync
+      ? new Promise<void>((resolve) => {
+          resolveRunSessionSync = resolve
+        })
+      : undefined
     const telemetryCapture = spyOn(Telemetry, "capture").mockResolvedValue(false)
     const createSession = spyOn(
       {
         create: async () => ({
           data: {
-            id: "session_auth_race",
+            id: targetSessionID,
           },
         }),
       },
@@ -1409,26 +1862,121 @@ describe("prompt auth rejection handling", () => {
     )
     const deleteSession = spyOn(
       {
-        delete: async () => ({}),
+        delete: async () => {
+          cleanupOrder.push("delete")
+          return {}
+        },
       },
       "delete",
     )
+    const rejects: Array<(error: unknown) => void> = []
+    const failures: Promise<never>[] = []
+    const nextFailure = () => {
+      const failed = new Promise<never>((_, reject) => {
+        rejects.push(reject)
+      })
+      failures.push(failed)
+      return failed
+    }
     const promptSession = spyOn(
       {
-        prompt: async () => {
-          await Bun.sleep(75)
-          throw promptError
-        },
+        prompt: (_request: { $body_agencyRecipientAgent?: string }) => nextFailure(),
       },
       "prompt",
     )
+    const messageSession = spyOn(
+      {
+        message: (request: { messageID: string; sessionID: string }) => {
+          if (input.serverPersistenceError) throw new Error("message lookup failed")
+          return input.serverPersisted
+            ? {
+                data: {
+                  info: {
+                    agent: "builder",
+                    id: request.messageID,
+                    model: {
+                      providerID: "agency-swarm",
+                      modelID: "default",
+                    },
+                    role: "user",
+                    sessionID: request.sessionID,
+                    time: { created: 1 },
+                  },
+                  parts: [],
+                },
+              }
+            : {
+                error: {
+                  name: "NotFoundError",
+                  data: {
+                    message: "Message not found",
+                  },
+                },
+              }
+        },
+      },
+      "message",
+    )
+    let selectionSent = false
     const editor = {
-      markSelectionSent() {},
+      markSelectionSent() {
+        selectionSent = true
+      },
       preserveSelectionFromNewSession() {},
+      restoreSelectionPending(_selection: ReturnType<typeof createEditorSelection>) {
+        selectionSent = false
+      },
     }
     const markSelectionSent = spyOn(editor, "markSelectionSent")
+    const restoreSelectionPending = spyOn(editor, "restoreSelectionPending")
+    const selection = createEditorSelection()
 
-    spyOn(AgencySwarmRunSession, "sync").mockResolvedValue(undefined)
+    const syncRunSession = spyOn(AgencySwarmRunSession, "sync").mockImplementation(async () => {
+      cleanupOrder.push("sync:start")
+      await runSessionSync
+      cleanupOrder.push("sync:end")
+    })
+    const [syncData, setSyncData] = createSignal({
+      command: [],
+      config: {
+        model: "agency-swarm/default",
+        experimental: {},
+        provider: {} as Record<string, { name: string; options: Record<string, unknown> }>,
+      },
+      console_state: {
+        activeOrgName: "",
+        consoleManagedProviders: [],
+        switchableOrgCount: 0,
+      },
+      message: {} as Record<string, Array<{ id: string; role: "user"; sessionID: string; time: { created: number } }>>,
+      provider: [
+        {
+          id: "agency-swarm",
+          name: "Agency Swarm",
+          source: "config",
+          env: [],
+          options: {},
+          models: {},
+        },
+        {
+          id: "openai",
+          name: "OpenAI",
+          source: "config",
+          env: ["OPENAI_API_KEY"],
+          options: {},
+          models: {},
+        },
+      ],
+      provider_auth: {
+        openai: [{ type: "api", label: "API key" }],
+      },
+      provider_next: {
+        all: [{ id: "openai", name: "OpenAI" }],
+        connected: [],
+        default: {},
+      },
+      session_status: {},
+    })
     spyOn(AutocompleteModule, "Autocomplete").mockImplementation((props: any) => {
       props.ref?.({
         onInput() {},
@@ -1463,10 +2011,13 @@ describe("prompt auth rejection handling", () => {
     spyOn(EditorContext, "useEditorContext").mockReturnValue({
       enabled: () => false,
       connected: () => false,
-      selection: () => createEditorSelection(),
-      labelState: () => "pending",
-      markSelectionSent: editor.markSelectionSent,
-      preserveSelectionFromNewSession: editor.preserveSelectionFromNewSession,
+      selection: () => selection,
+      labelState: () => (selectionSent ? "sent" : "pending"),
+      clearSelection: () => undefined,
+      markSelectionSent: () => editor.markSelectionSent(),
+      preserveSelectionFromNewSession: () => editor.preserveSelectionFromNewSession(),
+      restoreSelectionPending: (value: ReturnType<typeof createEditorSelection>) =>
+        editor.restoreSelectionPending(value),
       onMention: () => () => {},
       server: () => undefined,
     } as any)
@@ -1515,59 +2066,31 @@ describe("prompt auth rejection handling", () => {
           set: () => {},
         },
       },
+      ...(input.runMode
+        ? {
+            product: {
+              current: () => "run" as const,
+            },
+          }
+        : {}),
     } as any)
     spyOn(SDKContext, "useSDK").mockReturnValue({
       client: {
         session: {
           create: createSession,
-          prompt: promptSession,
           delete: deleteSession,
+          message: messageSession,
+          prompt: promptSession,
         },
       },
       event: events,
     } as any)
     spyOn(SyncContext, "useSync").mockReturnValue({
       path: { directory: "/tmp", worktree: "/tmp" },
-      data: {
-        command: [],
-        config: {
-          model: "agency-swarm/default",
-          experimental: {},
-        },
-        console_state: {
-          activeOrgName: "",
-          consoleManagedProviders: [],
-          switchableOrgCount: 0,
-        },
-        message: {},
-        provider: [
-          {
-            id: "agency-swarm",
-            name: "Agency Swarm",
-            source: "config",
-            env: [],
-            options: {},
-            models: {},
-          },
-          {
-            id: "openai",
-            name: "OpenAI",
-            source: "config",
-            env: ["OPENAI_API_KEY"],
-            options: {},
-            models: {},
-          },
-        ],
-        provider_auth: {
-          openai: [{ type: "api", label: "API key" }],
-        },
-        provider_next: {
-          all: [{ id: "openai", name: "OpenAI" }],
-          connected: [],
-          default: {},
-        },
-        session_status: {},
+      get data() {
+        return syncData()
       },
+      ready: true,
       session: { get: () => undefined },
     } as any)
     spyOn(ThemeContext, "useTheme").mockReturnValue({
@@ -1618,10 +2141,32 @@ describe("prompt auth rejection handling", () => {
     const { Prompt } = await import("../../../src/cli/cmd/tui/component/prompt")
 
     let promptRef: PromptRef | undefined
+    let routeContext: ReturnType<typeof useRoute> | undefined
+    let dialogContext: ReturnType<typeof useDialog> | undefined
+    let textarea: TextareaRenderable | undefined
+    let activeContext: ReturnType<typeof PromptRefContext.usePromptRef> | undefined
+    let homeSlotRef: ((ref: PromptRef | undefined) => void) | undefined
+    let legacyPrompt: PromptRef["current"] | undefined
+    let legacySetCount = 0
+    if (input.failBeforeNavigation) {
+      type SlotProps = Parameters<typeof TuiPluginRuntime.Slot>[0]
+      const isPromptSlotRef = (value: unknown): value is (ref: PromptRef | undefined) => void =>
+        typeof value === "function"
+      spyOn(TuiPluginRuntime, "Slot").mockImplementation((props: SlotProps) => {
+        if (props.name === "home_prompt" && isPromptSlotRef(props.ref)) homeSlotRef = props.ref
+        return props.children ?? null
+      })
+    }
+    const HomeRoute = input.failBeforeNavigation
+      ? (await import("../../../src/cli/cmd/tui/routes/home")).Home
+      : undefined
 
     const Capture = () => {
       const route = useRoute()
       const dialog = useDialog()
+      activeContext = PromptRefContext.usePromptRef()
+      routeContext = route
+      dialogContext = dialog
 
       createEffect(() => {
         const current = route.data
@@ -1635,23 +2180,60 @@ describe("prompt auth rejection handling", () => {
       return <box />
     }
 
-    await testRender(() => (
+    const PromptRoute = () => {
+      const route = useRoute()
+      const active = PromptRefContext.usePromptRef()
+      const bind = (value: PromptRef | undefined) => {
+        active.set(value)
+        if (value) promptRef = value
+      }
+
+      return (
+        <Switch>
+          <Match when={route.data.type === "home"}>
+            {HomeRoute ? (
+              <HomeRoute />
+            ) : (
+              <Prompt ref={bind} workspaceID="workspace_auth_race" placeholders={{ normal: [] }} />
+            )}
+          </Match>
+          <Match when={route.data.type === "session"}>
+            <Prompt
+              ref={bind}
+              sessionID={route.data.type === "session" ? route.data.sessionID : undefined}
+              workspaceID="workspace_auth_race"
+              placeholders={{ normal: [] }}
+            />
+          </Match>
+        </Switch>
+      )
+    }
+
+    const rendered = await testRender(() => (
       <TestKeymapProvider>
-        <RouteProvider>
-          <DialogProvider>
-            <CommandPaletteProvider>
-              <Capture />
-              <Prompt
-                ref={(value) => (promptRef = value)}
-                workspaceID="workspace_auth_race"
-                placeholders={{ normal: [] }}
-              />
-            </CommandPaletteProvider>
-          </DialogProvider>
+        <RouteProvider
+          initialRoute={
+            input.existingSessionID
+              ? {
+                  type: "session",
+                  sessionID: input.existingSessionID,
+                }
+              : undefined
+          }
+        >
+          <PromptRefContext.PromptRefProvider>
+            <DialogProvider>
+              <CommandPaletteProvider>
+                <Capture />
+                <PromptRoute />
+              </CommandPaletteProvider>
+            </DialogProvider>
+          </PromptRefContext.PromptRefProvider>
         </RouteProvider>
       </TestKeymapProvider>
     ))
 
+    promptRef ??= activeContext?.current
     expect(promptRef).toBeDefined()
 
     promptRef!.set({
@@ -1663,31 +2245,293 @@ describe("prompt auth rejection handling", () => {
 
     expect(promptRef!.focused).toBe(true)
 
+    if (input.explicitRecipientRetry) {
+      setSyncData((data) => ({
+        ...data,
+        config: {
+          ...data.config,
+          provider: {
+            ...data.config.provider,
+            "agency-swarm": {
+              name: "agency-swarm",
+              options: {
+                agency: "test_agency",
+                recipientAgent: "support_agent",
+                recipientAgentSelectedAt: 123,
+              },
+            },
+          },
+        },
+      }))
+      await flushEffects()
+    }
+
     promptRef!.submit()
     await flushEffects()
-    await Bun.sleep(90)
-    await flushEffects()
+    if (input.failBeforeNavigation) {
+      expect(routeStates.at(-1)).toBe("home")
+    } else {
+      await Bun.sleep(60)
+      await flushEffects()
+      expect(routeStates.at(-1)).toBe(`session:${targetSessionID}`)
+    }
 
-    expect(createSession).toHaveBeenCalledWith({
-      workspace: "workspace_auth_race",
-      agent: "build",
-      model: {
+    if (input.newerDraft) {
+      promptRef!.set({
+        input: input.newerDraft,
+        parts: [],
+      })
+      await flushEffects()
+    }
+    if (input.newerLiveDraft) {
+      textarea = findTextarea(rendered.renderer.root)
+      expect(textarea).toBeDefined()
+      Object.defineProperty(textarea!, "plainText", {
+        configurable: true,
+        get: () => input.newerLiveDraft,
+      })
+      expect(textarea!.plainText).toBe(input.newerLiveDraft)
+      expect(promptRef!.current).toEqual({
+        input: "",
+        parts: [],
+      })
+    }
+    if (input.newerSubmit) {
+      promptRef!.set({
+        input: input.newerSubmit,
+        parts: [],
+      })
+      await flushEffects()
+      promptRef!.submit()
+      await flushEffects()
+      expect(promptSession).toHaveBeenCalledTimes(2)
+      expect(promptRef!.current).toEqual({
+        input: "",
+        parts: [],
+      })
+    }
+    if (input.laterSessionUserMessage) {
+      setSyncData((data) => ({
+        ...data,
+        message: {
+          ...data.message,
+          [targetSessionID]: [
+            ...(data.message[targetSessionID] ?? []),
+            {
+              id: "message_later_user",
+              role: "user",
+              sessionID: targetSessionID,
+              time: { created: 2 },
+            },
+          ],
+        },
+      }))
+      await flushEffects()
+    }
+    if (input.returnHome) {
+      routeContext!.navigate({
+        type: "home",
+      })
+      await flushEffects()
+      expect(routeStates.at(-1)).toBe("home")
+      expect(promptRef!.current).toEqual({
+        input: "",
+        parts: [],
+      })
+    }
+    if (input.legacyActivePromptRef) {
+      let current: PromptRef["current"] = {
+        input: "",
+        parts: [],
+      }
+      const legacyRef: PromptRef = {
+        focused: false,
+        get current() {
+          return current
+        },
+        blur() {},
+        focus() {},
+        reset() {},
+        set(prompt) {
+          current = prompt
+          legacyPrompt = prompt
+          legacySetCount += 1
+        },
+        submit() {},
+      }
+      activeContext!.set(legacyRef)
+      await flushEffects()
+    }
+
+    rejects[0]?.(promptError)
+    await failures[0]?.catch(() => undefined)
+    await flushEffects()
+    if (input.deferRunSessionSync) {
+      expect(syncRunSession).toHaveBeenCalledWith({
+        sessionID: targetSessionID,
         providerID: "agency-swarm",
-        id: "default",
-        variant: undefined,
-      },
-    })
-    expect(promptSession).toHaveBeenCalledTimes(1)
-    expect(markSelectionSent).toHaveBeenCalledTimes(1)
-    expect(deleteSession).not.toHaveBeenCalled()
-    expect(routeStates.some((state) => state.startsWith("session:"))).toBe(true)
-    expect(routeStates.at(-1)).toBe("session:session_auth_race")
-    expect(promptRef!.current).toEqual({
-      input: "",
-      parts: [],
-    })
-    expect(promptRef!.focused).toBe(false)
-    expect(dialogDepth.at(-1)).toBe(1)
+        directory: undefined,
+      })
+      expect(deleteSession).not.toHaveBeenCalled()
+      expect(cleanupOrder).toEqual(["sync:start"])
+      resolveRunSessionSync?.()
+      await flushEffects()
+    }
+    if (input.failBeforeNavigation) {
+      await Bun.sleep(60)
+      await flushEffects()
+      expect(routeStates.at(-1)).toBe("home")
+      expect(homeSlotRef).toBeDefined()
+    }
+    if (input.homeSlotRebindDraft) {
+      promptRef!.set({
+        input: input.homeSlotRebindDraft,
+        parts: [],
+      })
+      await flushEffects()
+      const rebindSet = mock((_prompt: PromptRef["current"]) => undefined)
+      homeSlotRef?.({
+        focused: false,
+        current: {
+          input: input.homeSlotRebindDraft,
+          parts: [],
+        },
+        blur() {},
+        focus() {},
+        reset() {},
+        set: rebindSet,
+        submit() {},
+      })
+      expect(rebindSet).not.toHaveBeenCalled()
+      expect(routeContext!.data).toEqual({
+        type: "home",
+      })
+    }
+    if (input.newerSubmit) {
+      expect(promptRef!.current).toEqual({
+        input: "",
+        parts: [],
+      })
+      rejects[1]?.(promptError)
+      await failures[1]?.catch(() => undefined)
+      await flushEffects()
+    }
+    if (input.explicitRecipientRetry) {
+      expect(promptRef!.current).toEqual({
+        input: "recover this draft",
+        mode: "normal",
+        parts: [],
+      })
+      dialogContext!.clear()
+      await flushEffects()
+      promptRef!.submit()
+      await flushEffects()
+    }
+
+    if (input.existingSessionID) {
+      expect(createSession).not.toHaveBeenCalled()
+    } else {
+      expect(createSession).toHaveBeenCalledWith({
+        workspace: input.failBeforeNavigation ? undefined : "workspace_auth_race",
+        agent: "build",
+        model: {
+          providerID: "agency-swarm",
+          id: "default",
+          variant: undefined,
+        },
+      })
+    }
+    expect(promptSession).toHaveBeenCalledTimes(input.newerSubmit || input.explicitRecipientRetry ? 2 : 1)
+    if (input.explicitRecipientRetry) {
+      expect(promptSession.mock.calls[0]?.[0]).toMatchObject({
+        $body_agencyRecipientAgent: "support_agent",
+      })
+      expect(promptSession.mock.calls[1]?.[0]).toMatchObject({
+        $body_agencyRecipientAgent: "support_agent",
+      })
+    }
+    expect(markSelectionSent).toHaveBeenCalledTimes(input.explicitRecipientRetry ? 2 : 1)
+    const skippedRestore = input.existingSessionID && input.returnHome
+    if (skippedRestore || input.serverPersisted || input.newerDraft || input.newerLiveDraft || input.newerSubmit)
+      expect(restoreSelectionPending).not.toHaveBeenCalled()
+    else expect(restoreSelectionPending).toHaveBeenCalledWith(selection)
+    if (
+      input.returnHome &&
+      !input.existingSessionID &&
+      !input.serverPersistenceError &&
+      !input.serverPersisted &&
+      !input.laterSessionUserMessage
+    )
+      expect(deleteSession).toHaveBeenCalledWith({
+        sessionID: targetSessionID,
+      })
+    else if (input.failBeforeNavigation && !input.serverPersistenceError && !input.serverPersisted)
+      expect(deleteSession).toHaveBeenCalledWith({
+        sessionID: targetSessionID,
+      })
+    else expect(deleteSession).not.toHaveBeenCalled()
+    if (input.deferRunSessionSync) expect(cleanupOrder).toEqual(["sync:start", "sync:end", "delete"])
+    expect(routeStates.some((state) => state.startsWith("session:"))).toBe(!input.failBeforeNavigation)
+    expect(routeStates.at(-1)).toBe(
+      input.returnHome || input.failBeforeNavigation ? "home" : `session:${targetSessionID}`,
+    )
+    if ((input.existingSessionID && input.returnHome) || input.serverPersisted) {
+      expect(promptRef!.current).toEqual({
+        input: "",
+        parts: [],
+      })
+    } else if (input.homeSlotRebindDraft) {
+      expect(promptRef!.current).toEqual({
+        input: input.homeSlotRebindDraft,
+        parts: [],
+      })
+    } else if (input.newerSubmit) {
+      expect(promptRef!.current).toEqual({
+        input: input.newerSubmit,
+        parts: [],
+      })
+    } else if (input.newerLiveDraft) {
+      expect(textarea!.plainText).toBe(input.newerLiveDraft)
+      expect(promptRef!.current).toEqual({
+        input: "",
+        parts: [],
+      })
+      textarea!.onContentChange?.({})
+      await flushEffects()
+      expect(promptRef!.current).toEqual({
+        input: input.newerLiveDraft,
+        parts: [],
+      })
+    } else if (input.newerDraft) {
+      expect(promptRef!.current).toEqual({
+        input: input.newerDraft,
+        parts: [],
+      })
+    } else if (input.explicitRecipientRetry) {
+      expect(promptRef!.current).toEqual({
+        input: "",
+        mode: "normal",
+        parts: [],
+      })
+    } else if (input.legacyActivePromptRef) {
+      expect(legacySetCount).toBe(1)
+      expect(legacyPrompt).toEqual({
+        input: "recover this draft",
+        mode: "normal",
+        parts: [],
+      })
+      expect(promptRef!.current).toEqual({
+        input: "",
+        parts: [],
+      })
+    } else {
+      expect(promptRef!.current).toEqual({
+        input: "recover this draft",
+        ...(input.failBeforeNavigation ? {} : { mode: "normal" as const }),
+        parts: [],
+      })
+    }
+    expect(dialogDepth.at(-1)).toBe(input.explicitRecipientRetry ? 0 : 1)
     expect(toasts.at(-1)).toEqual({
       variant: "error",
       message: "The current provider credential was rejected. Run /auth to update it.",
@@ -1704,6 +2548,264 @@ describe("prompt auth rejection handling", () => {
     })
     expect(JSON.stringify(telemetryCapture.mock.calls)).not.toContain("Invalid API key for OpenAI")
     expect(JSON.stringify(telemetryCapture.mock.calls)).not.toContain("recover this draft")
-    expect(JSON.stringify(telemetryCapture.mock.calls)).not.toContain("session_auth_race")
+    expect(JSON.stringify(telemetryCapture.mock.calls)).not.toContain(targetSessionID)
+  }
+
+  test("restores first-prompt draft when failure arrives after navigation and session prompt is empty", async () => {
+    await runFirstPromptNavigationFailure({})
+  })
+
+  test("restores first-prompt draft into legacy active prompt refs without version", async () => {
+    await runFirstPromptNavigationFailure({
+      legacyActivePromptRef: true,
+    })
+  })
+
+  test("keeps explicit recipient when retrying a restored active prompt", async () => {
+    await runFirstPromptNavigationFailure({
+      explicitRecipientRetry: true,
+    })
+  })
+
+  test("keeps newer session draft when first-prompt failure arrives after navigation", async () => {
+    await runFirstPromptNavigationFailure({
+      newerDraft: "newer session draft",
+    })
+  })
+
+  test("restores later cleared session submission instead of stale first-prompt draft", async () => {
+    await runFirstPromptNavigationFailure({
+      newerSubmit: "newer submitted session draft",
+    })
+  })
+
+  test("keeps newer live session text when first-prompt failure arrives after navigation", async () => {
+    await runFirstPromptNavigationFailure({
+      newerLiveDraft: "newer live session draft",
+    })
+  })
+
+  test("restores first-prompt draft into active home prompt after returning home before failure", async () => {
+    await runFirstPromptNavigationFailure({
+      returnHome: true,
+    })
+  })
+
+  test("keeps created sessions with later user activity after returning home", async () => {
+    await runFirstPromptNavigationFailure({
+      laterSessionUserMessage: true,
+      returnHome: true,
+    })
+  })
+
+  test("does not leave restored active home prompts on route state for later remounts", async () => {
+    await runFirstPromptNavigationFailure({
+      failBeforeNavigation: true,
+      homeSlotRebindDraft: "newer home draft",
+    })
+  })
+
+  test("waits for Run-session sync before deleting recovered first-prompt sessions", async () => {
+    await runFirstPromptNavigationFailure({
+      deferRunSessionSync: true,
+      failBeforeNavigation: true,
+      runMode: true,
+    })
+  })
+
+  test("does not restore or delete first-prompt session when server already stored the user turn", async () => {
+    await runFirstPromptNavigationFailure({
+      returnHome: true,
+      serverPersisted: true,
+    })
+  })
+
+  test("restores first-prompt draft without deleting when submitted user turn persistence cannot be checked", async () => {
+    await runFirstPromptNavigationFailure({
+      returnHome: true,
+      serverPersistenceError: true,
+    })
+  })
+
+  test("does not restore existing-session draft into active home prompt after returning home before failure", async () => {
+    await runFirstPromptNavigationFailure({
+      existingSessionID: "session_existing_home_retry",
+      returnHome: true,
+    })
+  })
+
+  test("applies recovered home route prompts after startup bind without clearing editor context", async () => {
+    let ready = false
+    const { promptSession } = await renderTelemetryPrompt({
+      events: createEventBus(),
+      sessionID: "session_home_recovery_context",
+      workspaceID: "workspace_home_recovery_context",
+      localModelReady: () => ready,
+      syncReady: () => ready,
+      prompt: async () => ({ data: {} }),
+    })
+
+    let argsPrompt: string | undefined = "startup draft"
+    spyOn(ArgsContext, "useArgs").mockImplementation(() => ({ prompt: argsPrompt }) as any)
+
+    const clearSelection = mock(() => undefined)
+    spyOn(EditorContext, "useEditorContext").mockReturnValue({
+      enabled: () => false,
+      connected: () => false,
+      selection: () => createEditorSelection(),
+      labelState: () => "pending",
+      clearSelection,
+      markSelectionSent: () => undefined,
+      preserveSelectionFromNewSession: () => undefined,
+      restoreSelectionPending: () => undefined,
+      onMention: () => () => {},
+      server: () => undefined,
+    } as any)
+
+    const refs: PromptRef[] = []
+    spyOn(PromptRefContext, "usePromptRef").mockReturnValue({
+      set(ref: PromptRef | undefined) {
+        if (ref) refs.push(ref)
+      },
+    } as any)
+    let homeSlotRef: ((ref: PromptRef | undefined) => void) | undefined
+    spyOn(TuiPluginRuntime, "Slot").mockImplementation(
+      (props: { children?: unknown; name?: string; ref?: (ref: PromptRef | undefined) => void }) => {
+        if (props.name === "home_prompt") homeSlotRef = props.ref
+        return (props.children ?? null) as any
+      },
+    )
+
+    const { Home } = await import("../../../src/cli/cmd/tui/routes/home")
+
+    await testRender(() => (
+      <TestKeymapProvider>
+        <RouteProvider>
+          <DialogProvider>
+            <CommandPaletteProvider>
+              <Home />
+            </CommandPaletteProvider>
+          </DialogProvider>
+        </RouteProvider>
+      </TestKeymapProvider>
+    ))
+
+    expect(refs.at(-1)?.current).toEqual({
+      input: "startup draft",
+      parts: [],
+    })
+    expect(clearSelection).toHaveBeenCalledTimes(1)
+
+    argsPrompt = undefined
+    clearSelection.mockClear()
+    const routes: Array<{ prompt?: unknown; type: string }> = []
+    const CaptureRoute = () => {
+      const route = useRoute()
+
+      createEffect(() => {
+        routes.push({
+          type: route.data.type,
+          prompt: route.data.type === "plugin" ? undefined : route.data.prompt,
+        })
+      })
+
+      return <box />
+    }
+
+    await testRender(() => (
+      <TestKeymapProvider>
+        <RouteProvider
+          initialRoute={{
+            type: "home",
+            prompt: {
+              input: "recovered draft",
+              parts: [],
+            },
+          }}
+        >
+          <DialogProvider>
+            <CommandPaletteProvider>
+              <CaptureRoute />
+              <Home />
+            </CommandPaletteProvider>
+          </DialogProvider>
+        </RouteProvider>
+      </TestKeymapProvider>
+    ))
+
+    expect(refs.at(-1)?.current).toEqual({
+      input: "recovered draft",
+      parts: [],
+    })
+    expect(routes.at(-1)).toEqual({
+      type: "home",
+      prompt: undefined,
+    })
+    const rebindSet = mock((_prompt: PromptRef["current"]) => undefined)
+    homeSlotRef?.({
+      focused: false,
+      current: {
+        input: "edited recovered draft",
+        parts: [],
+      },
+      blur() {},
+      focus() {},
+      reset() {},
+      set: rebindSet,
+      submit() {},
+    })
+    expect(rebindSet).not.toHaveBeenCalled()
+    expect(clearSelection).not.toHaveBeenCalled()
+
+    promptSession.mockClear()
+    clearSelection.mockClear()
+    const recovered = "startup draft"
+    argsPrompt = recovered
+    ready = true
+    const routePrompts: Array<{ prompt?: unknown; type: string }> = []
+    const CaptureRecoveredRoute = () => {
+      const route = useRoute()
+
+      createEffect(() => {
+        routePrompts.push({
+          type: route.data.type,
+          prompt: route.data.type === "plugin" ? undefined : route.data.prompt,
+        })
+      })
+
+      return <box />
+    }
+
+    await testRender(() => (
+      <TestKeymapProvider>
+        <RouteProvider
+          initialRoute={{
+            type: "home",
+            prompt: {
+              input: recovered,
+              parts: [],
+            },
+          }}
+        >
+          <DialogProvider>
+            <CommandPaletteProvider>
+              <CaptureRecoveredRoute />
+              <Home />
+            </CommandPaletteProvider>
+          </DialogProvider>
+        </RouteProvider>
+      </TestKeymapProvider>
+    ))
+
+    expect(refs.at(-1)?.current).toEqual({
+      input: recovered,
+      parts: [],
+    })
+    expect(routePrompts.at(-1)).toEqual({
+      type: "home",
+      prompt: undefined,
+    })
+    expect(promptSession).not.toHaveBeenCalled()
+    expect(clearSelection).not.toHaveBeenCalled()
   })
 })

--- a/packages/opencode/test/cli/tui/prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/prompt.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { RGBA, TextareaRenderable, type Renderable } from "@opentui/core"
 import { testRender, useRenderer } from "@opentui/solid"
 import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
-import { createEffect, createSignal, Match, Switch, type ParentProps } from "solid-js"
+import { createEffect, createSignal, Match, Show, Switch, type ParentProps } from "solid-js"
 import * as AutocompleteModule from "../../../src/cli/cmd/tui/component/prompt/autocomplete"
 import * as CommandDialogModule from "../../../src/cli/cmd/tui/component/dialog-command"
 import { CommandPaletteProvider } from "../../../src/cli/cmd/tui/context/command-palette"
@@ -2631,6 +2631,291 @@ describe("prompt auth rejection handling", () => {
     await runFirstPromptNavigationFailure({
       existingSessionID: "session_existing_home_retry",
       returnHome: true,
+    })
+  })
+
+  async function renderRecoveredSessionRoutePrompt() {
+    const sessionID = "session_recovered_route_prompt"
+    const recovered = {
+      input: "recover this draft",
+      parts: [],
+    }
+    const routes: Array<{ prompt?: unknown; type: string }> = []
+    const promptSets: Array<ReturnType<typeof mock>> = []
+    const [showSession, setShowSession] = createSignal(true)
+
+    spyOn(EventContext, "useEvent").mockReturnValue({
+      subscribe: () => () => {},
+      on: () => () => {},
+    } as any)
+    spyOn(ExitContext, "useExit").mockReturnValue(
+      Object.assign(async () => {}, {
+        message: {
+          set: () => () => {},
+          clear: () => undefined,
+          get: () => undefined,
+        },
+      }) as any,
+    )
+    spyOn(ProjectContext, "useProject").mockReturnValue({
+      workspace: {
+        current: () => "workspace_recovered_route_prompt",
+        get: () => undefined,
+        list: () => [],
+        set: () => undefined,
+        status: () => "connected",
+      },
+      instance: { directory: () => "/tmp" },
+    } as any)
+    spyOn(EditorContext, "useEditorContext").mockReturnValue({
+      enabled: () => false,
+      connected: () => false,
+      selection: () => undefined,
+      labelState: () => "idle",
+      clearSelection: () => undefined,
+      markSelectionSent: () => undefined,
+      preserveSelectionFromNewSession: () => undefined,
+      restoreSelectionPending: () => undefined,
+      reconnect: () => undefined,
+      onMention: () => () => {},
+      server: () => undefined,
+    } as any)
+    spyOn(KeybindContext, "useKeybind").mockReturnValue({
+      leader: false,
+      match: () => false,
+      print: () => "",
+    } as any)
+    spyOn(KVContext, "useKV").mockReturnValue({
+      get: (_key: string, fallback?: unknown) => fallback,
+      signal: (_key: string, fallback: unknown) => [() => fallback, () => undefined],
+    } as any)
+    spyOn(LocalContext, "useLocal").mockReturnValue({
+      agent: {
+        color: () => RGBA.fromHex("#38bdf8"),
+        current: () => ({
+          name: "build",
+          model: {
+            providerID: "openai",
+            modelID: "gpt-4.1",
+          },
+        }),
+        list: () => [{ name: "build" }],
+        set: () => undefined,
+      },
+      model: {
+        current: () => ({
+          providerID: "openai",
+          modelID: "gpt-4.1",
+        }),
+        parsed: () => ({
+          provider: "OpenAI",
+          model: "gpt-4.1",
+        }),
+        set: () => undefined,
+        variant: {
+          current: () => undefined,
+          list: () => [],
+          set: () => undefined,
+        },
+      },
+      product: {
+        current: () => "build",
+        set: () => undefined,
+      },
+    } as any)
+    spyOn(SDKContext, "useSDK").mockReturnValue({
+      client: {
+        session: {
+          get: async () => ({
+            data: {
+              id: sessionID,
+              title: "Recovered route prompt",
+              workspaceID: "workspace_recovered_route_prompt",
+              directory: "/tmp",
+            },
+          }),
+        },
+      },
+    } as any)
+    spyOn(SyncContext, "useSync").mockReturnValue({
+      path: { directory: "/tmp", worktree: "/tmp" },
+      bootstrap: async () => undefined,
+      data: {
+        command: [],
+        config: {
+          experimental: {},
+          model: "openai/gpt-4.1",
+          provider: {},
+          share: "disabled",
+        },
+        message: {
+          [sessionID]: [],
+        },
+        part: {},
+        permission: {},
+        provider: [
+          {
+            id: "openai",
+            name: "OpenAI",
+            source: "config",
+            env: [],
+            options: {},
+            models: {},
+          },
+        ],
+        provider_auth: {},
+        provider_next: {
+          all: [],
+          connected: [],
+          default: {},
+        },
+        question: {},
+        session: [
+          {
+            id: sessionID,
+            title: "Recovered route prompt",
+            workspaceID: "workspace_recovered_route_prompt",
+            directory: "/tmp",
+          },
+        ],
+        session_status: {},
+      },
+      session: {
+        get: (id: string) =>
+          id === sessionID
+            ? {
+                id: sessionID,
+                title: "Recovered route prompt",
+                workspaceID: "workspace_recovered_route_prompt",
+                directory: "/tmp",
+              }
+            : undefined,
+        sync: async () => undefined,
+      },
+    } as any)
+    spyOn(ThemeContext, "useTheme").mockReturnValue({
+      theme: {
+        _hasSelectedListItemText: false,
+        accent: RGBA.fromHex("#14b8a6"),
+        background: RGBA.fromHex("#020617"),
+        backgroundElement: RGBA.fromHex("#111827"),
+        backgroundPanel: RGBA.fromHex("#0f172a"),
+        border: RGBA.fromHex("#334155"),
+        diffAdded: RGBA.fromHex("#22c55e"),
+        diffRemoved: RGBA.fromHex("#ef4444"),
+        error: RGBA.fromHex("#ef4444"),
+        primary: RGBA.fromHex("#38bdf8"),
+        secondary: RGBA.fromHex("#94a3b8"),
+        selectedListItemText: RGBA.fromHex("#f8fafc"),
+        success: RGBA.fromHex("#22c55e"),
+        text: RGBA.fromHex("#f8fafc"),
+        textMuted: RGBA.fromHex("#94a3b8"),
+        warning: RGBA.fromHex("#f59e0b"),
+      },
+      syntax: () => ({
+        getStyleId: () => 1,
+      }),
+    } as any)
+    spyOn(TuiConfigContext, "useTuiConfig").mockReturnValue(testTuiConfig)
+    spyOn(ToastModule, "useToast").mockReturnValue({
+      show: () => undefined,
+      error: () => undefined,
+      currentToast: null,
+    } as any)
+    spyOn(TuiPluginRuntime, "Slot").mockImplementation(
+      (props: { children?: unknown; name?: string; ref?: (ref: PromptRef | undefined) => void }) => {
+        if (props.name === "session_prompt") {
+          let current: PromptRef["current"] = {
+            input: "newer typed draft",
+            parts: [],
+          }
+          const set = mock((prompt: PromptRef["current"]) => {
+            current = prompt
+          })
+          promptSets.push(set)
+          props.ref?.({
+            focused: false,
+            get current() {
+              return current
+            },
+            blur() {},
+            focus() {},
+            reset() {},
+            set,
+            submit() {},
+          })
+          return null
+        }
+        return (props.children ?? null) as any
+      },
+    )
+
+    const { Session } = await import("../../../src/cli/cmd/tui/routes/session")
+    const CaptureRoute = () => {
+      const route = useRoute()
+
+      createEffect(() => {
+        routes.push({
+          type: route.data.type,
+          prompt: route.data.type === "plugin" ? undefined : route.data.prompt,
+        })
+      })
+
+      return <box />
+    }
+
+    await testRender(() => (
+      <TestKeymapProvider>
+        <RouteProvider
+          initialRoute={{
+            type: "session",
+            sessionID,
+            prompt: recovered,
+          }}
+        >
+          <PromptRefContext.PromptRefProvider>
+            <DialogProvider>
+              <CommandPaletteProvider>
+                <CaptureRoute />
+                <Show when={showSession()}>
+                  <Session />
+                </Show>
+              </CommandPaletteProvider>
+            </DialogProvider>
+          </PromptRefContext.PromptRefProvider>
+        </RouteProvider>
+      </TestKeymapProvider>
+    ))
+
+    return {
+      promptSets,
+      recovered,
+      routes,
+      async remount() {
+        setShowSession(false)
+        await flushEffects()
+        setShowSession(true)
+        await flushEffects()
+      },
+    }
+  }
+
+  test("clears recovered session route prompts after seeding", async () => {
+    const rendered = await renderRecoveredSessionRoutePrompt()
+
+    expect(rendered.promptSets[0]).toHaveBeenCalledWith(rendered.recovered)
+    expect(rendered.routes.at(-1)).toEqual({
+      type: "session",
+      prompt: undefined,
+    })
+
+    await rendered.remount()
+
+    expect(rendered.promptSets).toHaveLength(2)
+    expect(rendered.promptSets.reduce((count, set) => count + set.mock.calls.length, 0)).toBe(1)
+    expect(rendered.routes.at(-1)).toEqual({
+      type: "session",
+      prompt: undefined,
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Fixes #305

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Restores a submitted prompt draft when `session.prompt` fails after the TUI has already cleared the input. The recovery only restores when the cleared prompt is still untouched and the submitted user turn is not known to be stored, so newer edits and already-persisted turns are preserved.

It also keeps editor context retryable, preserves explicit Agent Swarm Run recipients for retry, avoids deleting a newly-created failed session unless the server confirms the submitted turn is missing, and documents the release QA expectation.

### How did you verify your code works?

- `bun test --timeout 30000 test/cli/tui/prompt.test.tsx`
- `bun typecheck`
- `bun turbo typecheck` from the pre-push hook
- `git diff --check origin/dev...HEAD`
- Independent review found no blocking issues after the docs and route-flag cleanup.

### Screenshots / recordings

No screenshot. This is terminal prompt state recovery covered by focused TUI prompt tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
