### PR TITLE
fix(tui): explain the pre-filled startup error with a toast

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -339,6 +339,7 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
   - Behavior: auto-project launch requires a detected Agency project.
   - Behavior: if a detected local project has a ready Python environment but fails during project startup, the TUI opens Build with the startup error prefilled instead of exiting to the shell. After the user fixes the project, choosing Run from `/agents` starts the same local project.
   - Behavior: from that Build fallback, typing `/` keeps slash commands available by replacing the prefilled repair prompt instead of submitting the startup error text.
+  - Behavior: the Build fallback announces the failed start with a toast, so the prefilled startup error is not mistaken for typed input.
   - Behavior: stale Agency Swarm settings from `OPENCODE_CONFIG_CONTENT` cannot override the freshly prepared local Run server after startup falls back to Build.
   - Behavior: if the user connects to an external server from that Build fallback, choosing Run uses the connected server instead of replacing it with the pending local project.
   - Behavior: non-Agency explicit models do not trigger fork auto-project setup.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -241,6 +241,7 @@ For each failure scenario, capture the visible user result and cite the matching
 - **User story:** When restarting a project fails because the swarm code cannot load or start, the user lands in Build with the startup error already in the prompt.
 - **Success looks like:** The user can submit that prompt to Build, fix the code, choose Run from `/agents`, and start the same project as the Run server.
 - **Success looks like:** The user can type `/` from that Build fallback and access slash commands, even while the startup error is prefilled.
+- **Success looks like:** A toast explains that the project failed to start and that the error was placed in the message, so the prefilled text is not mistaken for typed input.
 - **Success looks like:** After choosing Run, the next prompt is handled by the repaired swarm, not echoed or ignored by the terminal.
 - **Success looks like:** A stale env-provided Agency Swarm server config cannot override the repaired local project when the user returns to Run.
 - **Success looks like:** Selecting the already-current local server in `/connect` keeps the local project Run state instead of saving a stale random port.

--- a/e2e/agent-swarm-tui/terminal-tui.test.ts
+++ b/e2e/agent-swarm-tui/terminal-tui.test.ts
@@ -592,6 +592,7 @@ describe("Agent Swarm terminal TUI e2e", () => {
     await currentTui.waitForText("Your agency project failed to start.", tuiInteractionTimeoutMs)
     await currentTui.waitForText("SyntaxError: invalid syntax", tuiInteractionTimeoutMs)
     await currentTui.waitForText("At: agency.py:1", tuiInteractionTimeoutMs)
+    await currentTui.waitForText("The startup error was added to your message", tuiInteractionTimeoutMs)
 
     currentTui.write("\r")
     const request = await waitForNativeLLMRequest(currentTui, currentNativeServer, "SyntaxError: invalid syntax")

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -9,6 +9,7 @@ import { usePromptRef } from "../context/prompt"
 import { useLocal } from "../context/local"
 import { TuiPluginRuntime } from "@/cli/cmd/tui/plugin/runtime"
 import { useEditorContext } from "@tui/context/editor"
+import { useToast } from "../ui/toast"
 
 let once = false
 const placeholder = {
@@ -25,6 +26,7 @@ export function Home() {
   const args = useArgs()
   const local = useLocal()
   const editor = useEditorContext()
+  const toast = useToast()
   let sent = false
 
   onMount(() => {
@@ -44,6 +46,12 @@ export function Home() {
       r.set({
         input: ["Fix this startup error:", "", args.startupFailure].join("\n"),
         parts: [],
+      })
+      toast.show({
+        variant: "warning",
+        title: "Agency project failed to start",
+        message: "The startup error was added to your message. Press Enter to have Build fix it.",
+        duration: 10000,
       })
       once = true
       return

--- a/packages/opencode/test/cli/tui/home-startup-failure.test.tsx
+++ b/packages/opencode/test/cli/tui/home-startup-failure.test.tsx
@@ -1,0 +1,98 @@
+/** @jsxImportSource @opentui/solid */
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
+import type { CliRenderer } from "@opentui/core"
+import { testRender } from "@opentui/solid"
+import * as ArgsContext from "../../../src/cli/cmd/tui/context/args"
+import * as EditorContext from "../../../src/cli/cmd/tui/context/editor"
+import * as LocalContext from "../../../src/cli/cmd/tui/context/local"
+import * as LogoModule from "../../../src/cli/cmd/tui/component/logo"
+import * as ProjectContext from "../../../src/cli/cmd/tui/context/project"
+import * as PromptModule from "../../../src/cli/cmd/tui/component/prompt"
+import * as SyncContext from "../../../src/cli/cmd/tui/context/sync"
+import * as ToastModule from "../../../src/cli/cmd/tui/ui/toast"
+import * as TuiPluginRuntimeModule from "../../../src/cli/cmd/tui/plugin/runtime"
+import type { PromptRef } from "../../../src/cli/cmd/tui/component/prompt"
+import { PromptRefProvider } from "../../../src/cli/cmd/tui/context/prompt"
+import { RouteProvider } from "../../../src/cli/cmd/tui/context/route"
+
+const renderers: CliRenderer[] = []
+
+afterEach(() => {
+  for (const renderer of renderers) renderer.destroy()
+  renderers.length = 0
+  mock.restore()
+})
+
+async function renderHome(input: { startupFailure?: string }) {
+  const toasts: ToastModule.ToastOptions[] = []
+  let promptRef: PromptRef | undefined
+
+  spyOn(ArgsContext, "useArgs").mockReturnValue({ startupFailure: input.startupFailure } as any)
+  spyOn(EditorContext, "useEditorContext").mockReturnValue({ clearSelection: () => {} } as any)
+  spyOn(LocalContext, "useLocal").mockReturnValue({ model: { ready: false } } as any)
+  spyOn(LogoModule, "Logo").mockImplementation(() => <box />)
+  spyOn(ProjectContext, "useProject").mockReturnValue({
+    workspace: { current: () => "workspace" },
+  } as any)
+  spyOn(SyncContext, "useSync").mockReturnValue({ ready: false } as any)
+  spyOn(ToastModule, "useToast").mockReturnValue({
+    show: (options: any) => toasts.push(options),
+    error: () => {},
+    currentToast: null,
+  } as any)
+  // Render slot children directly, as the live runtime does when no plugin replaces the slot.
+  spyOn(TuiPluginRuntimeModule, "Slot").mockImplementation((props: any) => <>{props.children}</>)
+  spyOn(PromptModule, "Prompt").mockImplementation((props: any) => {
+    const ref: PromptRef = {
+      focused: false,
+      current: { input: "", parts: [] },
+      set(prompt) {
+        ref.current = prompt
+      },
+      reset() {},
+      blur() {},
+      focus() {},
+      submit() {},
+    }
+    promptRef = ref
+    props.ref?.(ref)
+    return <box />
+  })
+
+  const { Home } = await import("../../../src/cli/cmd/tui/routes/home")
+
+  const rendered = await testRender(
+    () => (
+      <RouteProvider>
+        <PromptRefProvider>
+          <Home />
+        </PromptRefProvider>
+      </RouteProvider>
+    ),
+    { width: 120, height: 30 },
+  )
+  renderers.push(rendered.renderer)
+
+  expect(promptRef).toBeDefined()
+  return { promptRef: promptRef!, toasts }
+}
+
+test("home without a startup failure keeps the composer empty and shows no toast", async () => {
+  const { promptRef, toasts } = await renderHome({})
+
+  expect(promptRef.current.input).toBe("")
+  expect(toasts).toHaveLength(0)
+})
+
+test("home seeds the startup failure into the composer and explains it with a toast", async () => {
+  const failure = "Your agency project failed to start.\nSyntaxError: invalid syntax\nAt: agency.py:1"
+  const { promptRef, toasts } = await renderHome({ startupFailure: failure })
+
+  expect(promptRef.current.input).toBe(["Fix this startup error:", "", failure].join("\n"))
+  expect(toasts).toHaveLength(1)
+  expect(toasts[0]).toMatchObject({
+    variant: "warning",
+    title: "Agency project failed to start",
+    message: "The startup error was added to your message. Press Enter to have Build fix it.",
+  })
+})


### PR DESCRIPTION
### Issue for this PR

No linked issue; QA feedback from release testing: when starting a broken agency, there is no notification about the issue — the error text just sits in the prompt input, which can confuse the user.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a detected local agency project fails to import or start, `prepareProjectLaunch` returns the startup failure and `routes/home.tsx` seeds "Fix this startup error: ..." into the prompt composer so Build can repair the project. Nothing announces this, because the pre-TUI hint is wiped when the TUI takes over the screen — so the user just finds error text sitting in the input as if they typed it.

This shows a one-time warning toast in the same seed branch — "Agency project failed to start: the startup error was added to your message. Press Enter to have Build fix it." — using the existing toast surface, the same pattern as the invalid-model startup toast in app.tsx. The persistent error surfaces (full failure in `/agents` with retry) are unchanged; the toast only explains the pre-filled composer. Works because the seed branch runs exactly once when the TUI opens with a startup failure, so the toast cannot repeat or fire in healthy launches.

### How did you verify your code works?

- New unit test `test/cli/tui/home-startup-failure.test.tsx` reproduces the reported state (seed present, no toast — fails without the fix) and asserts seed + toast with the fix; 2 pass.
- Real-terminal e2e: the syntax-error Build-fallback test in `e2e/agent-swarm-tui/terminal-tui.test.ts` now also waits for the toast text on the rendered screen; all 4 Build-fallback startup tests pass.
- Full TUI unit suite: 346 pass. `bun run typecheck` clean.

### Screenshots / recordings

Terminal UI change; the real-terminal e2e asserts the rendered toast text on screen during the broken-agency flow (toast: "Agency project failed to start").

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR