### PR TITLE
test(opencode): close product build child handles

### DIFF
--- a/packages/opencode/test/agency-swarm/product-build.test.ts
+++ b/packages/opencode/test/agency-swarm/product-build.test.ts
@@ -76,20 +76,16 @@ describe("product build config", () => {
         }
       | undefined
     try {
-      const generate = Bun.spawn(["bun", "script/generate.ts"], {
+      const generate = Bun.spawnSync({
+        cmd: [process.execPath, "script/generate.ts"],
         cwd: packageRoot,
         env: { ...process.env, MODELS_DEV_API_JSON: fixture },
         stdout: "pipe",
         stderr: "pipe",
       })
-      const [exitCode, stdout, stderr] = await Promise.all([
-        generate.exited,
-        new Response(generate.stdout).text(),
-        new Response(generate.stderr).text(),
-      ])
       result = {
-        exitCode,
-        output: `${stdout}\n${stderr}`,
+        exitCode: generate.exitCode,
+        output: `${generate.stdout.toString()}\n${generate.stderr.toString()}`,
         generatedSnapshot: await Bun.file(snapshot).text(),
         generatedDeclaration: await Bun.file(snapshotDeclaration).text(),
       }


### PR DESCRIPTION
### Issue for this PR

Fixes #298

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The product-build test started a generated Bun script asynchronously and read its piped output through separate promises. This was the only asynchronous Bun child added to the test suite after the earlier Windows process-exit fix in #321.

This change uses the same synchronous child-process pattern as #321. The command, environment, output checks, generated-file checks, and cleanup stay the same, but the test no longer leaves asynchronous process or stream handles behind.

The timed-out run did not identify a retained handle, so this does not claim the child was conclusively the root cause. Windows full-suite CI—preferably an unchanged rerun—is required before treating #298 as fixed.

### How did you verify your code works?

- Focused product-build test: 2 passed
- Telemetry lifecycle tests: 30 passed
- `packages/opencode` typecheck
- Prettier
- Targeted and repository oxlint
- `git diff --check`

### Screenshots / recordings

Not applicable; this is a test-process lifecycle change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
