### PR TITLE
feat(telemetry): add GitHub repo marketplace ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Set `ENABLE_TELEMETRY=0`, `OPEN_SWARM_TELEMETRY=0`, `AGENTSWARM_TELEMETRY=0`, or
 
 Every sent PostHog event sets `$process_person_profile: false` and includes safe base properties such as `version` (the Agent Swarm binary version), `app`, `platform`, `arch`, `channel`, and `terminal` when available.
 
-Product launchers may attach an allowlisted package version as `product_version` and marketplace metadata as `swarm_id`, `parent_swarm_id`, and `swarm_origin` (`original`, `fork`, or `unknown`). Official release binaries use the embedded capture key; runtime PostHog key environment variables do not redirect production telemetry.
+Product launchers may attach an allowlisted package version as `product_version` and marketplace metadata as `swarm_id`, `parent_swarm_id`, and `swarm_origin` (`original`, `fork`, or `unknown`). `swarm_id` and `parent_swarm_id` must be GitHub `owner/repo` names, not repository URLs, git remotes, local paths, or generic slugs. Official release binaries use the embedded capture key; runtime PostHog key environment variables do not redirect production telemetry.
 
 Supported events and properties:
 

--- a/packages/opencode/src/telemetry/telemetry.ts
+++ b/packages/opencode/src/telemetry/telemetry.ts
@@ -320,7 +320,7 @@ function safeGitHubRepo(value: string) {
   if (parts.length !== 2) return undefined
   const [owner, repo] = parts
   if (!githubOwnerPattern.test(owner) || owner.includes("--")) return undefined
-  if (repo.endsWith(".git")) return undefined
+  if (repo.toLowerCase().endsWith(".git")) return undefined
   if (!githubRepositoryNamePattern.test(repo)) return undefined
   return trimmed
 }

--- a/packages/opencode/src/telemetry/telemetry.ts
+++ b/packages/opencode/src/telemetry/telemetry.ts
@@ -15,6 +15,9 @@ const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"
 const STATE_FILE = "telemetry.json"
 const FALSE_VALUES = new Set(["0", "false", "off", "no"])
 const REQUEST_TIMEOUT_MS = 2_000
+const STRING_MAX_LENGTH = 128
+const githubOwnerPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
+const githubRepositoryNamePattern = /^[A-Za-z0-9._-]{1,100}$/
 const publicProviderIDs = new Set([
   "agency-swarm",
   "amazon-bedrock",
@@ -87,6 +90,9 @@ type PropertySpec =
       type: "integration_id"
     }
   | {
+      type: "github_repo"
+    }
+  | {
       type: "provider_id"
     }
   | {
@@ -108,6 +114,7 @@ const authDialogSources = new Set(["auth_dialog"])
 const agentModes = new Set(["all", "primary", "subagent"])
 const agentScopes = new Set(["custom", "global", "project"])
 const booleanField = { type: "boolean" } satisfies PropertySpec
+const githubRepoField = { type: "github_repo" } satisfies PropertySpec
 const providerIDField = { type: "provider_id" } satisfies PropertySpec
 const integrationIDField = { type: "integration_id" } satisfies PropertySpec
 const durationBuckets = new Set(["lt_2s", "2s_10s", "10s_60s", "gte_60s", "unknown"])
@@ -131,10 +138,10 @@ const baseProperties: Record<string, PropertySpec> = {
   app: stringField(),
   arch: stringField(),
   channel: stringField(),
-  parent_swarm_id: stringField(),
+  parent_swarm_id: githubRepoField,
   platform: stringField(platforms),
   product_version: stringField(),
-  swarm_id: stringField(),
+  swarm_id: githubRepoField,
   swarm_origin: stringField(swarmOrigins),
   terminal: stringField(terminalClients),
   version: stringField(),
@@ -301,14 +308,26 @@ function isDisabledByEnvironment() {
 
 function safeString(value: string) {
   const trimmed = value.trim()
-  if (!trimmed || trimmed.length > 128) return undefined
+  if (!trimmed || trimmed.length > STRING_MAX_LENGTH) return undefined
   if (/[\r\n\t]/.test(trimmed)) return undefined
+  return trimmed
+}
+
+function safeGitHubRepo(value: string) {
+  const trimmed = value.trim()
+  if (!trimmed || /[\r\n\t]/.test(trimmed)) return undefined
+  const parts = trimmed.split("/")
+  if (parts.length !== 2) return undefined
+  const [owner, repo] = parts
+  if (!githubOwnerPattern.test(owner) || owner.includes("--")) return undefined
+  if (!githubRepositoryNamePattern.test(repo)) return undefined
   return trimmed
 }
 
 function safeValue(spec: PropertySpec, value: unknown): SafeValue | undefined {
   if (spec.type === "boolean") return typeof value === "boolean" ? value : undefined
   if (typeof value !== "string") return undefined
+  if (spec.type === "github_repo") return safeGitHubRepo(value)
 
   const safe = safeString(value)
   if (!safe) return undefined

--- a/packages/opencode/src/telemetry/telemetry.ts
+++ b/packages/opencode/src/telemetry/telemetry.ts
@@ -320,6 +320,7 @@ function safeGitHubRepo(value: string) {
   if (parts.length !== 2) return undefined
   const [owner, repo] = parts
   if (!githubOwnerPattern.test(owner) || owner.includes("--")) return undefined
+  if (repo.endsWith(".git")) return undefined
   if (!githubRepositoryNamePattern.test(repo)) return undefined
   return trimmed
 }

--- a/packages/opencode/test/telemetry/telemetry.test.ts
+++ b/packages/opencode/test/telemetry/telemetry.test.ts
@@ -425,7 +425,7 @@ describe("Telemetry", () => {
     const output = await runCompiledTelemetry({
       env: {
         AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: "bad--owner/leak-parent",
-        AGENTSWARM_MARKETPLACE_SWARM_ID: "private/leak-swarm.git",
+        AGENTSWARM_MARKETPLACE_SWARM_ID: "private/leak-swarm.GIT",
         AGENTSWARM_MARKETPLACE_SWARM_ORIGIN: "fork",
       },
       event: "app_started",
@@ -439,7 +439,7 @@ describe("Telemetry", () => {
     expect(JSON.stringify(output.requests[0].body)).not.toContain("leak-parent")
     expect(JSON.stringify(output.requests[0].body)).not.toContain("leak-swarm")
     expect(JSON.stringify(output.requests[0].body)).not.toContain("bad--owner")
-    expect(JSON.stringify(output.requests[0].body)).not.toContain(".git")
+    expect(JSON.stringify(output.requests[0].body).toLowerCase()).not.toContain(".git")
   })
 
   test("uses the default host when no host is compiled", async () => {

--- a/packages/opencode/test/telemetry/telemetry.test.ts
+++ b/packages/opencode/test/telemetry/telemetry.test.ts
@@ -32,6 +32,9 @@ type RunnerInput = {
   event?: Parameters<typeof Telemetry.capture>[0]
   host?: string | null
   key?: string | null
+  marketplaceParentSwarmID?: string | null
+  marketplaceSwarmID?: string | null
+  marketplaceSwarmOrigin?: string | null
   mode?: RunnerMode
   productVersion?: string | null
   properties?: Record<string, unknown>
@@ -171,6 +174,9 @@ async function buildRunnerUnlocked(input: RunnerInput) {
     define: {
       AGENTSWARM_POSTHOG_API_KEY: defineString(input.key, "ph_test"),
       AGENTSWARM_POSTHOG_HOST: defineString(input.host, "https://posthog.example"),
+      AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: defineString(input.marketplaceParentSwarmID),
+      AGENTSWARM_MARKETPLACE_SWARM_ID: defineString(input.marketplaceSwarmID),
+      AGENTSWARM_MARKETPLACE_SWARM_ORIGIN: defineString(input.marketplaceSwarmOrigin),
       AGENTSWARM_PRODUCT_VERSION: defineString(input.productVersion),
       AGENTSWARM_TELEMETRY_TEST: input.testMode === false ? "undefined" : "true",
       OPENCODE_VERSION: defineString(input.binaryVersion, "local"),
@@ -370,6 +376,69 @@ describe("Telemetry", () => {
     })
 
     expect(output.requests[0].body.properties?.product_version).toBe("2.0.0-compiled")
+  })
+
+  test("preserves full GitHub repository marketplace ids", async () => {
+    await using tmp = await tmpdir()
+    const owner = "a".repeat(39)
+    const repo = "b".repeat(100)
+    const id = `${owner}/${repo}`
+    const parent = `${"c".repeat(39)}/${"d".repeat(100)}`
+    const output = await runCompiledTelemetry({
+      env: {
+        AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: parent,
+        AGENTSWARM_MARKETPLACE_SWARM_ID: id,
+        AGENTSWARM_MARKETPLACE_SWARM_ORIGIN: "fork",
+      },
+      event: "app_started",
+      properties: { entrypoint: "tui" },
+      stateDir: tmp.path,
+    })
+
+    expect(output.requests[0].body.properties).toMatchObject({
+      parent_swarm_id: parent,
+      swarm_id: id,
+      swarm_origin: "fork",
+    })
+  })
+
+  test("preserves compiled GitHub repository marketplace ids", async () => {
+    await using tmp = await tmpdir()
+    const output = await runCompiledTelemetry({
+      event: "app_started",
+      marketplaceParentSwarmID: "VRSEN/OpenSwarm",
+      marketplaceSwarmID: "example/compiled-swarm",
+      marketplaceSwarmOrigin: "fork",
+      properties: { entrypoint: "tui" },
+      stateDir: tmp.path,
+    })
+
+    expect(output.requests[0].body.properties).toMatchObject({
+      parent_swarm_id: "VRSEN/OpenSwarm",
+      swarm_id: "example/compiled-swarm",
+      swarm_origin: "fork",
+    })
+  })
+
+  test("drops invalid marketplace ids without leaking raw values", async () => {
+    await using tmp = await tmpdir()
+    const output = await runCompiledTelemetry({
+      env: {
+        AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: "git@github.com:private/leak-parent.git",
+        AGENTSWARM_MARKETPLACE_SWARM_ID: "bad--owner/leak-swarm",
+        AGENTSWARM_MARKETPLACE_SWARM_ORIGIN: "fork",
+      },
+      event: "app_started",
+      properties: { entrypoint: "tui" },
+      stateDir: tmp.path,
+    })
+
+    expect(output.requests[0].body.properties?.parent_swarm_id).toBeUndefined()
+    expect(output.requests[0].body.properties?.swarm_id).toBeUndefined()
+    expect(output.requests[0].body.properties?.swarm_origin).toBe("fork")
+    expect(JSON.stringify(output.requests[0].body)).not.toContain("leak-parent")
+    expect(JSON.stringify(output.requests[0].body)).not.toContain("leak-swarm")
+    expect(JSON.stringify(output.requests[0].body)).not.toContain("bad--owner")
   })
 
   test("uses the default host when no host is compiled", async () => {
@@ -1051,7 +1120,7 @@ describe("Telemetry", () => {
     await using tmp = await tmpdir()
     const output = await runCompiledTelemetry({
       env: {
-        AGENTSWARM_PRODUCT_VERSION: "bad\nprivate product sentinel",
+        AGENTSWARM_PRODUCT_VERSION: "v".repeat(129),
         OPENCODE_CLIENT: "bad\nterminal",
       },
       event: "app_started",
@@ -1061,6 +1130,6 @@ describe("Telemetry", () => {
 
     expect(output.requests[0].body.properties?.terminal).toBeUndefined()
     expect(output.requests[0].body.properties?.product_version).toBeUndefined()
-    expect(JSON.stringify(output.requests[0].body)).not.toContain("private product sentinel")
+    expect(JSON.stringify(output.requests[0].body)).not.toContain("v".repeat(129))
   })
 })

--- a/packages/opencode/test/telemetry/telemetry.test.ts
+++ b/packages/opencode/test/telemetry/telemetry.test.ts
@@ -424,8 +424,8 @@ describe("Telemetry", () => {
     await using tmp = await tmpdir()
     const output = await runCompiledTelemetry({
       env: {
-        AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: "git@github.com:private/leak-parent.git",
-        AGENTSWARM_MARKETPLACE_SWARM_ID: "bad--owner/leak-swarm",
+        AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: "bad--owner/leak-parent",
+        AGENTSWARM_MARKETPLACE_SWARM_ID: "private/leak-swarm.git",
         AGENTSWARM_MARKETPLACE_SWARM_ORIGIN: "fork",
       },
       event: "app_started",
@@ -439,6 +439,7 @@ describe("Telemetry", () => {
     expect(JSON.stringify(output.requests[0].body)).not.toContain("leak-parent")
     expect(JSON.stringify(output.requests[0].body)).not.toContain("leak-swarm")
     expect(JSON.stringify(output.requests[0].body)).not.toContain("bad--owner")
+    expect(JSON.stringify(output.requests[0].body)).not.toContain(".git")
   })
 
   test("uses the default host when no host is compiled", async () => {


### PR DESCRIPTION
### Issue for this PR

Feature PR; no linked issue required for `feat` titles.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a GitHub `owner/repo` telemetry property type for marketplace swarm identifiers, so `swarm_id` and `parent_swarm_id` can carry full repository names for Agencii/PostHog joins without loosening generic string telemetry. Invalid repository URLs, git remotes, local paths, generic slugs, and invalid GitHub owners are dropped.

Updates the telemetry contract docs to make the marketplace ID format explicit.

### How did you verify your code works?

Verified the current diff with focused telemetry and product-profile checks, typechecking, formatting, and independent structural review.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR