### PR TITLE
fix(tui): open connect dialog when no agencies are discovered

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/session-error.ts
+++ b/packages/opencode/src/cli/cmd/tui/session-error.ts
@@ -245,7 +245,11 @@ export function shouldHideNativeCommandInRunMode(input: { frameworkMode: boolean
 
 export function shouldOpenAgencyConnectDialog(input: { providerID?: string; message: string }) {
   if (input.providerID !== AgencySwarmAdapter.PROVIDER_ID) return false
-  if (/cannot reach agency-swarm backend/i.test(input.message)) {
+  if (
+    /cannot reach agency-swarm backend|no agencies were discovered from agency-swarm OpenAPI metadata/i.test(
+      input.message,
+    )
+  ) {
     log.error("agency-swarm bridge failure requires reconnect dialog", {
       message: input.message,
     })

--- a/packages/opencode/test/cli/tui/session-error.test.ts
+++ b/packages/opencode/test/cli/tui/session-error.test.ts
@@ -33,6 +33,16 @@ describe("agency session errors", () => {
     ).toBe(true)
   })
 
+  test("opens connect dialog when agency discovery returns no agencies", () => {
+    expect(
+      shouldOpenAgencyConnectDialog({
+        providerID: "agency-swarm",
+        message:
+          "No agencies were discovered from agency-swarm OpenAPI metadata. Configure provider.options.agency in your config, or run `agentswarm agency use <agency-id>`.",
+      }),
+    ).toBe(true)
+  })
+
   test("ignores unrelated providers and errors", () => {
     expect(
       shouldOpenAgencyConnectDialog({


### PR DESCRIPTION
### Issue for this PR

Fixes #328

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The fork-owned TUI classifier did not recognize the existing provider-scoped no-agencies discovery error. This change classifies that exact error so the existing `/connect` dialog opens, without changing discovery, resolution, error copy, dialog UI, or multiple-agency behavior.

### How did you verify your code works?

- Before the classifier change, the focused suite had 68 passing tests and the new regression failed; after it, all 69 tests passed.
- Package typecheck, Prettier, Oxlint error check, and diff check passed.
- A fresh macOS arm64 binary reported version `1.4.40` and SHA-256 `82bb0cd61aa416abd7b1962f343bb075ffa5bbc80b340d352376f73a006af022`.
- Terminal QA against HTTP 200 OpenAPI metadata with empty paths opened the persistent existing Connect dialog, accepted alternate port `59475`, made three discovery requests to that port, and exited cleanly without process or repository drift.

### Screenshots / recordings

Not applicable; the existing dialog UI and copy are unchanged.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
