### PR TITLE
fix(opencode): gate handoff recipient output parsing

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/agency-target.ts
@@ -3,6 +3,8 @@ import { AgencySwarmAdapter } from "@/agency-swarm/adapter"
 import {
   hasAgencyHandoffEvidence,
   isAgencyAgentUpdatedHandoffMetadata,
+  isAgencyHandoffOutputMetadata,
+  isAgencyHandoffToolName,
   isTopLevelAgencyHandoffMetadata,
 } from "@/session/agency-swarm-utils"
 import * as Locale from "@/util/locale"
@@ -300,7 +302,11 @@ export function resolveAgencyHandoffRecipientFromParts(parts: AgencyHandoffPart[
     if (metadataAgent) return metadataAgent
     if (part.type !== "tool") continue
     const outputAgent =
-      isTopLevelAgencyHandoffMetadata(partMetadata) && isTopLevelAgencyHandoffMetadata(stateMetadata)
+      isTopLevelAgencyHandoffMetadata(partMetadata) &&
+      isTopLevelAgencyHandoffMetadata(stateMetadata) &&
+      (isAgencyHandoffOutputMetadata(partMetadata) ||
+        isAgencyHandoffOutputMetadata(stateMetadata) ||
+        isAgencyHandoffToolName(part.tool))
         ? (readHandoffOutputAgent(part.state?.output) ?? readHandoffMetadataAgent(stateMetadata))
         : undefined
     if (outputAgent) return outputAgent

--- a/packages/opencode/src/session/agency-swarm-utils.ts
+++ b/packages/opencode/src/session/agency-swarm-utils.ts
@@ -106,7 +106,7 @@ export function isTopLevelAgencyHandoffMetadata(metadata: Record<string, unknown
   return !hasCallerAgentMarker(metadata["callerAgent"] ?? metadata["caller_agent"] ?? metadata["caller"])
 }
 
-function isAgencyHandoffOutputMetadata(metadata: Record<string, unknown> | undefined) {
+export function isAgencyHandoffOutputMetadata(metadata: Record<string, unknown> | undefined) {
   return (
     asString(metadata?.["type"]) === "handoff_output_item" ||
     asString(metadata?.["item_type"]) === "handoff_output_item"

--- a/packages/opencode/src/session/agency-swarm.ts
+++ b/packages/opencode/src/session/agency-swarm.ts
@@ -39,6 +39,8 @@ import {
   findRecipientAgent,
   hasAgencyHandoffEvidence,
   isAgencyAgentUpdatedHandoffMetadata,
+  isAgencyHandoffOutputMetadata,
+  isAgencyHandoffToolName,
   isTopLevelAgencyHandoffMetadata,
   normalizeCallerAgent as normalizeCallerAgentValue,
   type AgencyMessageInput,
@@ -995,6 +997,9 @@ export namespace SessionAgencySwarm {
       const outputAgent =
         isTopLevelAgencyHandoffMetadata(partMetadata) &&
         isTopLevelAgencyHandoffMetadata(stateMetadata) &&
+        (isAgencyHandoffOutputMetadata(partMetadata) ||
+          isAgencyHandoffOutputMetadata(stateMetadata) ||
+          isAgencyHandoffToolName(part.tool)) &&
         part.state.status === "completed"
           ? (readHandoffOutputAgent(part.state.output) ?? readHandoffMetadataAgent(stateMetadata))
           : undefined

--- a/packages/opencode/test/cli/tui/agency-target.test.ts
+++ b/packages/opencode/test/cli/tui/agency-target.test.ts
@@ -252,6 +252,57 @@ describe("agency target options", () => {
     })
   })
 
+  test("restores top-level handoff over later top-level SendMessage output", () => {
+    expect(
+      resolveAgencyHandoffRecipientFromMessages({
+        frameworkMode: true,
+        agency: "my-agency",
+        currentRecipient: "UserSupportAgent",
+        currentRecipientSelectedAt: 1,
+        sessionID: "session_1",
+        messages: [
+          {
+            id: "message_1",
+            role: "assistant",
+            providerID: "agency-swarm",
+            agent: "MathAgent",
+            time: {
+              completed: 2,
+            },
+          },
+        ],
+        partsByMessage: {
+          message_1: [
+            {
+              type: "tool",
+              tool: "transfer_to_SupportAgent",
+              state: {
+                status: "completed",
+                output: '{"assistant":"SupportAgent"}',
+              },
+            },
+            {
+              type: "tool",
+              tool: "SendMessage",
+              state: {
+                status: "completed",
+                output: '{"assistant":"MathAgent"}',
+                metadata: {
+                  item_type: "function_call_output",
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      sessionID: "session_1",
+      messageID: "message_1",
+      agent: "SupportAgent",
+      selectedAt: 1,
+    })
+  })
+
   test("restores handed off recipient from synced session messages", () => {
     expect(
       resolveAgencyHandoffRecipientFromMessages({

--- a/packages/opencode/test/session/agency-swarm.test.ts
+++ b/packages/opencode/test/session/agency-swarm.test.ts
@@ -6142,6 +6142,187 @@ describe("session.agency-swarm", () => {
     })
   })
 
+  test("stream restores top-level handoff over later top-level SendMessage output", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        enabled_providers: ["agency-swarm"],
+        provider: {
+          "agency-swarm": {},
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        mockHistory()
+        const sentRecipients: Array<string | undefined> = []
+        AgencySwarmAdapter.getMetadata = (async () => ({
+          metadata: {
+            agents: ["UserSupportAgent", "support_agent", "MathAgent"],
+          },
+          nodes: [
+            {
+              id: "UserSupportAgent",
+              type: "agent",
+              data: {
+                label: "User Support Agent",
+              },
+            },
+            {
+              id: "support_agent",
+              type: "agent",
+              data: {
+                label: "Support Agent",
+              },
+            },
+            {
+              id: "MathAgent",
+              type: "agent",
+              data: {
+                label: "Math Agent",
+              },
+            },
+          ],
+        })) as typeof AgencySwarmAdapter.getMetadata
+        let turn = 0
+        AgencySwarmAdapter.streamRun = async function* (args) {
+          turn++
+          sentRecipients.push(args.recipientAgent ?? undefined)
+          if (turn === 1) {
+            yield {
+              type: "data",
+              payload: {
+                type: "raw_response_event",
+                data: {
+                  type: "response.output_item.added",
+                  output_index: 1,
+                  item: {
+                    type: "function_call",
+                    id: "fc_handoff",
+                    call_id: "call_handoff",
+                    name: "transfer_to_support_agent",
+                    arguments: "{}",
+                  },
+                },
+              },
+            }
+            yield {
+              type: "messages",
+              payload: {
+                new_messages: [
+                  {
+                    type: "handoff_output_item",
+                    call_id: "call_handoff",
+                    output: '{"assistant":"support_agent"}',
+                  },
+                ],
+              },
+            }
+            yield {
+              type: "data",
+              payload: {
+                type: "raw_response_event",
+                data: {
+                  type: "response.output_item.added",
+                  output_index: 2,
+                  item: {
+                    type: "function_call",
+                    id: "fc_send_message",
+                    call_id: "call_send_message",
+                    name: "SendMessage",
+                    arguments: JSON.stringify({
+                      recipient_agent: "MathAgent",
+                      message: "Please check this.",
+                    }),
+                  },
+                },
+              },
+            }
+            yield {
+              type: "messages",
+              payload: {
+                new_messages: [
+                  {
+                    type: "function_call_output",
+                    call_id: "call_send_message",
+                    output: '{"assistant":"MathAgent","response":"Delegated without transfer."}',
+                  },
+                ],
+              },
+            }
+            yield {
+              type: "messages",
+              payload: {
+                new_messages: [
+                  {
+                    id: "msg_mixed_top_level_send_message",
+                    type: "message",
+                    role: "assistant",
+                    agent: "MathAgent",
+                    content: [{ type: "output_text", text: "Delegation replied after handoff." }],
+                  },
+                ],
+              },
+            }
+          }
+          yield { type: "end" }
+        } as typeof AgencySwarmAdapter.streamRun
+
+        const session = await Session.create({ title: "mixed handoff top-level delegation" })
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("agency-swarm"),
+            modelID: ModelID.make("default"),
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: user.id,
+          sessionID: session.id,
+          type: "text",
+          text: "handoff then top-level delegate",
+        })
+
+        const first = helper()
+        first.input.sessionID = session.id
+        first.input.assistantMessage.sessionID = session.id
+        first.input.assistantMessage.id = MessageID.ascending()
+        first.input.assistantMessage.parentID = user.id
+        first.input.userMessage.info.id = user.id
+        first.input.options.recipientAgent = "UserSupportAgent"
+        ;(first.input.options as any).recipientAgentSelectedAt = 1
+
+        const firstStream = await SessionAgencySwarm.stream(first.input)
+        for await (const _ of firstStream.fullStream) {
+        }
+
+        const second = helper()
+        second.input.sessionID = session.id
+        second.input.assistantMessage.sessionID = session.id
+        second.input.assistantMessage.id = MessageID.ascending()
+        second.input.userMessage.info.id = MessageID.ascending()
+        second.input.userMessage.parts = [{ type: "text", text: "follow up", ignored: false }] as any
+        second.input.options.recipientAgent = "UserSupportAgent"
+        ;(second.input.options as any).recipientAgentSelectedAt = 1
+
+        const secondStream = await SessionAgencySwarm.stream(second.input)
+        for await (const _ of secondStream.fullStream) {
+        }
+
+        expect(sentRecipients).toEqual(["UserSupportAgent", "support_agent"])
+      },
+    })
+  })
+
   test("stream keeps agent_updated handoff metadata when raw text is replayed by messages", async () => {
     await using tmp = await tmpdir({
       git: true,


### PR DESCRIPTION
### Issue for this PR

Fixes #319

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevents normal `SendMessage` tool output from overwriting the active Agency Swarm handoff recipient.

Recipient recovery now reads recipient fields only from actual handoff output metadata or `transfer_to_*` tools, and the session and TUI recipient resolvers stay aligned.

### How did you verify your code works?

- `bun test test/cli/tui/agency-target.test.ts test/session/agency-swarm-utils.test.ts`
- `bun test test/session/agency-swarm.test.ts --timeout 30000`
- `bun typecheck`
- `bun turbo typecheck` through the pre-push hook
- `git diff --check`

### Screenshots / recordings

Not applicable. This fixes routing logic covered by automated tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
