### PR TITLE
test(opencode): use sync telemetry runner process

### DIFF
--- a/packages/opencode/test/telemetry/telemetry.test.ts
+++ b/packages/opencode/test/telemetry/telemetry.test.ts
@@ -187,7 +187,8 @@ async function buildRunnerUnlocked(input: RunnerInput) {
       `}`,
     ].join("\n"),
   )
-  const proc = Bun.spawn([process.execPath, builder], {
+  const proc = Bun.spawnSync({
+    cmd: [process.execPath, builder],
     cwd: root,
     env: Object.fromEntries(
       Object.entries({ PATH: process.env.PATH }).filter((entry): entry is [string, string] => entry[1] !== undefined),
@@ -195,11 +196,9 @@ async function buildRunnerUnlocked(input: RunnerInput) {
     stdout: "pipe",
     stderr: "pipe",
   })
-  const [stdout, stderr, code] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ])
+  const stdout = proc.stdout.toString()
+  const stderr = proc.stderr.toString()
+  const code = proc.exitCode
   if (code !== 0) throw new Error(stderr || stdout)
   return path.join(outdir, "telemetry-runner.js")
 }
@@ -227,17 +226,16 @@ async function runCompiledTelemetry(input: RunnerInput) {
   const env = Object.fromEntries(
     Object.entries(baseEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
   )
-  const proc = Bun.spawn([process.execPath, runner, payload], {
+  const proc = Bun.spawnSync({
+    cmd: [process.execPath, runner, payload],
     cwd: path.resolve(import.meta.dir, "../.."),
     env,
     stdout: "pipe",
     stderr: "pipe",
   })
-  const [stdout, stderr, code] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ])
+  const stdout = proc.stdout.toString()
+  const stderr = proc.stderr.toString()
+  const code = proc.exitCode
 
   expect(stderr).toBe("")
   expect(code).toBe(0)


### PR DESCRIPTION
### Issue for this PR

Fixes #298

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes the compiled telemetry test harness use synchronous child processes for its generated builder and runner helpers.

The release-candidate Windows unit job completed all tests with zero failures, but the Bun test process stayed alive until the CI step timeout killed it. This removes the async child-process stream lifetime from the parent telemetry tests while keeping the same assertions.

### How did you verify your code works?

- `bun test --timeout 30000 test/telemetry/telemetry.test.ts test/telemetry/command.test.ts`
- `bun typecheck`
- `bun turbo typecheck` through the pre-push hook
- `git diff --check`

Windows CI is the required proof that the post-success process exits cleanly.

### Screenshots / recordings

Not applicable. This fixes test-harness process cleanup.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
