### PR TITLE
fix(opencode): clarify launcher environment prompt

### DIFF
--- a/packages/opencode/src/agency-swarm/npx.ts
+++ b/packages/opencode/src/agency-swarm/npx.ts
@@ -1185,7 +1185,7 @@ async function ensureProjectPython(
 
   if (!selfHealing) {
     const createVenv = await prompts.confirm({
-      message: "Set up this project now?",
+      message: "Create an isolated project environment?",
       initialValue: true,
     })
     if (prompts.isCancel(createVenv)) {

--- a/packages/opencode/test/agency-swarm/npx.test.ts
+++ b/packages/opencode/test/agency-swarm/npx.test.ts
@@ -1571,7 +1571,7 @@ describe("agency-swarm npx onboarding", () => {
     })
 
     const visible = info.mock.calls.map((call) => String(call[0])).join("\n")
-    expect(confirms).toContain("Set up this project now?")
+    expect(confirms).toContain("Create an isolated project environment?")
     expect(confirms.join("\n")).not.toContain(".venv")
     expect(info).toHaveBeenCalledWith("Preparing Agent Swarm...")
     expect(spinnerStarts).toEqual(["Setting up Agent Swarm", "Starting Agent Swarm"])


### PR DESCRIPTION
### Issue for this PR

Fixes #322

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates the first-time launcher setup prompt to say it creates an isolated project environment. The matching onboarding test now checks the new prompt text.

### How did you verify your code works?

- `bun install --frozen-lockfile`
- From `packages/opencode`: `bun test test/agency-swarm/npx.test.ts --timeout 120000`
- Pre-push hook ran `bun turbo typecheck` successfully

### Screenshots / recordings

N/A - terminal prompt copy only; covered by the launcher onboarding test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR