### PR TITLE
test(opencode): stabilize timing-sensitive Windows unit CI flakes

### DIFF
--- a/packages/opencode/test/control-plane/workspace.test.ts
+++ b/packages/opencode/test/control-plane/workspace.test.ts
@@ -1409,6 +1409,8 @@ describe("workspace sync state", () => {
     { git: true },
   )
 
+  // Runs in ~1s but can stall past the 30s suite default on slow Windows CI
+  // runners (spawn/filesystem latency), so give it explicit headroom.
   it.live("remote start emits disconnected, connecting, and connected then refuses duplicate listeners", () => {
     const calls: FetchCall[] = []
     return Effect.gen(function* () {
@@ -1472,7 +1474,7 @@ describe("workspace sync state", () => {
         { git: true },
       )
     })
-  })
+  }, 60_000)
 
   it.live("remote connection HTTP failures set error and clear syncing", () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/plugin/install-concurrency.test.ts
+++ b/packages/opencode/test/plugin/install-concurrency.test.ts
@@ -67,7 +67,7 @@ describe("plugin.install.concurrent", () => {
   test("serializes concurrent server config updates across processes", async () => {
     await using tmp = await tmpdir()
     const target = await plugin(tmp.path, ["server"])
-    const all = mods("mod-server", 12)
+    const all = mods("mod-server", 6)
 
     const out = await Promise.all(
       all.map((mod) =>
@@ -90,7 +90,7 @@ describe("plugin.install.concurrent", () => {
   test("serializes concurrent server+tui config updates across processes", async () => {
     await using tmp = await tmpdir()
     const target = await plugin(tmp.path, ["server", "tui"])
-    const all = mods("mod-both", 10)
+    const all = mods("mod-both", 6)
 
     const out = await Promise.all(
       all.map((mod) =>
@@ -119,7 +119,7 @@ describe("plugin.install.concurrent", () => {
     await fs.mkdir(path.dirname(cfg), { recursive: true })
     await Bun.write(cfg, JSON.stringify({ plugin: ["seed@1.0.0"] }, null, 2))
 
-    const next = mods("mod-json", 8)
+    const next = mods("mod-json", 5)
     const out = await Promise.all(
       next.map((mod) =>
         run({

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -865,7 +865,7 @@ it.instance(
   Effect.gen(function* () {
     const tmp = yield* bootstrap()
     const snapshot = yield* Snapshot.Service
-    const ids = Array.from({ length: 140 }, (_, i) => i.toString().padStart(3, "0"))
+    const ids = Array.from({ length: OVER_BATCH_COUNT }, (_, i) => i.toString().padStart(3, "0"))
     yield* mkdirp(`${tmp.path}/order`)
     yield* Effect.all(
       ids.map((id) => write(`${tmp.path}/order/${id}.txt`, `before-${id}`)),
@@ -1093,8 +1093,8 @@ it.instance(
   Effect.gen(function* () {
     const tmp = yield* bootstrap()
     const snapshot = yield* Snapshot.Service
-    const base = Array.from({ length: 140 }, (_, i) => fwd(tmp.path, "batch", `${i}.txt`))
-    const fresh = Array.from({ length: 140 }, (_, i) => fwd(tmp.path, "fresh", `${i}.txt`))
+    const base = Array.from({ length: OVER_BATCH_COUNT }, (_, i) => fwd(tmp.path, "batch", `${i}.txt`))
+    const fresh = [fwd(tmp.path, "fresh", "0.txt")]
     yield* mkdirp(`${tmp.path}/batch`)
     yield* mkdirp(`${tmp.path}/fresh`)
     yield* Effect.all(


### PR DESCRIPTION
### Issue for this PR

Closes #337

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`unit (windows)` failed on three different timing-sensitive tests across recent PRs (#330, #331, #336), each passing on rerun. All three share one axis: Windows runners are slow at process spawning and filesystem work, and these tests combine heavy spawn/IO load with fixed timeouts. Issue #337 has the full failure evidence with links to the failing runs.

Three surgical test-only changes, upstream-first:

1. **`test/plugin/install-concurrency.test.ts`** — port of upstream commit `896ad7b8` ("Speed up targeted opencode tests"): worker counts drop from 12/10/8 to 6/6/5. The observed failure was one of 12 competing processes exiting 1 while contending on the directory-based config lock, whose `mkdir`/`rm` stale-recovery races are more error-prone on Windows; contention probability scales with worker count. Upstream reduced the counts for exactly this class of slowness while keeping the cross-process serialization coverage (the tests still assert every concurrent worker lands in the merged config). This fork never received that commit.

2. **`test/snapshot/snapshot.test.ts`** — completes upstream #28381 ("Reduce snapshot batch test fixture sizes"), which a previous sync applied only partially: the fork got the `SNAPSHOT_BATCH_BOUNDARY`/`OVER_BATCH_COUNT` constants and the mixed-batch usage, but the "diffFull preserves git diff order" and "revert handles large mixed batches" tests kept hardcoded 140s. The revert test built 280 fixture files and ran 18–21s on passing Windows runs against the 30s `bun test` timeout — PR #336 crossed it. Crossing the 100-file chunk boundary only needs 101 base files plus one fresh file, which is what upstream uses; the hunks here match upstream `dev` byte-for-byte.

3. **`test/control-plane/workspace.test.ts`** — fork-owned single line: an explicit 60s timeout on the remote-start sync test. It runs in 0.6–1.3s on passing Windows runs, but one run stalled to the 30s ceiling and was killed mid-fiber (`All fibers interrupted without error`). Upstream has no fix for this test; the extra headroom converts a rare runner stall into a pass and costs nothing on the normal path.

Why this works: the two ported changes remove the load that put tests near their ceilings (fewer contending processes, ~3x smaller snapshot fixture), and the timeout gives the one fast-but-stall-prone test room to survive a slow runner. No runtime code changes; upstream delta shrinks rather than grows.

### How did you verify your code works?

- Ran all three touched files locally: `bun test test/plugin/install-concurrency.test.ts test/snapshot/snapshot.test.ts test/control-plane/workspace.test.ts --timeout 30000` (same timeout as `test:ci`) — 95 pass, 1 pre-existing skip, 0 fail, 46.5s total.
- Verified the ported hunks match upstream `anomalyco/opencode` `dev` exactly (fetched upstream file contents and diffed).
- Confirmed via `git log -S` that the fork's 140s and 12/10/8 counts predate the upstream reductions and that no fork commit intentionally chose them.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
