### PR TITLE
fix(build): secure env handling and plan_enter availability for builder switching

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -238,8 +238,17 @@ Use this index with `USER_FLOWS.md` when a QA row needs the owning fork implemen
 - **Plan instructions are retuned for Agency Swarm handoffs**
   - Intent: keep Plan behavior aligned with the fork while preserving native OpenCode Plan behavior.
   - Behavior: the Plan prompt keeps the native OpenCode system prompt and adds fork-specific Agency Swarm handoff instructions.
+  - Behavior: Plan asks how the result should be delivered (add agents to the existing OpenSwarm or create a standalone agency), requires an explicit user-provided output location before a standalone plan counts as complete, runs MCP and existing-API discovery when the planned agents need tools, and proposes switching to Build via `plan_exit` once the plan is complete.
   - Implementation: `agentPlannerInstructions` in `packages/opencode/src/session/agent-planner.ts` with `packages/opencode/src/session/prompt/agent-planner.txt`.
   - Added by: `7643fcde`
+
+- **Build can propose switching to Plan for unclear swarm work**
+  - Intent: route unclear or new swarm work through Plan before Build edits files, without making the user switch modes manually.
+  - Behavior: with native plan mode active in the CLI client, Build has a `plan_enter` tool that asks the user whether to switch to Plan. Choosing `Yes` appends a synthetic Plan handoff turn so the session continues in Plan; choosing `No` keeps Build working without planning.
+  - Behavior: the injected Build prompt mentions `plan_enter` only when the tool is actually registered for the session. When it is unavailable, the prompt instead tells Build to ask the user in chat for clarifications and for the standalone-agency output location.
+  - Behavior: Build never copies an existing parent-directory `.env` into a new standalone agency silently. It asks the user in chat for explicit confirmation first, naming source and destination. On decline, or when no `.env` exists, it creates a template `.env` containing only the required key names with empty values and tells the user which keys to fill. Secret values are never read into the conversation or exposed.
+  - Behavior: smoke tests for generated swarms stay safe. Tools whose real execution would send messages or emails, spend money, or delete or modify external data are smoke-tested with read-only or clearly reversible inputs, and Build never makes a destructive or outward-facing real call without explicit user confirmation in chat.
+  - Implementation: `PlanEnterTool` in `packages/opencode/src/tool/plan.ts`, registration in `packages/opencode/src/tool/registry.ts`, availability-aware prompt substitution in `packages/opencode/src/session/agent-builder.ts` with `packages/opencode/src/session/prompt/agent-builder.txt`, and injection wiring in `packages/opencode/src/session/prompt.ts`.
 
 - **`/agents` exposes Plan, Build, and Run**
   - Intent: let users move between native Build, native Plan, and server-backed Run inside one project without adding parallel Build or Plan behavior.

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -229,6 +229,11 @@ For each failure scenario, capture the visible user result and cite the matching
 - **Happy-path proof:** Shell commands in Build and Plan preserve native mode when the session is reopened.
 - **Happy-path proof:** In Build and Plan, `/compact` and auto-compaction keep prompts on OpenCode routing and do not switch the session back to server-backed Run routing.
 - **Happy-path proof:** When Plan finishes and asks whether to switch to Build, pressing Enter on `Yes` follows the upstream OpenCode Plan approval flow, switches the TUI to Build, and creates the native approved-plan handoff turn.
+- **Happy-path proof:** When Build receives unclear or new swarm work with native plan mode active, it proposes switching to Plan; `Yes` moves the session to Plan with a planning handoff turn, `No` keeps Build working without planning.
+- **Happy-path proof:** Without native plan mode, the Build guidance never mentions `plan_enter` and instead asks the user in chat for clarifications and the standalone-agency output location.
+- **Happy-path proof:** Plan asks whether new agents join the existing OpenSwarm or become a standalone agency, and a standalone plan is not complete until the user names the output location.
+- **Happy-path proof:** Before Build copies an existing parent-folder `.env` into a new standalone agency, it asks for explicit confirmation naming source and destination; on decline or when none exists it creates a template `.env` with empty values and names the keys to fill, and secret values never appear in chat.
+- **Happy-path proof:** Smoke tests for generated tools use read-only or clearly reversible inputs, and Build never makes a destructive or outward-facing real call without explicit user confirmation in chat.
 - **Happy-path proof:** The Plan approval question owns keyboard input while it is open, so session shortcuts do not fire at the same time.
 - **Failure scenario to test:** A transient empty recovery response must not permanently hide a still-pending Plan approval question.
 - **Happy-path proof:** Switching back to Run in the same project reconnects to or keeps using the Agency Swarm server and returns `/agents` to Plan and Build rows above the swarm/agent picker.

--- a/packages/opencode/src/session/agent-builder.ts
+++ b/packages/opencode/src/session/agent-builder.ts
@@ -1,8 +1,23 @@
 import PROMPT_AGENT_BUILDER from "./prompt/agent-builder.txt"
 import { SessionAgencySwarm } from "./agency-swarm"
 
-export function agentBuilderInstructions(agent: string, providerID: string) {
+const UNCLEAR_REQUIREMENTS_PLAN =
+  "call `plan_enter` immediately before doing anything else. Do not plan, research, inspect files, or take any other action first; let Plan clarify requirements and create the implementation plan."
+const UNCLEAR_REQUIREMENTS_ASK =
+  "ask the user focused clarifying questions in chat and wait for the answers before doing anything else."
+const MISSING_OUTPUT_LOCATION_PLAN = "call `plan_enter` immediately and do not create files."
+const MISSING_OUTPUT_LOCATION_ASK =
+  "ask the user in chat for the output location and do not create files until they provide it."
+
+export function agentBuilderInstructions(agent: string, providerID: string, planEnterAvailable = false) {
   if (agent !== "build") return []
   if (providerID === SessionAgencySwarm.PROVIDER_ID) return []
-  return [PROMPT_AGENT_BUILDER]
+  const prompt = PROMPT_AGENT_BUILDER.replaceAll(
+    "{{unclear_requirements_action}}",
+    planEnterAvailable ? UNCLEAR_REQUIREMENTS_PLAN : UNCLEAR_REQUIREMENTS_ASK,
+  ).replaceAll(
+    "{{missing_output_location_action}}",
+    planEnterAvailable ? MISSING_OUTPUT_LOCATION_PLAN : MISSING_OUTPUT_LOCATION_ASK,
+  )
+  return [prompt]
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2007,7 +2007,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               MessageV2.toModelMessagesEffect(msgs, model),
             ])
             const modeInstructions = [
-              ...agentBuilderInstructions(agent.name, model.providerID),
+              // plan_enter is only registered for cli clients with native plan mode (see ToolRegistry);
+              // keep the injected Build instructions aligned with the tools that actually exist.
+              ...agentBuilderInstructions(
+                agent.name,
+                model.providerID,
+                flags.experimentalPlanMode && flags.client === "cli",
+              ),
               ...agentPlannerInstructions(agent.name, model.providerID, flags.experimentalPlanMode),
             ]
             const system = [...env, ...instructions, ...modeInstructions, ...(skills ? [skills] : [])]

--- a/packages/opencode/src/session/prompt/agent-builder.txt
+++ b/packages/opencode/src/session/prompt/agent-builder.txt
@@ -26,14 +26,14 @@ Agency Swarm is built on the OpenAI Agents SDK. Your job in Build mode is to cre
 - Inspect the OpenSwarm `.env.example` file to understand which environment variables the user can configure through `/addons`.
 - Remove example agents if they are still present and clean the example wiring out of `agency.py`.
 - If the task needs external systems such as Slack or Notion, verify the needed API keys exist in `.env` before proceeding.
-- If requirements are missing or unclear for new or substantial swarm work, call `plan_enter` immediately before doing anything else. Do not plan, research, inspect files, or take any other action first; let Plan clarify requirements and create the implementation plan.
+- If requirements are missing or unclear for new or substantial swarm work, {{unclear_requirements_action}}
 
 ## Output Mode
 
 - Follow the approved plan's output mode.
 - If the output mode is to integrate into OpenSwarm, inspect the current OpenSwarm state first. Keep the existing agents, create a new folder for the new agent or agents, implement them there, and wire them into `swarm.py` the same way the existing OpenSwarm agents are wired.
-- If the output mode is standalone agency, the approved plan must include an explicit output location from the user. If that location is missing, call `plan_enter` immediately and do not create files.
-- If the output mode is standalone agency, first inspect the OpenSwarm repository to understand its folder structure and conventions. Then move to the output location selected during planning, create the chosen agency folder there, copy the `.env` file from the directory above the openswarm into the created agency when it exists, and build the standalone agency using the same folder structure and conventions as OpenSwarm.
+- If the output mode is standalone agency, the approved plan must include an explicit output location from the user. If that location is missing, {{missing_output_location_action}}
+- If the output mode is standalone agency, first inspect the OpenSwarm repository to understand its folder structure and conventions. Then move to the output location selected during planning, create the chosen agency folder there, set up its `.env` by following the Environment Files rules, and build the standalone agency using the same folder structure and conventions as OpenSwarm.
 - Do not create a standalone agency inside the OpenSwarm project folder unless the user explicitly selected that folder as the output location during planning.
 - Do not replace or remove existing OpenSwarm agents unless the approved plan explicitly says to.
 
@@ -41,8 +41,9 @@ Agency Swarm is built on the OpenAI Agents SDK. Your job in Build mode is to cre
 
 - Use the OpenSwarm `.env.example` file as the reference for environment variables the user can set through `/addons`.
 - The `.env.example` sections labeled `Provider (one required)` and `Model selection` are only required for backend or direct-script implementations. If the user will run the swarm through the OpenSwarm chat window, do not require those keys; the user can select providers and models in the UI.
-- For standalone agencies, copy the `.env` file located in the parent directory of the openswarm agency into the new agency folder when that file exists.
-- Inspect the copied `.env` file only for key names and whether values are present or empty. Do not read, copy into the conversation, log, summarize, or expose actual secret values. Treat keys as optional unless the planned tools or APIs require them.
+- Never copy any existing `.env` file silently. When a `.env` exists in the parent directory of the OpenSwarm agency, ask the user in chat for explicit confirmation before copying it into the new agency folder, naming the source and destination paths, and copy it only after the user confirms.
+- If the user declines the copy, or no `.env` exists to copy, create a template `.env` in the new agency folder that contains only the required key names with empty values, and tell the user exactly which keys they need to fill in.
+- Inspect any existing `.env` file only for key names and whether values are present or empty. Do not read, copy into the conversation, log, summarize, or expose actual secret values. Treat keys as optional unless the planned tools or APIs require them.
 - Do not overwrite an existing `.env` in the target agency without preserving its current values.
 
 ## Folder Structure
@@ -87,6 +88,7 @@ Agency Swarm is built on the OpenAI Agents SDK. Your job in Build mode is to cre
 - Reuse the existing `.venv` or `venv` for testing. Repair it if activation, Python, uv, imports, or dependency installation fails.
 - Add a minimal `if __name__ == "__main__":` guard to each new or substantially modified tool, agent, and agency file so the generated swarm can be smoke-tested directly.
 - Tool main guards should run one realistic minimal call with test input data. Do not exhaustively test every option or edge case.
+- Keep smoke tests safe. If really executing a tool would send messages or emails, spend money, or delete or modify external data, smoke-test it with read-only or clearly reversible inputs instead, and never make a destructive or outward-facing real call without the user's explicit confirmation in chat.
 - Agent main guards should create a simple temporary agency around that agent and call `get_response_sync` once with a single prompt that tests one representative use of the agent.
 - Agency main guards should call `get_response_sync` once with a single prompt that tests one representative agency workflow.
 - If a smoke test requires API keys or credentials that are missing, do not fake the call. Tell the user the path to the `.env` file and the exact environment variable names they need to fill in there.

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1042,6 +1042,118 @@ planMode.instance(
       const payload = JSON.stringify(input)
       expect(payload).toContain("Agent Swarm Build Instructions")
       expect(payload).toContain("plan_enter")
+      expect(payload).not.toContain("{{")
+    }),
+  { git: true },
+)
+
+it.instance(
+  "Build prompt asks for the output location in chat when plan_enter is unavailable",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Build without plan mode",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "build a cold email swarm" }],
+      })
+
+      yield* llm.text("building")
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.role).toBe("assistant")
+
+      const [input] = yield* llm.inputs
+      const payload = JSON.stringify(input)
+      expect(payload).toContain("Agent Swarm Build Instructions")
+      expect(payload).not.toContain("plan_enter")
+      expect(payload).toContain("ask the user in chat for the output location")
+      expect(payload).not.toContain("{{")
+    }),
+  { git: true },
+)
+
+planMode.instance(
+  "plan_enter appends a synthetic Plan message after the user confirms the switch",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const question = yield* Question.Service
+      const chat = yield* sessions.create({
+        title: "Build to plan switch",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "build a cold email swarm" }],
+      })
+      yield* llm.tool("plan_enter", {})
+      yield* llm.text("switching")
+
+      const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkScoped)
+      const request = yield* pollWithTimeout(
+        question.list().pipe(Effect.map((items) => items[0])),
+        "plan_enter never asked the switch question",
+      )
+      expect(request.questions[0]?.question).toContain("switch to Plan")
+      yield* question.reply({ requestID: request.id, answers: [["Yes"]] })
+      const result = yield* Fiber.join(fiber)
+      expect(result.info.role).toBe("assistant")
+
+      const msgs = yield* sessions.messages({ sessionID: chat.id })
+      const planMsg = msgs.find((msg) => msg.info.role === "user" && msg.info.agent === "plan")
+      expect(planMsg).toBeDefined()
+      const part = planMsg?.parts.find((part) => part.type === "text" && part.synthetic)
+      expect(part?.type === "text" ? part.text : "").toContain("Build needs planning before implementation")
+    }),
+  { git: true },
+)
+
+planMode.instance(
+  "plan_enter keeps the session in Build when the user declines the switch",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const question = yield* Question.Service
+      const chat = yield* sessions.create({
+        title: "Build stays in build",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "build a cold email swarm" }],
+      })
+      yield* llm.tool("plan_enter", {})
+      yield* llm.text("continuing in build")
+
+      const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkScoped)
+      const request = yield* pollWithTimeout(
+        question.list().pipe(Effect.map((items) => items[0])),
+        "plan_enter never asked the switch question",
+      )
+      yield* question.reply({ requestID: request.id, answers: [["No"]] })
+      const result = yield* Fiber.join(fiber)
+      expect(result.info.role).toBe("assistant")
+
+      const msgs = yield* sessions.messages({ sessionID: chat.id })
+      expect(msgs.some((msg) => msg.info.role === "user" && msg.info.agent === "plan")).toBe(false)
     }),
   { git: true },
 )


### PR DESCRIPTION
### Issue for this PR

Closes #335. Chained on #331.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Three small fixes to the Build prompt added in #331:

- Ask the user before copying the parent `.env` into a new standalone agency; if declined or absent, write a template with the required key names instead.
- Mention `plan_enter` only in sessions that actually register the tool; otherwise the prompt says to ask in chat.
- Tool smoke calls must use harmless test input (nothing that sends messages, spends money, or changes external data).

Plus end-to-end tests for the Yes/No plan switch and changelog entries.

### How did you verify your code works?

`bun run typecheck` clean; `bun test test/session/prompt.test.ts` 74 pass, including the new end-to-end plan_enter flow tests.

### Screenshots / recordings

n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR